### PR TITLE
dev mode fixes

### DIFF
--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -69,7 +69,8 @@
           "https://login.microsoftonline.com/**",
           "https://data.amplitude.com/**",
           "https://x2.amplitude.com/**",
-          "https://api.github.com/**"
+          "https://api.github.com/**",
+          "https://registry.npmjs.org/**"
         ]
       },
       "notification": {
@@ -192,7 +193,7 @@
       }
     },
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.cdnfonts.com https://www.nerdfonts.com https://fonts.googleapis.com; font-src 'self' https://fonts.cdnfonts.com https://www.nerdfonts.com https://fonts.gstatic.com data:; img-src 'self' asset: https: data: blob:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://127.0.0.1:* https://knap.ai https://api.knapsack.ai https://api.openai.com https://gmail.googleapis.com https://www.googleapis.com https://accounts.google.com https://login.microsoftonline.com https://data.amplitude.com https://x2.amplitude.com https://api.github.com https://*.loom.com; media-src 'self' blob: data:; frame-src 'self' https://*.loom.com; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.cdnfonts.com https://www.nerdfonts.com https://fonts.googleapis.com; font-src 'self' https://fonts.cdnfonts.com https://www.nerdfonts.com https://fonts.gstatic.com data:; img-src 'self' asset: https: data: blob:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://127.0.0.1:* https://knap.ai https://api.knapsack.ai https://api.openai.com https://gmail.googleapis.com https://www.googleapis.com https://accounts.google.com https://login.microsoftonline.com https://data.amplitude.com https://x2.amplitude.com https://api.github.com https://registry.npmjs.org https://*.loom.com; media-src 'self' blob: data:; frame-src 'self' https://*.loom.com; worker-src 'self' blob:"
     },
     "updater": {
       "active": true,

--- a/src/src/components/organisms/DeveloperModePanel/GitHubConnect.tsx
+++ b/src/src/components/organisms/DeveloperModePanel/GitHubConnect.tsx
@@ -27,11 +27,7 @@ export default function GitHubConnect({ activeRepo }: GitHubConnectProps) {
   // Check GitHub skill status
   const checkStatus = useCallback(async () => {
     try {
-      const resp = await fetch(`${API_BASE}/api/clawd/skills/status`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      })
+      const resp = await fetch(`${API_BASE}/api/clawd/skills/status`)
       const data = await resp.json()
       const skills: SkillStatus[] = data?.skills || []
       const gh = skills.find((s: SkillStatus) => s.name === 'github')


### PR DESCRIPTION
- GitHubConnect: skills/status was called with POST but backend is GET → 405 → "Could not check skill status"
- tauri.conf.json: registry.npmjs.org missing from CSP connect-src and HTTP allowlist → fetch blocked → "Load failed" on OpenClaw version check

https://claude.ai/code/session_012JMM2jTVGgdPFkiTr5z1Tn