### PR TITLE
Additional calendar fixes

### DIFF
--- a/src/src-tauri/src/audio/audio.rs
+++ b/src/src-tauri/src/audio/audio.rs
@@ -573,8 +573,10 @@ pub async fn stop_recording(
 
   if let Some(handle) = output_handle {
     if let Err(e) = handle.await {
-      let err_msg = format!("Audio output recording task failed to complete: {:?}", e);
-      return HttpResponse::InternalServerError().body(err_msg);
+      // System audio recording is optional (started only when permission is
+      // granted). A panic here must not abort stop_recording — the mic track
+      // and transcript are still valid and must be processed.
+      log::error!("Audio output recording task failed (non-fatal): {:?}", e);
     }
   }
 

--- a/src/src/automations/steps/MeetingPrep.tsx
+++ b/src/src/automations/steps/MeetingPrep.tsx
@@ -91,39 +91,37 @@ Using any of the above information, help me prepare for this meeting:
     ${meeting.description}
     the meeting is ${isRecurrent ? 'recurring' : 'not recurring'}
 
-Speak to me in the second person (e.g., Your last interaction with this person was…”).  Do not use any information about people who are not participants in this meeting unless they work at the same company as people in this meeting.
+You are my chief of staff. Speak to me in the second person and write a thorough briefing that ensures I walk into this meeting completely prepared. Do not use any information about people who are not participants in this meeting unless they work at the same company as people in this meeting. My email is ${userEmail}.
 
-Output the meeting preparation in this format (without printing the <format> and </format> tags:
+Output the meeting preparation in this format (without printing the <format> and </format> tags):
 
 <format>
 
 ## Location/Video Call link
 ${meeting.location === undefined ? meeting.google_meet_url : ''}
+<If the meeting has additional location, arrival, or call info beyond the above, include it here. Never list more than two phone numbers.>
 
-<If the meeting has additional data about location, arrival, or video / audio call information beyond anything listed above, you can tell me more here. Never list more than two phone numbers.>
+## Briefing
 
-## Background
-<Use bullets separated by line breaks and be concise.>
-<In this section, comment on my relationship and previous interactions with each of the participants, and any recent previous meetings. Do not include information on colleagues who share my email domain.  If it is a recurring meeting, mention that, and look for details on what was discussed in previous instances of the meeting.  If the context includes any insight on the purpose of the meeting, include it here. If not, make your best guess on what may be discussed in the meeting based on any information provided about the companies involved. Include in markdown link format any relevant links to documents or web pages - i.e. [Product Spreadsheet](https://sheets.google.com/id/sheet) or [Presentation video](https://youtube.com/our_video) - that were shared in the context that may be relevant to the meeting.  The max length of this should be 100 words, with a few punchy bullets.>
+Write two full paragraphs as a seasoned chief of staff briefing an executive:
 
-## Summary
-<Use bullets and be concise.>
-<If there are people with emails domains different than mine (${userEmail}), include relevant insights about them from the web pages above, including recent news or social media posts.>
-<In this section, write out important details or context for how each of the participants is coming into the meeting and what they are likely to want to discuss, including any ongoing issues or challenges that have been discussed previously.>
-<Include information from the web pages, if it's relevant to where the invitees work, their roles, or our agenda.  The max length of this should be 100 words, with a few punchy bullets.>
+**Paragraph 1 — Context & Relationships:** Who are these people and what is your history with them? Cover your relationship with each external participant, any recent interactions or meetings, what they care about, and what has been discussed or agreed previously. If it is a recurring meeting, surface what was covered last time. Include any relevant links in markdown format — e.g. [Deck](https://drive.google.com/...) — for documents shared in context. Do not include internal colleagues who share your email domain unless relevant.
 
-## Action items & proposed questions
-<Use bullets and be concise.>
-<If any action items or next steps were discussed in the context, please list them out here, including the current status.  Include proposed questions that you recommend I should ask of the participants based on the context provided. The max length of this should be 100 words, with a few punchy bullets.>
+**Paragraph 2 — Situation & Stakes:** What is each participant likely to want from this meeting and why does it matter? Draw on web research, recent news, or social media about their company or role if available. Describe the dynamics walking in — any tensions, open items, or opportunities — and your recommended approach or posture for the conversation.
+
+## Your game plan
+
+Provide a short bulleted list (4–6 bullets) of:
+- Any open action items or outstanding commitments from previous interactions, with status
+- The 2–3 most important things you want to accomplish or get agreement on in this meeting
+- Sharp, specific questions you should ask — tailored to what you know about each participant
 
 ## Icebreaker
-<Include one interesting fact, insight, or joke that you think the participants in the meeting who are not on your domain would not already know and find funny or interesting.>
+One genuinely interesting or funny observation about one of the external participants or their company that would make for a natural opener.
 
 </format>
 
-For all of the above meeting preparation, keep in mind that my email is ${userEmail}. Pay particular attention to emails from people who have a different domain than me. Try not to include names if they're not in the meeting invite, but you can mention other names if the information is relevant to our agenda for the upcoming meeting.
-
-Be informative, and keep responses for each section short. Provide as much info as the user needs. Give your response in Markdown, so that it can be rendered nicely. Talk to me warmly and encouragingly as if you're my assistant.`
+Give your response in Markdown so it renders well. Be thorough — this is a full chief-of-staff briefing, not a summary.`
 
     const identifiers = [...emails.map(email => email.emailUid), ...driveDocumentIds.map(id => id)]
     const types = [

--- a/src/src/components/organisms/CenterWorkspace/index.tsx
+++ b/src/src/components/organisms/CenterWorkspace/index.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useState, useEffect, useMemo } from 'react'
 import { invoke } from '@tauri-apps/api/tauri'
+import { Workspace } from 'src/api/workspaces'
 
 import './style.scss'
 
@@ -57,6 +58,7 @@ interface CenterWorkspaceProps {
   profileProvider?: string
   handleErrorContact: (message: string) => void
   recordingHandlers: RecordingContextProps
+  onLibraryWorkspaceOpen?: (ws: Workspace) => void
 }
 
 export enum SubTabChoices {
@@ -103,6 +105,7 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
   profileProvider,
   handleErrorContact,
   recordingHandlers,
+  onLibraryWorkspaceOpen,
 }) => {
   const [synthesisState, setSynthesisState] = useState(false)
   const [transcriptState, setTranscriptState] = useState<TranscriptState>({ isOpen: false })
@@ -351,6 +354,7 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
                       handleErrorContact={handleErrorContact}
                       recordingHandlers={recordingHandlers}
                       handleOpenTasks={handleOpenTasks}
+                      onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
                     />
                   </div>
                   )

--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -40,6 +40,7 @@ import { invoke } from '@tauri-apps/api/tauri'
 import MeetingChatNotice from 'src/components/molecules/MeetingChatNotice'
 import { TaskItem } from '../CenterWorkspace'
 import { RecordingContextProps } from './RecordingContext'
+import { listWorkspaces, Workspace } from 'src/api/workspaces'
 
 interface MenuButtonProps<T = any> {
   isActive: boolean
@@ -98,6 +99,7 @@ interface MeetingNotesModeProps {
   handleOpenInsights?: (threadId: number | undefined) => void
   onChatClick?: () => void
   onEmailClick?: (notesMarkdown: string) => void
+  onLibraryWorkspaceOpen?: (ws: Workspace) => void
 }
 
 const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
@@ -123,11 +125,26 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   handleOpenInsights,
   onChatClick,
   onEmailClick,
+  onLibraryWorkspaceOpen,
 }) => {
   const [isInitialLoading, setIsInitialLoading] = useState(true)
   const [disableIsRecording, setDisableIsRecording] = useState(false)
   const [permissionError, setPermissionError] = useState<string | null>(null)
   const [notesMarkdown, setNotesMarkdown] = useState<string>('')
+  const [personWorkspaces, setPersonWorkspaces] = useState<Record<string, Workspace>>({})
+
+  useEffect(() => {
+    listWorkspaces().then(res => {
+      if (!res.success) return
+      const map: Record<string, Workspace> = {}
+      res.data.forEach(ws => {
+        if (ws.entityType === 'person' && ws.entityKey) {
+          map[ws.entityKey.toLowerCase()] = ws
+        }
+      })
+      setPersonWorkspaces(map)
+    }).catch(() => {})
+  }, [])
   const [isTitleSet, setIsTitleSet] = useState(thread.subtitle !== 'Untitled Meeting')
   const [transcribingTextIndex, setTranscribingTextIndex] = useState(0)
   const transcribingTexts = [
@@ -985,11 +1002,27 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
                 <div className="notetaker-note__prep-row">
                   <span className="notetaker-note__prep-label">Attendees</span>
                   <div className="notetaker-note__prep-chips">
-                    {meeting.participants.map((p, i) => (
-                      <span key={i} className="notetaker-note__prep-chip">
-                        {p.name || p.email.split('@')[0]}
-                      </span>
-                    ))}
+                    {meeting.participants.map((p, i) => {
+                      const ws = personWorkspaces[p.email?.toLowerCase()]
+                      const label = p.name || p.email.split('@')[0]
+                      if (ws && onLibraryWorkspaceOpen) {
+                        return (
+                          <button
+                            key={i}
+                            className="notetaker-note__prep-chip notetaker-note__prep-chip--linked"
+                            onClick={() => onLibraryWorkspaceOpen(ws)}
+                            title={`Open ${label}'s library record`}
+                          >
+                            {label}
+                          </button>
+                        )
+                      }
+                      return (
+                        <span key={i} className="notetaker-note__prep-chip">
+                          {label}
+                        </span>
+                      )
+                    })}
                   </div>
                 </div>
               )}

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -86,11 +86,12 @@ function NotetakerSidebar({
 
   const upcomingEvents = useMemo(() => {
     if (!feed.feedContent) return {}
+    const startOfToday = dayjs().startOf('day').valueOf()
     const events: { item: FeedItem; key: string }[] = []
     Object.entries(feed.feedContent).forEach(([key, items]) => {
       if (key === STATIONARY_ITEMS) return
       items.forEach(item => {
-        if (item.calendarEvent) {
+        if (item.calendarEvent && item.timestamp.getTime() >= startOfToday) {
           events.push({ item, key })
         }
       })

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -515,6 +515,10 @@ function Home({
                     feed={feed}
                     llmBar={llmBar}
                     userImg={userImage}
+                    onLibraryWorkspaceOpen={(ws) => {
+                      setCurrentTab(TabChoices.Library)
+                      setSelectedWorkspace(ws)
+                    }}
                     updateAutomation={updateAutomation}
                     handleVote={handleVote}
                     votes={votes}
@@ -648,8 +652,12 @@ function Home({
                   }}
                   onChatClick={() => setMeetingSubView('chat')}
                   onEmailClick={(notesMarkdown) => {
-                    if (copyToClipboard) copyToClipboard(notesMarkdown)
-                    setCurrentTab(TabChoices.Email)
+                    setMeetingSubView('chat')
+                    setTimeout(() => {
+                      window.dispatchEvent(new CustomEvent('clawd-send-user', {
+                        detail: `Write a professional follow-up email based on these meeting notes:\n\n${notesMarkdown}`,
+                      }))
+                    }, 300)
                   }}
                 />
               )}

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -591,4 +591,16 @@ html, body {
   background: #EBEBEB;
   padding: 3px 8px;
   border-radius: 12px;
+  border: none;
+  cursor: default;
+}
+
+.notetaker-note__prep-chip--linked {
+  color: #4A6FA5;
+  background: #EAF0FB;
+  cursor: pointer;
+}
+
+.notetaker-note__prep-chip--linked:hover {
+  background: #D5E3F7;
 }


### PR DESCRIPTION
Meeting prep — prompt rewritten as a two-paragraph chief-of-staff briefing (context/relationships + situation/stakes) with a game-plan bullet list, replacing the short bullet format.
Attendee chips — now show as blue clickable links when a library record exists for that person; click opens their library workspace.
Write follow-up email — no longer opens Email Autopilot. Now switches to the meeting chat and sends a prompt asking the AI to draft the email from the meeting notes.
Recording crash — JoinError::Panic from the optional system-audio output task no longer aborts stop_recording. It logs the error and continues, so mic recording and transcript processing always complete.