### PR TITLE
fix: open BotFather without ?start=newbot payload

### DIFF
--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -100,10 +100,8 @@ function AgentBotCard({
   const handleSetUp = async () => {
     onChange({ phase: 'entering_token', errorMessage: '' })
     try {
-      await openUrl('https://t.me/BotFather?start=newbot')
-    } catch {
-      try { await openUrl('https://t.me/BotFather') } catch { /* ignore */ }
-    }
+      await openUrl('https://t.me/BotFather')
+    } catch { /* ignore */ }
   }
 
   const handleConnect = async () => {


### PR DESCRIPTION
## Summary

- Remove `?start=newbot` from the BotFather URL in the Telegram onboarding screen
- `?start=newbot` sends `/start newbot` to BotFather, which interprets `"newbot"` as a bot username payload and replies "Invalid bot passed." instead of opening the new-bot creation flow
- Opening `https://t.me/BotFather` directly lets the user see BotFather's menu and follow the `/newbot` instructions shown in the onboarding card

## Test plan

- [ ] Click "Set up →" on any agent card in the Telegram onboarding screen
- [ ] Verify BotFather opens without an "Invalid bot passed." error
- [ ] Follow the on-screen instructions (send `/newbot`, enter the suggested name/username)
- [ ] Paste the token and confirm the card shows the connected username

https://claude.ai/code/session_01HQL545iM9FaivM6URpRtsg