### PR TITLE
claude/fix-macos-compatibility-PqNq4

### DIFF
--- a/src/src-tauri/src/audio/audio.rs
+++ b/src/src-tauri/src/audio/audio.rs
@@ -370,9 +370,11 @@ pub async fn start_recording(
     }
   });
 
-  // Start system audio recording via Core Audio Taps.
-  // Both mic and system audio permissions are checked upfront before reaching here.
-  {
+  // Start system audio recording via Core Audio Taps — only if the user has
+  // granted System Audio Recording permission. On macOS 15 (Sequoia) many users
+  // have microphone but not system audio permission; we record mic-only in that
+  // case rather than blocking recording entirely.
+  if crate::audio::permission::has_system_audio_permission() {
     let output_file_semaphore = Arc::clone(&recording_state.output_file_semaphore);
     let output_thread = handle.spawn_blocking(move || {
       if let Err(e) = tokio::runtime::Runtime::new()
@@ -396,6 +398,8 @@ pub async fn start_recording(
       let mut output_thread_guard = recording_state.output_thread.lock().unwrap();
       *output_thread_guard = Some(output_thread);
     }
+  } else {
+    log::info!("[recording] Recording mic only — system audio permission not granted");
   }
 
   {

--- a/src/src-tauri/src/audio/permission.rs
+++ b/src/src-tauri/src/audio/permission.rs
@@ -274,7 +274,8 @@ pub async fn check_audio_permissions() -> Result<serde_json::Value, String> {
                 json!({
                     "microphone": mic_granted,
                     "screen_recording": system_audio_granted,
-                    "all_granted": mic_granted && system_audio_granted
+                    "system_audio": system_audio_granted,
+                    "all_granted": mic_granted
                 })
             }),
         )
@@ -332,6 +333,18 @@ return status as integer"#,
             false
         }
     }
+}
+
+/// Public helper for other modules (e.g. audio.rs) to gate the speaker-output
+/// thread on system audio permission without re-doing the full TCC check.
+#[cfg(target_os = "macos")]
+pub fn has_system_audio_permission() -> bool {
+    check_system_audio_permission_macos()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn has_system_audio_permission() -> bool {
+    true // Windows/Linux handle audio capture without this permission
 }
 
 /// Check if the app has "System Audio Recording Only" permission

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1196,9 +1196,9 @@ fn generate_plist(program_args: &[String], env: &[(String, String)]) -> String {
   }
 
   format!(
-    r#"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
   <key>Label</key>
   <string>{label}</string>

--- a/src/src/components/molecules/AudioPermissionChecker/index.tsx
+++ b/src/src/components/molecules/AudioPermissionChecker/index.tsx
@@ -53,8 +53,8 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
     }
   }, []);
 
