### PR TITLE
claude/fix-stuck-state-mBbMg

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -742,10 +742,27 @@ fn is_empty_allow_from(value: Option<&serde_json::Value>) -> bool {
 /// Strategy: downgrade `dmPolicy` from "allowlist" to "pairing" so the
 /// gateway can start. The user retains their other channel settings intact.
 ///
+/// `openclaw doctor --fix` (v2026.4+) migrates `streaming: "partial"` → `streaming: {mode: "partial"}`.
+/// The bundled gateway still validates `streaming` as a scalar.  Extract `mode` and restore the scalar.
+fn downgrade_streaming_if_object(val: &serde_json::Value) -> Option<serde_json::Value> {
+  let obj = val.as_object()?;
+  let mode = obj.get("mode")?;
+  match mode {
+    serde_json::Value::Bool(_) => Some(mode.clone()),
+    serde_json::Value::String(s)
+      if matches!(s.as_str(), "off" | "partial" | "block" | "progress") =>
+    {
+      Some(mode.clone())
+    }
+    _ => None,
+  }
+}
+
 /// Handles:
 ///   - Top-level per-channel `dmPolicy` / `allowFrom`
 ///   - Per-account `dmPolicy` / `allowFrom` inside `channels.*.accounts.*`
 ///   - Google Chat's `dm.policy` / `dm.allowFrom` sub-object
+///   - `streaming` object → scalar downgrade (doctor --fix version mismatch)
 ///
 /// Returns `true` if any fields were modified (caller should persist config).
 fn sanitize_channel_allowlist_configs(cfg: &mut serde_json::Value) -> bool {
@@ -808,6 +825,29 @@ fn sanitize_channel_allowlist_configs(cfg: &mut serde_json::Value) -> bool {
       }
     }
 
+    // ── Streaming object → scalar downgrade (channel-level) ──────────
+    // `openclaw doctor --fix` converts `streaming: "partial"` to `streaming: {mode: "partial"}`.
+    // The bundled gateway only accepts a scalar; extract `.mode` and restore it.
+    let streaming_is_obj = cfg
+      .pointer(&format!("{}/streaming", channel_ptr))
+      .map(|v| v.is_object())
+      .unwrap_or(false);
+    if streaming_is_obj {
+      let scalar_opt = cfg
+        .pointer(&format!("{}/streaming", channel_ptr))
+        .and_then(downgrade_streaming_if_object);
+      if let Some(scalar) = scalar_opt {
+        if let Some(ch) = cfg.pointer_mut(&channel_ptr).and_then(|v| v.as_object_mut()) {
+          ch.insert("streaming".to_string(), scalar);
+          eprintln!(
+            "[clawd/service] Auto-fixed channels.{}.streaming: object → scalar",
+            channel_name
+          );
+          patched = true;
+        }
+      }
+    }
+
     // ── Per-account dmPolicy / allowFrom ────────────────────────────
     // Multi-account channels (telegram, discord, slack, irc, …) can have
     // per-account overrides under `channels.<channel>.accounts.<id>`.
@@ -845,6 +885,30 @@ fn sanitize_channel_allowlist_configs(cfg: &mut serde_json::Value) -> bool {
               "[clawd/service] Auto-fixed invalid OpenClaw config: \
                channels.{}.accounts.{}.dmPolicy=\"allowlist\" but allowFrom is \
                missing/empty (and no parent allowFrom) — downgraded to \"pairing\"",
+              channel_name, account_name
+            );
+            patched = true;
+          }
+        }
+      }
+
+      // ── Streaming object → scalar downgrade (per-account) ──────────
+      let acct_streaming_is_obj = cfg
+        .pointer(&format!("{}/streaming", acct_ptr))
+        .map(|v| v.is_object())
+        .unwrap_or(false);
+      if acct_streaming_is_obj {
+        let scalar_opt = cfg
+          .pointer(&format!("{}/streaming", acct_ptr))
+          .and_then(downgrade_streaming_if_object);
+        if let Some(scalar) = scalar_opt {
+          if let Some(acct) = cfg
+            .pointer_mut(&acct_ptr)
+            .and_then(|v| v.as_object_mut())
+          {
+            acct.insert("streaming".to_string(), scalar);
+            eprintln!(
+              "[clawd/service] Auto-fixed channels.{}.accounts.{}.streaming: object → scalar",
               channel_name, account_name
             );
             patched = true;

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -413,6 +413,89 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
       ),
     }
   }
