### PR TITLE
add meeting prep

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -950,6 +950,60 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
           />
         )}
 
+        {/* Meeting prep: shown when notes are empty and not recording */}
+        {!notesMarkdown.trim() &&
+          !recordingHandlers.isRecording(thread.id) &&
+          !isSynthesizing() &&
+          meeting &&
+          (getEventUrl(meeting) || (meeting.participants && meeting.participants.length > 0) || meeting.description) && (
+            <div className="notetaker-note__prep">
+              <div className="notetaker-note__prep-header">Meeting Prep</div>
+              {getEventUrl(meeting) && (
+                <div className="notetaker-note__prep-row">
+                  <span className="notetaker-note__prep-label">Video</span>
+                  <a
+                    href={getEventUrl(meeting)}
+                    className="notetaker-note__prep-link"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {meeting.meeting_platform === 'zoom'
+                      ? 'Zoom'
+                      : meeting.meeting_platform === 'teams'
+                        ? 'Microsoft Teams'
+                        : 'Google Meet'}
+                  </a>
+                </div>
+              )}
+              {!getEventUrl(meeting) && meeting.location && (
+                <div className="notetaker-note__prep-row">
+                  <span className="notetaker-note__prep-label">Location</span>
+                  <span className="notetaker-note__prep-value">{meeting.location}</span>
+                </div>
+              )}
+              {meeting.participants && meeting.participants.length > 0 && (
+                <div className="notetaker-note__prep-row">
+                  <span className="notetaker-note__prep-label">Attendees</span>
+                  <div className="notetaker-note__prep-chips">
+                    {meeting.participants.map((p, i) => (
+                      <span key={i} className="notetaker-note__prep-chip">
+                        {p.name || p.email.split('@')[0]}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {meeting.description && (
+                <div className="notetaker-note__prep-row">
+                  <span className="notetaker-note__prep-label">Agenda</span>
+                  <span className="notetaker-note__prep-value notetaker-note__prep-value--description">
+                    {meeting.description}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
       </div>
 
       {/* Notetaker bottom bar */}

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -86,7 +86,6 @@ function NotetakerSidebar({
 
   const upcomingEvents = useMemo(() => {
     if (!feed.feedContent) return {}
-    const now = Date.now()
     const events: { item: FeedItem; key: string }[] = []
     Object.entries(feed.feedContent).forEach(([key, items]) => {
       if (key === STATIONARY_ITEMS) return

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -517,3 +517,78 @@ html, body {
 .notetaker-note__permission-error-dismiss:hover {
   background: rgba(0, 0, 0, 0.08);
 }
+
+.notetaker-note__prep {
+  background: #F8F7F7;
+  border: 1px solid #E3E2E2;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.notetaker-note__prep-header {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #969595;
+  font-family: 'Inter', sans-serif;
+}
+
+.notetaker-note__prep-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.notetaker-note__prep-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #969595;
+  font-family: 'Inter', sans-serif;
+  min-width: 64px;
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
+.notetaker-note__prep-link {
+  font-size: 12px;
+  color: #6474AC;
+  font-family: 'Inter', sans-serif;
+  text-decoration: none;
+}
+
+.notetaker-note__prep-link:hover {
+  text-decoration: underline;
+}
+
+.notetaker-note__prep-value {
+  font-size: 12px;
+  color: #333333;
+  font-family: 'Inter', sans-serif;
+  line-height: 1.5;
+}
+
+.notetaker-note__prep-value--description {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.notetaker-note__prep-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.notetaker-note__prep-chip {
+  font-size: 11px;
+  font-family: 'Inter', sans-serif;
+  color: #6A6969;
+  background: #EBEBEB;
+  padding: 3px 8px;
+  border-radius: 12px;
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "baseUrl": "./",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Shows a brief prep card below the notes editor when a meeting is opened with no notes, surfacing video link, attendees, and agenda from calendar data.

https://claude.ai/code/session_01ReeHbY57wTe7gWY1rsBCqF