### PR TITLE
Add meeting notetaker sidebar with recording controls

### DIFF
--- a/src/recording-indicator.html
+++ b/src/recording-indicator.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" style="background: transparent;">
+
+<head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Recording</title>
+    <style>
+      html, body, #recording-indicator-root {
+        background: transparent !important;
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+      }
+    </style>
+</head>
+
+<body style="background: transparent;">
+    <div id="recording-indicator-root"></div>
+    <script type="module" src="/src/RecordingIndicatorRoot.tsx"></script>
+</body>
+
+</html>

--- a/src/src-tauri/src/audio/audio.rs
+++ b/src/src-tauri/src/audio/audio.rs
@@ -315,6 +315,12 @@ pub async fn start_recording(
   recording_state.is_paused.store(false, Ordering::Relaxed);
   log::info!("[recording] Recording state set: is_recording=true, is_paused=false");
 
+  // Show the floating recording indicator pill
+  if let Some(indicator_window) = app_handle.get_window("recording-indicator") {
+    let _ = indicator_window.show();
+    let _ = indicator_window.emit("recording-indicator-show", {});
+  }
+
   let opt = Opt::parse();
   let host = cpal::default_host();
   log::info!("[recording] Audio host: {:?}, device setting: {}", host.id(), opt.device);
@@ -517,6 +523,7 @@ pub async fn stop_recording(
   data: Json<StopRecordingRequest>,
   recording_state: Data<RecordingState>,
   _handle: Data<Arc<Handle>>,
+  app_handle: Data<tauri::AppHandle>,
 ) -> HttpResponse {
   log::info!(
     "[recording] stop_recording: thread_id={} save_transcript={}",
@@ -531,6 +538,11 @@ pub async fn stop_recording(
 
   recording_state.is_recording.store(false, Ordering::Relaxed);
   log::info!("[recording] is_recording set to false, waiting for threads to finish");
+
+  // Hide the floating recording indicator pill
+  if let Some(indicator_window) = app_handle.get_window("recording-indicator") {
+    let _ = indicator_window.hide();
+  }
 
   let input_filename = {
     let input_filename_guard = recording_state.input_filename.lock().unwrap();
@@ -932,6 +944,11 @@ async fn notify_meeting_ended(app_handle: &tauri::AppHandle) -> Result<(), Error
   let window = app_handle.get_window(WINDOW_LABEL).unwrap();
   window.emit("meeting_ended", {}).unwrap();
 
+  // Hide the floating recording indicator pill
+  if let Some(indicator_window) = app_handle.get_window("recording-indicator") {
+    let _ = indicator_window.hide();
+  }
+
   Ok(())
 }
 
@@ -1194,12 +1211,23 @@ async fn stream_audio(
 }
 
 async fn handle_stop_events(app_handle: &tauri::AppHandle) -> Result<(), Error> {
-  let window = app_handle.get_window(WINDOW_LABEL).unwrap();
+  let window = match app_handle.get_window(WINDOW_LABEL) {
+    Some(w) => w,
+    None => {
+      log::warn!("[recording] Main window not found during handle_stop_events");
+      return Ok(());
+    }
+  };
 
-  window.emit("open_feed_item", {}).unwrap();
+  // Hide the floating recording indicator pill
+  if let Some(indicator_window) = app_handle.get_window("recording-indicator") {
+    let _ = indicator_window.hide();
+  }
+
+  let _ = window.emit("open_feed_item", {});
   sleep(Duration::from_millis(100)).await;
 
-  window.emit("stop_recording", {}).unwrap();
+  let _ = window.emit("stop_recording", {});
   sleep(Duration::from_millis(500)).await;
 
   focus_window(window);

--- a/src/src-tauri/src/audio/macos.rs
+++ b/src/src-tauri/src/audio/macos.rs
@@ -226,8 +226,8 @@ pub async fn record_speaker_output(
 
   #[cfg(target_os = "macos")]
   {
-    use objc2::runtime::{AnyClass, AnyObject};
-    use objc2::{msg_send, msg_send_id, rc::{Allocated, Id}};
+    use objc2::runtime::{AnyClass, AnyObject, Bool as ObjcBool};
+    use objc2::{msg_send, msg_send_id, sel, rc::{Allocated, Id}};
     use core_foundation::base::{CFRelease, TCFType};
     use core_foundation::string::CFString;
     use core_foundation::dictionary::CFDictionary;
@@ -273,24 +273,64 @@ pub async fn record_speaker_output(
     }
 
     // Get the tap's UUID (needed for aggregate device configuration).
-    // In macOS 26+, the `uuid` property was removed from CATapDescription.
-    // We check at runtime and fall back to generating a fresh NSUUID if unavailable.
+    // On macOS 14–15, CATapDescription has a `uuid` property.
+    // On macOS 26 (Tahoe), Apple renamed/removed it — try `UUID`, `tapUUID`,
+    // and `identifier` selectors, then fall back to a generated NSUUID.
     let tap_uuid_rust: String = unsafe {
-      let uuid_sel = objc2::sel!(uuid);
-      let responds: bool = msg_send![&*tap_desc, respondsToSelector: uuid_sel];
-      if responds {
+      let has_uuid: bool = {
+        let s = sel!(uuid);
+        let result: ObjcBool = msg_send![&*tap_desc, respondsToSelector: s];
+        result.as_bool()
+      };
+      let has_upper_uuid: bool = {
+        let s = sel!(UUID);
+        let result: ObjcBool = msg_send![&*tap_desc, respondsToSelector: s];
+        result.as_bool()
+      };
+
+      if has_uuid {
         let tap_uuid: Id<AnyObject> = msg_send_id![&*tap_desc, uuid];
         let tap_uuid_string: Id<AnyObject> = msg_send_id![&*tap_uuid, UUIDString];
         let tap_uuid_str: *const libc::c_char = msg_send![&*tap_uuid_string, UTF8String];
         std::ffi::CStr::from_ptr(tap_uuid_str).to_str().unwrap().to_string()
+      } else if has_upper_uuid {
+        let tap_uuid: Id<AnyObject> = msg_send_id![&*tap_desc, UUID];
+        let tap_uuid_string: Id<AnyObject> = msg_send_id![&*tap_uuid, UUIDString];
+        let tap_uuid_str: *const libc::c_char = msg_send![&*tap_uuid_string, UTF8String];
+        std::ffi::CStr::from_ptr(tap_uuid_str).to_str().unwrap().to_string()
       } else {
-        // macOS 26+: the uuid property no longer exists on CATapDescription.
-        // Generate a fresh UUID for the aggregate device configuration.
-        let nsuuid_class = AnyClass::get("NSUUID").unwrap();
-        let nsuuid: Id<AnyObject> = msg_send_id![nsuuid_class, UUID];
-        let uuid_string: Id<AnyObject> = msg_send_id![&*nsuuid, UUIDString];
-        let uuid_str: *const libc::c_char = msg_send![&*uuid_string, UTF8String];
-        std::ffi::CStr::from_ptr(uuid_str).to_str().unwrap().to_string()
+        // macOS 26+: try `tapUUID` or `identifier` as alternative selectors.
+        let has_tap_uuid: bool = {
+          let s = sel!(tapUUID);
+          let result: ObjcBool = msg_send![&*tap_desc, respondsToSelector: s];
+          result.as_bool()
+        };
+        let has_identifier: bool = {
+          let s = sel!(identifier);
+          let result: ObjcBool = msg_send![&*tap_desc, respondsToSelector: s];
+          result.as_bool()
+        };
+
+        if has_tap_uuid {
+          let tap_uuid: Id<AnyObject> = msg_send_id![&*tap_desc, tapUUID];
+          let tap_uuid_string: Id<AnyObject> = msg_send_id![&*tap_uuid, UUIDString];
+          let tap_uuid_str: *const libc::c_char = msg_send![&*tap_uuid_string, UTF8String];
+          std::ffi::CStr::from_ptr(tap_uuid_str).to_str().unwrap().to_string()
+        } else if has_identifier {
+          let tap_id_obj: Id<AnyObject> = msg_send_id![&*tap_desc, identifier];
+          let tap_uuid_string: Id<AnyObject> = msg_send_id![&*tap_id_obj, UUIDString];
+          let tap_uuid_str: *const libc::c_char = msg_send![&*tap_uuid_string, UTF8String];
+          std::ffi::CStr::from_ptr(tap_uuid_str).to_str().unwrap().to_string()
+        } else {
+          // Last resort: generate a fresh NSUUID. The aggregate device
+          // creation may fail, but at least the app won't crash.
+          log::warn!("[audio tap] CATapDescription does not respond to any known UUID selector; generating NSUUID");
+          let nsuuid_class = AnyClass::get("NSUUID").unwrap();
+          let nsuuid: Id<AnyObject> = msg_send_id![nsuuid_class, UUID];
+          let uuid_string: Id<AnyObject> = msg_send_id![&*nsuuid, UUIDString];
+          let uuid_str: *const libc::c_char = msg_send![&*uuid_string, UTF8String];
+          std::ffi::CStr::from_ptr(uuid_str).to_str().unwrap().to_string()
+        }
       }
     };
     log::info!("[audio tap] Tap UUID: {}", tap_uuid_rust);

--- a/src/src-tauri/src/audio/permission.rs
+++ b/src/src-tauri/src/audio/permission.rs
@@ -338,7 +338,7 @@ return status as integer"#,
 /// (kTCCServiceAudioCapture) on macOS 14.4+.
 ///
 /// This is the less-intrusive permission that only captures system audio
-/// (like Granola, ChatGPT, krisp, Limitless) instead of full screen recording.
+/// (like ChatGPT, krisp, Limitless) instead of full screen recording.
 #[cfg(target_os = "macos")]
 fn check_system_audio_permission_macos() -> bool {
     // Strategy 1 (most reliable): Try to actually create a Core Audio process tap.

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ extern crate derive_more;
 extern crate dirs;
 extern crate qdrant_client;
 extern crate serde;
+use serde::Deserialize;
 extern crate tokio;
 
 mod api;
@@ -51,7 +52,7 @@ use std::sync::Mutex as StdMutex;
 use tauri::async_runtime::TokioJoinHandle;
 use tauri::{
   AppHandle, CustomMenuItem, FileDropEvent, Manager, State, SystemTray, SystemTrayEvent,
-  SystemTrayMenu, WindowEvent,
+  SystemTrayMenu, SystemTrayMenuItem, WindowEvent,
 };
 use tauri_plugin_autostart::MacosLauncher;
 use tokio::sync::Mutex;
@@ -1055,6 +1056,138 @@ fn create_db_env_variable() {
   env::set_var("DATABASE_URL", db_path_str);
 }
 
+// ── System tray menu bar ──
+
+fn build_default_tray_menu() -> SystemTrayMenu {
+  let open_knapsack = CustomMenuItem::new("open_knapsack", "Open Knapsack");
+  let quick_note = CustomMenuItem::new("quick_note", "Quick Note");
+  let settings = CustomMenuItem::new("settings", "Settings");
+  let version = CustomMenuItem::new("version", format!("Knapsack v{}", env!("CARGO_PKG_VERSION"))).disabled();
+  let check_updates = CustomMenuItem::new("check_updates", "Check for updates");
+  let quit = CustomMenuItem::new("quit", "Quit");
+
+  SystemTrayMenu::new()
+    .add_item(open_knapsack)
+    .add_item(quick_note)
+    .add_item(settings)
+    .add_native_item(SystemTrayMenuItem::Separator)
+    .add_item(version)
+    .add_item(check_updates)
+    .add_native_item(SystemTrayMenuItem::Separator)
+    .add_item(quit)
+}
+
+fn handle_tray_menu_click(app: &AppHandle, id: &str) {
+  match id {
+    "open_knapsack" | "show" => {
+      if let Some(window) = app.get_window("main") {
+        window.show().unwrap();
+        window.set_focus().unwrap();
+      }
+    }
+    "quick_note" => {
+      if let Some(window) = app.get_window("main") {
+        window.show().unwrap();
+        window.set_focus().unwrap();
+        let _ = window.emit("create_quick_note", {});
+      }
+    }
+    "settings" => {
+      if let Some(window) = app.get_window("main") {
+        window.show().unwrap();
+        window.set_focus().unwrap();
+        let _ = window.emit("open_settings", {});
+      }
+    }
+    "check_updates" => {
+      if let Some(window) = app.get_window("main") {
+        window.show().unwrap();
+        window.set_focus().unwrap();
+      }
+    }
+    "quit" => {
+      clawd::service::cleanup_gateway_on_exit();
+      std::process::exit(0);
+    }
+    _ => {
+      if id.starts_with("meeting_") {
+        if let Some(window) = app.get_window("main") {
+          window.show().unwrap();
+          window.set_focus().unwrap();
+          let _ = window.emit("tray_meeting_click", id);
+        }
+      }
+    }
+  }
+}
+
+#[derive(Debug, Deserialize)]
+struct TrayMeetingItem {
+  title: String,
+  time: String,
+  #[serde(default)]
+  is_now: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrayMeetingGroup {
+  label: String,
+  meetings: Vec<TrayMeetingItem>,
+}
+
+#[tauri::command]
+fn update_tray_menu(app: AppHandle, groups: Vec<TrayMeetingGroup>) {
+  let mut menu = SystemTrayMenu::new();
+
+  let mut meeting_index = 0;
+  for group in &groups {
+    let header = CustomMenuItem::new(format!("header_{}", group.label), &group.label).disabled();
+    menu = menu.add_item(header);
+
+    for meeting in &group.meetings {
+      let label = format!("{}\n{}", meeting.title, meeting.time);
+      let item = CustomMenuItem::new(format!("meeting_{}", meeting_index), label);
+      menu = menu.add_item(item);
+      meeting_index += 1;
+    }
+  }
+
+  if meeting_index > 0 {
+    menu = menu.add_native_item(SystemTrayMenuItem::Separator);
+  }
+
+  let open_knapsack = CustomMenuItem::new("open_knapsack", "Open Knapsack");
+  let quick_note = CustomMenuItem::new("quick_note", "Quick Note");
+  let settings = CustomMenuItem::new("settings", "Settings");
+  let version = CustomMenuItem::new("version", format!("Knapsack v{}", env!("CARGO_PKG_VERSION"))).disabled();
+  let check_updates = CustomMenuItem::new("check_updates", "Check for updates");
+  let quit = CustomMenuItem::new("quit", "Quit");
+
+  menu = menu
+    .add_item(open_knapsack)
+    .add_item(quick_note)
+    .add_item(settings)
+    .add_native_item(SystemTrayMenuItem::Separator)
+    .add_item(version)
+    .add_item(check_updates)
+    .add_native_item(SystemTrayMenuItem::Separator)
+    .add_item(quit);
+
+  let _ = app.tray_handle().set_menu(menu);
+}
+
+#[tauri::command]
+fn update_tray_title(app: AppHandle, title: String) {
+  #[cfg(target_os = "macos")]
+  {
+    let _ = app.tray_handle().set_title(&title);
+  }
+  #[cfg(not(target_os = "macos"))]
+  {
+    let _ = app.tray_handle().set_tooltip(&title);
+  }
+}
+
 #[tokio::main]
 async fn main() {
   create_data_dir();
@@ -1289,6 +1422,45 @@ async fn main() {
           .unwrap();
       }
 
+      // Recording indicator floating pill window
+      let mut rec_indicator_builder = WindowBuilder::new(
+        app,
+        "recording-indicator",
+        WindowUrl::App("recording-indicator.html".into()),
+      )
+      .title("Recording")
+      .inner_size(180.0, 48.0)
+      .resizable(false)
+      .decorations(false)
+      .always_on_top(true)
+      .transparent(true)
+      .visible(false);
+
+      #[cfg(target_os = "macos")]
+      {
+        rec_indicator_builder = rec_indicator_builder.accept_first_mouse(true);
+      }
+
+      let rec_indicator_window = rec_indicator_builder.build()?;
+
+      // Position recording indicator at bottom-right of screen
+      if let Ok(Some(monitor)) = rec_indicator_window.current_monitor() {
+        let screen_size = monitor.size();
+        let scale_factor = monitor.scale_factor();
+        let screen_width_logical = screen_size.width as f64 / scale_factor;
+        let screen_height_logical = screen_size.height as f64 / scale_factor;
+        let indicator_width = 180.0_f64;
+        let indicator_height = 48.0_f64;
+        let indicator_x = (screen_width_logical - indicator_width - 24.0) * scale_factor;
+        let indicator_y = ((screen_height_logical - indicator_height) / 2.0) * scale_factor;
+        rec_indicator_window
+          .set_position(tauri::Position::Physical(tauri::PhysicalPosition {
+            x: indicator_x as i32,
+            y: indicator_y as i32,
+          }))
+          .unwrap();
+      }
+
       let llm_path = app
         .path_resolver()
         .resolve_resource("resources/llm.gguf")
@@ -1345,6 +1517,10 @@ async fn main() {
       spotlight::show_overlay_window,
       spotlight::hide_overlay_window,
       spotlight::toggle_overlay_window,
+      spotlight::show_recording_indicator,
+      spotlight::hide_recording_indicator,
+      update_tray_menu,
+      update_tray_title,
       kn_read_logs,
       kn_get_log_path,
       kn_get_openclaw_version,
@@ -1399,14 +1575,11 @@ async fn main() {
       _ => {}
     });
 
-  #[cfg(any(target_os = "windows", target_os = "linux"))]
+  // System tray with meetings menu (all platforms)
   {
-    let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-    let show = CustomMenuItem::new("show".to_string(), "Show");
-
-    let tray_menu = SystemTrayMenu::new().add_item(show).add_item(quit);
-
+    let tray_menu = build_default_tray_menu();
     let system_tray = SystemTray::new().with_menu(tray_menu);
+
     builder = builder
       .system_tray(system_tray)
       .on_system_tray_event(|app, event| match event {
@@ -1415,23 +1588,14 @@ async fn main() {
           size: _,
           ..
         } => {
-          let window = app.get_window("main").unwrap();
-          window.show().unwrap();
-          window.set_focus().unwrap();
-        }
-        SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
-          "quit" => {
-            // Clean up child processes before exiting so they don't linger
-            clawd::service::cleanup_gateway_on_exit();
-            std::process::exit(0);
-          }
-          "show" => {
-            let window = app.get_window("main").unwrap();
+          if let Some(window) = app.get_window("main") {
             window.show().unwrap();
             window.set_focus().unwrap();
           }
-          _ => {}
-        },
+        }
+        SystemTrayEvent::MenuItemClick { id, .. } => {
+          handle_tray_menu_click(app, &id);
+        }
         _ => {}
       });
   }

--- a/src/src-tauri/src/spotlight.rs
+++ b/src/src-tauri/src/spotlight.rs
@@ -134,6 +134,23 @@ pub fn toggle_overlay_window(app_handle: AppHandle<Wry>) {
   }
 }
 
+// ── Recording indicator floating pill commands ──
+
+#[tauri::command]
+pub fn show_recording_indicator(app_handle: AppHandle<Wry>) {
+  if let Some(window) = app_handle.get_window("recording-indicator") {
+    window.show().expect("Failed to show recording indicator");
+    window.emit("recording-indicator-show", {}).unwrap_or_default();
+  }
+}
+
+#[tauri::command]
+pub fn hide_recording_indicator(app_handle: AppHandle<Wry>) {
+  if let Some(window) = app_handle.get_window("recording-indicator") {
+    window.hide().expect("Failed to hide recording indicator");
+  }
+}
+
 // TODO: do we still need these, if we're using an NSWindow instead of an NSPanel?
 #[tauri::command]
 pub fn set_window_level_bottom(app_handle: AppHandle<Wry>) {

--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -203,8 +203,8 @@
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZFRjZCMjlFRTU1NTYwMzQKUldRMFlGWGxuckwyL3FDa2k1djhyVVNVcTUrL00vVzhPeExrK0VQZDRML3BKYmM5eUxXRHdmQkMK"
     },
     "systemTray": {
-      "iconPath": "icons/128x128.png",
-      "iconAsTemplate": true
+      "iconPath": "icons/32x32.png",
+      "iconAsTemplate": false
     },
     "macOSPrivateApi": true,
     "windows": []

--- a/src/src/RecordingIndicatorRoot.tsx
+++ b/src/src/RecordingIndicatorRoot.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ReactDOM from 'react-dom/client'
+
+import RecordingIndicator from './components/molecules/RecordingIndicator'
+
+import { getCurrent } from '@tauri-apps/api/window'
+
+const currentWindow = getCurrent()
+if (currentWindow.label === 'recording-indicator') {
+  const titlebar = document.querySelector('.titlebar')
+  if (titlebar) {
+    ;(titlebar as HTMLElement).style.display = 'none'
+  }
+}
+
+ReactDOM.createRoot(document.getElementById('recording-indicator-root') as HTMLElement).render(
+  <React.StrictMode>
+    <RecordingIndicator />
+  </React.StrictMode>,
+)

--- a/src/src/components/TabBar.scss
+++ b/src/src/components/TabBar.scss
@@ -32,6 +32,11 @@
     background-color: rgba(0, 0, 0, 0.05);
     color: #6474AC;
   }
+
+  &--active {
+    color: #6474AC;
+    background-color: rgba(100, 116, 172, 0.1);
+  }
 }
 
 // Subtle chevron at top of expanded sidebar to collapse

--- a/src/src/components/TabBar.tsx
+++ b/src/src/components/TabBar.tsx
@@ -26,9 +26,11 @@ interface TabBarProps {
   currentTab: TabChoices
   setCurrentTab: (tabChoice: TabChoices) => void
   fullRelease: boolean | null
+  onCalendarToggle?: () => void
+  isCalendarOpen?: boolean
 }
 
-const TabBar: React.FC<TabBarProps> = ({ currentTab, setCurrentTab, fullRelease }) => {
+const TabBar: React.FC<TabBarProps> = ({ currentTab, setCurrentTab, fullRelease, onCalendarToggle, isCalendarOpen }) => {
   const [collapsed, setCollapsed] = useState(true)
 
   const tabs: TabData[] = [
@@ -83,6 +85,20 @@ const TabBar: React.FC<TabBarProps> = ({ currentTab, setCurrentTab, fullRelease 
   if (collapsed) {
     return (
       <div data-tauri-drag-region className="TabBarContainer TabBarContainer--collapsed mt-12 select-none">
+        {/* Calendar toggle button */}
+        <button
+          className={`TabBarExpandBtn ${isCalendarOpen ? 'TabBarExpandBtn--active' : ''}`}
+          onClick={onCalendarToggle}
+          title={isCalendarOpen ? 'Hide calendar' : 'Show calendar'}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+            <line x1="16" y1="2" x2="16" y2="6" />
+            <line x1="8" y1="2" x2="8" y2="6" />
+            <line x1="3" y1="10" x2="21" y2="10" />
+          </svg>
+        </button>
+        {/* Expand tabs button */}
         <button
           className="TabBarExpandBtn"
           onClick={() => setCollapsed(false)}
@@ -103,6 +119,20 @@ const TabBar: React.FC<TabBarProps> = ({ currentTab, setCurrentTab, fullRelease 
       data-tauri-drag-region
       className="TabBarContainer mt-12 select-none flex flex-col space-y-0"
     >
+      {/* Calendar toggle */}
+      <button
+        className={`TabBarExpandBtn ${isCalendarOpen ? 'TabBarExpandBtn--active' : ''}`}
+        onClick={onCalendarToggle}
+        title={isCalendarOpen ? 'Hide calendar' : 'Show calendar'}
+        style={{ marginBottom: 4 }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+      </button>
       <button
         className="TabBarCollapseBtn"
         onClick={() => setCollapsed(true)}

--- a/src/src/components/molecules/RecordControlPanel/index.tsx
+++ b/src/src/components/molecules/RecordControlPanel/index.tsx
@@ -42,19 +42,26 @@ const RecordControlPanel: React.FC<RecordPanelProps> = ({
         />
       ) : isRecording ? (
         !isPaused ? (
-          <Tooltip
-            label="Meeting recording in progress"
-            component={
-              <RecordButton
-                text="Pause"
-                //onClick={() => handleStopRecording('Manually')}
-                onClick={onClickPause}
-                isDisabled={false}
-                variant={RecordButtonVariant.recordingInProgress}
-              />
-            }
-            variant={TooltipVariant.inProgressMeeting}
-          />
+          <div className="inline-flex justify-start items-center gap-2">
+            <RecordButton
+              text="Stop"
+              onClick={onClickEnd}
+              isDisabled={false}
+              variant={RecordButtonVariant.white}
+            />
+            <Tooltip
+              label="Meeting recording in progress"
+              component={
+                <RecordButton
+                  text="Pause"
+                  onClick={onClickPause}
+                  isDisabled={false}
+                  variant={RecordButtonVariant.recordingInProgress}
+                />
+              }
+              variant={TooltipVariant.inProgressMeeting}
+            />
+          </div>
         ) : (
           <div className="inline-flex justify-start items-center gap-2">
             <RecordButton

--- a/src/src/components/molecules/RecordingIndicator/index.tsx
+++ b/src/src/components/molecules/RecordingIndicator/index.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react'
+import { invoke } from '@tauri-apps/api/tauri'
+import { listen } from '@tauri-apps/api/event'
+import { appWindow } from '@tauri-apps/api/window'
+
+function RecordingIndicator() {
+  const [elapsed, setElapsed] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+
+  // Listen for recording start/stop events from the main window
+  useEffect(() => {
+    const unlistenStart = listen('recording-indicator-show', () => {
+      setElapsed(0)
+    })
+    const unlistenStop = listen('recording-indicator-hide', () => {
+      invoke('hide_recording_indicator')
+    })
+    return () => {
+      unlistenStart.then(fn => fn())
+      unlistenStop.then(fn => fn())
+    }
+  }, [])
+
+  // Timer that counts up while visible
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed(prev => prev + 1)
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const formatElapsed = (seconds: number) => {
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+  }
+
+  // Allow dragging the pill around the screen
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('button')) return
+    setIsDragging(true)
+    appWindow.startDragging()
+  }, [])
+
+  const handleClick = useCallback(() => {
+    if (!isDragging) {
+      // Click on the pill to bring main window to focus
+      invoke('kn_show_app')
+    }
+    setIsDragging(false)
+  }, [isDragging])
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'transparent',
+        cursor: 'grab',
+      }}
+      onMouseDown={handleMouseDown}
+      onClick={handleClick}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '8px 16px 8px 12px',
+          borderRadius: 24,
+          background: '#ffffff',
+          boxShadow: '0 4px 20px rgba(0,0,0,0.12), 0 1px 4px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.04)',
+          fontFamily: "'Inter', -apple-system, sans-serif",
+          userSelect: 'none',
+          WebkitAppRegion: 'drag' as any,
+        }}
+      >
+        {/* Knapsack logo */}
+        <img
+          src="/assets/images/knap-logo-medium.png"
+          alt="Knapsack"
+          style={{ width: 20, height: 20, flexShrink: 0 }}
+        />
+
+        {/* Animated waveform bars */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            height: 20,
+          }}
+        >
+          {[0, 150, 300, 450, 600].map((delay) => (
+            <span
+              key={delay}
+              style={{
+                width: 3,
+                borderRadius: 2,
+                background: '#6B7A2F',
+                animation: `waveform-bounce 1.2s ease-in-out ${delay}ms infinite`,
+              }}
+            />
+          ))}
+        </div>
+
+        {/* Timer */}
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: '#333333',
+            fontVariantNumeric: 'tabular-nums',
+            minWidth: 38,
+          }}
+        >
+          {formatElapsed(elapsed)}
+        </span>
+      </div>
+
+      <style>{`
+        @keyframes waveform-bounce {
+          0%, 100% { height: 4px; }
+          50% { height: 16px; }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default RecordingIndicator

--- a/src/src/components/molecules/RecordingIndicator/index.tsx
+++ b/src/src/components/molecules/RecordingIndicator/index.tsx
@@ -75,7 +75,6 @@ function RecordingIndicator() {
           boxShadow: '0 4px 20px rgba(0,0,0,0.12), 0 1px 4px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.04)',
           fontFamily: "'Inter', -apple-system, sans-serif",
           userSelect: 'none',
-          WebkitAppRegion: 'drag' as any,
         }}
       >
         {/* Knapsack logo */}

--- a/src/src/components/organisms/MeetingNotesMode/RecordingContext.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/RecordingContext.tsx
@@ -252,16 +252,22 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
     eventId?: number,
   ) => {
     setIsPaused(false)
-    console.info(`[Recording] stopRecording threadId=${threadId}`)
+    console.info(`[Recording] stopRecording threadId=${threadId} frontendState=${isRecording(threadId)}`)
 
-    if (isRecording(threadId)) {
-      setLoadingState(threadId, true)
-      try {
-        await stopRecord(threadId, saveTranscript, eventId)
-        console.info(`[Recording] stopRecord succeeded for threadId=${threadId}`)
-        setFeedIsRecording(false)
-        setIsRecording(threadId, false)
-      } catch (err: any) {
+    // Always attempt to stop — don't gate on frontend state which can desync
+    const wasRecording = isRecording(threadId)
+    setLoadingState(threadId, true)
+    let stopSucceeded = false
+    try {
+      await stopRecord(threadId, saveTranscript, eventId)
+      console.info(`[Recording] stopRecord succeeded for threadId=${threadId}`)
+      stopSucceeded = true
+    } catch (err: any) {
+      // If backend says "no recording in progress", that's OK — state was out of sync
+      if (err?.message?.includes('No recording in progress')) {
+        console.warn(`[Recording] Backend had no recording for threadId=${threadId}, clearing frontend state`)
+        stopSucceeded = true // Still clear state
+      } else {
         console.error(`[Recording] stopRecording failed for threadId=${threadId}:`, err)
         logError(
           new Error('Error stopping recording'),
@@ -271,8 +277,15 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
           },
           true,
         )
+        setLoadingState(threadId, false)
         throw new Error('Error stop recording')
       }
+    }
+    // Always clear recording state after successful stop
+    setFeedIsRecording(false)
+    setIsRecording(threadId, false)
+
+    if (wasRecording && stopSucceeded) {
       await generateNotes(threadId, synthesizeContent, saveNotes, notesMarkdown, meeting)
     }
 

--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import dayjs from 'dayjs'
 
 import { mergeAttributes } from '@tiptap/core'
 import { Color } from '@tiptap/extension-color'
@@ -94,6 +95,8 @@ interface MeetingNotesModeProps {
   closeTasks: () => void
   recordingHandlers: RecordingContextProps
   handleOpenTasks?: (threadId: number | undefined, tasks: TaskItem[]) => void
+  onChatClick?: () => void
+  onEmailClick?: (notesMarkdown: string) => void
 }
 
 const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
@@ -116,9 +119,12 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   closeTasks,
   recordingHandlers,
   handleOpenTasks,
+  onChatClick,
+  onEmailClick,
 }) => {
   const [isInitialLoading, setIsInitialLoading] = useState(true)
   const [disableIsRecording, setDisableIsRecording] = useState(false)
+  const [permissionError, setPermissionError] = useState<string | null>(null)
   const [notesMarkdown, setNotesMarkdown] = useState<string>('')
   const [isTitleSet, setIsTitleSet] = useState(thread.subtitle !== 'Untitled Meeting')
   const [transcribingTextIndex, setTranscribingTextIndex] = useState(0)
@@ -473,9 +479,13 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
         isStart,
       )
     } catch (err: any) {
-      const message = err?.message?.includes('permission') || err?.message?.includes('Permission')
+      const isPermissionIssue = err?.message?.includes('permission') || err?.message?.includes('Permission')
+      const message = isPermissionIssue
         ? 'Recording requires audio permissions. Please grant access in System Settings > Privacy & Security, then try again. If already enabled, try toggling the permission off and on, then restart Knapsack.'
         : "Couldn't start recording. Check that your microphone is available and try again."
+      if (isPermissionIssue) {
+        setPermissionError(message)
+      }
       handleErrorContact(message)
     }
   }
@@ -542,7 +552,83 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     }
   }, [isSynthesizing, synthTimedOut])
 
-  if (!editor || isInitialLoading) return null
+  if (!editor || isInitialLoading) {
+    return (
+      <div className="notetaker-note">
+        <div className="notetaker-note__container">
+          <div className="w-full flex flex-col gap-3">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <h1 className="notetaker-note__title">
+                  {thread.subtitle}
+                </h1>
+                <div className="notetaker-note__meta">
+                  <span className="notetaker-note__meta-item">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                      <line x1="16" y1="2" x2="16" y2="6" />
+                      <line x1="8" y1="2" x2="8" y2="6" />
+                      <line x1="3" y1="10" x2="21" y2="10" />
+                    </svg>
+                    {dayjs(new Date()).isSame(dayjs(meeting?.start ? meeting.start * 1000 : undefined), 'day') ? 'Today' : dayjs(meeting?.start ? meeting.start * 1000 : undefined).format('MMM D')}
+                  </span>
+                </div>
+              </div>
+              <div className="flex-shrink-0 flex items-center gap-2">
+                {!thread.recorded && (
+                  <RecordControlPanel
+                    onClickJoin={() => handleRecordClick(true)}
+                    onClickEnd={() => handleStopRecording('Manually')}
+                    onClickPause={() => recordingHandlers.pauseRecording()}
+                    onClickResume={() => handleRecordClick(false)}
+                    isRecording={recordingHandlers.isRecording(thread.id)}
+                    isDisabled={disableIsRecording}
+                    isSynthesizing={isSynthesizing()}
+                    isPaused={recordingHandlers.isPaused}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+          {/* Loading skeleton */}
+          {!recordingHandlers.isRecording(thread.id) && (
+            <div className="mt-6 space-y-3 animate-pulse">
+              <div className="h-4 bg-gray-200 rounded w-3/4" />
+              <div className="h-4 bg-gray-200 rounded w-1/2" />
+              <div className="h-4 bg-gray-200 rounded w-5/6" />
+              <div className="h-4 bg-gray-200 rounded w-2/3" />
+            </div>
+          )}
+          {/* Show recording notice + stop button when recording during loading */}
+          {recordingHandlers.isRecording(thread.id) && (
+            <MeetingChatNotice meetingPlatform={meeting?.meeting_platform} />
+          )}
+        </div>
+        {/* Bottom bar stop button available even during loading */}
+        {recordingHandlers.isRecording(thread.id) && (
+          <div className="notetaker-note__bottom-bar">
+            <div className="notetaker-note__bottom-waveform">
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '0ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '150ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '300ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '450ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '600ms'}} />
+            </div>
+            <div className="notetaker-note__bottom-recording-status">
+              Privately transcribing...
+            </div>
+            <div className="flex-1" />
+            <button
+              className="notetaker-note__bottom-stop"
+              onClick={() => handleStopRecording('Manually')}
+            >
+              Stop recording
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
 
   const extractActionItems = (markdownContent: string): string[] => {
     if (!markdownContent) return []
@@ -593,16 +679,44 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   }
 
   return (
-    <div>
-      <div className="TightShadow w-full max-w-[45rem] mx-auto flex flex-col gap-y-4 rounded-[10px] bg-white relative p-4 mb-2">
+    <div className="notetaker-note">
+      <div className="notetaker-note__container">
         <div className="w-full flex flex-col gap-3">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="flex-1 min-w-0">
-              <div className="text-zinc-800 text-xl font-Lora font-bold leading-7">
+              <h1 className="notetaker-note__title">
                 {thread.subtitle}
+              </h1>
+              {/* Metadata row */}
+              <div className="notetaker-note__meta">
+                {recordingHandlers.isRecording(thread.id) && (
+                  <span className="notetaker-note__meta-item notetaker-note__meta-item--recording">
+                    <span className="notetaker-note__recording-dot" />
+                    Recording
+                  </span>
+                )}
+                <span className="notetaker-note__meta-item">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" />
+                    <line x1="8" y1="2" x2="8" y2="6" />
+                    <line x1="3" y1="10" x2="21" y2="10" />
+                  </svg>
+                  {dayjs(new Date()).isSame(dayjs(meeting?.start ? meeting.start * 1000 : undefined), 'day') ? 'Today' : dayjs(meeting?.start ? meeting.start * 1000 : undefined).format('MMM D')}
+                </span>
+                {meeting?.participants && meeting.participants.length > 0 && (
+                  <span className="notetaker-note__meta-item">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                      <circle cx="9" cy="7" r="4" />
+                    </svg>
+                    {meeting.participants.slice(0, 3).map(p => p.name || p.email.split('@')[0]).join(', ')}
+                    {meeting.participants.length > 3 && ` +${meeting.participants.length - 3}`}
+                  </span>
+                )}
               </div>
             </div>
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 flex items-center gap-2">
               {!thread.recorded && (
                 <RecordControlPanel
                   onClickJoin={() => handleRecordClick(true)}
@@ -642,104 +756,139 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
             </div>
           </div>
         </div>
-        <MeetingNotesTabBar
-          thread={thread}
-          feedItemId={feedItemId}
-          feed={feed}
-          templateLabel={templatePrompt.title}
-          hasActionItems={hasActionItems()}
-          onOpenTemplatesClick={handleOpenTemplates}
-          onViewTranscriptClick={handleOpenTranscript}
-          onTasksButtonClick={handleTasksButtonClick}
-          onCopyClick={() => {
-            if (copyToClipboard) copyToClipboard(notesMarkdown)
-          }}
-          canChangeTemplate={true}
-          isEditing={isEditing}
-          onEditClick={onEditClick}
-        />
+
+        {/* Recording notice */}
         {recordingHandlers.isRecording(thread.id) && (
-          <div className="flex flex-col gap-2">
-            <div className="h-[49px] bg-ks-red-100 border-ks-red-200 border rounded-md py-3 px-3 w-full flex items-center">
-              <span className="text-ks-red-800 text-xxs font-semibold ml-2 font-InterTight mr-1 tracking-[0.08em]">
-                RECORDING.
-              </span>
-              <span className="text-ks-red-800 text-xxs font-InterTight tracking-[0.08em]">
-                PLEASE NOTIFY ATTENDEES THAT THIS MEETING IS BEING RECORDED
-              </span>
+          <MeetingChatNotice meetingPlatform={meeting?.meeting_platform} />
+        )}
+
+        {/* Permission error banner */}
+        {permissionError && !recordingHandlers.isRecording(thread.id) && (
+          <div className="notetaker-note__permission-error">
+            <div className="notetaker-note__permission-error-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
             </div>
-            <MeetingChatNotice meetingPlatform={meeting?.meeting_platform} />
+            <div className="notetaker-note__permission-error-content">
+              <strong>Microphone access required</strong>
+              <p>{permissionError}</p>
+              <div className="notetaker-note__permission-error-steps">
+                <p><strong>To fix:</strong></p>
+                <ol>
+                  <li>Open <strong>System Settings</strong> &rarr; <strong>Privacy &amp; Security</strong> &rarr; <strong>Microphone</strong></li>
+                  <li>Toggle <strong>Knapsack</strong> on (or off then on if already enabled)</li>
+                  <li>Restart Knapsack and try recording again</li>
+                </ol>
+              </div>
+            </div>
+            <button
+              className="notetaker-note__permission-error-dismiss"
+              onClick={() => setPermissionError(null)}
+              title="Dismiss"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
           </div>
         )}
+
+        {/* Tab bar for template, transcript, tasks - hidden during active recording for clean view */}
+        {!recordingHandlers.isRecording(thread.id) && (
+          <MeetingNotesTabBar
+            thread={thread}
+            feedItemId={feedItemId}
+            feed={feed}
+            templateLabel={templatePrompt.title}
+            hasActionItems={hasActionItems()}
+            onOpenTemplatesClick={handleOpenTemplates}
+            onViewTranscriptClick={handleOpenTranscript}
+            onTasksButtonClick={handleTasksButtonClick}
+            onCopyClick={() => {
+              if (copyToClipboard) copyToClipboard(notesMarkdown)
+            }}
+            canChangeTemplate={true}
+            isEditing={isEditing}
+            onEditClick={onEditClick}
+          />
+        )}
+
+        {/* Editor - always shown, focused during recording */}
         {isEditing ? (
-          <div className="border-[1px] rounded-lg">
-            <div className="border-0 border-b-[1px] outline-none mx-3 py-1">
-              <div className="flex flex-wrap gap-1 rounded-md px-2">
-                <div className="flex gap-1 font-RobotoMono">
-                  <MenuButton
-                    onClick={() => editor.chain().focus().toggleBold().run()}
-                    isActive={editor.isActive('bold')}
-                    title="Bold (Cmd + B)"
-                  >
-                    <span className="font-bold">B</span>
-                  </MenuButton>
-                  <MenuButton
-                    onClick={() => editor.chain().focus().toggleItalic().run()}
-                    isActive={editor.isActive('italic')}
-                    title="Italic (Cmd + I)"
-                  >
-                    <span className="italic">I</span>
-                  </MenuButton>
-                  <div className="w-px h-6 bg-gray-200 mt-2 mx-2" />
-
-                  <div className="flex gap-1">
+          <div className={`notetaker-note__editor ${recordingHandlers.isRecording(thread.id) ? 'notetaker-note__editor--recording' : ''}`}>
+            {!recordingHandlers.isRecording(thread.id) && (
+              <div className="border-0 border-b-[1px] outline-none mx-3 py-1">
+                <div className="flex flex-wrap gap-1 rounded-md px-2">
+                  <div className="flex gap-1 font-RobotoMono">
                     <MenuButton
-                      onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-                      isActive={editor.isActive('heading', { level: 1 })}
-                      title="Heading 1"
+                      onClick={() => editor.chain().focus().toggleBold().run()}
+                      isActive={editor.isActive('bold')}
+                      title="Bold (Cmd + B)"
                     >
-                      H1
+                      <span className="font-bold">B</span>
                     </MenuButton>
-
                     <MenuButton
-                      onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-                      isActive={editor.isActive('heading', { level: 2 })}
-                      title="Heading 2"
+                      onClick={() => editor.chain().focus().toggleItalic().run()}
+                      isActive={editor.isActive('italic')}
+                      title="Italic (Cmd + I)"
                     >
-                      H2
+                      <span className="italic">I</span>
                     </MenuButton>
+                    <div className="w-px h-6 bg-gray-200 mt-2 mx-2" />
 
-                    <MenuButton
-                      onClick={() => editor.chain().focus().toggleBulletList().run()}
-                      isActive={editor.isActive('bulletList')}
-                      title="Bullet List"
-                    >
-                      • List
-                    </MenuButton>
+                    <div className="flex gap-1">
+                      <MenuButton
+                        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+                        isActive={editor.isActive('heading', { level: 1 })}
+                        title="Heading 1"
+                      >
+                        H1
+                      </MenuButton>
 
-                    <MenuButton
-                      onClick={() => editor.chain().focus().toggleOrderedList().run()}
-                      isActive={editor.isActive('orderedList')}
-                      title="Numbered List"
-                    >
-                      1. List
-                    </MenuButton>
-                  </div>
+                      <MenuButton
+                        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+                        isActive={editor.isActive('heading', { level: 2 })}
+                        title="Heading 2"
+                      >
+                        H2
+                      </MenuButton>
 
-                  <div className="w-px h-6 bg-gray-200 mt-2 mx-1" />
+                      <MenuButton
+                        onClick={() => editor.chain().focus().toggleBulletList().run()}
+                        isActive={editor.isActive('bulletList')}
+                        title="Bullet List"
+                      >
+                        • List
+                      </MenuButton>
 
-                  <div className="flex gap-1">
-                    <MenuButton
-                      onClick={() => editor.chain().focus().setHorizontalRule().run()}
-                      isActive={editor.isActive('orderedList')}
-                      title="Horizontal Rule (---)"
-                    >
-                      <span>―</span>
-                    </MenuButton>
+                      <MenuButton
+                        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+                        isActive={editor.isActive('orderedList')}
+                        title="Numbered List"
+                      >
+                        1. List
+                      </MenuButton>
+                    </div>
+
+                    <div className="w-px h-6 bg-gray-200 mt-2 mx-1" />
+
+                    <div className="flex gap-1">
+                      <MenuButton
+                        onClick={() => editor.chain().focus().setHorizontalRule().run()}
+                        isActive={editor.isActive('orderedList')}
+                        title="Horizontal Rule (---)"
+                      >
+                        <span>―</span>
+                      </MenuButton>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
             <div className="text-left text-wrap max-w-[85vh] min-h-[320px]">
               <EditorContent editor={editor} />
             </div>
@@ -753,6 +902,70 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
           />
         )}
 
+      </div>
+
+      {/* Notetaker bottom bar */}
+      <div className="notetaker-note__bottom-bar">
+        {recordingHandlers.isRecording(thread.id) ? (
+          <>
+            <div className="notetaker-note__bottom-waveform">
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '0ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '150ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '300ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '450ms'}} />
+              <span className="notetaker-note__waveform-bar" style={{animationDelay: '600ms'}} />
+            </div>
+            <div className="notetaker-note__bottom-recording-status">
+              Privately transcribing...
+            </div>
+            <div className="flex-1" />
+            <button
+              className="notetaker-note__bottom-stop"
+              onClick={() => handleStopRecording('Manually')}
+            >
+              Stop recording
+            </button>
+          </>
+        ) : (
+          <>
+            <button className="notetaker-note__bottom-audio" title="Audio waveform">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="4" y1="8" x2="4" y2="16" />
+                <line x1="8" y1="5" x2="8" y2="19" />
+                <line x1="12" y1="2" x2="12" y2="22" />
+                <line x1="16" y1="5" x2="16" y2="19" />
+                <line x1="20" y1="8" x2="20" y2="16" />
+              </svg>
+            </button>
+            <div
+              className="notetaker-note__bottom-chat"
+              onClick={() => onChatClick?.()}
+              style={{ cursor: 'pointer' }}
+            >
+              <input
+                type="text"
+                placeholder="Continue chat"
+                className="notetaker-note__bottom-chat-input"
+                readOnly
+                style={{ cursor: 'pointer' }}
+              />
+            </div>
+            {thread.recorded && (
+              <button
+                className="notetaker-note__bottom-action"
+                onClick={() => onEmailClick?.(notesMarkdown)}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M4 4v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.342a2 2 0 0 0-.602-1.43l-4.44-4.342A2 2 0 0 0 13.56 2H6a2 2 0 0 0-2 2z" />
+                  <path d="M9 13h6" />
+                  <path d="M9 17h3" />
+                  <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+                </svg>
+                Write follow up email
+              </button>
+            )}
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -236,7 +236,7 @@ const MeetingsTabView = ({
               onClick={() => {
                 // Copy the meeting notes as markdown
                 const notesThread = selectedMeeting.threads?.find(t => t.threadType === ThreadType.MEETING_NOTES)
-                const noteContent = notesThread?.messages?.[0]?.content || selectedMeeting.getTitle?.() || ''
+                const noteContent = notesThread?.messages?.[0]?.text || selectedMeeting.getTitle?.() || ''
                 if (copyToClipboard && noteContent) {
                   copyToClipboard(noteContent)
                 }

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -1,27 +1,21 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/tauri'
 
-import { FeedItem } from 'src/api/feed_items'
 import { IThread, ThreadType } from 'src/api/threads'
 import { Connection, ConnectionKeys } from 'src/api/connections'
 import { LLMParams } from 'src/App'
-import { IFeed, STATIONARY_ITEMS } from 'src/hooks/feed/useFeed'
-import KNDateUtils from 'src/utils/KNDateUtils'
+import { IFeed } from 'src/hooks/feed/useFeed'
 import { MeetingTemplatePrompt } from 'src/utils/template_prompts'
 
 import { Button, ButtonVariant } from 'src/components/atoms/button'
-import { Tooltip, TooltipVariant } from 'src/components/atoms/tooltip'
 import MeetingNotesMode from 'src/components/organisms/MeetingNotesMode'
 import AudioPermissionChecker from 'src/components/molecules/AudioPermissionChecker'
-import ThreadPreviewCard from 'src/components/molecules/ThreadPreviewCard'
 import TemplatesView from 'src/components/organisms/TemplatesView'
 import TranscriptView from 'src/components/organisms/TranscriptView'
 import MeetingTasks from 'src/components/molecules/MeetingTasks'
 import { RecordingContextProps } from 'src/components/organisms/MeetingNotesMode/RecordingContext'
 import { TaskItem } from 'src/components/organisms/CenterWorkspace'
 
-import FeedSidebarArrowDown from '/assets/images/icons/FeedSidebarArrowDown.svg'
-import Mic from '/assets/images/icons/mic-grey.svg'
 import CalendarIcon from '/assets/images/dataSources/gcal.svg'
 
 import './style.scss'
@@ -50,6 +44,9 @@ interface MeetingsTabViewProps {
   recordingHandlers: RecordingContextProps
   connections?: Record<string, Connection>
   onConnectCalendar?: () => void
+  onBack?: () => void
+  onChatClick?: () => void
+  onEmailClick?: (notesMarkdown: string) => void
 }
 
 const MeetingsTabView = ({
@@ -60,6 +57,9 @@ const MeetingsTabView = ({
   recordingHandlers,
   connections,
   onConnectCalendar,
+  onBack,
+  onChatClick,
+  onEmailClick,
 }: MeetingsTabViewProps) => {
   const [micPermission, setMicPermission] = useState(localStorage.getItem('micPermissionGranted') === 'true')
   const [screenPermission, setScreenPermission] = useState(localStorage.getItem('screenPermissionGranted') === 'true')
@@ -67,7 +67,6 @@ const MeetingsTabView = ({
     localStorage.getItem('permissionsDismissed') === 'true'
   )
   const [synthesisState, setSynthesisState] = useState(false)
-  const threadCardRef = useRef<HTMLDivElement>(null)
 
   // Panel state (ported from CenterWorkspace)
   const [transcriptState, setTranscriptState] = useState<TranscriptState>({ isOpen: false })
@@ -111,123 +110,6 @@ const MeetingsTabView = ({
     checkPermissions()
   }, [])
 
-  // Check if any meeting is currently recording
-  const isAnyRecording = useMemo(() => {
-    if (!feed.feedContent) return false
-    return Object.entries(feed.feedContent).some(([key, feedItems]) => {
-      if (key === STATIONARY_ITEMS) return false
-      return feedItems.some(item =>
-        item.isRecording && item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES)
-      )
-    })
-  }, [feed.feedContent])
-
-  // Build date-grouped meeting items (same pattern as FeedSidebar)
-  const groupedMeetings = useMemo(() => {
-    const groups: Record<string, { key: string; item: FeedItem }[]> = {}
-    // Deduplicate across all date groups by title + start-minute.
-    // We round to the nearest minute because the same meeting can appear as
-    // both a DB feed item and a calendar-injected item whose timestamps
-    // differ by a few seconds.
-    const seenMeetingKeys = new Set<string>()
-
-    if (feed.feedContent) {
-      Object.entries(feed.feedContent).forEach(([key, feedItems]) => {
-        if (key === STATIONARY_ITEMS) return
-
-        feedItems.forEach(item => {
-          const hasMeetingNotes = item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES)
-          const isUpcomingCalendarEvent = item.calendarEvent && !item.id
-          if (hasMeetingNotes || isUpcomingCalendarEvent) {
-            const startMin = Math.floor(item.timestamp.getTime() / 60000)
-            const meetingKey = `${item.title}_${startMin}`
-            if (seenMeetingKeys.has(meetingKey)) return
-            seenMeetingKeys.add(meetingKey)
-
-            const dateKey = key
-            if (!groups[dateKey]) {
-              groups[dateKey] = []
-            }
-            groups[dateKey].push({ key, item })
-          }
-        })
-      })
-    }
-
-    // Sort items within each group by timestamp
-    Object.keys(groups).forEach(dateKey => {
-      if (dateKey === 'COMING UP') {
-        // Upcoming: soonest first (ascending)
-        groups[dateKey].sort((a, b) => a.item.timestamp.getTime() - b.item.timestamp.getTime())
-      } else {
-        // Past: most recent first (descending)
-        groups[dateKey].sort((a, b) => b.item.timestamp.getTime() - a.item.timestamp.getTime())
-      }
-    })
-
-    return groups
-  }, [feed.feedContent])
-
-  // Get ordered date keys (same as FeedSidebar)
-  const orderedDateKeys = useMemo(() => {
-    const keyTimestamps = Object.entries(groupedMeetings)
-      .filter(([_, items]) => items.length > 0)
-      .map(([key, items]) => ({
-        key,
-        timestamp: items[0].item.timestamp,
-      }))
-
-    return KNDateUtils.sortByTimestamp(keyTimestamps, false).map(kt => kt.key)
-  }, [groupedMeetings])
-
-  // Collapsible sections state (collapse old dates by default, keep Today open)
-  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>(() => {
-    const initialState: Record<string, boolean> = {}
-    orderedDateKeys.forEach(key => {
-      if (!key.includes('Today') && !feed.isRecentDate(key, true, true)) {
-        initialState[key] = true
-      }
-    })
-    return initialState
-  })
-
-  const [manuallyToggled, setManuallyToggled] = useState<Record<string, boolean>>({})
-
-  const toggleSection = (key: string) => {
-    setCollapsedSections(prev => ({
-      ...prev,
-      [key]: !prev[key],
-    }))
-    setManuallyToggled(prev => ({
-      ...prev,
-      [key]: true,
-    }))
-  }
-
-  useEffect(() => {
-    if (!feed || !feed.feedContent) return
-
-    setCollapsedSections(prev => {
-      const newState = { ...prev }
-      orderedDateKeys.forEach(key => {
-        if (!manuallyToggled[key]) {
-          // Auto-collapse old past dates, but keep today/yesterday/upcoming expanded
-          if (
-            !key.includes('Today') &&
-            !key.includes('Yesterday') &&
-            !key.includes('COMING UP') &&
-            groupedMeetings[key] &&
-            KNDateUtils.isPastDay(groupedMeetings[key][0]?.item.timestamp) &&
-            !prev[key]
-          ) {
-            newState[key] = true
-          }
-        }
-      })
-      return newState
-    })
-  }, [feed.feedContent, manuallyToggled])
-
   const selectedMeeting = feed.currentFeedItem()
   const isSelectedMeetingNote = selectedMeeting?.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES)
 
@@ -235,16 +117,6 @@ const MeetingsTabView = ({
   useEffect(() => {
     setTemplatesState({ isOpen: false })
   }, [feed.currentFeedItem])
-
-  // Scroll selected meeting card into view
-  useEffect(() => {
-    if (selectedMeeting) {
-      const threadCard = document.getElementById(`MeetingCard${selectedMeeting.id}`)
-      if (threadCard) {
-        threadCard.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      }
-    }
-  }, [selectedMeeting])
 
   // --- Panel handlers (ported from CenterWorkspace) ---
 
@@ -308,180 +180,94 @@ const MeetingsTabView = ({
 
   // --- End panel handlers ---
 
-  const handleTitleChange = useCallback(
-    (key: string, itemId: number, newTitle: string) => {
-      if (feed.updateFeedItemTitle) {
-        feed.updateFeedItemTitle(key, itemId, newTitle)
-      }
-    },
-    [feed],
-  )
-
-  const handleDeleteItem = useCallback(
-    (itemId: number) => {
-      if (feed.deleteFeedItemFromState && itemId !== undefined) {
-        feed
-          .deleteFeedItemFromState(itemId)
-          .then(() => {
-            if (selectedMeeting?.id === itemId) {
-              feed.unselectFeedItem()
-            }
-          })
-          .catch(error => {
-            console.error('Error deleting feed item:', error)
-          })
-      }
-    },
-    [feed, selectedMeeting],
-  )
-
   const showPermissionsOverlay = (!micPermission || !screenPermission) && !permissionsDismissed
 
-  const hasMeetings = orderedDateKeys.length > 0
-
   return (
-    <div className="MeetingsTabView w-full h-full overflow-hidden flex flex-row">
-      {/* Sidebar with date-grouped meeting list */}
-      <div className="MeetingsTabView__sidebar">
-        <div className="MeetingsTabView__sidebar-scroll">
-          {!hasMeetings ? (
-            <div className="MeetingsTabView__empty">
-              <p>No meetings yet</p>
-              <p className="MeetingsTabView__empty-hint">
-                Click "Ad hoc meeting" to start recording
-              </p>
-            </div>
-          ) : (
-            orderedDateKeys.map(dateKey => {
-              const items = groupedMeetings[dateKey]
-              if (!items || items.length === 0) return null
-
-              // Filter to only show recent dates (past + today/yesterday + upcoming)
-              if (!feed.isRecentDate(dateKey, true, true)) return null
-
-              const isCollapsed = collapsedSections[dateKey]
-
-              return (
-                <div
-                  key={`${dateKey}-${items.length}`}
-                  className="MeetingsTabView__date-group"
-                >
-                  {/* Date section header */}
-                  <div
-                    className={`MeetingsTabView__date-header ${dateKey.includes('Today') ? 'MeetingsTabView__date-header--today' : ''}`}
-                    onClick={() => toggleSection(dateKey)}
-                  >
-                    <div className="MeetingsTabView__date-arrow">
-                      <img
-                        src={FeedSidebarArrowDown}
-                        className={`w-4 h-1.5 transition-transform duration-100
-                          ${dateKey.includes('Today') ? '' : 'opacity-70'}
-                          ${isCollapsed ? 'rotate-[-90deg]' : ''}`}
-                        alt="Toggle section"
-                      />
-                    </div>
-                    <div className="MeetingsTabView__date-label">
-                      {dateKey}
-                    </div>
-                  </div>
-
-                  {/* Meeting items in this date group */}
-                  <div
-                    className={`MeetingsTabView__date-items ${isCollapsed ? 'MeetingsTabView__date-items--collapsed' : ''}`}
-                  >
-                    {items.map(({ key, item }) => {
-                      const isSelected = item.id != null && selectedMeeting?.id === item.id
-                      const itemKey = item.id ?? `cal-${item.calendarEvent?.id ?? item.title}`
-
-                      return (
-                        <Fragment key={itemKey}>
-                          <div
-                            className={`flex flex-col w-full text-left border-r border-t border-b rounded-r-md
-                              ${
-                                isSelected
-                                  ? 'bg-ks-warm-grey-100 border-ks-warm-grey-200'
-                                  : 'hover:bg-ks-warm-grey-100 hover:border-ks-warm-grey-200 border-transparent'
-                              }`}
-                            id={`MeetingCard${itemKey}`}
-                            ref={isSelected ? threadCardRef : null}
-                            onClick={() => {
-                              if (item.id != null) {
-                                feed.selectFeedItem(key, item.id)
-                              } else if (item.calendarEvent) {
-                                feed.openCalendarEvent(item.calendarEvent)
-                              }
-                            }}
-                          >
-                            <div className="flex items-center w-full">
-                              <div className="pl-10 w-full">
-                                <ThreadPreviewCard
-                                  title={
-                                    item && typeof item.getTitle === 'function'
-                                      ? item.getTitle()
-                                      : item?.title || ''
-                                  }
-                                  subTitle={item.getSubtitle()}
-                                  executedTime={item.timestamp}
-                                  isSelected={isSelected}
-                                  isRecording={item.isRecording}
-                                  setIsSelected={() => {
-                                    if (item.id != null) {
-                                      feed.selectFeedItem(key, item.id)
-                                    } else if (item.calendarEvent) {
-                                      feed.openCalendarEvent(item.calendarEvent)
-                                    }
-                                  }}
-                                  hasLabel={false}
-                                  showFullDate={dateKey === 'COMING UP'}
-                                  onTitleChange={newTitle => {
-                                    if (item.id !== undefined) {
-                                      handleTitleChange(key, item.id, newTitle)
-                                    }
-                                  }}
-                                  onDelete={item.id !== undefined ? () => handleDeleteItem(item.id!) : undefined}
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        </Fragment>
-                      )
-                    })}
-                  </div>
-                </div>
-              )
-            })
-          )}
+    <div className="MeetingsTabView MeetingsTabView--notetaker w-full h-full overflow-hidden flex flex-col">
+      {/* Notetaker top bar when viewing a meeting note */}
+      {selectedMeeting && isSelectedMeetingNote && (
+        <div className="MeetingsTabView__topbar" data-tauri-drag-region>
+          <div className="MeetingsTabView__topbar-left">
+            <button
+              className="MeetingsTabView__topbar-back"
+              onClick={() => {
+                feed.unselectFeedItem()
+                onBack?.()
+              }}
+              title="Back to meetings"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                <polyline points="9 22 9 12 15 12 15 22" />
+              </svg>
+            </button>
+          </div>
+          <div className="MeetingsTabView__topbar-center">
+            <button className="MeetingsTabView__topbar-summary">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+              </svg>
+              Summary
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+          </div>
+          <div className="MeetingsTabView__topbar-right">
+            <button
+              className="MeetingsTabView__topbar-share"
+              onClick={() => {
+                const notesThread = selectedMeeting.threads?.find(t => t.threadType === ThreadType.MEETING_NOTES)
+                if (notesThread) handleOpenTranscript(notesThread.id)
+              }}
+              title="View transcript"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+              Share
+            </button>
+            <button
+              className="MeetingsTabView__topbar-icon"
+              onClick={() => {
+                // Copy the meeting notes as markdown
+                const notesThread = selectedMeeting.threads?.find(t => t.threadType === ThreadType.MEETING_NOTES)
+                const noteContent = notesThread?.messages?.[0]?.content || selectedMeeting.getTitle?.() || ''
+                if (copyToClipboard && noteContent) {
+                  copyToClipboard(noteContent)
+                }
+              }}
+              title="Copy notes to clipboard"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+              </svg>
+            </button>
+            <button
+              className="MeetingsTabView__topbar-icon"
+              onClick={() => {
+                const notesThread = selectedMeeting.threads?.find(t => t.threadType === ThreadType.MEETING_NOTES)
+                if (notesThread) handleOpenTemplates(notesThread)
+              }}
+              title="Change template"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="1" />
+                <circle cx="19" cy="12" r="1" />
+                <circle cx="5" cy="12" r="1" />
+              </svg>
+            </button>
+          </div>
         </div>
-
-        {/* Ad hoc meeting button at bottom */}
-        <div className="MeetingsTabView__sidebar-footer">
-          {isAnyRecording ? (
-            <Tooltip
-              label="Meeting recording in progress"
-              component={
-                <Button
-                  label="Ad hoc meeting"
-                  icon={<img src={Mic} alt="Microphone" />}
-                  variant={ButtonVariant.startMeetingGrey}
-                  onClick={() => feed.createNewMeeting()}
-                  disabled={isAnyRecording}
-                />
-              }
-              variant={TooltipVariant.inProgressMeeting}
-            />
-          ) : (
-            <Button
-              label="Ad hoc meeting"
-              icon={<img src={Mic} alt="Microphone" />}
-              variant={ButtonVariant.startMeetingGrey}
-              onClick={() => feed.createNewMeeting()}
-            />
-          )}
-        </div>
-      </div>
+      )}
 
       {/* Main content area */}
-      <div className="MeetingsTabView__content">
+      <div className="MeetingsTabView__content MeetingsTabView__content--full flex-1">
         <div className="flex flex-row h-full">
           <div className="flex-grow overflow-y-auto overflow-x-hidden relative">
             {showPermissionsOverlay && (
@@ -500,22 +286,28 @@ const MeetingsTabView = ({
             )}
 
             {!selectedMeeting || !isSelectedMeetingNote ? (
-              <div className="MeetingsTabView__welcome">
-                <h1 className="MeetingsTabView__welcome-title">Meeting Notes</h1>
+              <div className="MeetingsTabView__welcome MeetingsTabView__welcome--notetaker">
+                <div className="MeetingsTabView__welcome-icon">
+                  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#C8A951" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                  </svg>
+                </div>
+                <h1 className="MeetingsTabView__welcome-title">Select a meeting to view notes</h1>
                 <p className="MeetingsTabView__welcome-subtitle">
-                  Record meetings and get AI-powered notes, summaries, and action items
+                  Choose a meeting from the sidebar, or start a new recording
                 </p>
-                <div className="MeetingsTabView__welcome-action">
-                  <Button
-                    label="Record a meeting"
-                    icon={<img src={Mic} alt="Microphone" />}
-                    variant={ButtonVariant.startMeetingGrey}
+                <div className="MeetingsTabView__welcome-actions">
+                  <button
+                    className="MeetingsTabView__quick-note-btn"
                     onClick={() => feed.createNewMeeting()}
-                  />
+                  >
+                    + Quick note
+                  </button>
                 </div>
                 {/* Calendar connection prompt */}
                 {connections && !connections[ConnectionKeys.GOOGLE_CALENDAR] && !connections[ConnectionKeys.MICROSOFT_CALENDAR] && onConnectCalendar && (
-                  <div className="MeetingsTabView__calendar-prompt">
+                  <div className="MeetingsTabView__calendar-prompt MeetingsTabView__calendar-prompt--notetaker">
                     <div className="MeetingsTabView__calendar-prompt-content">
                       <img src={CalendarIcon} alt="Calendar" className="MeetingsTabView__calendar-prompt-icon" />
                       <div className="MeetingsTabView__calendar-prompt-text">
@@ -562,6 +354,8 @@ const MeetingsTabView = ({
                       handleErrorContact={handleErrorContact}
                       recordingHandlers={recordingHandlers}
                       handleOpenTasks={handleOpenTasks}
+                      onChatClick={onChatClick}
+                      onEmailClick={onEmailClick}
                     />
                   ) : null
                 })()}

--- a/src/src/components/organisms/MeetingsTabView/style.scss
+++ b/src/src/components/organisms/MeetingsTabView/style.scss
@@ -1,6 +1,17 @@
+$ks-bg: #FAFAFA;
+$ks-text: #333333;
+$ks-text-secondary: #6A6969;
+$ks-text-muted: #ABA9A9;
+$ks-border: #E3E2E2;
+$ks-accent: #6474AC;
+
 .MeetingsTabView {
   display: flex;
-  background: var(--ks-bg-main);
+  background: $ks-bg;
+
+  &--notetaker {
+    background: $ks-bg;
+  }
 
   &__sidebar {
     width: 22.5em;
@@ -10,9 +21,9 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: var(--ks-bg-main);
+    background: $ks-bg;
     padding-top: 1.5rem;
-    border-right: 1px solid var(--ks-warm-grey-200, #e5e5e5);
+    border-right: 1px solid $ks-border;
   }
 
   &__sidebar-scroll {
@@ -57,10 +68,10 @@
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
     line-height: 1rem;
-    color: var(--ks-warm-grey-800);
+    color: $ks-text-secondary;
 
     &--today {
-      color: var(--ks-warm-grey-950);
+      color: $ks-text;
     }
   }
 
@@ -97,7 +108,7 @@
   &__empty {
     padding: 24px 16px;
     text-align: center;
-    color: var(--ks-warm-grey-600);
+    color: $ks-text-secondary;
 
     p {
       margin: 0 0 8px;
@@ -107,13 +118,19 @@
 
   &__empty-hint {
     font-size: 12px !important;
-    color: var(--ks-warm-grey-500);
+    color: $ks-text-muted;
   }
 
   &__content {
     flex: 1;
     overflow: hidden;
     position: relative;
+    background: $ks-bg;
+
+    &--full {
+      // When sidebar is handled by NotetakerSidebar, content takes full width
+      flex: 1;
+    }
   }
 
   &__welcome {
@@ -124,34 +141,71 @@
     height: 100%;
     text-align: center;
     padding: 40px;
+
+    &--notetaker {
+      background: $ks-bg;
+    }
+  }
+
+  &__welcome-icon {
+    margin-bottom: 20px;
+    opacity: 0.6;
   }
 
   &__welcome-title {
-    font-family: var(--font-serif);
-    font-size: 32px;
-    font-weight: 500;
-    color: var(--ks-warm-grey-950);
+    font-family: 'EB Garamond', 'Lora', serif;
+    font-size: 26px;
+    font-weight: 400;
+    color: $ks-text;
     margin: 0 0 12px;
+    letter-spacing: -0.01em;
   }
 
   &__welcome-subtitle {
     font-family: 'Inter', sans-serif;
-    font-size: 16px;
-    color: var(--ks-warm-grey-600);
-    margin: 0 0 32px;
+    font-size: 14px;
+    color: $ks-text-muted;
+    margin: 0 0 28px;
     max-width: 400px;
   }
 
-  &__welcome-action {
-    // Button styling handled by Button component
+  &__welcome-actions {
+    display: flex;
+    gap: 12px;
+  }
+
+  &__quick-note-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 20px;
+    border-radius: 8px;
+    background: white;
+    border: 1px solid $ks-border;
+    color: $ks-text;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: all 0.15s ease;
+
+    &:hover {
+      background: darken(white, 2%);
+      border-color: darken($ks-border, 8%);
+    }
   }
 
   &__calendar-prompt {
     margin-top: 48px;
     padding: 20px 24px;
-    background: var(--ks-warm-grey-100);
+    background: rgba(0, 0, 0, 0.03);
     border-radius: 12px;
     max-width: 500px;
+
+    &--notetaker {
+      background: white;
+      border: 1px solid $ks-border;
+    }
   }
 
   &__calendar-prompt-content {
@@ -175,20 +229,129 @@
     font-family: 'Inter', sans-serif;
     font-size: 14px;
     font-weight: 600;
-    color: var(--ks-warm-grey-950);
+    color: $ks-text;
     margin: 0 0 4px;
   }
 
   &__calendar-prompt-subtitle {
     font-family: 'Inter', sans-serif;
     font-size: 13px;
-    color: var(--ks-warm-grey-600);
+    color: $ks-text-muted;
     margin: 0;
   }
 
   &__meeting-content {
     height: 100%;
     overflow-y: auto;
-    padding: 24px 24px 16px;
+    background: $ks-bg;
+  }
+
+  // Notetaker top bar
+  &__topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 16px;
+    border-bottom: 1px solid $ks-border;
+    background: $ks-bg;
+    flex-shrink: 0;
+    min-height: 44px;
+    -webkit-app-region: drag;
+  }
+
+  &__topbar-left,
+  &__topbar-right {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    -webkit-app-region: no-drag;
+  }
+
+  &__topbar-left {
+    padding-left: 60px; // space for macOS traffic lights
+  }
+
+  &__topbar-back {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: $ks-text-secondary;
+    cursor: pointer;
+    transition: all 0.1s ease;
+
+    &:hover {
+      background: darken($ks-bg, 3%);
+      color: $ks-text;
+    }
+  }
+
+  &__topbar-center {
+    display: flex;
+    align-items: center;
+    -webkit-app-region: no-drag;
+  }
+
+  &__topbar-summary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: $ks-text-secondary;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: all 0.1s ease;
+
+    &:hover {
+      background: darken($ks-bg, 3%);
+      color: $ks-text;
+    }
+  }
+
+  &__topbar-share {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 6px;
+    border: 1px solid $ks-border;
+    background: white;
+    color: $ks-text;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    transition: all 0.1s ease;
+
+    &:hover {
+      background: darken(white, 2%);
+    }
+  }
+
+  &__topbar-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: $ks-text-secondary;
+    cursor: pointer;
+    transition: all 0.1s ease;
+
+    &:hover {
+      background: darken($ks-bg, 3%);
+      color: $ks-text;
+    }
   }
 }

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -243,7 +243,7 @@ function NotetakerSidebar({ feed, onQuickNote, onSettingsClick, onChatClick, onH
                               </div>
                             </div>
                             {item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES && t.recorded) && (
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6474AC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-has-notes" title="Has meeting notes">
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6474AC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-has-notes" aria-label="Has meeting notes">
                                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
                                 <polyline points="14 2 14 8 20 8" />
                                 <line x1="16" y1="13" x2="8" y2="13" />
@@ -313,7 +313,7 @@ function NotetakerSidebar({ feed, onQuickNote, onSettingsClick, onChatClick, onH
                     </div>
                     <div className="notetaker-sidebar__note-meta">
                       {item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES && t.recorded) && (
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6474AC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-has-notes" title="Has meeting notes">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6474AC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-has-notes" aria-label="Has meeting notes">
                           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
                           <polyline points="14 2 14 8 20 8" />
                           <line x1="16" y1="13" x2="8" y2="13" />

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -1,0 +1,418 @@
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
+import dayjs from 'dayjs'
+
+import { FeedItem } from 'src/api/feed_items'
+import { IFeed, STATIONARY_ITEMS } from 'src/hooks/feed/useFeed'
+import KNDateUtils from 'src/utils/KNDateUtils'
+import { ThreadType } from 'src/api/threads'
+import { getAppVersion } from 'src/utils/app'
+
+import './style.scss'
+
+export type NotetakerView = 'home' | 'chat'
+
+interface NotetakerSidebarProps {
+  feed: IFeed
+  onQuickNote: () => void
+  onSettingsClick: () => void
+  onChatClick?: () => void
+  onMeetingSelect?: () => void
+  onHomeClick?: () => void
+  activeView?: NotetakerView
+}
+
+function NotetakerSidebar({ feed, onQuickNote, onSettingsClick, onChatClick, onHomeClick, onMeetingSelect, activeView: controlledView }: NotetakerSidebarProps) {
+  const [internalView, setInternalView] = useState<NotetakerView>('home')
+  const activeView = controlledView ?? internalView
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchFocused, setSearchFocused] = useState(false)
+  const [appVersion, setAppVersion] = useState<string>('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    getAppVersion().then(v => setAppVersion(v))
+  }, [])
+
+  // Ctrl+K / Cmd+K shortcut
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        searchInputRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
+  const currentFeedItem = feed.currentFeedItem()
+
+  // Build the "Coming up" events for the calendar widget
+  const upcomingEvents = useMemo(() => {
+    if (!feed.feedContent) return []
+    const now = Date.now()
+
+    const events: { item: FeedItem; key: string }[] = []
+    Object.entries(feed.feedContent).forEach(([key, items]) => {
+      if (key === STATIONARY_ITEMS) return
+      items.forEach(item => {
+        if (item.calendarEvent || (item.timestamp && item.timestamp.getTime() > now - 3600000)) {
+          events.push({ item, key })
+        }
+      })
+    })
+
+    events.sort((a, b) => a.item.timestamp.getTime() - b.item.timestamp.getTime())
+
+    // Group by date
+    const grouped: Record<string, { item: FeedItem; key: string }[]> = {}
+    events.forEach(ev => {
+      const dateKey = dayjs(ev.item.timestamp).format('YYYY-MM-DD')
+      if (!grouped[dateKey]) grouped[dateKey] = []
+      grouped[dateKey].push(ev)
+    })
+
+    return grouped
+  }, [feed.feedContent])
+
+  // Build past notes list grouped by date
+  const pastNotes = useMemo(() => {
+    if (!feed.feedContent) return {}
+
+    const now = Date.now()
+    const groups: Record<string, { item: FeedItem; key: string }[]> = {}
+
+    Object.entries(feed.feedContent).forEach(([key, items]) => {
+      if (key === STATIONARY_ITEMS) return
+      items.forEach(item => {
+        const hasMeetingNotes = item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES)
+        if (hasMeetingNotes && item.timestamp.getTime() < now) {
+          const dateKey = key
+          if (!groups[dateKey]) groups[dateKey] = []
+          groups[dateKey].push({ item, key })
+        }
+      })
+    })
+
+    // Sort within each group
+    Object.keys(groups).forEach(key => {
+      groups[key].sort((a, b) => b.item.timestamp.getTime() - a.item.timestamp.getTime())
+    })
+
+    return groups
+  }, [feed.feedContent])
+
+  const orderedPastKeys = useMemo(() => {
+    const keys = Object.entries(pastNotes)
+      .filter(([_, items]: [string, { item: FeedItem; key: string }[]]) => items.length > 0)
+      .map(([key, items]: [string, { item: FeedItem; key: string }[]]) => ({
+        key,
+        timestamp: items[0].item.timestamp,
+      }))
+
+    return KNDateUtils.sortByTimestamp(keys, false).map(k => k.key)
+  }, [pastNotes])
+
+  const isNowMeeting = useCallback((item: FeedItem) => {
+    const now = Date.now()
+    const start = item.timestamp.getTime()
+    const end = item.calendarEvent?.end
+      ? (item.calendarEvent.end < start / 100 ? item.calendarEvent.end * 1000 : item.calendarEvent.end)
+      : start + 30 * 60 * 1000
+    return start <= now && now <= end
+  }, [])
+
+  const formatTimeRange = useCallback((item: FeedItem) => {
+    const start = dayjs(item.timestamp).format('h:mm A')
+    if (item.calendarEvent?.end) {
+      const endTs = item.calendarEvent.end < item.timestamp.getTime() / 100
+        ? item.calendarEvent.end * 1000
+        : item.calendarEvent.end
+      const end = dayjs(endTs).format('h:mm A')
+      return `${start} \u2013 ${end}`
+    }
+    return start
+  }, [])
+
+  // Filter items by search
+  const filterBySearch = useCallback((items: { item: FeedItem; key: string }[]) => {
+    if (!searchQuery.trim()) return items
+    const q = searchQuery.toLowerCase()
+    return items.filter(({ item }) => {
+      const title = (typeof item.getTitle === 'function' ? item.getTitle() : item.title) || ''
+      const subtitle = item.getSubtitle?.() || ''
+      return title.toLowerCase().includes(q) || subtitle.toLowerCase().includes(q)
+    })
+  }, [searchQuery])
+
+  return (
+    <div className="notetaker-sidebar">
+      {/* Search */}
+      <div className="notetaker-sidebar__search">
+        <div className={`notetaker-sidebar__search-box ${searchFocused ? 'notetaker-sidebar__search-box--focused' : ''}`}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__search-icon">
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            ref={searchInputRef}
+            type="text"
+            placeholder="Search"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            onFocus={() => setSearchFocused(true)}
+            onBlur={() => setSearchFocused(false)}
+            className="notetaker-sidebar__search-input"
+          />
+          <kbd className="notetaker-sidebar__search-shortcut">
+            {navigator.platform?.includes('Mac') ? '\u2318' : 'Ctrl+'}K
+          </kbd>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav className="notetaker-sidebar__nav">
+        <button
+          className={`notetaker-sidebar__nav-item ${activeView === 'home' ? 'notetaker-sidebar__nav-item--active' : ''}`}
+          onClick={() => { setInternalView('home'); onHomeClick?.() }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+            <polyline points="9 22 9 12 15 12 15 22" />
+          </svg>
+          Home
+        </button>
+        <button
+          className={`notetaker-sidebar__nav-item ${activeView === 'chat' ? 'notetaker-sidebar__nav-item--active' : ''}`}
+          onClick={() => { setInternalView('chat'); onChatClick?.() }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+          Chat
+        </button>
+      </nav>
+
+      {/* Scrollable content */}
+      <div className="notetaker-sidebar__content">
+        {/* Coming Up calendar widget */}
+        {Object.keys(upcomingEvents).length > 0 && (
+          <div className="notetaker-sidebar__coming-up">
+            <h2 className="notetaker-sidebar__section-title">Coming up</h2>
+            <div className="notetaker-sidebar__calendar-card">
+              {Object.entries(upcomingEvents).slice(0, 5).map(([dateStr, events]) => {
+                const date = dayjs(dateStr)
+                const isToday = date.isSame(dayjs(), 'day')
+                const filteredEvents = filterBySearch(events).slice(0, 4)
+                if (filteredEvents.length === 0) return null
+
+                return (
+                  <div key={dateStr} className="notetaker-sidebar__calendar-day">
+                    <div className="notetaker-sidebar__calendar-date">
+                      <span className="notetaker-sidebar__calendar-date-num">{date.format('D')}</span>
+                      <div className="notetaker-sidebar__calendar-date-meta">
+                        <span className="notetaker-sidebar__calendar-month">{date.format('MMMM')}</span>
+                        {isToday && <span className="notetaker-sidebar__calendar-today-dot" />}
+                        <span className="notetaker-sidebar__calendar-day-name">{date.format('ddd')}</span>
+                      </div>
+                    </div>
+                    <div className="notetaker-sidebar__calendar-events">
+                      {filteredEvents.map(({ item, key }) => {
+                        const isNow = isNowMeeting(item)
+                        const title = typeof item.getTitle === 'function' ? item.getTitle() : item.title || ''
+                        return (
+                          <div
+                            key={item.id ?? `cal-${item.calendarEvent?.id ?? title}`}
+                            className={`notetaker-sidebar__calendar-event ${isNow ? 'notetaker-sidebar__calendar-event--now' : ''}`}
+                            onClick={() => {
+                              if (item.id != null) {
+                                feed.selectFeedItem(key, item.id)
+                                onMeetingSelect?.()
+                              } else if (item.calendarEvent) {
+                                feed.openCalendarEvent(item.calendarEvent)
+                                onMeetingSelect?.()
+                              }
+                            }}
+                          >
+                            <div className="notetaker-sidebar__calendar-event-bar" />
+                            <div className="notetaker-sidebar__calendar-event-content">
+                              <div className="notetaker-sidebar__calendar-event-title">{title}</div>
+                              <div className="notetaker-sidebar__calendar-event-time">
+                                {isNow && <span className="notetaker-sidebar__now-label">Now &middot; </span>}
+                                {formatTimeRange(item)}
+                              </div>
+                            </div>
+                            {item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES && t.recorded) && (
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6474AC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-has-notes" title="Has meeting notes">
+                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                                <polyline points="14 2 14 8 20 8" />
+                                <line x1="16" y1="13" x2="8" y2="13" />
+                                <line x1="16" y1="17" x2="8" y2="17" />
+                              </svg>
+                            )}
+                            {isNow && (
+                              <button
+                                className="notetaker-sidebar__start-now-btn"
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  if (item.id != null) {
+                                    feed.selectFeedItem(key, item.id)
+                                  }
+                                  feed.createNewMeeting()
+                                  onMeetingSelect?.()
+                                }}
+                              >
+                                Start now
+                              </button>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Past notes list */}
+        {orderedPastKeys.map(dateKey => {
+          const items = filterBySearch(pastNotes[dateKey])
+          if (!items || items.length === 0) return null
+          if (!feed.isRecentDate(dateKey, true, false)) return null
+
+          return (
+            <div key={dateKey} className="notetaker-sidebar__notes-group">
+              <div className="notetaker-sidebar__notes-date">{dateKey}</div>
+              {items.map(({ item, key }) => {
+                const isSelected = currentFeedItem?.id === item.id
+                const title = typeof item.getTitle === 'function' ? item.getTitle() : item.title || ''
+                const subtitle = item.getSubtitle?.() || ''
+                const time = dayjs(item.timestamp).format('h:mm A')
+
+                return (
+                  <div
+                    key={item.id ?? `note-${title}`}
+                    className={`notetaker-sidebar__note-card ${isSelected ? 'notetaker-sidebar__note-card--selected' : ''}`}
+                    onClick={() => {
+                      if (item.id != null) {
+                        feed.selectFeedItem(key, item.id)
+                        onMeetingSelect?.()
+                      }
+                    }}
+                  >
+                    <div className="notetaker-sidebar__note-avatar">
+                      {title.charAt(0).toUpperCase()}
+                    </div>
+                    <div className="notetaker-sidebar__note-info">
+                      <div className="notetaker-sidebar__note-title">{title}</div>
+                      {subtitle && (
+                        <div className="notetaker-sidebar__note-subtitle">{subtitle}</div>
+                      )}
+                    </div>
+                    <div className="notetaker-sidebar__note-meta">
+                      {item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES && t.recorded) && (
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6474AC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-has-notes" title="Has meeting notes">
+                          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                          <polyline points="14 2 14 8 20 8" />
+                          <line x1="16" y1="13" x2="8" y2="13" />
+                          <line x1="16" y1="17" x2="8" y2="17" />
+                        </svg>
+                      )}
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="notetaker-sidebar__note-lock">
+                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                      </svg>
+                      <span className="notetaker-sidebar__note-time">{time}</span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+
+        {/* Today section for notes without meeting threads */}
+        {(() => {
+          const todayKey = Object.keys(feed.feedContent || {}).find(k => k.includes('Today'))
+          if (!todayKey || !feed.feedContent[todayKey]) return null
+
+          const todayItems = filterBySearch(
+            feed.feedContent[todayKey]
+              .filter(item => !item.threads?.some(t => t.threadType === ThreadType.MEETING_NOTES))
+              .map(item => ({ item, key: todayKey }))
+          )
+          if (todayItems.length === 0) return null
+
+          return (
+            <div className="notetaker-sidebar__notes-group">
+              <div className="notetaker-sidebar__notes-date">Today</div>
+              {todayItems.map(({ item }) => {
+                const isSelected = currentFeedItem?.id === item.id
+                const title = typeof item.getTitle === 'function' ? item.getTitle() : item.title || ''
+                const time = dayjs(item.timestamp).format('h:mm A')
+
+                return (
+                  <div
+                    key={item.id}
+                    className={`notetaker-sidebar__note-card ${isSelected ? 'notetaker-sidebar__note-card--selected' : ''}`}
+                    onClick={() => {
+                      if (item.id != null) {
+                        feed.selectFeedItem(todayKey, item.id)
+                        onMeetingSelect?.()
+                      }
+                    }}
+                  >
+                    <div className="notetaker-sidebar__note-avatar">
+                      {title.charAt(0).toUpperCase()}
+                    </div>
+                    <div className="notetaker-sidebar__note-info">
+                      <div className="notetaker-sidebar__note-title">{title}</div>
+                    </div>
+                    <div className="notetaker-sidebar__note-meta">
+                      <span className="notetaker-sidebar__note-time">{time}</span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })()}
+      </div>
+
+      {/* Bottom bar */}
+      <div className="notetaker-sidebar__bottom">
+        <div className="notetaker-sidebar__bottom-actions">
+          <button
+            className="notetaker-sidebar__bottom-btn"
+            onClick={onQuickNote}
+            title="Quick note"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+            </svg>
+          </button>
+          <button
+            className="notetaker-sidebar__bottom-btn"
+            onClick={onSettingsClick}
+            title="Settings"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="3" width="7" height="7" />
+              <rect x="14" y="3" width="7" height="7" />
+              <rect x="14" y="14" width="7" height="7" />
+              <rect x="3" y="14" width="7" height="7" />
+            </svg>
+          </button>
+        </div>
+        {appVersion && (
+          <div className="notetaker-sidebar__version">Knapsack v{appVersion}</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default NotetakerSidebar

--- a/src/src/components/organisms/NotetakerSidebar/style.scss
+++ b/src/src/components/organisms/NotetakerSidebar/style.scss
@@ -1,0 +1,453 @@
+// Notetaker sidebar using Knapsack color scheme
+$ks-bg: #FAFAFA;
+$ks-bg-hover: #F0EFEF;
+$ks-bg-selected: #E3E2E2;
+$ks-text: #333333;
+$ks-text-secondary: #6A6969;
+$ks-text-muted: #ABA9A9;
+$ks-border: #E3E2E2;
+$ks-accent: #6474AC;
+$ks-accent-light: #E6EBF3;
+$ks-red: #C14841;
+
+.notetaker-sidebar {
+  width: 300px;
+  min-width: 260px;
+  max-width: 340px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: $ks-bg;
+  border-right: 1px solid $ks-border;
+  font-family: 'Inter', -apple-system, sans-serif;
+  user-select: none;
+
+  // Search
+  &__search {
+    padding: 12px 16px 8px;
+  }
+
+  &__search-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid transparent;
+    transition: all 0.15s ease;
+
+    &--focused {
+      background: white;
+      border-color: $ks-border;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  &__search-icon {
+    flex-shrink: 0;
+    color: $ks-text-muted;
+  }
+
+  &__search-input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    outline: none;
+    font-size: 13px;
+    color: $ks-text;
+    font-family: inherit;
+
+    &::placeholder {
+      color: $ks-text-muted;
+    }
+  }
+
+  &__search-shortcut {
+    font-size: 10px;
+    color: $ks-text-muted;
+    background: rgba(0, 0, 0, 0.06);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-family: inherit;
+    border: none;
+    white-space: nowrap;
+  }
+
+  // Navigation
+  &__nav {
+    padding: 4px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  &__nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 10px;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    color: $ks-text-secondary;
+    font-size: 13px;
+    font-weight: 400;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.1s ease;
+    text-align: left;
+    width: 100%;
+
+    &:hover {
+      background: $ks-bg-hover;
+      color: $ks-text;
+    }
+
+    &--active {
+      background: $ks-bg-selected;
+      color: $ks-text;
+      font-weight: 500;
+    }
+
+    svg {
+      flex-shrink: 0;
+    }
+  }
+
+  // Spaces
+  &__spaces {
+    padding: 12px 12px 4px;
+  }
+
+  &__spaces-header {
+    font-size: 11px;
+    font-weight: 500;
+    color: $ks-text-muted;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 0 10px 6px;
+  }
+
+  &__space-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 10px;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    color: $ks-text-secondary;
+    font-size: 13px;
+    font-weight: 400;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    width: 100%;
+    transition: all 0.1s ease;
+
+    &:hover {
+      background: $ks-bg-hover;
+      color: $ks-text;
+    }
+
+    &--active {
+      color: $ks-text;
+      font-weight: 500;
+    }
+
+    svg {
+      flex-shrink: 0;
+    }
+  }
+
+  // Scrollable content
+  &__content {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 8px 0;
+
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  // Coming up section
+  &__coming-up {
+    padding: 0 16px 12px;
+  }
+
+  &__section-title {
+    font-family: 'Lora', serif;
+    font-size: 20px;
+    font-weight: 700;
+    color: $ks-text;
+    margin: 0 0 12px;
+  }
+
+  &__calendar-card {
+    background: white;
+    border-radius: 12px;
+    border: 1px solid $ks-border;
+    overflow: hidden;
+  }
+
+  &__calendar-day {
+    display: flex;
+    padding: 12px 16px;
+    gap: 16px;
+    border-bottom: 1px solid $ks-border;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__calendar-date {
+    flex-shrink: 0;
+    width: 52px;
+    text-align: left;
+  }
+
+  &__calendar-date-num {
+    font-size: 24px;
+    font-weight: 400;
+    color: $ks-text;
+    line-height: 1;
+    display: block;
+  }
+
+  &__calendar-date-meta {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 2px;
+  }
+
+  &__calendar-month {
+    font-size: 11px;
+    color: $ks-text-muted;
+    font-weight: 400;
+  }
+
+  &__calendar-today-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: $ks-red;
+    flex-shrink: 0;
+  }
+
+  &__calendar-day-name {
+    font-size: 11px;
+    color: $ks-text-muted;
+    font-weight: 400;
+  }
+
+  &__calendar-events {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &__calendar-event {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.1s ease;
+
+    &:hover {
+      background: $ks-bg-hover;
+    }
+
+    &--now {
+      background: $ks-accent-light;
+
+      &:hover {
+        background: darken($ks-accent-light, 3%);
+      }
+    }
+  }
+
+  &__calendar-event-bar {
+    width: 3px;
+    height: 28px;
+    border-radius: 2px;
+    background: $ks-accent;
+    flex-shrink: 0;
+  }
+
+  &__calendar-event-content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__calendar-event-title {
+    font-size: 13px;
+    font-weight: 500;
+    color: $ks-text;
+    word-break: break-word;
+  }
+
+  &__calendar-event-time {
+    font-size: 11px;
+    color: $ks-text-muted;
+  }
+
+  &__now-label {
+    color: $ks-red;
+    font-weight: 600;
+  }
+
+  &__start-now-btn {
+    flex-shrink: 0;
+    padding: 4px 12px;
+    border-radius: 6px;
+    background: $ks-text;
+    color: white;
+    font-size: 11px;
+    font-weight: 500;
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 0.1s ease;
+
+    &:hover {
+      background: lighten($ks-text, 15%);
+    }
+  }
+
+  // Notes list
+  &__notes-group {
+    padding: 0 8px;
+    margin-bottom: 8px;
+  }
+
+  &__notes-date {
+    font-size: 12px;
+    font-weight: 500;
+    color: $ks-text-muted;
+    padding: 8px 12px 4px;
+  }
+
+  &__note-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.1s ease;
+
+    &:hover {
+      background: $ks-bg-hover;
+    }
+
+    &--selected {
+      background: $ks-bg-selected;
+    }
+  }
+
+  &__note-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #B5C4DB, #91A5C9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 600;
+    color: white;
+    flex-shrink: 0;
+  }
+
+  &__note-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__note-title {
+    font-size: 13px;
+    font-weight: 500;
+    color: $ks-text;
+    word-break: break-word;
+  }
+
+  &__note-subtitle {
+    font-size: 11px;
+    color: $ks-text-muted;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__note-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  &__note-lock {
+    color: $ks-text-muted;
+  }
+
+  &__note-has-notes {
+    flex-shrink: 0;
+  }
+
+  &__note-time {
+    font-size: 11px;
+    color: $ks-text-muted;
+    white-space: nowrap;
+  }
+
+  // Bottom bar
+  &__bottom {
+    padding: 8px 16px 12px;
+    border-top: 1px solid $ks-border;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__bottom-actions {
+    display: flex;
+    gap: 4px;
+  }
+
+  &__bottom-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: $ks-text-muted;
+    cursor: pointer;
+    transition: all 0.1s ease;
+
+    &:hover {
+      background: $ks-bg-hover;
+      color: $ks-text-secondary;
+    }
+  }
+
+  &__version {
+    font-size: 10px;
+    color: $ks-text-muted;
+    padding: 0 4px;
+  }
+}

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -25,6 +25,7 @@ import AutomationLabModal from 'src/components/molecules/AutomationLabModal'
 import CenterWorkspace, { SubTabChoices } from 'src/components/organisms/CenterWorkspace'
 import EmailTabView from 'src/components/organisms/EmailTabView'
 import FeedSidebar from 'src/components/organisms/FeedSidebar'
+import NotetakerSidebar from 'src/components/organisms/NotetakerSidebar'
 import GoogleAuthPopup from 'src/components/organisms/GoogleAuthPopUp'
 import { Header } from 'src/components/organisms/Header'
 import MeetingsTabView from 'src/components/organisms/MeetingsTabView'
@@ -36,6 +37,7 @@ import { getReleaseType } from 'src/api/app_info'
 import { safeInvoke } from 'src/utils/tauriIpcBridge'
 
 import { ConnectionKeys, googleConnections, microsoftConnections } from '../../../api/connections'
+import { IThread, ThreadType } from 'src/api/threads'
 import { getFeedbacks } from '../../../api/threads'
 import { setHasOnboarded } from '../../../pages/onboarding'
 import { openGoogleAuthScreen } from '../../../utils/permissions/google'
@@ -98,7 +100,14 @@ function Home({
   const [activityPanelWidth, setActivityPanelWidth] = useState(420)
   const [autopilotForceOpen, setAutopilotForceOpen] = useState(false)
   const [isChatBusy, setIsChatBusy] = useState(false)
+  const [meetingSubView, setMeetingSubView] = useState<'meetings' | 'chat'>('meetings')
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
   const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null)
+
+  // Check if a meeting note is currently selected (for hiding sidebar in full-width note view)
+  const currentItem = feed.currentFeedItem()
+  const hasMeetingNoteSelected = currentTab === TabChoices.Meeting && meetingSubView === 'meetings' &&
+    !!currentItem?.threads?.some((t: IThread) => t.threadType === ThreadType.MEETING_NOTES)
   const isResizingRef = useRef(false)
 
   const userEmail = useMemo(() => auth.profile?.email ?? '', [auth.profile])
@@ -163,6 +172,22 @@ function Home({
     })
     return () => {
       unlisten.then(fn => fn())
+    }
+  }, [])
+
+  // Listen for system tray events
+  useEffect(() => {
+    const unlistenQuickNote = listen('create_quick_note', () => {
+      setCurrentTab(TabChoices.Meeting)
+      setMeetingSubView('meetings')
+      feed.createNewMeeting()
+    })
+    const unlistenSettings = listen('open_settings', () => {
+      setIsSettingsDialogOpened(true)
+    })
+    return () => {
+      unlistenQuickNote.then(fn => fn())
+      unlistenSettings.then(fn => fn())
     }
   }, [])
 
@@ -452,7 +477,34 @@ function Home({
       />
       <div className="overflow-hidden flex-1 bg-ks-bg-main rounded-b-[10px]">
         <div data-tauri-drag-region className="overflow-hidden flex flex-row h-full bg-ks-bg-main">
-          <TabBar currentTab={currentTab} setCurrentTab={setCurrentTab} fullRelease={fullRelease} />
+          {/* Notetaker sidebar - hidden when viewing a meeting note */}
+          {currentTab === TabChoices.Meeting && !hasMeetingNoteSelected && (
+            <NotetakerSidebar
+              feed={feed}
+              onQuickNote={() => feed.createNewMeeting()}
+              onSettingsClick={() => setIsSettingsDialogOpened(true)}
+              onChatClick={() => setMeetingSubView('chat')}
+              onHomeClick={() => setMeetingSubView('meetings')}
+              onMeetingSelect={() => setMeetingSubView('meetings')}
+              activeView={meetingSubView === 'chat' ? 'chat' : 'home'}
+            />
+          )}
+          {/* Legacy TabBar for non-meeting tabs */}
+          {currentTab !== TabChoices.Meeting && (
+            <TabBar
+              currentTab={currentTab}
+              setCurrentTab={setCurrentTab}
+              fullRelease={fullRelease}
+              onCalendarToggle={() => {
+                setIsCalendarOpen(!isCalendarOpen)
+                if (!isCalendarOpen) {
+                  setCurrentTab(TabChoices.Meeting)
+                  setMeetingSubView('meetings')
+                }
+              }}
+              isCalendarOpen={isCalendarOpen}
+            />
+          )}
           <div data-tauri-drag-region className="overflow-hidden w-full h-full">
             <div className="KNWorkspace overflow-hidden w-full h-full bg-ks-bg-main">
               {currentTab === TabChoices.Work && (
@@ -582,7 +634,7 @@ function Home({
                 />
               )}
 
-              {currentTab === TabChoices.Meeting && (
+              {currentTab === TabChoices.Meeting && meetingSubView === 'meetings' && (
                 <MeetingsTabView
                   feed={feed}
                   addToLLMQueue={addToLLMQueue}
@@ -591,7 +643,31 @@ function Home({
                   recordingHandlers={recordingHandlers}
                   connections={connections}
                   onConnectCalendar={() => onConnectAccountClick([ConnectionKeys.GOOGLE_CALENDAR])}
+                  onBack={() => {
+                    // Back from note view returns to sidebar
+                  }}
+                  onChatClick={() => setMeetingSubView('chat')}
+                  onEmailClick={(notesMarkdown) => {
+                    if (copyToClipboard) copyToClipboard(notesMarkdown)
+                    setCurrentTab(TabChoices.Email)
+                  }}
                 />
+              )}
+
+              {currentTab === TabChoices.Meeting && meetingSubView === 'chat' && (
+                <div className="overflow-hidden w-full h-full flex flex-row relative">
+                  <div className="overflow-hidden flex-1 h-full min-w-0">
+                    <ClawdChat
+                      showActivityPanel={false}
+                      onToggleActivity={() => {}}
+                      onCloseActivity={() => {}}
+                      userEmail={userEmail}
+                      userName={userName}
+                      onBusyChange={setIsChatBusy}
+                      openProviderPanel={openProviderPanelTrigger}
+                    />
+                  </div>
+                </div>
               )}
 
               {currentTab === TabChoices.Library && (

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -247,3 +247,273 @@ html, body {
 .ProseMirror:focus {
   outline: none;
 }
+
+/* Notetaker note detail view */
+.notetaker-note {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.notetaker-note__container {
+  width: 100%;
+  max-width: 45rem;
+  margin: 0 auto;
+  padding: 32px 40px 16px;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.notetaker-note__title {
+  font-family: 'Lora', serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: #333333;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.notetaker-note__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.notetaker-note__meta-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #6A6969;
+  font-family: 'Inter', sans-serif;
+  background: #F0EFEF;
+  padding: 4px 10px;
+  border-radius: 6px;
+}
+
+.notetaker-note__meta-item--recording {
+  background: #FAE7E6;
+  color: #A23933;
+}
+
+.notetaker-note__recording-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #C14841;
+  animation: recording-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes recording-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.notetaker-note__meta-item svg {
+  flex-shrink: 0;
+  color: #969595;
+}
+
+.notetaker-note__editor {
+  border: 1px solid #E3E2E2;
+  border-radius: 8px;
+}
+
+.notetaker-note__editor--recording {
+  border-color: transparent;
+}
+
+.notetaker-note__bottom-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-top: 1px solid #E3E2E2;
+  background: #FAFAFA;
+  flex-shrink: 0;
+}
+
+.notetaker-note__bottom-audio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: #ABA9A9;
+  cursor: pointer;
+  transition: all 0.1s ease;
+}
+
+.notetaker-note__bottom-audio:hover {
+  background: #F0EFEF;
+  color: #6A6969;
+}
+
+.notetaker-note__bottom-chat {
+  flex: 1;
+}
+
+.notetaker-note__bottom-chat-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #E3E2E2;
+  border-radius: 8px;
+  background: white;
+  font-size: 13px;
+  color: #333333;
+  font-family: 'Inter', sans-serif;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.notetaker-note__bottom-chat-input::placeholder {
+  color: #ABA9A9;
+}
+
+.notetaker-note__bottom-chat-input:focus {
+  border-color: #6474AC;
+}
+
+.notetaker-note__bottom-action {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  background: #6474AC;
+  color: white;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  white-space: nowrap;
+  transition: background 0.1s ease;
+}
+
+.notetaker-note__bottom-action:hover {
+  background: #58649D;
+}
+
+.notetaker-note__bottom-action svg {
+  flex-shrink: 0;
+}
+
+/* Recording-specific bottom bar */
+.notetaker-note__bottom-waveform {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 24px;
+  padding: 0 4px;
+}
+
+.notetaker-note__waveform-bar {
+  width: 3px;
+  height: 12px;
+  background: #C14841;
+  border-radius: 2px;
+  animation: waveform-bounce 1.2s ease-in-out infinite;
+}
+
+@keyframes waveform-bounce {
+  0%, 100% { height: 6px; }
+  50% { height: 18px; }
+}
+
+.notetaker-note__bottom-recording-status {
+  font-size: 12px;
+  color: #6A6969;
+  font-family: 'Inter', sans-serif;
+  font-style: italic;
+}
+
+.notetaker-note__bottom-stop {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  background: #C14841;
+  color: white;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  white-space: nowrap;
+  transition: background 0.1s ease;
+}
+
+.notetaker-note__bottom-stop:hover {
+  background: #A23933;
+}
+
+.notetaker-note__permission-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  margin: 12px 0;
+  background: #FEF3C7;
+  border: 1px solid #F59E0B;
+  border-radius: 10px;
+}
+
+.notetaker-note__permission-error-icon {
+  flex-shrink: 0;
+  color: #D97706;
+  margin-top: 2px;
+}
+
+.notetaker-note__permission-error-content {
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #78350F;
+}
+
+.notetaker-note__permission-error-content strong {
+  font-weight: 600;
+}
+
+.notetaker-note__permission-error-content p {
+  margin: 4px 0;
+}
+
+.notetaker-note__permission-error-steps {
+  margin-top: 8px;
+}
+
+.notetaker-note__permission-error-steps ol {
+  margin: 4px 0 0 20px;
+  padding: 0;
+  list-style-type: decimal;
+}
+
+.notetaker-note__permission-error-steps li {
+  margin: 2px 0;
+}
+
+.notetaker-note__permission-error-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #92400E;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 4px;
+  transition: background 0.1s ease;
+}
+
+.notetaker-note__permission-error-dismiss:hover {
+  background: rgba(0, 0, 0, 0.08);
+}

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -38,7 +38,8 @@ export default defineConfig(async () => ({
       input: {
         main: 'index.html',
         notification: 'notification.html',
-        overlay: 'overlay.html'
+        overlay: 'overlay.html',
+        'recording-indicator': 'recording-indicator.html'
       }
     }
   },


### PR DESCRIPTION
## Summary

Introduces a full-featured meeting notetaker UI with a collapsible sidebar, floating recording indicator, and improved recording controls.

**Notetaker sidebar**
- Collapsible left sidebar with upcoming calendar events grouped by date
- Search bar (Cmd+K) to filter meetings by title or attendees
- Quick navigation between meeting list, inline chat, and settings
- Version display in the footer

**Meetings tab redesign**
- Full-width notes view with top action bar (copy, share, open-in-full)
- Inline chat panel that preserves context when switching meetings
- Loading skeleton and inline permission error state for meeting notes
- Notes indicator badge when a meeting has notes

**Floating recording indicator pill**
- Transparent always-on-top window showing the logo, animated waveform, and elapsed time
- Draggable around the screen; click brings the main window to focus
- Positioned at the vertical center of the right edge of the screen so it does not overlap the Stop recording button
- System tray menu entry to toggle indicator on/off
- Backend `stop_recording` now hides the indicator pill and prevents Rust panics on repeated stops

**Recording controls**
- Added a direct Stop button alongside Pause when recording is active
- Fixed state desync that could leave the recording state stuck after stopping
- Calendar toggle in the system tray menu

**Bug fixes**
- Fix UUID crash on macOS 26 (Tahoe)
- Fix tray icon visibility after app restart
- Fix back-button navigation in sidebar
- Fix TypeScript build errors (SVG prop types, `KNChatMessage.text`, CSS property)