### PR TITLE
feat: Telegram account onboarding — per-agent child bot provisioning

### DIFF
--- a/src/src-tauri/resources/clawdbot/skills/telegram-agent-bot/SKILL.md
+++ b/src/src-tauri/resources/clawdbot/skills/telegram-agent-bot/SKILL.md
@@ -95,7 +95,7 @@ Callback data format: `action:<verb>:<target_id>` (max 64 bytes).
 ## Provisioning flow (UI)
 
 1. User clicks "Set up →" for each agent on the Telegram onboarding screen
-2. App opens `https://t.me/newbot/{manager}/{suggested}` via Tauri shell.open()
+2. App opens `tg://newbot?manager={manager}&username={suggested}&name={name}` (native Telegram app); falls back to `https://t.me/newbot/{manager}/{suggested}?name={name}` if app not installed
 3. User creates the child bot in Telegram (~10 seconds)
 4. App polls every 3 s until `getManagedBotToken` succeeds
 5. Token written to `openclaw.json` and pushed to running gateway

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -3778,10 +3778,15 @@ pub async fn telegram_get_agent_bot_deep_link(
     }
     let m = manager.trim();
     let suggested = body.suggested_username.trim().trim_start_matches('@').to_string();
-    // tg:// opens the native Telegram app (macOS, Windows, Linux).
-    // https://t.me/ opens in the browser; used as a fallback when the app is not installed.
-    let deeplink = format!("tg://resolve?domain={}&start=newbot_{}", m, suggested);
-    let web_deeplink = format!("https://t.me/{}?start=newbot_{}", m, suggested);
+    let name_enc: String = body.agent_name.chars().map(|c| {
+        if c.is_alphanumeric() || c == ' ' || c == '-' || c == '_' { c } else { '_' }
+    }).collect();
+    // tg:// opens the native Telegram app on macOS/Windows/Linux.
+    // The tg://newbot scheme mirrors the official t.me/newbot deeplink (Bot API 9.6).
+    // https://t.me/newbot/{manager}/{suggested} is the documented managed-bot creation URL;
+    // used as fallback when Telegram is not installed (opens browser / Telegram Web).
+    let deeplink = format!("tg://newbot?manager={}&username={}&name={}", m, suggested, name_enc);
+    let web_deeplink = format!("https://t.me/newbot/{}/{}?name={}", m, suggested, name_enc);
     HttpResponse::Ok().json(TelegramAgentBotDeepLinkResponse {
         success: true,
         deeplink: Some(deeplink),

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -3750,14 +3750,19 @@ struct TelegramAgentBotDeepLinkRequest {
 #[derive(Serialize)]
 struct TelegramAgentBotDeepLinkResponse {
     success: bool,
+    /// tg:// URL — opens the Telegram desktop/mobile app directly.
     #[serde(skip_serializing_if = "Option::is_none")]
     deeplink: Option<String>,
+    /// https://t.me/ URL — fallback for users without the native Telegram app.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    web_deeplink: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     message: Option<String>,
 }
 
-/// Return a `https://t.me/newbot/{manager}/{suggested}` deep link for a child
-/// bot.  Reads `TELEGRAM_MANAGER_BOT_USERNAME` from the process environment.
+/// Return deeplinks for creating a managed child bot.
+/// Reads `TELEGRAM_MANAGER_BOT_USERNAME` from the process environment.
+/// Returns both a tg:// URL (native app) and an https://t.me/ URL (web fallback).
 #[post("/api/clawd/telegram/agent-bot/deep-link")]
 pub async fn telegram_get_agent_bot_deep_link(
     body: web::Json<TelegramAgentBotDeepLinkRequest>,
@@ -3767,24 +3772,20 @@ pub async fn telegram_get_agent_bot_deep_link(
         return HttpResponse::Ok().json(TelegramAgentBotDeepLinkResponse {
             success: false,
             deeplink: None,
+            web_deeplink: None,
             message: Some("TELEGRAM_MANAGER_BOT_USERNAME is not configured.".to_string()),
         });
     }
+    let m = manager.trim();
     let suggested = body.suggested_username.trim().trim_start_matches('@').to_string();
-    let name_enc: String = body.agent_name.chars().map(|c| {
-        if c.is_alphanumeric() || c == ' ' || c == '-' || c == '_' { c } else { '_' }
-    }).collect();
-    // tg:// scheme opens the Telegram app directly on macOS/Windows/Linux.
-    // https://t.me/ always opens in the browser because Telegram doesn't register
-    // as a universal-link handler on desktop OS — only tg:// is intercepted.
-    let deeplink = format!(
-        "tg://resolve?domain={}&start=newbot_{}",
-        manager.trim(),
-        suggested,
-    );
+    // tg:// opens the native Telegram app (macOS, Windows, Linux).
+    // https://t.me/ opens in the browser; used as a fallback when the app is not installed.
+    let deeplink = format!("tg://resolve?domain={}&start=newbot_{}", m, suggested);
+    let web_deeplink = format!("https://t.me/{}?start=newbot_{}", m, suggested);
     HttpResponse::Ok().json(TelegramAgentBotDeepLinkResponse {
         success: true,
         deeplink: Some(deeplink),
+        web_deeplink: Some(web_deeplink),
         message: None,
     })
 }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -3774,11 +3774,13 @@ pub async fn telegram_get_agent_bot_deep_link(
     let name_enc: String = body.agent_name.chars().map(|c| {
         if c.is_alphanumeric() || c == ' ' || c == '-' || c == '_' { c } else { '_' }
     }).collect();
+    // tg:// scheme opens the Telegram app directly on macOS/Windows/Linux.
+    // https://t.me/ always opens in the browser because Telegram doesn't register
+    // as a universal-link handler on desktop OS — only tg:// is intercepted.
     let deeplink = format!(
-        "https://t.me/newbot/{}/{}?name={}",
+        "tg://resolve?domain={}&start=newbot_{}",
         manager.trim(),
         suggested,
-        name_enc,
     );
     HttpResponse::Ok().json(TelegramAgentBotDeepLinkResponse {
         success: true,

--- a/src/src/api/channels.ts
+++ b/src/src/api/channels.ts
@@ -422,7 +422,8 @@ export const getTelegramManagedBotStatus = (agentId: string) =>
 
 export interface AgentBotDeepLinkResponse {
   success: boolean
-  deeplink?: string
+  deeplink?: string      // tg:// URL — opens native Telegram app
+  web_deeplink?: string  // https://t.me/ URL — fallback when app not installed
   message?: string
 }
 

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -122,10 +122,11 @@ function AgentBotCard({
     onChange({ phase: 'awaiting_telegram', errorMessage: '' })
     try {
       const resp = await getAgentBotDeepLink(suggestedUsername, `${name} (Knapsack)`)
+      // tg:// opens Telegram app; https://t.me/ opens the browser on desktop
       const url =
         resp.success && resp.deeplink
           ? resp.deeplink
-          : `https://t.me/newbot/${suggestedUsername}`
+          : `tg://resolve?domain=BotFather`
       await openUrl(url)
     } catch {
       // If deep-link call fails, still start polling — user may have opened Telegram manually

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -122,14 +122,17 @@ function AgentBotCard({
     onChange({ phase: 'awaiting_telegram', errorMessage: '' })
     try {
       const resp = await getAgentBotDeepLink(suggestedUsername, `${name} (Knapsack)`)
-      // tg:// opens Telegram app; https://t.me/ opens the browser on desktop
-      const url =
-        resp.success && resp.deeplink
-          ? resp.deeplink
-          : `tg://resolve?domain=BotFather`
-      await openUrl(url)
+      const tgUrl = resp.deeplink ?? `tg://resolve?domain=BotFather`
+      const webUrl = resp.web_deeplink ?? `https://t.me/BotFather`
+      try {
+        // tg:// opens the native Telegram app (macOS, Windows, Linux).
+        // Falls back to the https://t.me/ web version if Telegram isn't installed.
+        await openUrl(tgUrl)
+      } catch {
+        await openUrl(webUrl)
+      }
     } catch {
-      // If deep-link call fails, still start polling — user may have opened Telegram manually
+      // If the deeplink API call itself fails, keep polling — user may open Telegram manually
     }
     startPolling()
   }


### PR DESCRIPTION
## Summary

- Implements per-agent Telegram child bot provisioning using Bot API 9.6 Managed Bots
- Adds `TelegramAccountsScreen` onboarding step: one card per agent + Chief of Staff, each with a "Set up →" deeplink flow and 3s polling until the bot appears
- Deeplinks use `tg://newbot?manager=...&username=...&name=...` to open the native Telegram app, with `https://t.me/newbot/{manager}/{suggested}?name=...` as fallback for users without the app installed
- Bot statuses are pre-loaded from `openclaw.json` on screen entry so already-provisioned bots show as connected immediately
- Added `getAgentBotDeepLink`, `provisionAgentBot`, `getAgentBotStatuses`, `rotateAgentBotToken` API helpers in `channels.ts`
- Fixed tsconfig deprecation conflict blocking CI

## Test plan

- [ ] Click "Set up →" on an agent card — confirm Telegram opens to the managed bot creation flow (not BotFather main or the manager bot chat)
- [ ] Without Telegram installed: confirm fallback opens `https://t.me/newbot/...` in browser
- [ ] Complete bot creation in Telegram — card updates to "✓ @username" within ~3s automatically
- [ ] Skip a bot mid-flow — card grays out; Undo restores it to idle
- [ ] Re-enter the screen after completing setup — already-provisioned bots pre-populate as done
- [ ] Continue button activates once at least one bot is connected; shows count

https://claude.ai/code/session_01HQL545iM9FaivM6URpRtsg