### PR TITLE
Fix chalk Chalk compat for both CJS (v4) and ESM (v5)

### DIFF
--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -11,14 +11,20 @@
  * grammy, discord needs discord.js, slack needs @slack/bolt, etc.).
  * The upstream `scripts/postinstall-bundled-plugins.mjs` that normally
  * handles this is not included in the dist bundle.
+ *
+ * In `tauri dev` mode, Tauri copies resources from the source tree into
+ * src-tauri/target/debug/resources/ and runs the gateway from there.
+ * This script installs deps in both the source dir AND the target debug dir
+ * (when it exists) so that hot-reload cycles don't lose npm packages.
  */
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources', 'clawdbot');
-const NODE_MODULES = path.join(CLAWDBOT_DIR, 'node_modules');
-const EXTENSIONS_DIR = path.join(CLAWDBOT_DIR, 'dist', 'extensions');
+// Source (checked-in) clawdbot dir
+const SOURCE_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources', 'clawdbot');
+// Tauri dev target dir — only present during/after `tauri dev`
+const TARGET_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'target', 'debug', 'resources', 'clawdbot');
 
 function runNpmInstall(cwd, label) {
   console.log(`[ensure-clawdbot-deps] npm install in ${label}...`);
@@ -28,19 +34,36 @@ function runNpmInstall(cwd, label) {
   });
 }
 
