### PR TITLE
claude/fix-floating-square-artifact-oVqMX

### DIFF
--- a/src/src/components/organisms/WorkspaceView/index.tsx
+++ b/src/src/components/organisms/WorkspaceView/index.tsx
@@ -3,12 +3,10 @@ import { open } from '@tauri-apps/api/dialog'
 import {
   Workspace,
   WorkspaceDocument,
-  SearchResultItem,
   getWorkspace,
   updateWorkspace,
   addDocumentToWorkspace,
   removeDocumentFromWorkspace,
-  searchWorkspace,
   parseTags,
 } from '../../../api/workspaces'
 
@@ -23,8 +21,7 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
   const [currentWorkspace, setCurrentWorkspace] = useState<Workspace>(workspace)
   const [documents, setDocuments] = useState<WorkspaceDocument[]>(workspace.documents ?? [])
   const [searchQuery, setSearchQuery] = useState('')
-  const [searchResults, setSearchResults] = useState<SearchResultItem[]>([])
-  const [isSearching, setIsSearching] = useState(false)
+  const [activeSearchQuery, setActiveSearchQuery] = useState('')
   const [isDragging, setIsDragging] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editName, setEditName] = useState(workspace.name)
@@ -67,14 +64,26 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
     return [...tagSet].sort()
   }, [documents])
 
-  /** Filter documents by active tag. */
+  /** Filter documents by active tag and/or search query. */
   const filteredDocuments = useMemo(() => {
-    if (!activeTagFilter) return documents
-    return documents.filter(doc => {
-      const docTags = [...parseTags(doc.autoTags), ...parseTags(doc.tags)]
-      return docTags.includes(activeTagFilter)
-    })
-  }, [documents, activeTagFilter])
+    let result = documents
+    if (activeTagFilter) {
+      result = result.filter(doc => {
+        const docTags = [...parseTags(doc.autoTags), ...parseTags(doc.tags)]
+        return docTags.includes(activeTagFilter)
+      })
+    }
+    if (activeSearchQuery.trim()) {
+      const q = activeSearchQuery.toLowerCase()
+      result = result.filter(doc =>
+        doc.documentName.toLowerCase().includes(q) ||
+        (doc.summary?.toLowerCase().includes(q)) ||
+        parseTags(doc.autoTags).some(t => t.toLowerCase().includes(q)) ||
+        parseTags(doc.tags).some(t => t.toLowerCase().includes(q)),
+      )
+    }
+    return result
+  }, [documents, activeTagFilter, activeSearchQuery])
 
   const handleAddFiles = async () => {
     try {
@@ -135,23 +144,13 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
     }
   }
 
