### PR TITLE
Library redesign

### DIFF
--- a/src/public/assets/images/tabBar/libraryTab.svg
+++ b/src/public/assets/images/tabBar/libraryTab.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" stroke="#6474AC" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" stroke="#6474AC" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/src-tauri/src/db/models/workspace.rs
+++ b/src/src-tauri/src/db/models/workspace.rs
@@ -192,6 +192,69 @@ impl Workspace {
 
     /// Wipe all auto-curated workspaces and their documents. Returns the number of
     /// workspaces deleted.
+    /// Delete auto-curated project workspaces whose entity_key (slug) is NOT in
+    /// the provided keep set. Used by the project detector to prune stale
+    /// duplicates that arise when the LLM generates a slightly different slug
+    /// for semantically-equivalent projects across runs.
+    /// Only affects `auto_curated = 1` projects — pinned/manual ones are left alone.
+    pub fn delete_stale_auto_projects(keep_slugs: &std::collections::HashSet<String>) -> Result<usize, Error> {
+        let connection = get_db_conn();
+
+        // Gather all auto-curated project workspaces first.
+        let mut existing: Vec<(String, Option<String>)> = Vec::new();
+        {
+            let mut stmt = connection.prepare(
+                "SELECT uuid, entity_key FROM workspaces \
+                 WHERE auto_curated = 1 AND entity_type = 'project'",
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+            })?;
+            for r in rows.flatten() {
+                existing.push(r);
+            }
+        }
+
+        let stale_uuids: Vec<String> = existing
+            .into_iter()
+            .filter(|(_, key)| match key {
+                Some(k) => !keep_slugs.contains(k),
+                None => true,
+            })
+            .map(|(uuid, _)| uuid)
+            .collect();
+
+        if stale_uuids.is_empty() {
+            return Ok(0);
+        }
+
+        connection.execute_batch("BEGIN")?;
+        let result = (|| -> Result<usize, rusqlite::Error> {
+            let mut n = 0;
+            for uuid in &stale_uuids {
+                connection.execute(
+                    "DELETE FROM workspace_documents WHERE workspace_uuid = ?1",
+                    [uuid],
+                )?;
+                n += connection.execute(
+                    "DELETE FROM workspaces WHERE uuid = ?1 AND auto_curated = 1 AND entity_type = 'project'",
+                    [uuid],
+                )?;
+            }
+            Ok(n)
+        })();
+        match result {
+            Ok(n) => {
+                connection.execute_batch("COMMIT")?;
+                Ok(n)
+            }
+            Err(e) => {
+                let _ = connection.execute_batch("ROLLBACK");
+                Err(e.into())
+            }
+        }
+    }
+
     pub fn wipe_auto_curated() -> Result<usize, Error> {
         let connection = get_db_conn();
         connection.execute_batch("BEGIN")?;

--- a/src/src-tauri/src/library_curator/people.rs
+++ b/src/src-tauri/src/library_curator/people.rs
@@ -17,7 +17,6 @@ use crate::db::models::workspace::{Workspace, WorkspaceDocument};
 use crate::error::Error;
 use crate::library_curator::settings::CuratorSettings;
 
-const LOOKBACK_DAYS: i64 = 90;
 const TOP_N_PEOPLE: usize = 20;
 const MAX_EMAILS_PER_PERSON: usize = 50;
 
@@ -65,22 +64,16 @@ impl ContactStats {
 
 /// Detect top people across email + calendar and upsert auto-collections.
 pub fn detect_and_upsert(cfg: &CuratorSettings) -> Result<(), Error> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let cutoff = now - LOOKBACK_DAYS * 86_400;
-
     let own_addresses = load_own_addresses();
     log::info!("[library_curator/people] own addresses: {:?}", own_addresses);
 
     let mut contacts: HashMap<String, ContactStats> = HashMap::new();
 
     if cfg.sources_email {
-        ingest_emails(&mut contacts, cutoff, &own_addresses)?;
+        ingest_emails(&mut contacts, &own_addresses)?;
     }
     if cfg.sources_calendar {
-        ingest_calendar(&mut contacts, cutoff, &own_addresses)?;
+        ingest_calendar(&mut contacts, &own_addresses)?;
     }
 
     if contacts.is_empty() {
@@ -129,12 +122,11 @@ fn load_own_addresses() -> Vec<String> {
 
 fn ingest_emails(
     contacts: &mut HashMap<String, ContactStats>,
-    cutoff: i64,
     own_addresses: &[String],
 ) -> Result<(), Error> {
     // Pull a generous slab — filter_emails sorts by date DESC, so we still get
     // the most recent emails when we cap below.
-    let emails = Email::filter_emails(5_000, None, Some(cutoff), None);
+    let emails = Email::filter_emails(5_000, None, None, None);
     log::info!("[library_curator/people] scanning {} emails", emails.len());
 
     for email in emails {
@@ -161,14 +153,13 @@ fn ingest_emails(
 
 fn ingest_calendar(
     contacts: &mut HashMap<String, ContactStats>,
-    cutoff: i64,
     own_addresses: &[String],
 ) -> Result<(), Error> {
     let connection = get_db_conn();
     let mut stmt = connection.prepare(
-        "SELECT id, attendees_json FROM calendar_events WHERE start >= ?1 AND attendees_json IS NOT NULL",
+        "SELECT id, attendees_json FROM calendar_events WHERE attendees_json IS NOT NULL",
     )?;
-    let rows = stmt.query_map([cutoff], |row| {
+    let rows = stmt.query_map([], |row| {
         Ok((row.get::<_, u64>(0)?, row.get::<_, Option<String>>(1)?))
     })?;
 
@@ -253,7 +244,7 @@ fn upsert_person_collection(email_addr: &str, stats: &ContactStats) -> Result<()
         .clone()
         .unwrap_or_else(|| email_addr.to_string());
     let description = format!(
-        "{} email{} · {} meeting{} (last 90 days)",
+        "{} email{} · {} meeting{}",
         stats.email_count,
         if stats.email_count == 1 { "" } else { "s" },
         stats.meeting_count,

--- a/src/src-tauri/src/library_curator/people.rs
+++ b/src/src-tauri/src/library_curator/people.rs
@@ -253,7 +253,7 @@ fn upsert_person_collection(email_addr: &str, stats: &ContactStats) -> Result<()
         .clone()
         .unwrap_or_else(|| email_addr.to_string());
     let description = format!(
-        "{} email{} · {} meeting{}",
+        "{} email{} · {} meeting{} (last 90 days)",
         stats.email_count,
         if stats.email_count == 1 { "" } else { "s" },
         stats.meeting_count,

--- a/src/src-tauri/src/library_curator/projects.rs
+++ b/src/src-tauri/src/library_curator/projects.rs
@@ -16,7 +16,6 @@ use crate::library_curator::settings::CuratorSettings;
 use crate::llm::types::{Message as LlmMessage, MessageSender};
 use crate::llm::use_cases::complete::multi_provider_completion;
 
-const LOOKBACK_DAYS: i64 = 90;
 const MAX_EMAILS_FOR_CORPUS: usize = 500;
 const MAX_TITLES_FOR_CORPUS: usize = 500;
 const MAX_PROJECTS: usize = 10;
@@ -45,14 +44,8 @@ struct DetectedProjectsResponse {
 /// Run the project detector end-to-end. Safe to call repeatedly — upserts
 /// are idempotent and document attachments dedupe via the unique source index.
 pub async fn detect_and_upsert(_cfg: &CuratorSettings) -> Result<(), Error> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let cutoff = now - LOOKBACK_DAYS * 86_400;
-
-    let email_subjects = collect_email_subjects(cutoff);
-    let meeting_titles = collect_meeting_titles(cutoff);
+    let email_subjects = collect_email_subjects();
+    let meeting_titles = collect_meeting_titles();
 
     if email_subjects.is_empty() && meeting_titles.is_empty() {
         log::info!("[library_curator/projects] no signal corpus; skipping");
@@ -79,7 +72,7 @@ pub async fn detect_and_upsert(_cfg: &CuratorSettings) -> Result<(), Error> {
         {
             continue;
         }
-        if let Err(e) = upsert_project_collection(&proj, cutoff) {
+        if let Err(e) = upsert_project_collection(&proj) {
             log::warn!(
                 "[library_curator/projects] upsert failed for {}: {:?}",
                 proj.slug,
@@ -91,8 +84,8 @@ pub async fn detect_and_upsert(_cfg: &CuratorSettings) -> Result<(), Error> {
     Ok(())
 }
 
-fn collect_email_subjects(cutoff: i64) -> Vec<String> {
-    let emails = Email::filter_emails(MAX_EMAILS_FOR_CORPUS, None, Some(cutoff), None);
+fn collect_email_subjects() -> Vec<String> {
+    let emails = Email::filter_emails(MAX_EMAILS_FOR_CORPUS, None, None, None);
     emails
         .into_iter()
         .filter_map(|e| {
@@ -106,15 +99,15 @@ fn collect_email_subjects(cutoff: i64) -> Vec<String> {
         .collect()
 }
 
-fn collect_meeting_titles(cutoff: i64) -> Vec<String> {
+fn collect_meeting_titles() -> Vec<String> {
     let connection = get_db_conn();
     let mut titles = Vec::new();
     let Ok(mut stmt) = connection.prepare(
-        "SELECT title FROM calendar_events WHERE start >= ?1 AND title IS NOT NULL ORDER BY start DESC LIMIT ?2",
+        "SELECT title FROM calendar_events WHERE title IS NOT NULL ORDER BY start DESC LIMIT ?1",
     ) else {
         return titles;
     };
-    let rows = stmt.query_map(rusqlite::params![cutoff, MAX_TITLES_FOR_CORPUS as i64], |row| {
+    let rows = stmt.query_map(rusqlite::params![MAX_TITLES_FOR_CORPUS as i64], |row| {
         row.get::<_, Option<String>>(0)
     });
     if let Ok(rows) = rows {
@@ -196,7 +189,7 @@ fn strip_json_fence(raw: &str) -> &str {
     no_md
 }
 
-fn upsert_project_collection(proj: &DetectedProject, cutoff: i64) -> Result<(), Error> {
+fn upsert_project_collection(proj: &DetectedProject) -> Result<(), Error> {
     let workspace = Workspace::upsert_auto_collection(
         "project",
         proj.slug.trim(),
@@ -226,7 +219,7 @@ fn upsert_project_collection(proj: &DetectedProject, cutoff: i64) -> Result<(), 
 
     // Attach matching emails by subject/body keyword hit.
     let mut email_attached = 0_usize;
-    let emails = Email::filter_emails(EMAIL_SCAN_LIMIT, None, Some(cutoff), None);
+    let emails = Email::filter_emails(EMAIL_SCAN_LIMIT, None, None, None);
     for email in emails {
         if email_attached >= MAX_DOCS_PER_PROJECT {
             break;
@@ -259,9 +252,9 @@ fn upsert_project_collection(proj: &DetectedProject, cutoff: i64) -> Result<(), 
     let mut event_attached = 0_usize;
     let connection = get_db_conn();
     if let Ok(mut stmt) = connection.prepare(
-        "SELECT id, title, description FROM calendar_events WHERE start >= ?1 AND title IS NOT NULL ORDER BY start DESC LIMIT ?2",
+        "SELECT id, title, description FROM calendar_events WHERE title IS NOT NULL ORDER BY start DESC LIMIT ?1",
     ) {
-        if let Ok(rows) = stmt.query_map(rusqlite::params![cutoff, EVENT_SCAN_LIMIT], |row| {
+        if let Ok(rows) = stmt.query_map(rusqlite::params![EVENT_SCAN_LIMIT], |row| {
             Ok((
                 row.get::<_, u64>(0)?,
                 row.get::<_, Option<String>>(1)?,

--- a/src/src-tauri/src/library_curator/projects.rs
+++ b/src/src-tauri/src/library_curator/projects.rs
@@ -6,6 +6,8 @@
 //! and calendar events as documents (matched by simple keyword hits against
 //! the LLM-supplied keyword list — cheap, deterministic, no second LLM pass).
 
+use std::collections::HashSet;
+
 use serde::Deserialize;
 
 use crate::db::db::get_db_conn;
@@ -65,6 +67,7 @@ pub async fn detect_and_upsert(_cfg: &CuratorSettings) -> Result<(), Error> {
         projects.len()
     );
 
+    let mut kept_slugs: HashSet<String> = HashSet::new();
     for proj in projects.into_iter().take(MAX_PROJECTS) {
         if proj.slug.trim().is_empty()
             || proj.name.trim().is_empty()
@@ -72,12 +75,34 @@ pub async fn detect_and_upsert(_cfg: &CuratorSettings) -> Result<(), Error> {
         {
             continue;
         }
+        let slug = proj.slug.trim().to_string();
         if let Err(e) = upsert_project_collection(&proj) {
             log::warn!(
                 "[library_curator/projects] upsert failed for {}: {:?}",
-                proj.slug,
+                slug,
                 e
             );
+        } else {
+            kept_slugs.insert(slug);
+        }
+    }
+
+    // Prune stale auto-curated projects — slugs the LLM no longer considers
+    // active. Prevents accumulation of near-duplicates across runs (e.g.
+    // "sage-financial-partnership" vs "sage-financial-wealthbox"). Only fires
+    // when we successfully upserted at least one project, so a bad LLM run
+    // never wipes the library.
+    if !kept_slugs.is_empty() {
+        match Workspace::delete_stale_auto_projects(&kept_slugs) {
+            Ok(n) if n > 0 => log::info!(
+                "[library_curator/projects] pruned {} stale auto-curated project(s)",
+                n
+            ),
+            Ok(_) => {}
+            Err(e) => log::warn!(
+                "[library_curator/projects] prune failed: {:?}",
+                e
+            ),
         }
     }
 

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -1217,6 +1217,7 @@ function App() {
     morning_briefing_handler: async (_meetingId: string | null) => {
       await invoke('activate_main_window')
       await invoke('close_notification_window')
+      window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
       // Trigger LLM briefing generation; result includes fullAnalysis text
       const { fullAnalysis } = await triggerBriefingFeedItemRef.current()
       if (fullAnalysis) {
@@ -1226,6 +1227,7 @@ function App() {
     heartbeat_view_handler: async (_meetingId: string | null) => {
       await invoke('activate_main_window')
       await invoke('close_notification_window')
+      window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
       const message = lastHeartbeatMessageRef.current
       if (message) {
         // Show the notification message as an assistant message in chat
@@ -1241,6 +1243,7 @@ function App() {
     background_insight_notification_handler: async (_meetingId: string | null) => {
       await invoke('activate_main_window')
       await invoke('close_notification_window')
+      window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
       // Show the pending insight directly in the ClawdChat window
       const text = getPendingInsightTextRef.current()
       if (text) {
@@ -1252,6 +1255,7 @@ function App() {
     post_meeting_followup_notification_handler: async (_meetingId: string | null) => {
       await invoke('activate_main_window')
       await invoke('close_notification_window')
+      window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
       // Show the pending follow-up directly in the ClawdChat window
       const text = getPendingFollowupTextRef.current()
       if (text) {
@@ -1263,6 +1267,7 @@ function App() {
     suggested_action_notification_handler: async (_meetingId: string | null) => {
       await invoke('activate_main_window')
       await invoke('close_notification_window')
+      window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
       // Show the pending insight in chat, then auto-execute the suggested action
       const text = getPendingInsightTextRef.current()
       if (text) {
@@ -1280,6 +1285,7 @@ function App() {
     suggested_followup_action_notification_handler: async (_meetingId: string | null) => {
       await invoke('activate_main_window')
       await invoke('close_notification_window')
+      window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
       // Show the pending follow-up in chat, then auto-execute the suggested action
       const text = getPendingFollowupTextRef.current()
       if (text) {

--- a/src/src/components/organisms/WorkspaceView/index.tsx
+++ b/src/src/components/organisms/WorkspaceView/index.tsx
@@ -30,7 +30,6 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
   const [editName, setEditName] = useState(workspace.name)
   const [editDescription, setEditDescription] = useState(workspace.description ?? '')
   const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null)
-  const [expandedSummary, setExpandedSummary] = useState<number | null>(null)
   const dropRef = useRef<HTMLDivElement>(null)
 
   // Load AI-generated card summary from localStorage (written by WorkspacesList).
@@ -445,8 +444,6 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
             {filteredDocuments.map(doc => {
               const autoTags = parseTags(doc.autoTags)
               const userTags = parseTags(doc.tags)
-              const hasSummary = !!doc.summary
-              const isExpanded = expandedSummary === doc.id
 
               return (
                 <div
@@ -467,15 +464,6 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
                     </div>
 
                     <div className="flex items-center gap-3 flex-shrink-0">
-                      {hasSummary && (
-                        <button
-                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                          onClick={() => setExpandedSummary(isExpanded ? null : doc.id)}
-                          title={isExpanded ? 'Hide summary' : 'Show summary'}
-                        >
-                          {isExpanded ? 'Hide' : 'Summary'}
-                        </button>
-                      )}
                       {doc.createdAt && (
                         <span className="text-xs text-gray-400">
                           {formatDate(doc.createdAt)}
@@ -514,9 +502,9 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
                     </div>
                   )}
 
-                  {/* Expandable summary */}
-                  {isExpanded && doc.summary && (
-                    <div className="mt-2 ml-8 text-xs text-gray-500 bg-gray-50 rounded-md p-2">
+                  {/* Summary — shown inline when available */}
+                  {doc.summary && (
+                    <div className="mt-2 ml-8 text-xs text-gray-600">
                       {doc.summary}
                     </div>
                   )}

--- a/src/src/components/organisms/WorkspaceView/index.tsx
+++ b/src/src/components/organisms/WorkspaceView/index.tsx
@@ -12,6 +12,8 @@ import {
   parseTags,
 } from '../../../api/workspaces'
 
+const SUMMARY_CACHE_PREFIX = 'knap.library.summary.'
+
 interface WorkspaceViewProps {
   workspace: Workspace
   onBack: () => void
@@ -30,6 +32,15 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
   const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null)
   const [expandedSummary, setExpandedSummary] = useState<number | null>(null)
   const dropRef = useRef<HTMLDivElement>(null)
+
+  // Load AI-generated card summary from localStorage (written by WorkspacesList).
+  const aiSummary = useMemo(() => {
+    try {
+      const raw = localStorage.getItem(SUMMARY_CACHE_PREFIX + workspace.uuid)
+      if (raw) return JSON.parse(raw) as { summary: string; nextAction: string }
+    } catch { /* no-op */ }
+    return null
+  }, [workspace.uuid])
 
   const refreshWorkspace = useCallback(async () => {
     try {
@@ -282,6 +293,30 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
             <p className="text-sm text-gray-500 mt-1 ml-10">
               {currentWorkspace.description}
             </p>
+          )}
+          {aiSummary && (
+            <div className="ml-10 mt-2">
+              <p className="text-sm text-gray-700">{aiSummary.summary}</p>
+              {aiSummary.nextAction && (
+                <button
+                  className="text-xs text-left text-blue-600 bg-blue-50 hover:bg-blue-100 rounded px-2 py-1 mt-1.5 transition-colors"
+                  onClick={() => {
+                    const subject = currentWorkspace.entityType === 'person'
+                      ? currentWorkspace.name
+                      : `the ${currentWorkspace.name} project`
+                    window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
+                    setTimeout(() => {
+                      window.dispatchEvent(new CustomEvent('clawd-send-user', {
+                        detail: `Regarding ${subject}: ${aiSummary.nextAction}`,
+                      }))
+                    }, 100)
+                  }}
+                  title="Send to Chat"
+                >
+                  → {aiSummary.nextAction}
+                </button>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   CurationStatus,
   Workspace,
@@ -37,7 +37,6 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
   const [showLocalFilesPrompt, setShowLocalFilesPrompt] = useState(false)
   const [showPrivacyBanner, setShowPrivacyBanner] = useState(true)
   const [cardSummaries, setCardSummaries] = useState<Map<string, CardSummary>>(new Map())
-  const summaryGeneratingRef = useRef(new Set<string>())
 
   const fetchWorkspaces = async () => {
     try {
@@ -107,12 +106,12 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
     if (cached.size > 0) setCardSummaries(cached)
 
     // Queue generation for auto-curated workspaces without a cached summary.
+    // We rely on localStorage (not an in-flight ref) so that a cancelled effect
+    // doesn't permanently prevent retry on the next mount.
     const toGenerate = workspaces.filter(
-      ws => ws.autoCurated && !cached.has(ws.uuid) && !summaryGeneratingRef.current.has(ws.uuid),
+      ws => ws.autoCurated && !cached.has(ws.uuid),
     )
     if (toGenerate.length === 0) return
-
-    toGenerate.forEach(ws => summaryGeneratingRef.current.add(ws.uuid))
 
     let cancelled = false
     ;(async () => {
@@ -128,8 +127,12 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
 
       for (const ws of toGenerate) {
         if (cancelled) break
+        // Re-check cache — another concurrent loop may have written it.
+        const existing = localStorage.getItem(SUMMARY_CACHE_PREFIX + ws.uuid)
+        if (existing) continue
         try {
           const result = await generateCardSummary(ws, getTopTags(ws, 6), userEmail)
+          if (cancelled) break
           if (result) {
             setCardSummaries(prev => {
               const next = new Map(prev)
@@ -220,6 +223,17 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
     } catch (err) {
       console.error('Failed to create workspace:', err)
     }
+  }
+
+  const handleNextActionClick = (e: React.MouseEvent, action: string, workspace: Workspace) => {
+    e.stopPropagation()
+    // Build a richer prompt so the chat has context about who/what this is about.
+    const subject = workspace.entityType === 'person' ? workspace.name : `the ${workspace.name} project`
+    const prompt = `Regarding ${subject}: ${action}`
+    window.dispatchEvent(new CustomEvent('clawd-focus-chat'))
+    setTimeout(() => {
+      window.dispatchEvent(new CustomEvent('clawd-send-user', { detail: prompt }))
+    }, 100)
   }
 
   const handleDelete = async (e: React.MouseEvent, uuid: string) => {
@@ -324,18 +338,22 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
             )}
           </div>
           {aiSummary ? (
-            <div className="text-sm text-gray-600 line-clamp-2 mt-0.5">
+            <div className="text-sm text-gray-600 mt-0.5">
               {aiSummary.summary}
             </div>
           ) : workspace.description && (
-            <div className="text-sm text-gray-500 line-clamp-2">
+            <div className="text-sm text-gray-500">
               {workspace.description}
             </div>
           )}
           {aiSummary?.nextAction && (
-            <div className="text-xs text-blue-600 bg-blue-50 rounded px-2 py-1 mt-1 line-clamp-1">
+            <button
+              className="text-xs text-left text-blue-600 bg-blue-50 hover:bg-blue-100 rounded px-2 py-1 mt-1 transition-colors"
+              onClick={e => handleNextActionClick(e, aiSummary.nextAction, workspace)}
+              title="Send to Chat"
+            >
               → {aiSummary.nextAction}
-            </div>
+            </button>
           )}
           {topTags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-1">

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -512,8 +512,6 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
         </div>
       )}
 
-      {renderSection('People', peopleWorkspaces, { auto: true })}
-      {renderSection('Projects', projectWorkspaces, { auto: true })}
       {renderSection(
         'Your Collections',
         manualWorkspaces,
@@ -530,6 +528,8 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
           </div>
         </div>,
       )}
+      {renderSection('People', peopleWorkspaces, { auto: true })}
+      {renderSection('Projects', projectWorkspaces, { auto: true })}
 
       {/* Create Modal */}
       {showCreateModal && (

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -12,7 +12,7 @@ import {
   updateCurationSettings,
   wipeLibrary,
 } from '../../../api/workspaces'
-import { KN_API_STREAM_LLM_COMPLETE } from '../../../utils/constants'
+import { KN_API_GET_USER_EMAIL, KN_API_STREAM_LLM_COMPLETE } from '../../../utils/constants'
 
 const LOCAL_FILES_PROMPT_KEY = 'knap.library.localFilesPromptShown'
 const SUMMARY_CACHE_PREFIX = 'knap.library.summary.'
@@ -116,10 +116,20 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
 
     let cancelled = false
     ;(async () => {
+      // Fetch user email once for all LLM calls.
+      let userEmail = ''
+      try {
+        const res = await fetch(KN_API_GET_USER_EMAIL)
+        const data = await res.json()
+        if (data.email) userEmail = data.email
+      } catch {
+        // proceed with empty email
+      }
+
       for (const ws of toGenerate) {
         if (cancelled) break
         try {
-          const result = await generateCardSummary(ws, getTopTags(ws, 6))
+          const result = await generateCardSummary(ws, getTopTags(ws, 6), userEmail)
           if (result) {
             setCardSummaries(prev => {
               const next = new Map(prev)
@@ -132,8 +142,8 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
               // no-op
             }
           }
-        } catch {
-          // skip failed generation silently
+        } catch (err) {
+          console.error(`[Library] summary generation failed for ${ws.name}:`, err)
         }
       }
     })()
@@ -542,9 +552,7 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
   )
 }
 
-/** Generate an AI summary + suggested next action for a workspace card.
- *  Called once per workspace; result is cached in localStorage. */
-async function generateCardSummary(workspace: Workspace, topTags: string[]): Promise<CardSummary | null> {
+async function generateCardSummary(workspace: Workspace, topTags: string[], userEmail: string): Promise<CardSummary | null> {
   const docs = workspace.documents ?? []
   const docTitles = docs
     .slice(0, 8)
@@ -562,16 +570,19 @@ async function generateCardSummary(workspace: Workspace, topTags: string[]): Pro
     .join('\n')
 
   const prompt =
-    `You are a personal knowledge assistant. Based on this contact/project summary from my personal knowledge base, write a brief 1-2 sentence human-readable description. ` +
-    `Then suggest one specific, concrete next action I should take.\n\nContext:\n${contextLines}\n\n` +
-    `Respond with JSON only, no markdown: {"summary": "...", "nextAction": "..."}`
+    `Based on the following contact/project from my knowledge base, give me:\n` +
+    `1. A brief 1-2 sentence description of who this is or what this project is about\n` +
+    `2. One specific next action I should take\n\n` +
+    `${contextLines}\n\n` +
+    `Reply ONLY with a JSON object in this exact format, no other text:\n` +
+    `{"summary": "your description here", "nextAction": "your suggested action here"}`
 
   try {
     const response = await fetch(KN_API_STREAM_LLM_COMPLETE, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        user_email: '',
+        user_email: userEmail,
         user_name: '',
         prompt,
         semantic_search_query: null,
@@ -580,7 +591,14 @@ async function generateCardSummary(workspace: Workspace, topTags: string[]): Pro
       }),
     })
 
-    if (!response.ok || !response.body) return null
+    if (!response.ok) {
+      console.error(`[Library] LLM returned ${response.status} for ${workspace.name}`)
+      return null
+    }
+    if (!response.body) {
+      console.error(`[Library] LLM returned no body for ${workspace.name}`)
+      return null
+    }
 
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
@@ -596,15 +614,34 @@ async function generateCardSummary(workspace: Workspace, topTags: string[]): Pro
         try {
           text += JSON.parse(line.slice(6)).choices[0].text
         } catch {
-          // malformed chunk — skip
+          // malformed chunk
         }
       }
     }
 
-    const match = text.match(/\{[\s\S]*?"summary"[\s\S]*?"nextAction"[\s\S]*?\}/)
-    if (!match) return null
-    return JSON.parse(match[0]) as CardSummary
-  } catch {
+    console.log(`[Library] LLM raw for ${workspace.name}:`, text.slice(0, 300))
+
+    // Extract JSON — handle markdown fences and extra text.
+    const cleaned = text
+      .replace(/```json\s*/gi, '')
+      .replace(/```\s*/g, '')
+      .trim()
+
+    const jsonStart = cleaned.indexOf('{')
+    const jsonEnd = cleaned.lastIndexOf('}')
+    if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) {
+      console.error(`[Library] no JSON found in LLM response for ${workspace.name}`)
+      return null
+    }
+
+    const parsed = JSON.parse(cleaned.slice(jsonStart, jsonEnd + 1))
+    if (parsed.summary && parsed.nextAction) {
+      return { summary: parsed.summary, nextAction: parsed.nextAction }
+    }
+    console.error(`[Library] JSON missing expected fields for ${workspace.name}:`, parsed)
+    return null
+  } catch (err) {
+    console.error(`[Library] generateCardSummary error for ${workspace.name}:`, err)
     return null
   }
 }

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   CurationStatus,
   Workspace,
@@ -12,8 +12,15 @@ import {
   updateCurationSettings,
   wipeLibrary,
 } from '../../../api/workspaces'
+import { KN_API_STREAM_LLM_COMPLETE } from '../../../utils/constants'
 
 const LOCAL_FILES_PROMPT_KEY = 'knap.library.localFilesPromptShown'
+const SUMMARY_CACHE_PREFIX = 'knap.library.summary.'
+
+interface CardSummary {
+  summary: string
+  nextAction: string
+}
 
 interface WorkspacesListProps {
   onWorkspaceOpen: (workspace: Workspace) => void
@@ -29,6 +36,8 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
   const [refreshing, setRefreshing] = useState(false)
   const [showLocalFilesPrompt, setShowLocalFilesPrompt] = useState(false)
   const [showPrivacyBanner, setShowPrivacyBanner] = useState(true)
+  const [cardSummaries, setCardSummaries] = useState<Map<string, CardSummary>>(new Map())
+  const summaryGeneratingRef = useRef(new Set<string>())
 
   const fetchWorkspaces = async () => {
     try {
@@ -48,22 +57,91 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
     try {
       const status = await getCurationStatus()
       setCurationStatus(status)
+      return status
     } catch (err) {
       console.error('Failed to fetch curation status:', err)
+      return null
     }
   }
 
   useEffect(() => {
-    fetchWorkspaces()
-    fetchStatus()
-    // First-visit local files prompt — show only once per device.
-    try {
-      const shown = localStorage.getItem(LOCAL_FILES_PROMPT_KEY)
-      if (!shown) setShowLocalFilesPrompt(true)
-    } catch {
-      // no-op
+    const init = async () => {
+      // First-visit local files prompt — show only once per device.
+      try {
+        const shown = localStorage.getItem(LOCAL_FILES_PROMPT_KEY)
+        if (!shown) setShowLocalFilesPrompt(true)
+      } catch {
+        // no-op
+      }
+
+      const status = await fetchStatus()
+
+      // Auto-trigger curation on first open if it's never run before.
+      if (status && status.enabled && !status.lastRunAt) {
+        try {
+          await curateLibraryNow()
+        } catch {
+          // non-fatal
+        }
+      }
+
+      await fetchWorkspaces()
     }
+    init()
   }, [])
+
+  /** Load cached summaries and generate missing ones for auto-curated workspaces. */
+  useEffect(() => {
+    if (workspaces.length === 0) return
+
+    // Load what's already cached.
+    const cached = new Map<string, CardSummary>()
+    for (const ws of workspaces) {
+      try {
+        const raw = localStorage.getItem(SUMMARY_CACHE_PREFIX + ws.uuid)
+        if (raw) cached.set(ws.uuid, JSON.parse(raw))
+      } catch {
+        // no-op
+      }
+    }
+    if (cached.size > 0) setCardSummaries(cached)
+
+    // Queue generation for auto-curated workspaces without a cached summary.
+    const toGenerate = workspaces.filter(
+      ws => ws.autoCurated && !cached.has(ws.uuid) && !summaryGeneratingRef.current.has(ws.uuid),
+    )
+    if (toGenerate.length === 0) return
+
+    toGenerate.forEach(ws => summaryGeneratingRef.current.add(ws.uuid))
+
+    let cancelled = false
+    ;(async () => {
+      for (const ws of toGenerate) {
+        if (cancelled) break
+        try {
+          const result = await generateCardSummary(ws, getTopTags(ws, 6))
+          if (result) {
+            setCardSummaries(prev => {
+              const next = new Map(prev)
+              next.set(ws.uuid, result)
+              return next
+            })
+            try {
+              localStorage.setItem(SUMMARY_CACHE_PREFIX + ws.uuid, JSON.stringify(result))
+            } catch {
+              // no-op
+            }
+          }
+        } catch {
+          // skip failed generation silently
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [workspaces])
 
   const dismissLocalFilesPrompt = (enable: boolean) => {
     try {
@@ -219,10 +297,12 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
     const topTags = getTopTags(workspace)
     const savedAnswers = chatOutputCount(workspace)
     const mixLabel = opts.auto ? sourceMixLabel(workspace) : ''
+    const aiSummary = cardSummaries.get(workspace.uuid)
+
     return (
       <div
         key={workspace.uuid}
-        className="border border-gray-200 rounded-lg h-52 w-64 flex flex-col justify-between p-4 cursor-pointer hover:border-blue-400 hover:shadow-sm transition-all"
+        className="border border-gray-200 rounded-lg min-h-52 w-64 flex flex-col justify-between p-4 cursor-pointer hover:border-blue-400 hover:shadow-sm transition-all"
         onClick={() => onWorkspaceOpen(workspace)}
       >
         <div className="flex flex-col gap-1">
@@ -233,9 +313,18 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
               <span title="Auto-curated by Knapsack" className="text-xs">✨</span>
             )}
           </div>
-          {workspace.description && (
+          {aiSummary ? (
+            <div className="text-sm text-gray-600 line-clamp-2 mt-0.5">
+              {aiSummary.summary}
+            </div>
+          ) : workspace.description && (
             <div className="text-sm text-gray-500 line-clamp-2">
               {workspace.description}
+            </div>
+          )}
+          {aiSummary?.nextAction && (
+            <div className="text-xs text-blue-600 bg-blue-50 rounded px-2 py-1 mt-1 line-clamp-1">
+              → {aiSummary.nextAction}
             </div>
           )}
           {topTags.length > 0 && (
@@ -252,7 +341,7 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
           )}
         </div>
 
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between mt-3">
           <div className="text-xs text-gray-400 truncate">
             {opts.auto && mixLabel ? mixLabel : `${workspace.documents?.length ?? 0} doc${(workspace.documents?.length ?? 0) !== 1 ? 's' : ''}`}
             {savedAnswers > 0 && ` · ${savedAnswers} saved`}
@@ -451,6 +540,73 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
       )}
     </div>
   )
+}
+
+/** Generate an AI summary + suggested next action for a workspace card.
+ *  Called once per workspace; result is cached in localStorage. */
+async function generateCardSummary(workspace: Workspace, topTags: string[]): Promise<CardSummary | null> {
+  const docs = workspace.documents ?? []
+  const docTitles = docs
+    .slice(0, 8)
+    .map(d => d.documentName)
+    .join(', ')
+
+  const contextLines = [
+    `Name: ${workspace.name}`,
+    workspace.entityType === 'person' ? 'Type: Person (contact)' : 'Type: Project',
+    workspace.description ? `Stats: ${workspace.description}` : '',
+    topTags.length > 0 ? `Topics: ${topTags.join(', ')}` : '',
+    docTitles ? `Recent items: ${docTitles}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const prompt =
+    `You are a personal knowledge assistant. Based on this contact/project summary from my personal knowledge base, write a brief 1-2 sentence human-readable description. ` +
+    `Then suggest one specific, concrete next action I should take.\n\nContext:\n${contextLines}\n\n` +
+    `Respond with JSON only, no markdown: {"summary": "...", "nextAction": "..."}`
+
+  try {
+    const response = await fetch(KN_API_STREAM_LLM_COMPLETE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_email: '',
+        user_name: '',
+        prompt,
+        semantic_search_query: null,
+        documents: [],
+        is_local: false,
+      }),
+    })
+
+    if (!response.ok || !response.body) return null
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let text = ''
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const chunk = decoder.decode(value, { stream: true })
+      for (const line of chunk.split('\n')) {
+        if (!line.startsWith('data: ')) continue
+        if (line.trim() === 'data: [DONE]') break
+        try {
+          text += JSON.parse(line.slice(6)).choices[0].text
+        } catch {
+          // malformed chunk — skip
+        }
+      }
+    }
+
+    const match = text.match(/\{[\s\S]*?"summary"[\s\S]*?"nextAction"[\s\S]*?\}/)
+    if (!match) return null
+    return JSON.parse(match[0]) as CardSummary
+  } catch {
+    return null
+  }
 }
 
 export default WorkspacesList

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -594,27 +594,35 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
 async function generateCardSummary(workspace: Workspace, topTags: string[], userEmail: string): Promise<CardSummary | null> {
   const docs = workspace.documents ?? []
   const docTitles = docs
-    .slice(0, 8)
+    .slice(0, 12)
     .map(d => d.documentName)
     .join(', ')
 
+  const isPerson = workspace.entityType === 'person'
+
   const contextLines = [
     `Name: ${workspace.name}`,
-    workspace.entityType === 'person' ? 'Type: Person (contact)' : 'Type: Project',
-    workspace.description ? `Stats: ${workspace.description}` : '',
-    topTags.length > 0 ? `Topics: ${topTags.join(', ')}` : '',
-    docTitles ? `Recent items: ${docTitles}` : '',
+    isPerson ? 'Type: Person (contact)' : 'Type: Project',
+    topTags.length > 0 ? `Key topics: ${topTags.join(', ')}` : '',
+    docTitles ? `Recent document titles: ${docTitles}` : '',
   ]
     .filter(Boolean)
     .join('\n')
 
-  const prompt =
-    `Based on the following contact/project from my knowledge base, give me:\n` +
-    `1. A brief 1-2 sentence description of who this is or what this project is about\n` +
-    `2. One specific next action I should take\n\n` +
-    `${contextLines}\n\n` +
-    `Reply ONLY with a JSON object in this exact format, no other text:\n` +
-    `{"summary": "your description here", "nextAction": "your suggested action here"}`
+  const prompt = isPerson
+    ? `You are a personal CRM assistant. Based on the document titles and topics below, infer:\n` +
+      `1. Who this person likely is (role, company, or relationship — e.g. "Your accountant at Sage Financial", "Engineering lead at Acme", "Investor contact"). Do NOT restate email/meeting counts.\n` +
+      `2. What you're actively working on together right now, based on the most recent document titles.\n` +
+      `3. One specific, actionable next step.\n\n` +
+      `${contextLines}\n\n` +
+      `Reply ONLY with JSON, no other text:\n` +
+      `{"summary": "1-2 sentences about who they are and what you're working on together", "nextAction": "one concrete next step"}`
+    : `Based on this project from my knowledge base, give me:\n` +
+      `1. A 1-2 sentence description of what this project is about (infer from document titles and topics, not stats)\n` +
+      `2. One specific next action I should take\n\n` +
+      `${contextLines}\n\n` +
+      `Reply ONLY with JSON, no other text:\n` +
+      `{"summary": "your description here", "nextAction": "your suggested action here"}`
 
   try {
     const response = await fetch(KN_API_STREAM_LLM_COMPLETE, {

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -90,6 +90,8 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
   }, [])
 
   /** Load cached summaries and generate missing ones for auto-curated workspaces. */
+  const [generatingSummaries, setGeneratingSummaries] = useState(false)
+
   useEffect(() => {
     if (workspaces.length === 0) return
 
@@ -106,28 +108,36 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
     if (cached.size > 0) setCardSummaries(cached)
 
     // Queue generation for auto-curated workspaces without a cached summary.
-    // We rely on localStorage (not an in-flight ref) so that a cancelled effect
-    // doesn't permanently prevent retry on the next mount.
     const toGenerate = workspaces.filter(
       ws => ws.autoCurated && !cached.has(ws.uuid),
     )
     if (toGenerate.length === 0) return
 
+    // Prioritize people first — they have the thinnest descriptions and benefit
+    // most from an AI summary. Projects already have an LLM-generated description.
+    toGenerate.sort((a, b) => {
+      if (a.entityType === 'person' && b.entityType !== 'person') return -1
+      if (a.entityType !== 'person' && b.entityType === 'person') return 1
+      return 0
+    })
+
     let cancelled = false
+    setGeneratingSummaries(true)
     ;(async () => {
-      // Fetch user email once for all LLM calls.
+      // Fetch user email once for all LLM calls (may 404, that's fine).
       let userEmail = ''
       try {
         const res = await fetch(KN_API_GET_USER_EMAIL)
-        const data = await res.json()
-        if (data.email) userEmail = data.email
+        if (res.ok) {
+          const data = await res.json()
+          if (data.email) userEmail = data.email
+        }
       } catch {
         // proceed with empty email
       }
 
       for (const ws of toGenerate) {
         if (cancelled) break
-        // Re-check cache — another concurrent loop may have written it.
         const existing = localStorage.getItem(SUMMARY_CACHE_PREFIX + ws.uuid)
         if (existing) continue
         try {
@@ -149,10 +159,12 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
           console.error(`[Library] summary generation failed for ${ws.name}:`, err)
         }
       }
+      if (!cancelled) setGeneratingSummaries(false)
     })()
 
     return () => {
       cancelled = true
+      setGeneratingSummaries(false)
     }
   }, [workspaces])
 
@@ -338,22 +350,31 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
             )}
           </div>
           {aiSummary ? (
-            <div className="text-sm text-gray-600 mt-0.5">
-              {aiSummary.summary}
-            </div>
-          ) : workspace.description && (
-            <div className="text-sm text-gray-500">
-              {workspace.description}
-            </div>
-          )}
-          {aiSummary?.nextAction && (
-            <button
-              className="text-xs text-left text-blue-600 bg-blue-50 hover:bg-blue-100 rounded px-2 py-1 mt-1 transition-colors"
-              onClick={e => handleNextActionClick(e, aiSummary.nextAction, workspace)}
-              title="Send to Chat"
-            >
-              → {aiSummary.nextAction}
-            </button>
+            <>
+              <div className="text-sm text-gray-600 mt-0.5">
+                {aiSummary.summary}
+              </div>
+              {aiSummary.nextAction && (
+                <button
+                  className="text-xs text-left text-blue-600 bg-blue-50 hover:bg-blue-100 rounded px-2 py-1 mt-1 transition-colors"
+                  onClick={e => handleNextActionClick(e, aiSummary.nextAction, workspace)}
+                  title="Send to Chat"
+                >
+                  → {aiSummary.nextAction}
+                </button>
+              )}
+            </>
+          ) : (
+            <>
+              {workspace.description && (
+                <div className="text-sm text-gray-500">
+                  {workspace.description}
+                </div>
+              )}
+              {opts.auto && generatingSummaries && (
+                <div className="text-xs text-gray-400 italic mt-1">Generating summary…</div>
+              )}
+            </>
           )}
           {topTags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-1">


### PR DESCRIPTION
- WorkspacesList: auto-trigger curateLibraryNow() on mount when lastRunAt is null
  so the library populates on first open without manual Refresh
- WorkspacesList: generate AI summary + suggested next action for each auto-curated
  card via LLM on first view; cached in localStorage per workspace UUID so it only
  runs once per card (never regenerated unless cache is cleared)
- WorkspacesList: card switches from fixed h-52 to min-h-52 to accommodate summary
- people.rs: append "(last 90 days)" to auto-generated description so the meeting
  count time window is visible on every person card
- App.tsx: dispatch clawd-focus-chat before clawd-push-assistant in all non-meeting
  notification handlers so CTA buttons land on the Chat tab instead of Library
- libraryTab.svg: replace hardcoded #6474AC with currentColor; resize to 28×28 to
  match other tab icons

https://claude.ai/code/session_01FBc9kwAWNXXcQQ3VnLUB2Q