### PR TITLE
fix(telegram): use https://t.me/newbot URL to trigger managed bot creation flow

### DIFF
--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -122,17 +122,13 @@ function AgentBotCard({
     onChange({ phase: 'awaiting_telegram', errorMessage: '' })
     try {
       const resp = await getAgentBotDeepLink(suggestedUsername, `${name} (Knapsack)`)
-      const tgUrl = resp.deeplink ?? `tg://resolve?domain=BotFather`
-      const webUrl = resp.web_deeplink ?? `https://t.me/BotFather`
-      try {
-        // tg:// opens the native Telegram app (macOS, Windows, Linux).
-        // Falls back to the https://t.me/ web version if Telegram isn't installed.
-        await openUrl(tgUrl)
-      } catch {
-        await openUrl(webUrl)
-      }
+      // Use the https://t.me/newbot/{manager}/{suggested} URL — this opens the browser which
+      // shows an "Open in Telegram" button that correctly triggers the managed bot creation flow.
+      // tg://newbot is not a registered Telegram URL scheme and only opens BotFather without context.
+      const url = resp.web_deeplink ?? `https://t.me/BotFather`
+      await openUrl(url)
     } catch {
-      // If the deeplink API call itself fails, keep polling — user may open Telegram manually
+      // If the API call fails, keep polling — user may open Telegram manually
     }
     startPolling()
   }


### PR DESCRIPTION
## Summary

- `tg://newbot` is not a registered Telegram URL scheme — it opens BotFather without any managed bot creation context
- Switch to `https://t.me/newbot/{manager}/{suggested}?name={name}` as the primary URL
- This opens a browser page with an "Open in Telegram" button that correctly triggers the Bot API 9.6 managed bot creation flow in BotFather

## Test plan

- [ ] Click "Set up →" on an agent card — browser opens to `t.me/newbot/...`
- [ ] Click "Open in Telegram" on the t.me page — BotFather shows the managed bot creation prompt with suggested username pre-filled
- [ ] Complete bot creation — card updates to "✓ @username" within ~3s automatically

https://claude.ai/code/session_01HQL545iM9FaivM6URpRtsg