-  const handleSearch = async () => {
-    if (!searchQuery.trim()) {
-      setSearchResults([])
-      return
-    }
+  const handleSearch = () => {
+    setActiveSearchQuery(searchQuery)
+  }
 
-    try {
-      setIsSearching(true)
-      const res = await searchWorkspace(currentWorkspace.uuid, searchQuery.trim())
-      if (res.success) {
-        setSearchResults(res.results)
-      }
-    } catch (err) {
-      console.error('Search failed:', err)
-    } finally {
-      setIsSearching(false)
-    }
+  const handleClearSearch = () => {
+    setSearchQuery('')
+    setActiveSearchQuery('')
   }
 
   const handleSaveEdit = async () => {
@@ -357,33 +356,29 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
             className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             placeholder="Search within this collection..."
             value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
+            onChange={e => {
+              setSearchQuery(e.target.value)
+              if (!e.target.value.trim()) setActiveSearchQuery('')
+            }}
             onKeyDown={e => e.key === 'Enter' && handleSearch()}
           />
-          <button
-            className="px-4 py-2 text-sm bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 transition-colors"
-            onClick={handleSearch}
-            disabled={isSearching || !searchQuery.trim()}
-          >
-            {isSearching ? 'Searching...' : 'Search'}
-          </button>
+          {activeSearchQuery ? (
+            <button
+              className="px-4 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              onClick={handleClearSearch}
+            >
+              Clear
+            </button>
+          ) : (
+            <button
+              className="px-4 py-2 text-sm bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 transition-colors"
+              onClick={handleSearch}
+              disabled={!searchQuery.trim()}
+            >
+              Search
+            </button>
+          )}
         </div>
-
-        {/* Search results */}
-        {searchResults.length > 0 && (
-          <div className="mt-3 border border-gray-200 rounded-md divide-y divide-gray-100">
-            {searchResults.map((result, idx) => (
-              <div key={result.id || idx} className="p-3">
-                <div className="text-sm font-medium">
-                  Score: {result.score.toFixed(3)}
-                </div>
-                <div className="text-xs text-gray-500 mt-1">
-                  {JSON.stringify(result.payload, null, 2)}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
       </div>
 
       {/* Actions */}
@@ -415,19 +410,23 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
         onDrop={handleDrop}
       >
         <div className="text-sm font-medium text-gray-700 mb-3">
-          Documents ({filteredDocuments.length}{activeTagFilter ? ` of ${documents.length}` : ''})
+          Documents ({filteredDocuments.length}{(activeTagFilter || activeSearchQuery) ? ` of ${documents.length}` : ''})
         </div>
 
         {filteredDocuments.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-32 text-gray-400">
-            {activeTagFilter ? (
+            {activeTagFilter || activeSearchQuery ? (
               <>
-                <div className="text-sm">No documents matching tag &quot;{activeTagFilter}&quot;</div>
+                <div className="text-sm">
+                  {activeSearchQuery
+                    ? `No documents matching "${activeSearchQuery}"`
+                    : `No documents matching tag "${activeTagFilter}"`}
+                </div>
                 <button
                   className="text-xs text-blue-500 hover:text-blue-600 mt-2"
-                  onClick={() => setActiveTagFilter(null)}
+                  onClick={() => { setActiveTagFilter(null); handleClearSearch() }}
                 >
-                  Clear filter
+                  Clear filters
                 </button>
               </>
             ) : (
@@ -470,8 +469,9 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
                         </span>
                       )}
                       <button
-                        className="text-xs text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition-opacity px-2 py-1 rounded hover:bg-red-50"
+                        className="text-xs text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition-opacity px-2 py-1 rounded hover:bg-red-50 focus:outline-none"
                         onClick={() => doc.id && handleRemoveDocument(doc.id)}
+                        tabIndex={-1}
                       >
                         Remove
                       </button>

--- a/src/src/components/organisms/WorkspacesList/index.tsx
+++ b/src/src/components/organisms/WorkspacesList/index.tsx
@@ -15,6 +15,7 @@ import {
 import { KN_API_GET_USER_EMAIL, KN_API_STREAM_LLM_COMPLETE } from '../../../utils/constants'
 
 const LOCAL_FILES_PROMPT_KEY = 'knap.library.localFilesPromptShown'
+const GDRIVE_PROMPT_KEY = 'knap.library.gdrivePromptShown'
 const SUMMARY_CACHE_PREFIX = 'knap.library.summary.'
 
 interface CardSummary {
@@ -35,6 +36,7 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
   const [curationStatus, setCurationStatus] = useState<CurationStatus | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [showLocalFilesPrompt, setShowLocalFilesPrompt] = useState(false)
+  const [showGDrivePrompt, setShowGDrivePrompt] = useState(false)
   const [showPrivacyBanner, setShowPrivacyBanner] = useState(true)
   const [cardSummaries, setCardSummaries] = useState<Map<string, CardSummary>>(new Map())
 
@@ -65,6 +67,8 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
 
   useEffect(() => {
     const init = async () => {
+      const status = await fetchStatus()
+
       // First-visit local files prompt — show only once per device.
       try {
         const shown = localStorage.getItem(LOCAL_FILES_PROMPT_KEY)
@@ -73,7 +77,13 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
         // no-op
       }
 
-      const status = await fetchStatus()
+      // GDrive encouragement — show once if Drive curation isn't yet enabled.
+      try {
+        const shown = localStorage.getItem(GDRIVE_PROMPT_KEY)
+        if (!shown && status && !status.sourcesDrive) setShowGDrivePrompt(true)
+      } catch {
+        // no-op
+      }
 
       // Auto-trigger curation on first open if it's never run before.
       if (status && status.enabled && !status.lastRunAt) {
@@ -167,6 +177,20 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
       setGeneratingSummaries(false)
     }
   }, [workspaces])
+
+  const dismissGDrivePrompt = (enable: boolean) => {
+    try {
+      localStorage.setItem(GDRIVE_PROMPT_KEY, '1')
+    } catch {
+      // no-op
+    }
+    setShowGDrivePrompt(false)
+    if (enable) {
+      updateCurationSettings({ sourcesDrive: true })
+        .then(s => setCurationStatus(s))
+        .catch(err => console.error('Failed to enable GDrive:', err))
+    }
+  }
 
   const dismissLocalFilesPrompt = (enable: boolean) => {
     try {
@@ -493,6 +517,31 @@ function WorkspacesList({ onWorkspaceOpen }: WorkspacesListProps) {
             <button
               className="px-3 py-1.5 text-sm text-blue-700 hover:bg-blue-100 rounded-md"
               onClick={() => dismissLocalFilesPrompt(false)}
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showGDrivePrompt && (
+        <div className="flex items-center justify-between text-sm bg-green-50 border border-green-200 rounded-md px-4 py-3 mb-6">
+          <div>
+            <div className="font-semibold text-green-900">Enrich your library with Google Drive</div>
+            <div className="text-green-700 mt-0.5">
+              Connect your Google account in Settings → Connections, then enable Drive below to automatically import your docs and files into collections.
+            </div>
+          </div>
+          <div className="flex gap-2 ml-4 flex-shrink-0">
+            <button
+              className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-md hover:bg-green-700"
+              onClick={() => dismissGDrivePrompt(true)}
+            >
+              Enable
+            </button>
+            <button
+              className="px-3 py-1.5 text-sm text-green-700 hover:bg-green-100 rounded-md"
+              onClick={() => dismissGDrivePrompt(false)}
             >
               Not now
             </button>


### PR DESCRIPTION
- Remove button in doc list uses opacity-0 but was still keyboard-focusable,
  causing a visible browser focus ring (floating square). Fixed with tabIndex=-1
  and focus:outline-none.
- Semantic search backend is disabled (always returns []). Replace with
  client-side text search filtering by name, tags, and summary. Remove the
  raw JSON debug result display. Add Clear button when a search is active.
- Add a dismissible GDrive encouragement banner in WorkspacesList, shown once
  when sourcesDrive curation is not yet enabled. Enabling sets sourcesDrive=true
  so the curator picks up Drive docs once the user connects their Google account.

https://claude.ai/code/session_01NAABMSQ8o8F4mtuyt8wqaz