### PR TITLE
claude/fix-calendar-meetings-IsoQO

### DIFF
--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -1164,6 +1164,14 @@ export function useFeed(
             if (runParams?.event_id && meetings) {
               item.calendarEvent = Object.values(meetings).find(m => m.event_id === runParams.event_id)
             }
+            // Fallback: match by title + start-minute so feed items without an
+            // event_id (e.g. manually created sessions) still surface in Coming Up.
+            if (!item.calendarEvent && item.title && item.timestamp && meetings) {
+              const startMin = Math.floor(item.timestamp.getTime() / 60000)
+              item.calendarEvent = Object.values(meetings).find(
+                m => m.title === item.title && Math.floor(m.start / 60) === startMin,
+              )
+            }
 
             const timelineKey = KNDateUtils.timelineKeyFromTimestamp(item.timestamp)
             acc[timelineKey] = acc[timelineKey] || []


### PR DESCRIPTION
Feed items created without a calendar event_id (e.g. manually started
sessions) were not shown in the Coming Up sidebar because
calendarEvent was never set on them, even when a matching calendar
event existed. Add a title + start-minute fallback lookup so those
items surface in Coming Up alongside fresh calendar injections.

https://claude.ai/code/session_016AXBaqrYc2cuGbNzWwkP5Y