### PR TITLE
fix gateway issues

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -42,6 +42,10 @@ jobs:
         working-directory: src/src-tauri/resources/clawdbot
         run: npm ci --ignore-scripts
 
+      - name: Install bundled plugin runtime deps
+        working-directory: src
+        run: node scripts/install-bundled-plugin-deps.cjs
+
       - name: Run prebuild scripts
         working-directory: src
         env:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -40,6 +40,10 @@ jobs:
         working-directory: src/src-tauri/resources/clawdbot
         run: npm ci --ignore-scripts
 
+      - name: Install bundled plugin runtime deps
+        working-directory: src
+        run: node scripts/install-bundled-plugin-deps.cjs
+
       - name: Run prebuild scripts
         working-directory: src
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,10 @@ jobs:
         working-directory: src/src-tauri/resources/clawdbot
         run: npm ci --ignore-scripts
 
+      - name: Install bundled plugin runtime deps
+        working-directory: src
+        run: node scripts/install-bundled-plugin-deps.cjs
+
       - name: Run prebuild scripts
         working-directory: src
         env:
@@ -197,6 +201,10 @@ jobs:
       - name: Install clawdbot dependencies
         working-directory: src/src-tauri/resources/clawdbot
         run: npm ci --ignore-scripts
+
+      - name: Install bundled plugin runtime deps
+        working-directory: src
+        run: node scripts/install-bundled-plugin-deps.cjs
 
       - name: Run prebuild scripts
         working-directory: src

--- a/src/scripts/install-bundled-plugin-deps.cjs
+++ b/src/scripts/install-bundled-plugin-deps.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * install-bundled-plugin-deps.cjs — Pre-installs runtime dependencies for
+ * bundled plugins that declare `openclaw.bundle.stageRuntimeDependencies: true`.
+ *
+ * Run at BUILD TIME (after `npm ci` for the main clawdbot package), before
+ * `tauri build`, so plugin node_modules are included in the installer bundle.
+ *
+ * WHY THIS IS NEEDED:
+ * The fallback in service.rs that installs these deps at runtime cannot write
+ * to the app's install directory on production systems — on Windows the app
+ * lands in C:\Program Files\ (read-only without admin), and on macOS inside
+ * the signed app bundle (also read-only).  Pre-bundling the deps at build time
+ * is the correct fix; the runtime fallback remains as a best-effort safety net.
+ *
+ * SKIP_PLUGINS:
+ * Plugins listed here are excluded from build-time installation because their
+ * dependencies are too large, require a separate download step (e.g. browsers),
+ * or rely on native compilation that may not succeed in all CI environments.
+ * These plugins' deps can still be installed at runtime by the service.rs
+ * fallback when the environment allows it.
+ */
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources', 'clawdbot');
+const EXTENSIONS_DIR = path.join(CLAWDBOT_DIR, 'dist', 'extensions');
+
+// Excluded from build-time installation:
+// - diffs: playwright-core (~30 MB package + requires a separate browser
+//   download at runtime anyway; not needed for messaging workflows)
+const SKIP_PLUGINS = new Set(['diffs']);
+
+if (!fs.existsSync(EXTENSIONS_DIR)) {
+  console.log('[install-bundled-plugin-deps] dist/extensions not found — skipping.');
+  process.exit(0);
+}
+
+const entries = fs.readdirSync(EXTENSIONS_DIR, { withFileTypes: true });
+let installed = 0;
+let alreadyPresent = 0;
+let skipped = 0;
+
+for (const entry of entries) {
+  if (!entry.isDirectory()) continue;
+  const pluginName = entry.name;
+
+  if (SKIP_PLUGINS.has(pluginName)) {
+    console.log(`[install-bundled-plugin-deps] ${pluginName}: skipped (in SKIP_PLUGINS)`);
+    skipped++;
+    continue;
+  }
+
+  const pluginDir = path.join(EXTENSIONS_DIR, pluginName);
+  const pkgPath = path.join(pluginDir, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;
+
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  } catch {
+    continue;
+  }
+
+  const needsStage = pkg?.openclaw?.bundle?.stageRuntimeDependencies === true;
+  if (!needsStage) continue;
+
+  const deps = Object.keys(pkg.dependencies || {});
+  if (deps.length === 0) continue;
+
+  // Skip if all deps are already installed (e.g. re-running during development).
+  const nmDir = path.join(pluginDir, 'node_modules');
+  if (fs.existsSync(nmDir) && deps.every(dep => fs.existsSync(path.join(nmDir, dep)))) {
+    console.log(`[install-bundled-plugin-deps] ${pluginName}: already present`);
+    alreadyPresent++;
+    continue;
+  }
+
+  console.log(`[install-bundled-plugin-deps] ${pluginName}: installing ${deps.join(', ')}...`);
+  try {
+    execSync('npm install --omit=dev --ignore-scripts --no-audit --no-fund', {
+      cwd: pluginDir,
+      stdio: 'inherit',
+    });
+    console.log(`[install-bundled-plugin-deps] ${pluginName}: done`);
+    installed++;
+  } catch (err) {
+    // Non-fatal: the plugin simply won't load at runtime if its dep is missing.
+    console.warn(
+      `[install-bundled-plugin-deps] WARNING: npm install failed for ${pluginName}: ${err.message}`,
+    );
+  }
+}
+
+console.log(
+  `[install-bundled-plugin-deps] Finished. installed=${installed} already-present=${alreadyPresent} skipped=${skipped}`,
+);

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3565,6 +3565,22 @@ async fn prepare_gateway_config(
           }
         }
 
