### PR TITLE
claude/background-chat-switching-gUIrH

### DIFF
--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -553,8 +553,7 @@ function Home({
                 />
               )}
 
-              {currentTab === TabChoices.Openclaw && (
-                <div className="overflow-hidden w-full h-full flex flex-row relative">
+              <div className={`overflow-hidden w-full h-full flex flex-row relative${currentTab !== TabChoices.Openclaw ? ' hidden' : ''}`}>
                   <div className="overflow-hidden flex-1 h-full min-w-0">
                     <ClawdChat
                       showActivityPanel={showActivityPanel}
@@ -622,7 +621,6 @@ function Home({
                     />
                   )}
                 </div>
-              )}
 
               {currentTab === TabChoices.Email && (
                 <EmailTabView


### PR DESCRIPTION
Previously the component was conditionally rendered with
`{currentTab === TabChoices.Openclaw && ...}`, which unmounted it on
tab switch and killed any in-flight streaming request. Now the wrapper
div is always rendered but toggled with Tailwind's `hidden` class so
the component stays mounted and chat completes in the background.

https://claude.ai/code/session_01DbpBnjQiEZpNUSRdqVz9tu