+
+  // Pass 2: Shared bundler chunks (e.g. sticker-cache.js) sit in the root dist/ and
+  // resolve require() from the ROOT clawdbot node_modules — not from the per-plugin
+  // node_modules installed above.  Collect all plugin runtime deps that are missing
+  // from root node_modules and install them there with a targeted npm install.
+  let clawdbot_root = match extensions_dir.parent().and_then(|p| p.parent()) {
+    Some(r) => r.to_path_buf(),
+    None => return,
+  };
+  let root_nm = clawdbot_root.join("node_modules");
+
+  let mut missing_root: Vec<String> = Vec::new();
+  if let Ok(root_entries) = fs::read_dir(extensions_dir) {
+    for entry in root_entries.flatten() {
+      if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        continue;
+      }
+      let pkg: serde_json::Value = match fs::read_to_string(entry.path().join("package.json"))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+      {
+        Some(v) => v,
+        None => continue,
+      };
+      if !pkg
+        .pointer("/openclaw/bundle/stageRuntimeDependencies")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+      {
+        continue;
+      }
+      if let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) {
+        for dep in deps.keys() {
+          if !root_nm.join(dep).exists() && !missing_root.contains(dep) {
+            missing_root.push(dep.clone());
+          }
+        }
+      }
+    }
+  }
+
+  if missing_root.is_empty() {
+    return;
+  }
+
+  eprintln!(
+    "[clawd/service] Installing {} plugin runtime dep(s) into root node_modules: {}",
+    missing_root.len(),
+    missing_root.join(", ")
+  );
+
+  let mut root_args: Vec<&str> = vec!["install"];
+  let missing_refs: Vec<&str> = missing_root.iter().map(|s| s.as_str()).collect();
+  root_args.extend(missing_refs.iter().copied());
+  root_args.extend(["--no-save", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"]);
+
+  #[cfg(target_os = "windows")]
+  let root_result = {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    std::process::Command::new(&npm)
+      .args(&root_args)
+      .current_dir(&clawdbot_root)
+      .creation_flags(CREATE_NO_WINDOW)
+      .status()
+  };
+  #[cfg(not(target_os = "windows"))]
+  let root_result = std::process::Command::new(&npm)
+    .args(&root_args)
+    .current_dir(&clawdbot_root)
+    .status();
+
+  match root_result {
+    Ok(s) if s.success() => eprintln!("[clawd/service] Root plugin runtime deps installed"),
+    Ok(s) => eprintln!(
+      "[clawd/service] WARNING: root npm install for plugin runtime deps exited {}",
+      s
+    ),
+    Err(e) => eprintln!(
+      "[clawd/service] WARNING: root npm install for plugin runtime deps failed: {}",
+      e
+    ),
+  }
 }
 
 /// Check if the gateway Node.js binary or the bundled clawdbot directory is

--- a/src/src-tauri/src/local_fs.rs
+++ b/src/src-tauri/src/local_fs.rs
@@ -108,24 +108,36 @@ fn remove_repeated_whitespace(input: &str) -> String {
 }
 
 pub fn read_pdf_contents(path: PathBuf) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-  let cmd = Command::new_sidecar(PDF_TO_TEXT_BINARY_NAME)
-    .map_err(|e| format!("pdftotext sidecar not found (is it bundled?): {}", e))?;
-  let output = cmd
-    .args(&["-layout", path.to_str().unwrap_or(""), "-"])
-    .output()
-    .map_err(|e| format!("pdftotext failed to run: {}", e))?;
-  // println!("read_pdf_contents: after");
+  let path_str = path.to_str().unwrap_or("").to_string();
 
-  if !output.status.success() {
-    error!(
-      "pdftotext ERROR: command error {:?}",
-      path.to_str().unwrap()
-    );
-  }
-  debug!("Content len: {}", output.stdout.len());
+  // Try the bundled Tauri sidecar first; fall back to the system pdftotext binary
+  // (available via `brew install poppler` on macOS) so dev builds work without bundling.
+  let stdout: String = match Command::new_sidecar(PDF_TO_TEXT_BINARY_NAME) {
+    Ok(cmd) => {
+      let output = cmd
+        .args(&["-layout", &path_str, "-"])
+        .output()
+        .map_err(|e| format!("pdftotext failed to run: {}", e))?;
+      if !output.status.success() {
+        error!("pdftotext ERROR: command error {:?}", path_str);
+      }
+      debug!("Content len: {}", output.stdout.len());
+      output.stdout
+    }
+    Err(_) => {
+      let output = std::process::Command::new(PDF_TO_TEXT_BINARY_NAME)
+        .args(["-layout", &path_str, "-"])
+        .output()
+        .map_err(|e| format!("pdftotext failed to run: {}", e))?;
+      if !output.status.success() {
+        error!("pdftotext ERROR: command error {:?}", path_str);
+      }
+      debug!("Content len: {}", output.stdout.len());
+      String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+  };
 
-  let trimmed_output = remove_repeated_whitespace(&output.stdout);
-
+  let trimmed_output = remove_repeated_whitespace(&stdout);
   let pdf_text = String::from_utf8_lossy(trimmed_output.as_bytes()).to_string();
 
   let splitter = TextSplitter::default();

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -1443,8 +1443,11 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [editingQueuedIndex, setEditingQueuedIndex] = useState<number | null>(null)
   const [editingQueuedText, setEditingQueuedText] = useState('')
 
-  // Abort controller for stopping generation
-  const [abortController, setAbortController] = useState<AbortController | null>(null)
+  // Abort controller for stopping generation — stored in a ref for synchronous access.
+  // Using state here would cause stopGeneration to see a stale null value during the
+  // brief window between setAbortController(controller) being called and React committing
+  // the state update, leaving busy=true stuck forever if the user clicks Stop too fast.
+  const abortControllerRef = useRef<AbortController | null>(null)
   const [status, setStatus] = useState<ServiceStatus | null>(null)
   const [health, setHealth] = useState<ServiceHealth | null>(null)
   const [currentTargetId, setCurrentTargetId] = useState<string | null>(null)
@@ -3217,18 +3220,22 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
   // Stop current generation
   const stopGeneration = useCallback(() => {
-    if (abortController) {
-      abortController.abort()
-      setAbortController(null)
-      if (thinkingIntervalRef.current) {
-        clearInterval(thinkingIntervalRef.current)
-        thinkingIntervalRef.current = null
-      }
+    const hadController = !!abortControllerRef.current
+    const hadInterval = !!thinkingIntervalRef.current
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+    if (thinkingIntervalRef.current) {
+      clearInterval(thinkingIntervalRef.current)
+      thinkingIntervalRef.current = null
+    }
+    if (hadController || hadInterval) {
       setBusy(false)
       setThinkingMessage(null)
       pushAssistant('⏹️ Generation stopped.')
     }
-  }, [abortController, pushAssistant])
+  }, [pushAssistant])
 
   // Clear chat history and start fresh
   const clearHistory = useCallback(() => {
@@ -3819,7 +3826,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
       // Create abort controller for this request
       const controller = new AbortController()
-      setAbortController(controller)
+      abortControllerRef.current = controller
 
       try {
         // Get the current tone's system prompt addition
@@ -4059,7 +4066,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           thinkingIntervalRef.current = null
         }
         setThinkingMessage(null)
-        setAbortController(null)
+        abortControllerRef.current = null
       }
     } catch (e: any) {
       pushAssistant(friendlyError(e?.message || String(e), activeModelAtSend))


### PR DESCRIPTION
stopGeneration checked `if (abortController)` from React state, which can be
null during the brief window after setAbortController(controller) is called but
before React commits the update. If the user clicked Stop in that window, the
entire cleanup block was skipped — leaving busy=true and the thinking spinner
stuck forever.

Using a useRef mirrors the existing thinkingIntervalRef pattern and gives
stopGeneration synchronous access to the current controller regardless of
React's render cycle. The guard `hadController || hadInterval` prevents a
spurious "Generation stopped." message when nothing is actually running.

https://claude.ai/code/session_01LmpU21hfSauuxBZY8FbLua