### PR TITLE
Fix gateway startup failures, origin auth, missing scopes, and plugin deps

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -11,6 +11,11 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+# Allow the committed chalk shim (gateway externalizes chalk at runtime; this
+# passthrough shim prevents ERR_MODULE_NOT_FOUND without requiring npm install).
+!src-tauri/resources/clawdbot/node_modules/
+!src-tauri/resources/clawdbot/node_modules/chalk/
+!src-tauri/resources/clawdbot/node_modules/chalk/**
 # Unused extensions — desktop only ships discord, slack, telegram, signal, whatsapp, imessage, irc, googlechat
 src-tauri/resources/clawdbot/extensions/bluebubbles/
 src-tauri/resources/clawdbot/extensions/copilot-proxy/

--- a/src/src-tauri/resources/clawdbot/node_modules/chalk/index.js
+++ b/src/src-tauri/resources/clawdbot/node_modules/chalk/index.js
@@ -1,0 +1,52 @@
+/**
+ * Minimal chalk shim — no ANSI codes, returns strings unchanged.
+ *
+ * The gateway dist bundles externalize `chalk` and resolve it at runtime from
+ * node_modules.  In production (gateway logs go to a file) we don't need
+ * terminal colours, so this passthrough shim prevents ERR_MODULE_NOT_FOUND
+ * while keeping the bundle small.
+ *
+ * Supports the full chalk 5.x surface:
+ *   chalk.bold('text')          → 'text'
+ *   chalk.bold.dim('text')      → 'text'
+ *   chalk`template ${expr}`     → template + expr
+ *   new Chalk()                 → passthrough chalk instance
+ */
+function makeChalk() {
+  const fn = (...args) => {
+    if (args.length === 0) return '';
+    // Tagged template literal: chalk`foo ${bar}` passes ([['foo ', ''], bar])
+    if (Array.isArray(args[0]) && Object.prototype.hasOwnProperty.call(args[0], 'raw')) {
+      const strings = args[0];
+      let result = '';
+      for (let i = 0; i < strings.length; i++) {
+        result += strings[i];
+        if (i < args.length - 1) result += String(args[i + 1] ?? '');
+      }
+      return result;
+    }
+    return String(args[0] ?? '');
+  };
+  return new Proxy(fn, {
+    get(_, prop) {
+      if (prop === 'constructor') return Chalk;
+      if (prop === Symbol.toPrimitive) return () => '';
+      if (prop === Symbol.iterator) return undefined;
+      // Any style getter returns another passthrough chalk instance
+      return makeChalk();
+    },
+    apply(_, __, args) {
+      return fn(...args);
+    },
+  });
+}
+
+export class Chalk {
+  constructor() {
+    return makeChalk();
+  }
+}
+
+const chalk = makeChalk();
+export { chalk };
+export default chalk;

--- a/src/src-tauri/resources/clawdbot/node_modules/chalk/package.json
+++ b/src/src-tauri/resources/clawdbot/node_modules/chalk/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chalk",
+  "version": "5.4.1",
+  "description": "Terminal string styling (passthrough shim for Knapsack bundled gateway)",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -783,7 +783,7 @@ async fn apply_runtime_browser_config(token: &str) {
     },
     auth: Some(AuthInfo { token: token.to_string() }),
     role: "operator",
-    scopes: vec!["operator.admin"],
+    scopes: vec!["operator.admin", "operator.read"],
   };
 
   let connect_frame = RequestFrame {
@@ -1049,7 +1049,7 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
       token: token.to_string(),
     }),
     role: "operator",
-    scopes: vec!["operator.admin"],
+    scopes: vec!["operator.admin", "operator.read"],
   };
 
   let connect_frame = RequestFrame {


### PR DESCRIPTION
## Summary

- **Fix `ERR_MODULE_NOT_FOUND: chalk`** — Gateway dist externalizes `chalk` at runtime but it was never present in production builds. Committed a minimal passthrough ESM shim at `node_modules/chalk/` (with `.gitignore` exceptions) so it's always bundled with the Tauri app.
- **Fix `CONTROL_UI_ORIGIN_NOT_ALLOWED`** — Added `tauri://localhost` and `http://localhost:1420` to `gateway.controlUi.allowedOrigins` in all config-writing locations (both default templates, startup auto-patch, and `ensure_browser_config_at` on-connect patcher).
- **Fix `missing scope: operator.read`** — Both WS `connect_params` locations in `gateway_client.rs` only requested `operator.admin`. Gateway routes like `telegram_status` require `operator.read` — added it to both the main connection and the temp WS used by `apply_runtime_browser_config`.
- **Fix `Cannot find module 'grammy'`** — `ensure-clawdbot-deps.cjs` runs as `beforeDevCommand` before Tauri copies resources, so grammy was never installed at the runtime location. New `install_bundled_plugin_runtime_deps()` Rust function runs post-copy in both Windows and macOS gateway startup paths.
- **Fix gateway operator scope** — Gateway was clearing scopes for token-auth clients without device identity. Changed the Rust client to identify as `openclaw-control-ui` and added `allowInsecureAuth: true` to config so loopback token-auth connections preserve operator scopes.
- **Fix WS close diagnostics** — Close frame code and reason are now logged instead of the opaque "Connection closed during connect" message.
- **Fix Windows browser CDP timeouts** — Extended health check and startup-ready timeouts, added more retries for `browser_request` to handle slower Windows Chrome startup.
- **Fix Windows gateway restart** — Store `ServiceSetup` after successful spawn so background health-check restarts can re-spawn the gateway; clean stale lock files before re-spawning.
- **Fix `run_claude_code` on Windows** — Use double-quoted prompt strings on Windows (cmd doesn't handle single quotes); augment PATH with common npm global bin dirs.

## Test plan

- [ ] macOS: gateway starts without `ERR_MODULE_NOT_FOUND: chalk` crash
- [ ] Tauri frontend WebSocket connects without `CONTROL_UI_ORIGIN_NOT_ALLOWED`
- [ ] `telegram_status` calls succeed (no `missing scope: operator.read` errors)
- [ ] Telegram plugin loads grammy at runtime
- [ ] Windows: browser CDP connects within the extended timeout window
- [ ] Windows: gateway restarts after crash without manual intervention

https://claude.ai/code/session_01BkLJtFuoaUk3heF5GcRAfG