### PR TITLE
Refactor artifact pruning and clean extension node_modules

### DIFF
--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -188,19 +188,39 @@ const REMOVE_DIRS = new Set([
   '.cache', 'docs', 'example', 'examples', 'test', 'tests', '__tests__',
   '__image_snapshots__', 'benchmark', 'benchmarks', '.github',
 ]);
-walkAndRemove(nodeModules, (name, isDir) => {
-  if (isDir) return REMOVE_DIRS.has(name);
-  const lower = name.toLowerCase();
-  // Legal/doc files
-  if (REMOVE_EXACT_NAMES.has(lower)) return true;
-  // Changelog and similar (prefix match)
-  if (lower.startsWith('changelog') || lower.startsWith('changes')
-      || lower.startsWith('history') || lower.startsWith('authors')) return true;
-  // Source maps, TypeScript source/declarations, and docs — never needed at JS runtime
-  return name.endsWith('.map')
-    || name.endsWith('.ts') || name.endsWith('.cts') || name.endsWith('.mts')
-    || name.endsWith('.md') || name.endsWith('.MD');
-});
+function pruneArtifacts(dir) {
+  walkAndRemove(dir, (name, isDir) => {
+    if (isDir) return REMOVE_DIRS.has(name);
+    const lower = name.toLowerCase();
+    // Legal/doc files
+    if (REMOVE_EXACT_NAMES.has(lower)) return true;
+    // Changelog and similar (prefix match)
+    if (lower.startsWith('changelog') || lower.startsWith('changes')
+        || lower.startsWith('history') || lower.startsWith('authors')) return true;
+    // Source maps, TypeScript source/declarations, and docs — never needed at JS runtime
+    return name.endsWith('.map')
+      || name.endsWith('.ts') || name.endsWith('.cts') || name.endsWith('.mts')
+      || name.endsWith('.md') || name.endsWith('.MD');
+  });
+}
+
+pruneArtifacts(nodeModules);
+
+// Also clean up extension-level node_modules (installed by install-bundled-plugin-deps.cjs).
+// These can contain test artifacts like __image_snapshots__ with deeply-nested paths that
+// exceed the Windows MAX_PATH limit and cause NSIS bundling to fail.
+if (fs.existsSync(distExtensionsDir)) {
+  try {
+    for (const extEntry of fs.readdirSync(distExtensionsDir, { withFileTypes: true })) {
+      if (!extEntry.isDirectory()) continue;
+      const extNodeModules = path.join(distExtensionsDir, extEntry.name, 'node_modules');
+      if (fs.existsSync(extNodeModules)) {
+        console.log(`[prune-clawdbot]     cleaning extension node_modules: ${extEntry.name}`);
+        pruneArtifacts(extNodeModules);
+      }
+    }
+  } catch { /* skip */ }
+}
 
 // Step 5: Report results
 console.log('[prune-clawdbot] 5/5 Computing final sizes...');


### PR DESCRIPTION
## Summary
Refactored the artifact pruning logic into a reusable function and extended it to clean up `node_modules` directories within bundled extensions, which can contain deeply-nested test artifacts that exceed Windows MAX_PATH limits during NSIS bundling.

## Key Changes
- Extracted the artifact pruning logic into a `pruneArtifacts(dir)` function to enable reuse across multiple directories
- Added cleanup of extension-level `node_modules` directories located in `distExtensionsDir`
- Iterates through each extension directory and prunes artifacts from their `node_modules` if present
- Includes error handling to gracefully skip extensions if directory traversal fails
- Added informative logging when cleaning extension node_modules

## Implementation Details
- The pruning criteria remain unchanged (removes test directories, documentation, source maps, TypeScript files, etc.)
- Extension cleanup only runs if `distExtensionsDir` exists and is safely wrapped in a try-catch block
- Uses `fs.readdirSync` with `withFileTypes: true` for efficient directory filtering
- Targets test artifacts like `__image_snapshots__` that can have deeply-nested paths problematic for Windows MAX_PATH limits during NSIS bundling

https://claude.ai/code/session_01MRVDSk27ghXnxgX7Aq4GjL