### PR TITLE
Add .env.example and update README environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,17 @@ All commands should be run from the `src/` directory.
 
 ## Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `VITE_KN_API_SERVER` | Backend API server URL |
-| `VITE_SENTRY_DSN` | Sentry DSN for error tracking |
-| `SENTRY_AUTH_TOKEN` | Sentry authentication token |
+See `.env.example` for a ready-to-copy template. Variables marked **required** must be set for the build to succeed.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VITE_KN_API_SERVER` | Yes | Backend API server URL (default `http://localhost:8897`) |
+| `MICROSOFT_CLIENT_ID` | Yes | Microsoft OAuth client ID (compile-time) |
+| `VITE_GOOGLE_CLIENT_ID` | No | Google OAuth client ID for Drive picker and sign-in |
+| `VITE_GOOGLE_DEVELOPER_KEY` | No | Google API key for Drive file listing |
+| `VITE_SENTRY_DSN` | No | Sentry DSN for frontend error tracking |
+| `SENTRY_DSN` | No | Sentry DSN for Rust backend error tracking |
+| `SENTRY_AUTH_TOKEN` | No | Sentry auth token for source map uploads |
 
 ## Project Structure
 

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,40 @@
+# Knapsack Environment Variables
+# Copy this file to .env and fill in the values:
+#   cp .env.example .env
+#
+# This file is sourced before `tauri dev` and `tauri build` (see package.json).
+# Variables prefixed with VITE_ are available in the frontend via import.meta.env.
+# Variables used with Rust's env!() macro are required at compile time.
+
+# ---------------------------------------------------------------------------
+# Required
+# ---------------------------------------------------------------------------
+
+# Backend API server URL (used by both frontend and Rust backend at compile time)
+VITE_KN_API_SERVER=http://localhost:8897
+
+# Microsoft OAuth client ID (required at compile time for Microsoft sign-in)
+MICROSOFT_CLIENT_ID=
+
+# ---------------------------------------------------------------------------
+# Optional -- Google integration
+# ---------------------------------------------------------------------------
+
+# Google OAuth client ID (for Google Drive picker and sign-in)
+VITE_GOOGLE_CLIENT_ID=
+
+# Google API developer key (for Google Drive file listing)
+VITE_GOOGLE_DEVELOPER_KEY=
+
+# ---------------------------------------------------------------------------
+# Optional -- Observability
+# ---------------------------------------------------------------------------
+
+# Sentry DSN for frontend error tracking
+VITE_SENTRY_DSN=
+
+# Sentry DSN for Rust backend error tracking
+SENTRY_DSN=
+
+# Sentry auth token for source map uploads (used by vite-plugin during build)
+SENTRY_AUTH_TOKEN=

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -30,6 +30,7 @@ config
 # env files
 .env
 .env.*
+!.env.example
 .env_*
 
 # qdrant


### PR DESCRIPTION
Fixes #5. The README referenced `cp .env.example .env` but the file did not exist, blocking developer onboarding.

- Add src/.env.example with all required and optional env vars
- Add !.env.example exception to .gitignore so it is tracked
- Update README Environment Variables table with complete list including MICROSOFT_CLIENT_ID, VITE_GOOGLE_CLIENT_ID, VITE_GOOGLE_DEVELOPER_KEY, and SENTRY_DSN

https://claude.ai/code/session_01SuZZKwmcCv5kYp6vU5e7XV