### PR TITLE
Telegram account onboarding for digital employees

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/extensions/telegramuser/package.json
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/telegramuser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/telegramuser",
+  "version": "1.0.0",
+  "private": true,
+  "description": "MTProto user account creation and session management for Knapsack digital employees",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `TelegramAccountsScreen` onboarding step: guides users through linking a MTProto phone-based Telegram account for each digital employee, and connecting a Chief-of-Staff bot via Bot API token
- Add `telegramuser` OpenClaw gateway extension (GramJS MTProto, bundled via esbuild) implementing `telegram.user.requestCode`, `verifyCode`, `signUp`, and `status` RPC methods
- Add Rust backend endpoints for all MTProto user account operations and bot provisioning, registered in Actix
- Add `provisionChiefOfStaffBot` API — checks `KNAPSACK_TG_CHIEF_OF_STAFF_BOT_TOKEN` env var, falls back to manual token entry
- Fix: add `package.json` with `"type": "module"` to the telegramuser extension so Node.js loads it as ESM (without it, the ESM exports fail silently and gateway methods are never registered)

## Test plan

- [ ] Launch app and reach the Telegram onboarding screen
- [ ] Chief of Staff card: paste a valid bot token from @BotFather and click Connect — should show connected state with bot username
- [ ] Agent card: enter a phone number, receive OTP, enter code — should show linked state with display name
- [ ] Agent card: skip button dismisses the card
- [ ] Gateway restart picks up the telegramuser extension (`telegram.user.requestCode` no longer returns "unknown method")
- [ ] `KNAPSACK_TG_CHIEF_OF_STAFF_BOT_TOKEN` env var: if set, auto-provision skips manual entry

https://claude.ai/code/session_01HQL545iM9FaivM6URpRtsg
EOF
)