### PR TITLE
claude/fix-recurring-bug-kQEX9

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5148,6 +5148,19 @@ pub async fn set_service_enabled(
         .args(["kickstart", "-k", &service])
         .status();
 
+      // Workaround for OpenClaw #23006: patch paired.json after the gateway
+      // starts to ensure devices get operator.admin scope.  The gateway may
+      // rewrite paired.json during auto-pairing, so we retry several times.
+      {
+        let ah: tauri::AppHandle = app_handle.get_ref().clone();
+        tokio::spawn(async move {
+          for delay_s in [2u64, 5, 10, 20, 40] {
+            tokio::time::sleep(std::time::Duration::from_secs(delay_s)).await;
+            patch_paired_json_scopes(&ah);
+          }
+        });
+      }
+
       // Best-effort: auto-configure browser control URL for Knapsack (in-memory)
       {
         let mut cfg_guard = cfg.write().await;
@@ -5472,6 +5485,17 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
         .args(["kickstart", "-k", &service])
         .status();
       eprintln!("[clawd/service] auto_enable: LaunchAgent registered and started");
+
+      // Workaround for OpenClaw #23006: patch paired.json after the gateway
+      // starts to ensure devices get operator.admin scope.  The gateway may
+      // rewrite paired.json during auto-pairing, so we retry several times.
+      let ah = app_handle.clone();
+      tokio::spawn(async move {
+        for delay_s in [2u64, 5, 10, 20, 40] {
+          tokio::time::sleep(std::time::Duration::from_secs(delay_s)).await;
+          patch_paired_json_scopes(&ah);
+        }
+      });
     }
     Ok(s) => eprintln!("[clawd/service] auto_enable: launchctl bootstrap exited {}", s),
     Err(e) => eprintln!("[clawd/service] auto_enable: launchctl bootstrap failed: {}", e),


### PR DESCRIPTION
The OpenClaw #23006 workaround (patch_paired_json_scopes) was only
called in the Windows gateway-spawn path. On macOS, neither the
LaunchAgent enable path nor auto_enable_if_needed called it, so
paired devices kept only operator.read scope. This caused every
browser /start nudge and browser.request call to fail with
"missing scope: operator.write", producing the persistent
"Browser is not responding" banner.

Added the same deferred-retry schedule (2, 5, 10, 20, 40s) to
both the macOS set_service_enabled enable branch and
auto_enable_if_needed.

https://claude.ai/code/session_018NV5rk8tY6nzT7Qnkn4Wkm