### PR TITLE
claude/fix-library-search-navigation-BuVQJ

### DIFF
--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -21,6 +21,7 @@ interface NotetakerSidebarProps {
   onConnectCalendar: () => void
   onMeetingSelect?: () => void
   activeView?: 'home' | 'chat'
+  onLibraryWorkspaceOpen?: (ws: Workspace) => void
 }
 
 function NotetakerSidebar({
@@ -32,6 +33,7 @@ function NotetakerSidebar({
   onConnectCalendar,
   onMeetingSelect,
   activeView = 'home',
+  onLibraryWorkspaceOpen,
 }: NotetakerSidebarProps) {
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -519,7 +521,10 @@ function NotetakerSidebar({
               <div
                 key={ws.uuid}
                 className="notetaker-sidebar__note-card"
-                onClick={() => onTabChange(TabChoices.Library)}
+                onClick={() => {
+                  onTabChange(TabChoices.Library)
+                  onLibraryWorkspaceOpen?.(ws)
+                }}
               >
                 <div className="notetaker-sidebar__note-avatar notetaker-sidebar__note-avatar--library">
                   {libraryIcon}

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -483,6 +483,10 @@ function Home({
                 setMeetingSubView('meetings')
               }
             }}
+            onLibraryWorkspaceOpen={(ws) => {
+              setCurrentTab(TabChoices.Library)
+              setSelectedWorkspace(ws)
+            }}
             onQuickNote={() => {
               setCurrentTab(TabChoices.Meeting)
               setMeetingSubView('meetings')


### PR DESCRIPTION
When clicking a library entity in sidebar search results, also set
selectedWorkspace so the app opens that entity directly rather than
landing on the library home/collections view.

https://claude.ai/code/session_01YWkR3xUNhX8VnQvSSae3nG