### PR TITLE
fix(prune): don't delete runtime .js modules with changelog-prefix names

### DIFF
--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -193,9 +193,11 @@ walkAndRemove(nodeModules, (name, isDir) => {
   const lower = name.toLowerCase();
   // Legal/doc files
   if (REMOVE_EXACT_NAMES.has(lower)) return true;
-  // Changelog and similar (prefix match)
-  if (lower.startsWith('changelog') || lower.startsWith('changes')
-      || lower.startsWith('history') || lower.startsWith('authors')) return true;
+  // Changelog and similar — only doc/text extensions, never runtime .js/.cjs/.mjs modules
+  const ext = lower.slice(lower.lastIndexOf('.'));
+  const isRuntimeModule = ext === '.js' || ext === '.cjs' || ext === '.mjs';
+  if (!isRuntimeModule && (lower.startsWith('changelog') || lower.startsWith('changes')
+      || lower.startsWith('history') || lower.startsWith('authors'))) return true;
   // Source maps, TypeScript source/declarations, and docs — never needed at JS runtime
   return name.endsWith('.map')
     || name.endsWith('.ts') || name.endsWith('.cts') || name.endsWith('.mts')


### PR DESCRIPTION
## Summary

- `prune-clawdbot.cjs` had a `startsWith('changelog')` prefix rule that was deleting `changelog.js` from `@mariozechner/pi-coding-agent/dist/utils/`, causing `ERR_MODULE_NOT_FOUND` at gateway startup after install
- Fix restricts the rule to non-runtime files only — anything that isn't `.js`/`.cjs`/`.mjs` is safe to prune; runtime modules must survive

## Test plan

- [ ] Verify `node_modules/@mariozechner/pi-coding-agent/dist/utils/changelog.js` is present after running `node scripts/prune-clawdbot.cjs`
- [ ] Verify gateway starts successfully after install (no `ERR_MODULE_NOT_FOUND` for `changelog.js`)
- [ ] Confirm documentation files (CHANGELOG.md, CHANGES.txt, etc.) are still pruned

https://claude.ai/code/session_013jigtcpFrYRZNGqo3pj2cA