### PR TITLE
Suppress MaxListenersExceededWarning in clawdbot warning filter

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/infra/warnings.js
+++ b/src/src-tauri/resources/clawdbot/dist/infra/warnings.js
@@ -10,6 +10,9 @@ function shouldIgnoreWarning(warning) {
         warning.message?.includes("SQLite is an experimental feature")) {
         return true;
     }
+    if (warning.name === "MaxListenersExceededWarning") {
+        return true;
+    }
     return false;
 }
 export function installProcessWarningFilter() {


### PR DESCRIPTION
Fixes #4. The clawdbot process emits ~40 MaxListenersExceededWarning messages during startup due to concurrent TLS connections exceeding Node.js's default 10-listener limit. This is a benign warning (not an actual memory leak) already acknowledged in monitor.js which bumps the limit to 50 for its own use.

Add MaxListenersExceededWarning to the process warning filter in warnings.js so it is suppressed alongside the other known noisy warnings (DEP0040, DEP0060, ExperimentalWarning).

https://claude.ai/code/session_01SuZZKwmcCv5kYp6vU5e7XV