### PR TITLE
fix browser downloads

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/pw-ai-_2ysvYvZ.js
+++ b/src/src-tauri/resources/clawdbot/dist/pw-ai-_2ysvYvZ.js
@@ -864,14 +864,7 @@ async function saveDownloadPayload(download, outPath) {
 	const requestedPath = outPath?.trim();
 	const resolvedOutPath = path.resolve(requestedPath || buildTempDownloadPath(suggested));
 	await fs.mkdir(path.dirname(resolvedOutPath), { recursive: true });
-	if (!requestedPath) await download.saveAs?.(resolvedOutPath);
-	else await writeViaSiblingTempPath({
-		rootDir: path.dirname(resolvedOutPath),
-		targetPath: resolvedOutPath,
-		writeTemp: async (tempPath) => {
-			await download.saveAs?.(tempPath);
-		}
-	});
+	await download.saveAs?.(resolvedOutPath);
 	return {
 		url: download.url?.() || "",
 		suggestedFilename: suggested,


### PR DESCRIPTION
Previously saveDownloadPayload called download.saveAs(siblingTempPath)
then copied to the target via the Python pinned-write helper. This had
two side effects:

1. Chrome's download history pointed to the .openclaw-output-*.part
   temp file instead of the real target, surfacing a confusing UUID-
   named hidden file to users browsing their download history.
2. The sibling temp file was never cleaned up after the copy succeeded,
   leaking .openclaw-output-*.part files in the downloads directory.

Fix: call download.saveAs(resolvedOutPath) directly. Playwright's saveAs
is already atomic (it saves to an internal temp then renames), so the
pinned-write helper adds no correctness benefit here, only complexity.

https://claude.ai/code/session_0166S9oj9qaVyXwpBeTi8EXp