-function findPluginsNeedingRuntimeDeps() {
-  if (!fs.existsSync(EXTENSIONS_DIR)) return [];
+function needsMainInstall(clawdbotDir) {
+  const nodeModules = path.join(clawdbotDir, 'node_modules');
+  if (!fs.existsSync(nodeModules)) return true;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(clawdbotDir, 'package.json'), 'utf8'));
+    const deps = Object.keys(pkg.dependencies || {});
+    return deps.some(dep => !fs.existsSync(path.join(nodeModules, dep)));
+  } catch {
+    return true;
+  }
+}
+
+function findPluginsNeedingRuntimeDeps(extensionsDir) {
+  if (!fs.existsSync(extensionsDir)) return [];
   const plugins = [];
-  for (const entry of fs.readdirSync(EXTENSIONS_DIR, { withFileTypes: true })) {
+  for (const entry of fs.readdirSync(extensionsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    const pkgPath = path.join(EXTENSIONS_DIR, entry.name, 'package.json');
+    const pkgPath = path.join(extensionsDir, entry.name, 'package.json');
     if (!fs.existsSync(pkgPath)) continue;
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
       const staged = pkg?.openclaw?.bundle?.stageRuntimeDependencies === true;
       if (!staged) continue;
-      // Skip if the plugin's own node_modules already exists.
-      if (fs.existsSync(path.join(EXTENSIONS_DIR, entry.name, 'node_modules'))) continue;
+      // Skip if the plugin's own node_modules already has all deps.
+      const pluginNodeModules = path.join(extensionsDir, entry.name, 'node_modules');
+      if (fs.existsSync(pluginNodeModules)) {
+        const pluginDeps = Object.keys(pkg.dependencies || {});
+        const allPresent = pluginDeps.every(dep => fs.existsSync(path.join(pluginNodeModules, dep)));
+        if (allPresent) continue;
+      }
       plugins.push(entry.name);
     } catch {
       // Ignore unreadable package.json
@@ -49,42 +72,41 @@ function findPluginsNeedingRuntimeDeps() {
   return plugins;
 }
 
-// Step 1: install the main clawdbot deps if missing or out of date.
-// Re-run if node_modules doesn't exist OR if any direct dependency from
-// package.json is missing from node_modules (handles newly-added packages
-// without relying on mtime, which is unreliable on Windows with git).
-const needsInstall = (() => {
-  if (!fs.existsSync(NODE_MODULES)) return true;
-  try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(CLAWDBOT_DIR, 'package.json'), 'utf8'));
-    const deps = Object.keys(pkg.dependencies || {});
-    return deps.some(dep => !fs.existsSync(path.join(NODE_MODULES, dep)));
-  } catch {
-    return true;
-  }
-})();
+// Collect the directories to install into (source always; target when present).
+const clawdbotDirs = [SOURCE_CLAWDBOT_DIR];
+if (fs.existsSync(TARGET_CLAWDBOT_DIR)) {
+  clawdbotDirs.push(TARGET_CLAWDBOT_DIR);
+}
 
-if (needsInstall) {
-  try {
-    runNpmInstall(CLAWDBOT_DIR, 'clawdbot/');
-  } catch (err) {
-    console.error('[ensure-clawdbot-deps] clawdbot npm install failed:', err.message);
-    process.exit(1);
+// Step 1: install main clawdbot deps in each dir.
+for (const dir of clawdbotDirs) {
+  if (!fs.existsSync(dir)) continue;
+  if (needsMainInstall(dir)) {
+    try {
+      runNpmInstall(dir, path.relative(path.join(__dirname, '..'), dir));
+    } catch (err) {
+      console.error('[ensure-clawdbot-deps] clawdbot npm install failed:', err.message);
+      process.exit(1);
+    }
   }
 }
 
 // Step 2: install runtime deps for bundled plugins that need them.
-const pluginsToInstall = findPluginsNeedingRuntimeDeps();
-if (pluginsToInstall.length > 0) {
-  console.log(
-    `[ensure-clawdbot-deps] Installing runtime deps for ${pluginsToInstall.length} bundled plugin(s): ${pluginsToInstall.join(', ')}`,
-  );
-  for (const plugin of pluginsToInstall) {
-    try {
-      runNpmInstall(path.join(EXTENSIONS_DIR, plugin), `extensions/${plugin}/`);
-    } catch (err) {
-      // Non-fatal: a plugin dep failure just means that plugin won't load.
-      console.warn(`[ensure-clawdbot-deps] WARNING: failed to install deps for ${plugin}: ${err.message}`);
+for (const dir of clawdbotDirs) {
+  const extensionsDir = path.join(dir, 'dist', 'extensions');
+  if (!fs.existsSync(extensionsDir)) continue;
+  const pluginsToInstall = findPluginsNeedingRuntimeDeps(extensionsDir);
+  if (pluginsToInstall.length > 0) {
+    console.log(
+      `[ensure-clawdbot-deps] Installing runtime deps for ${pluginsToInstall.length} bundled plugin(s) in ${path.relative(path.join(__dirname, '..'), extensionsDir)}: ${pluginsToInstall.join(', ')}`,
+    );
+    for (const plugin of pluginsToInstall) {
+      try {
+        runNpmInstall(path.join(extensionsDir, plugin), `extensions/${plugin}/`);
+      } catch (err) {
+        // Non-fatal: a plugin dep failure just means that plugin won't load.
+        console.warn(`[ensure-clawdbot-deps] WARNING: failed to install deps for ${plugin}: ${err.message}`);
+      }
     }
   }
 }

--- a/src/src-tauri/resources/clawdbot/dist/subsystem-CJEvHE2o.js
+++ b/src/src-tauri/resources/clawdbot/dist/subsystem-CJEvHE2o.js
@@ -2,7 +2,7 @@ import { t as resolveNodeRequireFromMeta } from "./node-require-BgDD9bTi.js";
 import { S as shouldSkipMutatingLoggingConfigRead, a as getLogger, f as formatLocalIsoWithOffset, g as loggingState, h as resolveEnvLogLevelOverride, i as getChildLogger, p as formatTimestamp, s as isFileLogLevelEnabled, v as levelToMinLevel, x as readLoggingConfig, y as normalizeLogLevel } from "./logger-BCzP_yik.js";
 import { t as isVerbose } from "./global-state-DUuMGgts.js";
 import { r as stripAnsi } from "./ansi-B_0KjIJj.js";
-import chalk_pkg from "chalk"; const { Chalk } = chalk_pkg;
+import chalk_pkg from "chalk"; const Chalk = chalk_pkg.Chalk ?? chalk_pkg.constructor;
 import util from "node:util";
 //#region src/terminal/progress-line.ts
 let activeStream = null;

--- a/src/src-tauri/resources/clawdbot/dist/theme-D-TumEpz.js
+++ b/src/src-tauri/resources/clawdbot/dist/theme-D-TumEpz.js
@@ -1,4 +1,4 @@
-import chalk from "chalk"; const { Chalk } = chalk;
+import chalk from "chalk"; const Chalk = chalk.Chalk ?? chalk.constructor;
 //#region src/terminal/palette.ts
 const LOBSTER_PALETTE = {
 	accent: "#FF5A2D",

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2598,9 +2598,17 @@ pub async fn chat(
       // Build the claude command: use --yes for non-interactive mode that can still make changes.
       // --print only outputs text without making file changes; --yes auto-accepts tool use
       // so Claude Code can actually read/write files and run commands.
-      // Escape single quotes in the prompt for safe shell embedding
-      let escaped_prompt = prompt.replace('\'', "'\\''");
-      let claude_cmd = format!("claude --yes '{}'", escaped_prompt);
+      // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
+      #[cfg(target_os = "windows")]
+      let claude_cmd = {
+        let escaped = prompt.replace('"', "\\\"");
+        format!("claude --yes \"{}\"", escaped)
+      };
+      #[cfg(not(target_os = "windows"))]
+      let claude_cmd = {
+        let escaped_prompt = prompt.replace('\'', "'\\''");
+        format!("claude --yes '{}'", escaped_prompt)
+      };
 
       let wd_clone = wd.clone();
       let app1 = app_handle.clone();
@@ -2621,6 +2629,23 @@ pub async fn chat(
         let mut cmd = if cfg!(target_os = "windows") {
           let mut c = Command::new("cmd");
           c.args(["/C", &claude_cmd]);
+          // Augment PATH with common npm global bin dirs so `claude.cmd` is found
+          // even when Knapsack's process doesn't inherit the full user PATH.
+          if let Ok(existing_path) = std::env::var("PATH") {
+            let user_profile = std::env::var("USERPROFILE").unwrap_or_default();
+            let appdata = std::env::var("APPDATA").unwrap_or_default();
+            let extra = [
+              format!(r"{}\AppData\Roaming\npm", user_profile),
+              format!(r"{}\npm", appdata),
+              r"C:\Program Files\nodejs".to_string(),
+              r"C:\Program Files (x86)\nodejs".to_string(),
+            ];
+            let mut paths: Vec<&str> = existing_path.split(';').collect();
+            for e in &extra {
+              if !paths.contains(&e.as_str()) { paths.push(e); }
+            }
+            c.env("PATH", paths.join(";"));
+          }
           c
         } else {
           let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "bash".to_string());

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -988,7 +988,11 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
 
     match challenge_msg {
       Message::Text(t) => break t,
-      Message::Close(_) => return Err("Connection closed during challenge".to_string()),
+      Message::Close(frame) => return Err(format!(
+        "Connection closed during challenge (code={}, reason={})",
+        frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0),
+        frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("n/a")
+      )),
       _ => continue, // Skip ping/pong control frames
     }
   };
@@ -1039,7 +1043,11 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
 
     match connect_resp_msg {
       Message::Text(t) => break t,
-      Message::Close(_) => return Err("Connection closed during connect".to_string()),
+      Message::Close(frame) => return Err(format!(
+        "Connection closed during connect (code={}, reason={})",
+        frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0),
+        frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("n/a")
+      )),
       _ => continue, // Skip ping/pong control frames
     }
   };

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -588,6 +588,37 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
     }
   }
 
+  // ── Ensure Tauri app origins are in gateway.controlUi.allowedOrigins ──────
+  // Without this, the gateway refuses WebSocket connections from the Tauri
+  // webview with CONTROL_UI_ORIGIN_NOT_ALLOWED.
+  {
+    const REQUIRED_ORIGINS: &[&str] = &["tauri://localhost", "http://localhost:1420"];
+    let existing: Vec<String> = cfg
+      .pointer("/gateway/controlUi/allowedOrigins")
+      .and_then(|v| v.as_array())
+      .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+      .unwrap_or_default();
+    let missing: Vec<&str> = REQUIRED_ORIGINS.iter()
+      .filter(|&&o| !existing.iter().any(|e| e == o))
+      .copied()
+      .collect();
+    if !missing.is_empty() {
+      if cfg.get("gateway").is_none() {
+        cfg.as_object_mut().unwrap().insert("gateway".into(), serde_json::json!({}));
+      }
+      if cfg.pointer("/gateway/controlUi").is_none() {
+        cfg.pointer_mut("/gateway").unwrap().as_object_mut().unwrap()
+          .insert("controlUi".into(), serde_json::json!({}));
+      }
+      let mut merged = existing;
+      merged.extend(missing.iter().map(|s| s.to_string()));
+      cfg.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
+        .insert("allowedOrigins".into(), serde_json::json!(merged));
+      eprintln!("[gateway_client] Patched gateway.controlUi.allowedOrigins to include Tauri origins");
+      patched = true;
+    }
+  }
+
   if patched {
     if let Ok(json) = serde_json::to_string_pretty(&cfg) {
       let _ = std::fs::write(config_path, json);

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -744,7 +744,7 @@ async fn apply_runtime_browser_config(token: &str) {
     min_protocol: PROTOCOL_VERSION,
     max_protocol: PROTOCOL_VERSION,
     client: ClientInfo {
-      id: "gateway-client-patch",
+      id: "openclaw-control-ui",
       display_name: "Knapsack Desktop (config patch)",
       version: env!("CARGO_PKG_VERSION"),
       platform: std::env::consts::OS,
@@ -1004,7 +1004,7 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
     min_protocol: PROTOCOL_VERSION,
     max_protocol: PROTOCOL_VERSION,
     client: ClientInfo {
-      id: "gateway-client",
+      id: "openclaw-control-ui",
       display_name: "Knapsack Desktop",
       version: env!("CARGO_PKG_VERSION"),
       platform: std::env::consts::OS,

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -1594,7 +1594,10 @@ pub async fn browser_request(
 ) -> Result<Value, String> {
   let t = resolve_token(token)?;
 
-  let backoffs: &[u64] = &[500, 1000, 2000];
+  // Extra retries help on Windows where Chrome CDP startup is slower and
+  // more variable — the additional attempts catch the browser becoming
+  // ready 1-3s after the first attempt failed.
+  let backoffs: &[u64] = &[300, 600, 1200, 2000, 3000];
   let mut last_err = String::new();
 
   for attempt in 0..=backoffs.len() {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -15,6 +15,12 @@ use crate::clawd::sidecar::SharedClawdbotConfig;
 #[cfg(target_os = "windows")]
 static GATEWAY_PID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
+/// Stores the last successful ServiceSetup so the background restart task can
+/// re-spawn the gateway on Windows without needing the full enable flow.
+#[cfg(target_os = "windows")]
+static LAST_GATEWAY_SETUP: once_cell::sync::Lazy<std::sync::Mutex<Option<ServiceSetup>>> =
+  once_cell::sync::Lazy::new(|| std::sync::Mutex::new(None));
+
 #[cfg(target_os = "windows")]
 fn windows_log_path(stream: &str) -> PathBuf {
   let temp = std::env::temp_dir();
@@ -1259,6 +1265,57 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
               }
             }
           }
+        }
+
+        // On Windows, `kickstart_launch_agent` cannot start a new process.
+        // Re-spawn directly using the saved ServiceSetup from the last enable call.
+        #[cfg(target_os = "windows")]
+        {
+          let saved_setup = LAST_GATEWAY_SETUP.lock().unwrap().clone();
+          if let Some(setup) = saved_setup {
+            eprintln!("[clawd/service] Windows background restart: re-spawning gateway");
+            kill_process_on_port(18789);
+            // Clean up stale lock files
+            {
+              let lock_dir = std::env::temp_dir().join("openclaw");
+              if lock_dir.is_dir() {
+                if let Ok(entries) = fs::read_dir(&lock_dir) {
+                  for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    let s = name.to_string_lossy();
+                    if s.starts_with("gateway.") && s.ends_with(".lock") {
+                      let _ = fs::remove_file(entry.path());
+                    }
+                  }
+                }
+              }
+            }
+            let stdout_log = windows_log_path("stdout");
+            let stderr_log = windows_log_path("stderr");
+            if let (Ok(out_f), Ok(err_f)) = (fs::File::create(&stdout_log), fs::File::create(&stderr_log)) {
+              use std::os::windows::process::CommandExt;
+              const CREATE_NO_WINDOW: u32 = 0x08000000;
+              match std::process::Command::new(&setup.program_args[0])
+                .args(&setup.program_args[1..])
+                .envs(setup.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+                .current_dir(&setup.working_dir)
+                .stdout(out_f)
+                .stderr(err_f)
+                .creation_flags(CREATE_NO_WINDOW)
+                .spawn()
+              {
+                Ok(child) => {
+                  let pid = child.id();
+                  GATEWAY_PID.store(pid, Ordering::Relaxed);
+                  eprintln!("[clawd/service] Windows background restart: spawned gateway pid {}", pid);
+                }
+                Err(e) => eprintln!("[clawd/service] Windows background restart: spawn failed: {}", e),
+              }
+            }
+            GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
+            return;
+          }
+          eprintln!("[clawd/service] Windows background restart: no saved setup — use Enable in UI");
         }
 
         use crate::clawd::gateway_supervisor;
@@ -2889,6 +2946,7 @@ pub async fn set_llm_keys(
 
 // ── Shared gateway config setup (used by both macOS and Windows) ────────
 
+#[derive(Clone)]
 struct ServiceSetup {
   node_path: PathBuf,
   is_bundled_node: bool,
@@ -3028,7 +3086,8 @@ async fn prepare_gateway_config(
           "token": tokens.gateway_token.clone()
         },
         "controlUi": {
-          "allowInsecureAuth": true
+          "allowInsecureAuth": true,
+          "allowedOrigins": ["tauri://localhost", "http://localhost:1420"]
         }
       },
       "browser": {
@@ -3364,6 +3423,36 @@ async fn prepare_gateway_config(
             .insert("allowInsecureAuth".to_string(), serde_json::json!(true));
           eprintln!("[clawd/service] Patched gateway.controlUi.allowInsecureAuth to true");
           patched = true;
+        }
+
+        // Ensure the Tauri app origins are in gateway.controlUi.allowedOrigins
+        // so the frontend WebSocket connects without CONTROL_UI_ORIGIN_NOT_ALLOWED.
+        {
+          const REQUIRED_ORIGINS: &[&str] = &["tauri://localhost", "http://localhost:1420"];
+          let existing: Vec<String> = cfg_val
+            .pointer("/gateway/controlUi/allowedOrigins")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+            .unwrap_or_default();
+          let missing: Vec<&str> = REQUIRED_ORIGINS.iter()
+            .filter(|&&o| !existing.iter().any(|e| e == o))
+            .copied()
+            .collect();
+          if !missing.is_empty() {
+            if cfg_val.get("gateway").is_none() {
+              cfg_val.as_object_mut().unwrap().insert("gateway".to_string(), serde_json::json!({}));
+            }
+            let gw = cfg_val.pointer_mut("/gateway").unwrap().as_object_mut().unwrap();
+            if !gw.contains_key("controlUi") {
+              gw.insert("controlUi".to_string(), serde_json::json!({}));
+            }
+            let mut merged = existing;
+            merged.extend(missing.iter().map(|s| s.to_string()));
+            cfg_val.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
+              .insert("allowedOrigins".to_string(), serde_json::json!(merged));
+            eprintln!("[clawd/service] Patched gateway.controlUi.allowedOrigins to include Tauri origins");
+            patched = true;
+          }
         }
 
         // ── Auto-heal allowlist channels ──────────────────────────────
@@ -3835,6 +3924,9 @@ pub async fn set_service_enabled(
           GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           eprintln!("[clawd/service] Spawned gateway process (pid {})", pid);
 
+          // Save the setup for background restart (Windows-only restart path).
+          *LAST_GATEWAY_SETUP.lock().unwrap() = Some(setup.clone());
+
           // Workaround for OpenClaw #23006: patch paired.json periodically
           // during startup to ensure devices get operator.admin scope.  The
           // gateway may rewrite paired.json during auto-pairing, so we retry
@@ -4058,7 +4150,8 @@ pub async fn set_service_enabled(
               "token": tokens.gateway_token.clone()
             },
             "controlUi": {
-              "allowInsecureAuth": true
+              "allowInsecureAuth": true,
+              "allowedOrigins": ["tauri://localhost", "http://localhost:1420"]
             }
           },
           "browser": {
@@ -4138,6 +4231,35 @@ pub async fn set_service_enabled(
                 .insert("allowInsecureAuth".to_string(), serde_json::json!(true));
               eprintln!("[clawd/service] Patched gateway.controlUi.allowInsecureAuth to true");
               patched = true;
+            }
+
+            // Ensure the Tauri app origins are in gateway.controlUi.allowedOrigins.
+            {
+              const REQUIRED_ORIGINS: &[&str] = &["tauri://localhost", "http://localhost:1420"];
+              let existing: Vec<String> = cfg
+                .pointer("/gateway/controlUi/allowedOrigins")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+                .unwrap_or_default();
+              let missing: Vec<&str> = REQUIRED_ORIGINS.iter()
+                .filter(|&&o| !existing.iter().any(|e| e == o))
+                .copied()
+                .collect();
+              if !missing.is_empty() {
+                if cfg.get("gateway").is_none() {
+                  cfg.as_object_mut().unwrap().insert("gateway".to_string(), serde_json::json!({}));
+                }
+                let gw = cfg.pointer_mut("/gateway").unwrap().as_object_mut().unwrap();
+                if !gw.contains_key("controlUi") {
+                  gw.insert("controlUi".to_string(), serde_json::json!({}));
+                }
+                let mut merged = existing;
+                merged.extend(missing.iter().map(|s| s.to_string()));
+                cfg.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
+                  .insert("allowedOrigins".to_string(), serde_json::json!(merged));
+                eprintln!("[clawd/service] Patched gateway.controlUi.allowedOrigins to include Tauri origins");
+                patched = true;
+              }
             }
 
             // Ensure plugins.slots.memory is set to "none".

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -305,6 +305,116 @@ fn remove_stale_standalone_gateway() {
   // No-op on other platforms
 }
 
+/// Install runtime dependencies for bundled plugins that declare
+/// `openclaw.bundle.stageRuntimeDependencies: true` (e.g. telegram needs grammy).
+///
+/// This mirrors `ensure-clawdbot-deps.cjs` but runs inside the Tauri process,
+/// AFTER Tauri has already copied resources to their runtime location.  That
+/// eliminates the race condition where `beforeDevCommand` runs the script before
+/// Tauri's own resource copy, leaving the target dir without node_modules.
+fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_dir: &std::path::Path) {
+  if !extensions_dir.is_dir() {
+    return;
+  }
+
+  // Locate npm: prefer sibling of the node binary, fall back to PATH.
+  let npm: PathBuf = if let Some(node_dir) = node_path.parent() {
+    let candidate = if cfg!(target_os = "windows") {
+      node_dir.join("npm.cmd")
+    } else {
+      node_dir.join("npm")
+    };
+    if candidate.exists() { candidate } else { PathBuf::from("npm") }
+  } else {
+    PathBuf::from("npm")
+  };
+
+  let entries = match fs::read_dir(extensions_dir) {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  for entry in entries.flatten() {
+    if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+      continue;
+    }
+    let plugin_dir = entry.path();
+    let pkg_path = plugin_dir.join("package.json");
+    if !pkg_path.exists() {
+      continue;
+    }
+
+    let pkg: serde_json::Value = match fs::read_to_string(&pkg_path)
+      .ok()
+      .and_then(|s| serde_json::from_str(&s).ok())
+    {
+      Some(v) => v,
+      None => continue,
+    };
+
+    let needs_stage = pkg
+      .pointer("/openclaw/bundle/stageRuntimeDependencies")
+      .and_then(|v| v.as_bool())
+      .unwrap_or(false);
+    if !needs_stage {
+      continue;
+    }
+
+    let deps: Vec<String> = pkg
+      .get("dependencies")
+      .and_then(|v| v.as_object())
+      .map(|m| m.keys().cloned().collect())
+      .unwrap_or_default();
+
+    let nm_dir = plugin_dir.join("node_modules");
+    let all_present = !deps.is_empty() && deps.iter().all(|dep| nm_dir.join(dep).exists());
+    if all_present {
+      eprintln!(
+        "[clawd/service] Plugin {} runtime deps already present",
+        entry.file_name().to_string_lossy()
+      );
+      continue;
+    }
+
+    let plugin_name = entry.file_name().to_string_lossy().to_string();
+    eprintln!(
+      "[clawd/service] Installing runtime deps for plugin {}...",
+      plugin_name
+    );
+
+    #[cfg(target_os = "windows")]
+    let result = {
+      use std::os::windows::process::CommandExt;
+      const CREATE_NO_WINDOW: u32 = 0x08000000;
+      std::process::Command::new(&npm)
+        .args(["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"])
+        .current_dir(&plugin_dir)
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+    };
+    #[cfg(not(target_os = "windows"))]
+    let result = std::process::Command::new(&npm)
+      .args(["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"])
+      .current_dir(&plugin_dir)
+      .status();
+
+    match result {
+      Ok(s) if s.success() => eprintln!(
+        "[clawd/service] Plugin {} runtime deps installed",
+        plugin_name
+      ),
+      Ok(s) => eprintln!(
+        "[clawd/service] WARNING: npm install for plugin {} exited {}",
+        plugin_name, s
+      ),
+      Err(e) => eprintln!(
+        "[clawd/service] WARNING: npm install for plugin {} failed: {}",
+        plugin_name, e
+      ),
+    }
+  }
+}
+
 /// Check if the gateway Node.js binary or the bundled clawdbot directory is
 /// quarantined by macOS Gatekeeper.  When a DMG-installed app is not properly
 /// code-signed and notarized, macOS adds a `com.apple.quarantine` xattr to the
@@ -3750,6 +3860,10 @@ async fn prepare_gateway_config(
   let app_version = app_handle.package_info().version.to_string();
   let os_info = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
 
+  // Install runtime deps for bundled plugins (e.g. grammy for telegram).
+  // Must happen AFTER resource files are in place (i.e. here, not in beforeDevCommand).
+  install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
+
   eprintln!(
     "[clawd/service] Knapsack v{} on {} — starting service ({})",
     app_version, os_info, LAUNCH_AGENT_LABEL
@@ -4124,6 +4238,9 @@ pub async fn set_service_enabled(
       // OPENCLAW_BUNDLED_PLUGINS_DIR env var and for cleaning up stale
       // plugins.load.paths entries from older configs.
       let bundled_plugins_dir = resource_path(&app_handle, "resources/clawdbot/dist/extensions");
+
+      // Install runtime deps for bundled plugins (e.g. grammy for telegram).
+      install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
 
       // Ensure OpenClaw config exists with gateway.mode=local for first-run.
       // Without this, OpenClaw refuses to start on a fresh machine.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3026,6 +3026,9 @@ async fn prepare_gateway_config(
         "mode": "local",
         "auth": {
           "token": tokens.gateway_token.clone()
+        },
+        "controlUi": {
+          "allowInsecureAuth": true
         }
       },
       "browser": {
@@ -3337,6 +3340,29 @@ async fn prepare_gateway_config(
               "browser", "group:web"
             ]));
           eprintln!("[clawd/service] Created tools.sandbox.tools.allow (with browser + group:web)");
+          patched = true;
+        }
+
+        // Ensure gateway.controlUi.allowInsecureAuth = true so the desktop
+        // backend (which uses the "openclaw-control-ui" client ID) can connect
+        // with operator scopes using the shared token without device-pairing.
+        // The gateway only applies this to loopback connections so it does not
+        // weaken remote access.
+        let control_ui_allow_insecure = cfg_val
+          .pointer("/gateway/controlUi/allowInsecureAuth")
+          .and_then(|v| v.as_bool())
+          .unwrap_or(false);
+        if !control_ui_allow_insecure {
+          if cfg_val.get("gateway").is_none() {
+            cfg_val.as_object_mut().unwrap().insert("gateway".to_string(), serde_json::json!({}));
+          }
+          let gw = cfg_val.pointer_mut("/gateway").unwrap().as_object_mut().unwrap();
+          if !gw.contains_key("controlUi") {
+            gw.insert("controlUi".to_string(), serde_json::json!({}));
+          }
+          cfg_val.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
+            .insert("allowInsecureAuth".to_string(), serde_json::json!(true));
+          eprintln!("[clawd/service] Patched gateway.controlUi.allowInsecureAuth to true");
           patched = true;
         }
 
@@ -4030,6 +4056,9 @@ pub async fn set_service_enabled(
             "mode": "local",
             "auth": {
               "token": tokens.gateway_token.clone()
+            },
+            "controlUi": {
+              "allowInsecureAuth": true
             }
           },
           "browser": {
@@ -4089,6 +4118,25 @@ pub async fn set_service_enabled(
               cfg.pointer_mut("/gateway/auth").unwrap().as_object_mut().unwrap()
                 .insert("token".to_string(), serde_json::json!(tokens.gateway_token.trim()));
               eprintln!("[clawd/service] Synced gateway.auth.token in config to match tokens.json");
+              patched = true;
+            }
+
+            // Ensure gateway.controlUi.allowInsecureAuth = true
+            let control_ui_allow_insecure = cfg
+              .pointer("/gateway/controlUi/allowInsecureAuth")
+              .and_then(|v| v.as_bool())
+              .unwrap_or(false);
+            if !control_ui_allow_insecure {
+              if cfg.get("gateway").is_none() {
+                cfg.as_object_mut().unwrap().insert("gateway".to_string(), serde_json::json!({}));
+              }
+              let gw = cfg.pointer_mut("/gateway").unwrap().as_object_mut().unwrap();
+              if !gw.contains_key("controlUi") {
+                gw.insert("controlUi".to_string(), serde_json::json!({}));
+              }
+              cfg.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
+                .insert("allowInsecureAuth".to_string(), serde_json::json!(true));
+              eprintln!("[clawd/service] Patched gateway.controlUi.allowInsecureAuth to true");
               patched = true;
             }
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1273,11 +1273,18 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     // method.  Send a lightweight request to verify it's responsive.
     // Use a 5-second timeout to avoid blocking the health endpoint when the
     // browser RPC is slow (the default pooled request timeout is 30s).
+    // Windows Chrome startup is slower (antivirus, disk I/O) so we use
+    // longer timeouts there to avoid false browser_ok=false reports.
+    #[cfg(target_os = "windows")]
+    let (stage1_secs, stage2_secs) = (10u64, 6u64);
+    #[cfg(not(target_os = "windows"))]
+    let (stage1_secs, stage2_secs) = (5u64, 3u64);
+
     let browser_ok = if gateway_ok {
       // Try with "openclaw" profile (the managed, isolated browser profile
       // created by the gateway).  Fall back to no-profile if it fails.
       let check = tokio::time::timeout(
-        std::time::Duration::from_secs(5),
+        std::time::Duration::from_secs(stage1_secs),
         gateway_client::browser_request(
           "GET", "/tabs", Some(serde_json::json!({"profile": "openclaw"})), None, None,
         ),
@@ -1288,7 +1295,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
           eprintln!("[clawd/service] browser health check failed (profile=openclaw): {}", e);
           // Fallback: try without profile restriction
           match tokio::time::timeout(
-            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(stage2_secs),
             gateway_client::browser_request("GET", "/tabs", None, None, None),
           ).await {
             Ok(Ok(_)) => {
@@ -1300,13 +1307,13 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
               false
             }
             Err(_) => {
-              eprintln!("[clawd/service] browser health check timed out (no profile, 3s)");
+              eprintln!("[clawd/service] browser health check timed out (no profile, {}s)", stage2_secs);
               false
             }
           }
         }
         Err(_) => {
-          eprintln!("[clawd/service] browser health check timed out (5s)");
+          eprintln!("[clawd/service] browser health check timed out ({}s)", stage1_secs);
           false
         }
       }
@@ -1479,8 +1486,14 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
 
   // If gateway is up, also wait for the browser CDP to become reachable.
   // Chrome takes a few seconds to start after the gateway launches it.
+  // Windows Chrome startup is slower so we give it more time there.
+  #[cfg(target_os = "windows")]
+  let browser_wait_secs = 25u64;
+  #[cfg(not(target_os = "windows"))]
+  let browser_wait_secs = 15u64;
+
   let browser_ok = if ready {
-    gateway_client::wait_for_browser_ready(None, 15).await
+    gateway_client::wait_for_browser_ready(None, browser_wait_secs).await
   } else {
     false
   };


### PR DESCRIPTION
## Summary

Follow-up to #264. The first fix (`const { Chalk } = chalk_pkg`) resolved the CJS named-export error but broke ESM chalk v5, where `Chalk` is not a property on the default export instance — causing `TypeError: Chalk is not a constructor`.

**Root cause:** Two chalk versions behave differently:
- **chalk v4 (CJS):** `module.exports.Chalk` = the Chalk class ✓  
- **chalk v5 (ESM):** default export is a chalk *instance* — `Chalk` is only a named export, not on the instance

**Fix:** Use `chalk.Chalk ?? chalk.constructor` — works for both:
- CJS v4: `chalk.Chalk` is set explicitly on the export
- ESM v5: `chalk.constructor` is the `Chalk` class (since chalk is an instance of it)

Applied to both `dist/subsystem-CJEvHE2o.js` and `dist/theme-D-TumEpz.js`.

## Test plan

- [ ] Launch app — no chalk errors in the clawdbot/gateway logs
- [ ] Gateway connects successfully (no "reconnecting..." state)

https://claude.ai/code/session_01BkLJtFuoaUk3heF5GcRAfG