+        // Remove gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback.
+        // This flag was set as a break-glass workaround in older configs before
+        // the proper allowedOrigins fix was in place.  It weakens origin checks
+        // and is no longer needed now that allowedOrigins is managed above.
+        if cfg_val
+          .pointer("/gateway/controlUi/dangerouslyAllowHostHeaderOriginFallback")
+          .and_then(|v| v.as_bool())
+          .unwrap_or(false)
+        {
+          if let Some(cui) = cfg_val.pointer_mut("/gateway/controlUi").and_then(|v| v.as_object_mut()) {
+            cui.remove("dangerouslyAllowHostHeaderOriginFallback");
+            eprintln!("[clawd/service] Removed gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback (replaced by allowedOrigins)");
+            patched = true;
+          }
+        }
+
         // ── Auto-heal allowlist channels ──────────────────────────────
         // Must run AFTER other patches so that the in-memory cfg_val is
         // already up-to-date before we persist it.
@@ -4375,6 +4391,19 @@ pub async fn set_service_enabled(
                 cfg.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
                   .insert("allowedOrigins".to_string(), serde_json::json!(merged));
                 eprintln!("[clawd/service] Patched gateway.controlUi.allowedOrigins to include Tauri origins");
+                patched = true;
+              }
+            }
+
+            // Remove gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback.
+            if cfg
+              .pointer("/gateway/controlUi/dangerouslyAllowHostHeaderOriginFallback")
+              .and_then(|v| v.as_bool())
+              .unwrap_or(false)
+            {
+              if let Some(cui) = cfg.pointer_mut("/gateway/controlUi").and_then(|v| v.as_object_mut()) {
+                cui.remove("dangerouslyAllowHostHeaderOriginFallback");
+                eprintln!("[clawd/service] Removed gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback (replaced by allowedOrigins)");
                 patched = true;
               }
             }


### PR DESCRIPTION
Root cause: `install_bundled_plugin_runtime_deps()` in service.rs tries to
run `npm install` in the app's installed directory at runtime, but on Windows
(C:\Program Files\) and macOS (signed app bundle) those directories are
read-only — so the install silently fails and plugins like Telegram fail with
"Cannot find module 'grammy'".

Fix:
- Add `scripts/install-bundled-plugin-deps.cjs` which runs `npm install` for
  every plugin with `openclaw.bundle.stageRuntimeDependencies: true` during
  the CI build, so the node_modules are bundled into the installer package.
  `diffs` is excluded (playwright-core is large and needs a separate browser
  download anyway).
- Wire the new script into all three workflow files (build-windows.yml,
  build-macos.yml, release.yml) immediately after `npm ci` for clawdbot deps
  and before the Tauri build step.
- Remove `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback` from
  existing user configs in both config-patcher code paths in service.rs.
  This flag was an earlier break-glass workaround; now that allowedOrigins
  is properly managed, the insecure fallback should be cleaned up.

The runtime fallback in service.rs is kept as a best-effort safety net but
is no longer the primary mechanism.

https://claude.ai/code/session_01Hppg62Wn99CHFXdpJpZBBn