### PR TITLE
fix email button drawer

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -98,7 +98,7 @@ interface MeetingNotesModeProps {
   handleOpenTasks?: (threadId: number | undefined, tasks: TaskItem[]) => void
   handleOpenInsights?: (threadId: number | undefined) => void
   onChatClick?: () => void
-  onEmailClick?: (notesMarkdown: string) => void
+  onEmailClick?: (notesMarkdown: string, meeting: Meeting | undefined) => void
   onLibraryWorkspaceOpen?: (ws: Workspace) => void
 }
 
@@ -1088,7 +1088,7 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
             {thread.recorded && (
               <button
                 className="notetaker-note__bottom-action"
-                onClick={() => onEmailClick?.(notesMarkdown)}
+                onClick={() => onEmailClick?.(notesMarkdown, meeting)}
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M4 4v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.342a2 2 0 0 0-.602-1.43l-4.44-4.342A2 2 0 0 0 13.56 2H6a2 2 0 0 0-2 2z" />

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -5,6 +5,7 @@ import { IThread, ThreadType } from 'src/api/threads'
 import { Connection, ConnectionKeys } from 'src/api/connections'
 import { LLMParams } from 'src/App'
 import { IFeed } from 'src/hooks/feed/useFeed'
+import { Meeting } from 'src/hooks/dataSources/useCalendar'
 import { MeetingTemplatePrompt } from 'src/utils/template_prompts'
 
 import { Button, ButtonVariant } from 'src/components/atoms/button'
@@ -52,7 +53,7 @@ interface MeetingsTabViewProps {
   onConnectCalendar?: () => void
   onBack?: () => void
   onChatClick?: () => void
-  onEmailClick?: (notesMarkdown: string) => void
+  onEmailClick?: (notesMarkdown: string, meeting?: Meeting) => void
 }
 
 const MeetingsTabView = ({

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -506,7 +506,7 @@ function Home({
             }
           />
           <div data-tauri-drag-region className="overflow-hidden w-full h-full">
-            <div className="KNWorkspace overflow-hidden w-full h-full bg-ks-bg-main">
+            <div className="KNWorkspace overflow-hidden w-full h-full bg-ks-bg-main relative">
               {currentTab === TabChoices.Work && (
                 <div className="overflow-hidden w-full h-full flex flex-row">
                   <FeedSidebar feed={feed} isAnyRecording={isAnyRecording} />
@@ -601,14 +601,6 @@ function Home({
                       </div>
                     </>
                   )}
-                  {feed.loggedEmailAutopilot && feed.composedEmailDraft && (
-                    <EmailComposeDrawer
-                      draft={feed.composedEmailDraft}
-                      userEmail={userEmail}
-                      userName={userName}
-                      onDismiss={() => feed.setComposedEmailDraft(null)}
-                    />
-                  )}
                   {(feed.loggedEmailAutopilot || autopilotForceOpen) && (
                     <EmailNotificationDrawer
                       feed={feed}
@@ -649,13 +641,18 @@ function Home({
                     // Back from note view returns to sidebar
                   }}
                   onChatClick={() => setMeetingSubView('chat')}
-                  onEmailClick={(notesMarkdown) => {
-                    setMeetingSubView('chat')
-                    setTimeout(() => {
-                      window.dispatchEvent(new CustomEvent('clawd-send-user', {
-                        detail: `Write a professional follow-up email based on these meeting notes:\n\n${notesMarkdown}`,
-                      }))
-                    }, 300)
+                  onEmailClick={(notesMarkdown, meeting) => {
+                    const participants = meeting?.participants ?? []
+                    const toEmails = participants
+                      .filter(p => p.email && p.email !== userEmail)
+                      .map(p => p.email)
+                      .join(', ')
+                    const subject = meeting?.title ? `Follow up: ${meeting.title}` : 'Meeting Follow Up'
+                    const escapedNotes = notesMarkdown
+                      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                      .replace(/\n/g, '<br>')
+                    const body = `<p>Hi,</p><p>Thank you for our meeting${meeting?.title ? ` — ${meeting.title}` : ''}. Here's a summary of what we discussed:</p><p>${escapedNotes}</p><p>Please let me know if you have any questions!</p><p>Best,<br>${userName || ''}</p>`
+                    feed.setComposedEmailDraft({ to: toEmails, subject, body })
                   }}
                 />
               )}
@@ -727,6 +724,15 @@ function Home({
                 <div className="overflow-auto w-full h-full p-6">
                   <MCPMarketplace />
                 </div>
+              )}
+
+              {feed.loggedEmailAutopilot && feed.composedEmailDraft && (
+                <EmailComposeDrawer
+                  draft={feed.composedEmailDraft}
+                  userEmail={userEmail}
+                  userName={userName}
+                  onDismiss={() => feed.setComposedEmailDraft(null)}
+                />
               )}
 
             </div>


### PR DESCRIPTION
The "Write follow up email" button was dispatching a chat message instead of
opening the email drafting drawer. Now it builds a ComposedEmailDraft from
meeting participants and notes, sets it directly, and opens EmailComposeDrawer.
Also moved EmailComposeDrawer to KNWorkspace level so it renders on any tab.

https://claude.ai/code/session_012RHzuX8SFuYzFMehtFVsXC