### PR TITLE
claude/fix-telegram-gateway-9pU6w

### DIFF
--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Semaphore, oneshot};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{connect_async, tungstenite::{client::IntoClientRequest, http::HeaderValue, Message}};
 
 use crate::clawd::gateway_supervisor;
 
@@ -782,9 +782,14 @@ pub fn resolve_default_model() -> String {
 /// we use a throwaway connection and wait for the gateway to come back.
 async fn apply_runtime_browser_config(token: &str) {
   // Open a temporary WebSocket just for the config.patch exchange.
+  let tmp_req = {
+    let mut r = GATEWAY_WS_URL.into_client_request().expect("valid URL");
+    r.headers_mut().insert("Origin", HeaderValue::from_static("http://localhost:1420"));
+    r
+  };
   let tmp_ws = match tokio::time::timeout(
     Duration::from_secs(3),
-    connect_async(GATEWAY_WS_URL),
+    connect_async(tmp_req),
   ).await {
     Ok(Ok((ws, _))) => ws,
     _ => {
@@ -1048,9 +1053,15 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
 
   // Wrap the TCP/WebSocket connection in a short timeout so we don't hang
   // for 10-30 seconds when the gateway is down (system TCP timeout defaults).
+  let ws_req = {
+    let mut r = GATEWAY_WS_URL.into_client_request()
+      .map_err(|e| format!("Invalid gateway URL: {}", e))?;
+    r.headers_mut().insert("Origin", HeaderValue::from_static("http://localhost:1420"));
+    r
+  };
   let (ws_stream, _) = tokio::time::timeout(
     Duration::from_secs(3),
-    connect_async(GATEWAY_WS_URL),
+    connect_async(ws_req),
   )
     .await
     .map_err(|_| "Timeout connecting to gateway (3s)".to_string())?

--- a/src/src-tauri/src/clawd/gateway_ws.rs
+++ b/src/src-tauri/src/clawd/gateway_ws.rs
@@ -7,7 +7,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{connect_async, tungstenite::{client::IntoClientRequest, http::HeaderValue, Message}};
 
 use crate::clawd::gateway_supervisor;
 
@@ -117,7 +117,13 @@ pub async fn gateway_request(
     ensure_gateway_best_effort(token).await;
 
     // Connect to WebSocket
-    let (ws_stream, _) = connect_async(GATEWAY_WS_URL)
+    let ws_req = {
+        let mut r = GATEWAY_WS_URL.into_client_request()
+            .map_err(|e| format!("Invalid gateway URL: {}", e))?;
+        r.headers_mut().insert("Origin", HeaderValue::from_static("http://localhost:1420"));
+        r
+    };
+    let (ws_stream, _) = connect_async(ws_req)
         .await
         .map_err(|e| format!("Failed to connect to gateway: {}", e))?;
 


### PR DESCRIPTION
The gateway's Control UI enforces an allowedOrigins check on every
connect handshake. Rust's tokio-tungstenite does not add an Origin
header by default, so the gateway rejected every backend connection
with CONTROL_UI_ORIGIN_NOT_ALLOWED / "origin missing or invalid".

Set Origin: http://localhost:1420 (already in gateway.controlUi.allowedOrigins)
on all three connect_async call sites:
- gateway_client.rs connect_and_handshake() (pooled client)
- gateway_client.rs apply_runtime_browser_config() (config-patch WS)
- gateway_ws.rs gateway_request() (one-shot WS)

This resolves the "Gateway error — try restarting the service" shown
in the Telegram (and other) channel configuration UI.

https://claude.ai/code/session_01P2YHeLCLxtBi9M4LKhYAcx