-  // When both permissions are granted, transition to the chat notice step
-  // instead of immediately dismissing
+  // When microphone permission is granted, transition to the chat notice step
+  // (system audio is optional — mic-only recording is supported).
   const handleAudioPermissionsReady = useCallback(() => {
     // If the user has already configured the meeting chat notice before
     // (permissionsDismissed was set in a previous session), skip straight
@@ -113,7 +113,7 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
         localStorage.removeItem('micPermissionGranted');
       }
 
-      if (permissions.all_granted) {
+      if (permissions.microphone) {
         handleAudioPermissionsReady();
       }
     } finally {
@@ -163,7 +163,7 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
         localStorage.removeItem('screenPermissionGranted');
       }
 
-      if (permissions.all_granted) {
+      if (permissions.microphone) {
         handleAudioPermissionsReady();
       }
     } finally {
@@ -197,7 +197,7 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
       if (permissions.screen_recording) {
         localStorage.setItem('screenPermissionGranted', 'true');
       }
-      if (permissions.all_granted) {
+      if (permissions.microphone) {
         handleAudioPermissionsReady();
       }
     } finally {
@@ -224,7 +224,8 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
           localStorage.removeItem('screenPermissionGranted');
         }
 
-        if (permissions.all_granted) {
+        // Only microphone is required to proceed; system audio is optional.
+        if (permissions.microphone) {
           handleAudioPermissionsReady();
         }
       } catch (error) {
@@ -240,17 +241,17 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
     initialCheck();
   }, [handleAudioPermissionsReady, checkRealPermissions]);
 
-  // Both permissions required — transition to chat notice step when both are true
+  // Microphone is the only required permission — proceed as soon as it's granted.
   useEffect(() => {
-    if (micPermission && systemAudioPermission) {
+    if (micPermission) {
       handleAudioPermissionsReady();
     }
-  }, [micPermission, systemAudioPermission, handleAudioPermissionsReady]);
+  }, [micPermission, handleAudioPermissionsReady]);
 
   // Poll for permission changes while the component is visible
   // (user may grant permissions in System Settings without coming back to the app)
   useEffect(() => {
-    if (micPermission && systemAudioPermission) return;
+    if (micPermission) return;
 
     const interval = setInterval(async () => {
       const permissions = await checkRealPermissions();
@@ -262,7 +263,7 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
         setSystemAudioPermission(true);
         localStorage.setItem('screenPermissionGranted', 'true');
       }
-      if (permissions.all_granted) {
+      if (permissions.microphone) {
         handleAudioPermissionsReady();
       }
     }, 3000);
@@ -420,13 +421,13 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
         <div className="text-center">
           <div className="mb-8">
             <h1 className="text-4xl text-ks-warm-grey-950 !font-Lora">
-              <span className="font-bold">Audio</span> access<br/>
+              <span className="font-bold">Microphone</span> access<br/>
               is required<br/>
               to create meeting notes
             </h1>
           </div>
           <div className="flex flex-col gap-5 w-full max-w-[400px] mx-auto">
-            {/* Microphone permission */}
+            {/* Microphone permission — required */}
             {micPermission ? (
               <button
                 className="flex items-center justify-center gap-3 w-full py-4 px-8 bg-ks-warm-grey-50 rounded-full text-ks-warm-grey-950 font-normal border-[1px] border-solid border-ks-warm-grey-950"
@@ -449,7 +450,7 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
               </button>
             )}
 
-            {/* System audio permission */}
+            {/* System audio permission — optional, improves speaker capture */}
             {systemAudioPermission ? (
               <button
                 className="flex items-center justify-center gap-3 w-full py-4 px-8 bg-ks-warm-grey-50 rounded-full text-ks-warm-grey-950 font-normal border-[1px] border-solid border-ks-warm-grey-950"
@@ -466,17 +467,17 @@ const AudioPermissionChecker: React.FC<AudioPermissionCheckerProps> = ({
               <button
                 className={`w-full py-4 px-8 rounded-full font-normal transition-colors ${
                   micPermission
-                    ? 'bg-ks-red-800 hover:bg-ks-red-900 text-white'
-                    : 'bg-ks-warm-grey-200 text-ks-warm-grey-500 cursor-not-allowed'
+                    ? 'bg-ks-warm-grey-100 hover:bg-ks-warm-grey-200 text-ks-warm-grey-700 border border-ks-warm-grey-300'
+                    : 'bg-ks-warm-grey-100 text-ks-warm-grey-400 cursor-not-allowed'
                 }`}
                 onClick={requestSystemAudioAccess}
                 disabled={isCheckingSystemAudio || !micPermission}
               >
-                {isCheckingSystemAudio ? 'Checking...' : 'Enable system audio access'}
+                {isCheckingSystemAudio ? 'Checking...' : 'Enable system audio (optional — captures speaker)'}
               </button>
             )}
           </div>
-          {(!micPermission || !systemAudioPermission) && (
+          {!micPermission && (
             <div className="mt-6 max-w-[400px] mx-auto text-center">
               {systemAudioAttempts >= 2 && !systemAudioPermission ? (
                 <>

--- a/src/src/components/organisms/MeetingNotesMode/RecordingContext.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/RecordingContext.tsx
@@ -139,20 +139,17 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
           throw new Error(message)
         }
 
-        if (!permissions.all_granted) {
-          const missing = []
-          if (!permissions.microphone) missing.push('Microphone')
-          if (!permissions.screen_recording) missing.push('System Audio Recording')
-          const message = `Recording requires ${missing.join(' and ')} permission. Please grant access in System Settings > Privacy & Security, then try again.`
+        // Only microphone is required. System audio is optional — without it the
+        // app records mic only (still useful for meeting notes in most setups).
+        if (!permissions.microphone) {
+          const message = 'Recording requires Microphone permission. Please grant access in System Settings > Privacy & Security, then try again.'
 
           // Clear stale localStorage so AudioPermissionChecker re-shows
           localStorage.removeItem('micPermissionGranted')
-          localStorage.removeItem('screenPermissionGranted')
-          // Also clear the dismissal flag so the permission dialog re-appears
           localStorage.removeItem('permissionsDismissed')
 
           logError(
-            new Error('Missing recording permissions'),
+            new Error('Missing microphone permission'),
             {
               additionalInfo: message,
               error: `microphone=${permissions.microphone} system_audio=${permissions.screen_recording}`,


### PR DESCRIPTION
- Fix generate_plist XML bug: raw string literal had literal backslash-quote
  sequences (\"1.0\") in XML declaration and plist version attribute, producing
  invalid XML that could prevent launchd from loading the gateway LaunchAgent.
  Changed to proper unescaped quotes in the XML header.

- Audio-only permissions (macOS Sequoia): system audio recording is now
  optional. Users can record mic-only when they have microphone permission but
  not System Audio Recording permission. Backend checks has_system_audio_permission()
  before spawning the speaker output thread; frontend blocks on mic only.

- AudioPermissionChecker: microphone is the only required permission to proceed;
  system audio button now shown as optional with descriptive label.

- RecordingContext: only block recording if microphone is missing; system audio
  absence no longer throws an error or clears permissionsDismissed.

https://claude.ai/code/session_01WL2XYehfQb8tAGS657eV9b