### PR TITLE
feat(telegram): guided BotFather onboarding with copy-able name/username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 src/src-tauri/resources/clawdbot/dist/extensions/*/package-lock.json
+.claude/settings.local.json

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -3911,6 +3911,119 @@ pub async fn telegram_provision_agent_bot(
     }
 }
 
+// ── Manual token entry ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct TelegramConfigureAgentBotRequest {
+    agent_id: String,
+    agent_name: String,
+    bot_token: String,
+}
+
+#[derive(Serialize)]
+struct TelegramConfigureAgentBotResponse {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+/// Manually configure an agent bot from a user-supplied token.
+/// Validates via Telegram getMe, saves to openclaw.json, and pushes to the running gateway.
+#[post("/api/clawd/telegram/agent-bot/configure")]
+pub async fn telegram_configure_agent_bot(
+    body: web::Json<TelegramConfigureAgentBotRequest>,
+) -> impl Responder {
+    let token = body.bot_token.trim().to_string();
+    let agent_id = body.agent_id.trim().to_string();
+    let agent_name = body.agent_name.trim().to_string();
+
+    if token.is_empty() {
+        return HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+            success: false,
+            username: None,
+            message: Some("Bot token is required.".to_string()),
+        });
+    }
+
+    let url = format!("https://api.telegram.org/bot{}/getMe", token);
+    let client = match reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build() {
+        Ok(c) => c,
+        Err(e) => return HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+            success: false,
+            username: None,
+            message: Some(format!("Failed to build HTTP client: {e}")),
+        }),
+    };
+
+    let resp = match client.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => return HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+            success: false,
+            username: None,
+            message: Some(format!("Telegram API unreachable: {e}")),
+        }),
+    };
+
+    let body_json = match resp.json::<serde_json::Value>().await {
+        Ok(j) => j,
+        Err(e) => return HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+            success: false,
+            username: None,
+            message: Some(format!("Invalid response from Telegram: {e}")),
+        }),
+    };
+
+    let ok = body_json.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+    if !ok {
+        let desc = body_json.get("description").and_then(|v| v.as_str())
+            .unwrap_or("Invalid bot token").to_string();
+        return HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+            success: false,
+            username: None,
+            message: Some(desc),
+        });
+    }
+
+    let username = match body_json.pointer("/result/username").and_then(|v| v.as_str()) {
+        Some(u) => u.to_string(),
+        None => return HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+            success: false,
+            username: None,
+            message: Some("Bot has no username — set one in BotFather first.".to_string()),
+        }),
+    };
+
+    if let Some(config_path) = agent_bot_config_path() {
+        if let Err(e) = upsert_telegram_channel_entry(&config_path, &agent_id, &agent_name, &token, &username) {
+            eprintln!("[channels] configure_agent_bot: failed to write openclaw.json: {e}");
+        }
+        if let Ok(raw) = std::fs::read_to_string(&config_path) {
+            if let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&raw) {
+                if let Some(tg) = cfg.pointer("/channels/telegram") {
+                    let patch = serde_json::json!({ "channels": { "telegram": tg.clone() } });
+                    tokio::spawn(async move {
+                        if let Ok(cur) = crate::clawd::gateway_client::config_get(None).await {
+                            if let Some(hash) = cur.get("hash").and_then(|h| h.as_str()) {
+                                if !hash.is_empty() {
+                                    let _ = crate::clawd::gateway_client::config_patch(&patch.to_string(), hash, None).await;
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    HttpResponse::Ok().json(TelegramConfigureAgentBotResponse {
+        success: true,
+        username: Some(username),
+        message: None,
+    })
+}
+
 // ── Token rotation ────────────────────────────────────────────────────────
 
 #[derive(Deserialize)]

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -3690,6 +3690,7 @@ fn upsert_telegram_channel_entry(
     agent_name: &str,
     token: &str,
     username: &str,
+    bot_id: Option<i64>,
 ) -> Result<(), String> {
     let raw = std::fs::read_to_string(config_path)
         .map_err(|e| format!("read openclaw.json: {e}"))?;
@@ -3707,15 +3708,18 @@ fn upsert_telegram_channel_entry(
         .or_insert_with(|| serde_json::json!([]));
 
     let arr = telegram.as_array_mut().ok_or("channels.telegram not an array")?;
-    // Remove any existing entry for this agent.
     arr.retain(|e| e.get("agentId").and_then(|v| v.as_str()) != Some(agent_id));
-    arr.push(serde_json::json!({
+    let mut entry = serde_json::json!({
         "id": format!("{}-bot", agent_id),
         "agentId": agent_id,
         "token": token,
         "username": username,
         "description": format!("{} — Dedicated Telegram bot", agent_name),
-    }));
+    });
+    if let Some(id) = bot_id {
+        entry["botId"] = serde_json::json!(id);
+    }
+    arr.push(entry);
 
     let json = serde_json::to_string_pretty(&cfg).map_err(|e| format!("serialize: {e}"))?;
     std::fs::write(config_path, &json).map_err(|e| format!("write openclaw.json: {e}"))?;
@@ -3858,6 +3862,7 @@ pub async fn telegram_provision_agent_bot(
                         body.agent_name.trim(),
                         tok,
                         uname,
+                        bot_id,
                     ) {
                         eprintln!("[channels] telegram provision: failed to write openclaw.json: {e}");
                     }
@@ -3994,9 +3999,10 @@ pub async fn telegram_configure_agent_bot(
             message: Some("Bot has no username — set one in BotFather first.".to_string()),
         }),
     };
+    let bot_id = body_json.pointer("/result/id").and_then(|v| v.as_i64());
 
     if let Some(config_path) = agent_bot_config_path() {
-        if let Err(e) = upsert_telegram_channel_entry(&config_path, &agent_id, &agent_name, &token, &username) {
+        if let Err(e) = upsert_telegram_channel_entry(&config_path, &agent_id, &agent_name, &token, &username, bot_id) {
             eprintln!("[channels] configure_agent_bot: failed to write openclaw.json: {e}");
         }
         if let Ok(raw) = std::fs::read_to_string(&config_path) {
@@ -4081,7 +4087,7 @@ pub async fn telegram_rotate_agent_bot_token(
                                 .unwrap_or(&agent_id)
                                 .to_string();
                             let _ = upsert_telegram_channel_entry(
-                                &config_path, &agent_id, &agent_name, tok, uname,
+                                &config_path, &agent_id, &agent_name, tok, uname, None,
                             );
                         }
                     }

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -328,6 +328,7 @@ pub async fn start_server<'a>(
       .service(clawd::channels::telegram_managed_bot_status)
       .service(clawd::channels::telegram_get_agent_bot_deep_link)
       .service(clawd::channels::telegram_provision_agent_bot)
+      .service(clawd::channels::telegram_configure_agent_bot)
       .service(clawd::channels::telegram_rotate_agent_bot_token)
       .service(clawd::channels::telegram_get_agent_bot_statuses)
       .service(clawd::channels::voice_status)

--- a/src/src/api/channels.ts
+++ b/src/src/api/channels.ts
@@ -459,6 +459,23 @@ export const provisionAgentBot = (agentId: string, agentName: string, suggestedU
     suggested_username: suggestedUsername,
   }, 15_000)
 
+export interface AgentBotConfigureResponse {
+  success: boolean
+  username?: string
+  message?: string
+}
+
+/**
+ * Manually configure an agent bot by supplying a token obtained from BotFather.
+ * Validates via getMe, saves to openclaw.json, and pushes to the running gateway.
+ */
+export const configureAgentBot = (agentId: string, agentName: string, botToken: string) =>
+  post<AgentBotConfigureResponse>('/api/clawd/telegram/agent-bot/configure', {
+    agent_id: agentId,
+    agent_name: agentName,
+    bot_token: botToken,
+  })
+
 /** Rotate a provisioned bot's token silently (no user action required). */
 export const rotateAgentBotToken = (agentId: string) =>
   post<{ success: boolean; message?: string }>('/api/clawd/telegram/agent-bot/rotate', {

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -58,6 +58,25 @@ function agentUsername(userSlug: string, agentId: string) {
   return `knapsack_${toSlug(userSlug)}_${toSlug(agentId)}_bot`.slice(0, 32)
 }
 
+// ── Copy helper ──────────────────────────────────────────────
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <button
+      onClick={handleCopy}
+      className="text-xs text-gray-400 hover:text-[#913631] font-InterTight transition-colors whitespace-nowrap"
+    >
+      {copied ? '✓ Copied' : 'Copy'}
+    </button>
+  )
+}
+
 // ── Single card component ─────────────────────────────────────
 
 function AgentBotCard({
@@ -76,13 +95,13 @@ function AgentBotCard({
   onChange: (patch: Partial<BotState>) => void
 }) {
   const [tokenInput, setTokenInput] = useState('')
+  const botDisplayName = `${name} (Knapsack)`
 
   const handleSetUp = async () => {
     onChange({ phase: 'entering_token', errorMessage: '' })
     try {
       await openUrl('https://t.me/BotFather?start=newbot')
     } catch {
-      // Telegram not installed — browser will open instead
       try { await openUrl('https://t.me/BotFather') } catch { /* ignore */ }
     }
   }
@@ -118,6 +137,7 @@ function AgentBotCard({
         !isDone && !isSkipped && 'border-gray-200 bg-white',
       )}
     >
+      {/* Header row */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <span className="text-2xl">{emoji}</span>
@@ -149,7 +169,7 @@ function AgentBotCard({
           {(isEntering || isConnecting) && (
             <button
               className="text-xs text-gray-400 hover:text-gray-600 underline font-InterTight"
-              onClick={() => onChange({ phase: 'skipped', errorMessage: '' })}
+              onClick={() => { setTokenInput(''); onChange({ phase: 'skipped', errorMessage: '' }) }}
             >
               Skip
             </button>
@@ -166,31 +186,60 @@ function AgentBotCard({
         </div>
       </div>
 
+      {/* BotFather instructions + token entry */}
       {(isEntering || isConnecting) && (
-        <div className="mt-3 space-y-2">
-          <p className="text-xs text-gray-500 font-InterTight">
-            In BotFather, type <span className="font-mono text-gray-700">/newbot</span> and follow the steps. Then paste your token here:
-          </p>
-          {state.errorMessage && (
-            <p className="text-xs text-red-500 font-InterTight">{state.errorMessage}</p>
-          )}
-          <div className="flex gap-2">
-            <input
-              type="text"
-              placeholder="123456:ABC-DEF1234…"
-              value={tokenInput}
-              onChange={e => setTokenInput(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && handleConnect()}
-              disabled={isConnecting}
-              className="flex-1 text-xs border border-gray-200 rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50"
-            />
-            <button
-              onClick={handleConnect}
-              disabled={isConnecting || !tokenInput.trim()}
-              className="text-xs font-medium font-InterTight px-3 py-2 rounded-lg bg-[#913631] text-white hover:bg-[#7a2d29] disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
-            >
-              {isConnecting ? 'Connecting…' : 'Connect'}
-            </button>
+        <div className="mt-3 space-y-3">
+          {/* Step-by-step guidance */}
+          <div className="bg-gray-50 rounded-xl p-3 space-y-2.5">
+            <p className="text-xs font-medium text-gray-600 font-InterTight">
+              In BotFather, send{' '}
+              <span className="font-mono bg-gray-200 px-1 rounded">/newbot</span>{' '}
+              and use these when prompted:
+            </p>
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <span className="text-xs text-gray-400 font-InterTight">Name → </span>
+                  <span className="text-xs font-semibold text-gray-800 font-InterTight">{botDisplayName}</span>
+                </div>
+                <CopyButton text={botDisplayName} />
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <span className="text-xs text-gray-400 font-InterTight">Username → </span>
+                  <span className="text-xs font-semibold text-gray-800 font-mono">@{suggestedUsername}</span>
+                </div>
+                <CopyButton text={suggestedUsername} />
+              </div>
+            </div>
+          </div>
+
+          {/* Token entry */}
+          <div>
+            <p className="text-xs text-gray-500 font-InterTight mb-1.5">
+              Paste the token BotFather gives you:
+            </p>
+            {state.errorMessage && (
+              <p className="text-xs text-red-500 font-InterTight mb-1.5">{state.errorMessage}</p>
+            )}
+            <div className="flex gap-2">
+              <input
+                type="text"
+                placeholder="123456789:ABC-DEFghijk…"
+                value={tokenInput}
+                onChange={e => setTokenInput(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleConnect()}
+                disabled={isConnecting}
+                className="flex-1 text-xs border border-gray-200 rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50"
+              />
+              <button
+                onClick={handleConnect}
+                disabled={isConnecting || !tokenInput.trim()}
+                className="text-xs font-medium font-InterTight px-3 py-2 rounded-lg bg-[#913631] text-white hover:bg-[#7a2d29] disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+              >
+                {isConnecting ? 'Connecting…' : 'Connect'}
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -280,9 +329,9 @@ export function TelegramAccountsScreen({
           Give your team a voice
         </h2>
         <p className="mt-3 text-gray-500 text-base font-InterTight leading-relaxed">
-          Each agent gets their own Telegram bot. Click{' '}
-          <span className="font-medium text-gray-700">Set up →</span> to open
-          BotFather, create a bot with <span className="font-mono text-sm">/newbot</span>, then paste the token — takes about 30 seconds per bot.
+          Each agent gets its own Telegram bot. Click{' '}
+          <span className="font-medium text-gray-700">Set up →</span> — we'll
+          open BotFather and show you exactly what to type. Takes about 30 seconds per bot.
         </p>
       </div>
 

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -4,21 +4,19 @@ import { open as openUrl } from '@tauri-apps/api/shell'
 import cn from 'classnames'
 
 import {
-  getAgentBotDeepLink,
+  configureAgentBot,
   getAgentBotStatuses,
-  provisionAgentBot,
 } from 'src/api/channels'
 
 import styles from './styles.module.scss'
 
 // ── Types ────────────────────────────────────────────────────
 
-/** idle → awaiting_telegram (deeplink opened, polling) → done | error */
-type BotPhase = 'idle' | 'awaiting_telegram' | 'done' | 'skipped' | 'error'
+type BotPhase = 'idle' | 'entering_token' | 'connecting' | 'done' | 'skipped' | 'error'
 
 interface BotState {
   phase: BotPhase
-  username: string   // filled on success
+  username: string
   errorMessage: string
 }
 
@@ -62,9 +60,6 @@ function agentUsername(userSlug: string, agentId: string) {
 
 // ── Single card component ─────────────────────────────────────
 
-const POLL_INTERVAL_MS = 3_000
-const POLL_TIMEOUT_MS = 120_000
-
 function AgentBotCard({
   emoji,
   name,
@@ -80,61 +75,38 @@ function AgentBotCard({
   state: BotState
   onChange: (patch: Partial<BotState>) => void
 }) {
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const pollStartRef = useRef<number>(0)
-
-  const stopPolling = useCallback(() => {
-    if (pollRef.current !== null) {
-      clearInterval(pollRef.current)
-      pollRef.current = null
-    }
-  }, [])
-
-  // Clean up on unmount
-  useEffect(() => () => stopPolling(), [stopPolling])
-
-  const startPolling = useCallback(() => {
-    stopPolling()
-    pollStartRef.current = Date.now()
-    pollRef.current = setInterval(async () => {
-      if (Date.now() - pollStartRef.current > POLL_TIMEOUT_MS) {
-        stopPolling()
-        onChange({
-          phase: 'error',
-          errorMessage: 'Timed out waiting — make sure you completed bot creation in Telegram.',
-        })
-        return
-      }
-      try {
-        const resp = await provisionAgentBot(agentId, name, suggestedUsername)
-        if (resp.success && resp.username) {
-          stopPolling()
-          onChange({ phase: 'done', username: resp.username })
-        }
-        // Not ready yet — keep polling silently
-      } catch {
-        // Network hiccup — keep polling
-      }
-    }, POLL_INTERVAL_MS)
-  }, [agentId, name, suggestedUsername, onChange, stopPolling])
+  const [tokenInput, setTokenInput] = useState('')
 
   const handleSetUp = async () => {
-    onChange({ phase: 'awaiting_telegram', errorMessage: '' })
+    onChange({ phase: 'entering_token', errorMessage: '' })
     try {
-      const resp = await getAgentBotDeepLink(suggestedUsername, `${name} (Knapsack)`)
-      // Use the https://t.me/newbot/{manager}/{suggested} URL — this opens the browser which
-      // shows an "Open in Telegram" button that correctly triggers the managed bot creation flow.
-      // tg://newbot is not a registered Telegram URL scheme and only opens BotFather without context.
-      const url = resp.web_deeplink ?? `https://t.me/BotFather`
-      await openUrl(url)
+      await openUrl('https://t.me/BotFather?start=newbot')
     } catch {
-      // If the API call fails, keep polling — user may open Telegram manually
+      // Telegram not installed — browser will open instead
+      try { await openUrl('https://t.me/BotFather') } catch { /* ignore */ }
     }
-    startPolling()
+  }
+
+  const handleConnect = async () => {
+    const token = tokenInput.trim()
+    if (!token) return
+    onChange({ phase: 'connecting', errorMessage: '' })
+    try {
+      const resp = await configureAgentBot(agentId, name, token)
+      if (resp.success && resp.username) {
+        onChange({ phase: 'done', username: resp.username })
+        setTokenInput('')
+      } else {
+        onChange({ phase: 'entering_token', errorMessage: resp.message ?? 'Invalid token — try again.' })
+      }
+    } catch {
+      onChange({ phase: 'entering_token', errorMessage: 'Connection failed — check your token and try again.' })
+    }
   }
 
   const isDone = state.phase === 'done'
-  const isWaiting = state.phase === 'awaiting_telegram'
+  const isEntering = state.phase === 'entering_token'
+  const isConnecting = state.phase === 'connecting'
   const isSkipped = state.phase === 'skipped'
 
   return (
@@ -174,16 +146,10 @@ function AgentBotCard({
             </button>
           )}
 
-          {isWaiting && (
-            <span className="text-xs text-gray-400 font-InterTight animate-pulse">
-              Waiting for Telegram…
-            </span>
-          )}
-
-          {(isWaiting || state.phase === 'error') && !isSkipped && (
+          {(isEntering || isConnecting) && (
             <button
-              className="text-xs text-gray-400 hover:text-gray-600 underline font-InterTight ml-2"
-              onClick={() => { stopPolling(); onChange({ phase: 'skipped' }) }}
+              className="text-xs text-gray-400 hover:text-gray-600 underline font-InterTight"
+              onClick={() => onChange({ phase: 'skipped', errorMessage: '' })}
             >
               Skip
             </button>
@@ -200,22 +166,33 @@ function AgentBotCard({
         </div>
       </div>
 
-      {state.phase === 'error' && (
-        <div className="mt-2 flex items-center gap-3">
-          <p className="text-xs text-red-500 font-InterTight flex-1">{state.errorMessage}</p>
-          <button
-            className="text-xs text-[#913631] underline font-InterTight whitespace-nowrap"
-            onClick={handleSetUp}
-          >
-            Retry →
-          </button>
+      {(isEntering || isConnecting) && (
+        <div className="mt-3 space-y-2">
+          <p className="text-xs text-gray-500 font-InterTight">
+            In BotFather, type <span className="font-mono text-gray-700">/newbot</span> and follow the steps. Then paste your token here:
+          </p>
+          {state.errorMessage && (
+            <p className="text-xs text-red-500 font-InterTight">{state.errorMessage}</p>
+          )}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              placeholder="123456:ABC-DEF1234…"
+              value={tokenInput}
+              onChange={e => setTokenInput(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleConnect()}
+              disabled={isConnecting}
+              className="flex-1 text-xs border border-gray-200 rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50"
+            />
+            <button
+              onClick={handleConnect}
+              disabled={isConnecting || !tokenInput.trim()}
+              className="text-xs font-medium font-InterTight px-3 py-2 rounded-lg bg-[#913631] text-white hover:bg-[#7a2d29] disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+            >
+              {isConnecting ? 'Connecting…' : 'Connect'}
+            </button>
+          </div>
         </div>
-      )}
-
-      {isWaiting && (
-        <p className="mt-2 text-xs text-gray-400 font-InterTight">
-          Complete bot creation in Telegram — this will update automatically.
-        </p>
       )}
     </div>
   )
@@ -305,7 +282,7 @@ export function TelegramAccountsScreen({
         <p className="mt-3 text-gray-500 text-base font-InterTight leading-relaxed">
           Each agent gets their own Telegram bot. Click{' '}
           <span className="font-medium text-gray-700">Set up →</span> to open
-          Telegram and create it — takes about 10 seconds per bot.
+          BotFather, create a bot with <span className="font-mono text-sm">/newbot</span>, then paste the token — takes about 30 seconds per bot.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

- Replaces the managed-bot deeplink approach (which required Telegram's Bot Management Mode approval) with a direct BotFather flow — no backend dependency
- When the user clicks "Set up →", BotFather opens with `/newbot` pre-started and the card expands showing exactly what to type:
  - **Name →** `Polly (Knapsack)` [Copy]
  - **Username →** `@knapsack_mark_polly_bot` [Copy]
- User pastes the token BotFather gives them — validated instantly via Telegram's `getMe` API
- `botId` is stored alongside the token in `openclaw.json` (required for future token rotation)
- Card flips to ✓ `@username` on success; shows inline error with the exact rejection reason on failure

## Test plan

- [ ] Click "Set up →" — BotFather opens to `/newbot` flow
- [ ] Verify suggested name and username appear in the card and are copy-able
- [ ] Create the bot in BotFather using the suggested values, paste token → card shows ✓
- [ ] Paste an invalid token → inline error shown, can retry
- [ ] Skip a bot → grays out; Undo restores it
- [ ] Re-enter screen after setup — already-connected bots pre-populate from `openclaw.json`
- [ ] Continue button shows count of connected bots

https://claude.ai/code/session_01HQL545iM9FaivM6URpRtsg