### PR TITLE
Support multiple Google Calendar accounts per user

### DIFF
--- a/src/src-tauri/src/connections/google/auth.rs
+++ b/src/src-tauri/src/connections/google/auth.rs
@@ -46,6 +46,11 @@ pub struct SigninParams {
   scope: Option<String>,
   error: Option<String>,
   error_description: Option<String>,
+  /// When set, this is an "add calendar account" flow for an already-logged-in
+  /// user.  The new OAuth tokens belong to a second Google account; we skip
+  /// creating a new user and instead attach the calendar connection to the
+  /// existing user identified by this email.
+  primary_email: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -243,10 +248,18 @@ fn create_connections_from_scopes(
       if !(scopes.contains(scope_value)) {
         continue;
       }
+      // For the calendar scope, calendar_account_email = the Google account
+      // email whose calendar we're linking.
+      let calendar_account_email = if *scope_key == GOOGLE_CALENDAR_SCOPE {
+        email.clone()
+      } else {
+        String::new()
+      };
       let user_connection_creation_result = create_user_connection(
         email.clone(),
         refresh_token.clone(),
         String::from(*scope_key),
+        calendar_account_email,
       );
 
       match user_connection_creation_result {
@@ -264,6 +277,22 @@ fn create_connections_from_scopes(
     }
   }
   Ok(connected_scopes)
+}
+
+/// Create a calendar connection for a *secondary* Google account.  The
+/// `primary_user_email` identifies the existing user; `calendar_email` is the
+/// new account being linked.
+fn create_additional_calendar_connection(
+  primary_user_email: String,
+  calendar_email: String,
+  refresh_token: String,
+) -> Result<(), Error> {
+  create_user_connection(
+    primary_user_email,
+    refresh_token,
+    String::from(GOOGLE_CALENDAR_SCOPE),
+    calendar_email,
+  )
 }
 
 /// Exchange OAuth code for tokens locally using Google's token endpoint.
@@ -399,11 +428,39 @@ async fn complete_google_signin(
     }
   };
 
-  let email = profile.email.clone().unwrap();
-  // In self-hosted mode (local token exchange), uuid may not be available from knap.ai
-  // Use a placeholder or generate one locally
+  let calendar_email = profile.email.clone().unwrap();
+
+  // ── Add-calendar flow ──────────────────────────────────────────────────────
+  // When `primary_email` is provided the caller is already logged in as that
+  // user and just wants to link an additional Google Calendar account.
+  if let Some(primary_email) = params.primary_email.clone() {
+    match create_additional_calendar_connection(
+      primary_email.clone(),
+      calendar_email.clone(),
+      response.refresh_token.clone(),
+    ) {
+      Ok(_) => {
+        log::info!("Linked additional calendar {} to user {}", calendar_email, primary_email);
+      }
+      Err(err) => {
+        log::error!("Failed to link additional calendar: {:?}", err);
+        return HttpResponse::InternalServerError().json(json!({
+          "error": format!("Failed to link additional calendar: {:?}", err),
+          "success": false
+        }));
+      }
+    }
+
+    return HttpResponse::Ok().json(json!({
+      "success": true,
+      "calendar_email": calendar_email,
+      "connection_keys": [GOOGLE_CALENDAR_SCOPE]
+    }));
+  }
+
+  // ── Normal (primary) sign-in flow ──────────────────────────────────────────
+  let email = calendar_email.clone();
   let uuid = profile.uuid.clone().unwrap_or_else(|| {
-    // Generate a deterministic UUID from email for self-hosted mode
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
     let mut hasher = DefaultHasher::new();
@@ -416,7 +473,6 @@ async fn complete_google_signin(
     uuid: Some(uuid),
   }.create();
 
-  // Create Knapsack API connection only if we have internal tokens (non-self-hosted mode)
   if let Some(ref refresh_internal) = response.refresh_internal {
     create_knapsack_api_connection(
       email.clone(),
@@ -529,6 +585,7 @@ pub fn create_user_connection(
   email: String,
   refresh_token: String,
   scope: String,
+  calendar_account_email: String,
 ) -> Result<(), Error> {
   let user = User::find_by_email(email)?;
   let connection = Connection::find_by_scope(scope)?;
@@ -540,6 +597,7 @@ pub fn create_user_connection(
     refresh_token: Some(refresh_token.clone()),
     connection: None,
     last_synced: None,
+    calendar_account_email,
   };
   user_connection.upsert()
 }

--- a/src/src-tauri/src/connections/google/calendar.rs
+++ b/src/src-tauri/src/connections/google/calendar.rs
@@ -32,6 +32,9 @@ pub struct FetchGoogleCalendarResponse {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct FetchGoogleCalendarParams {
   email: String,
+  /// The Google account whose calendar to fetch.  Defaults to `email` when
+  /// omitted (single-account backwards compatibility).
+  calendar_account_email: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -42,32 +45,41 @@ pub struct FetchCalendarEventPayload {
 
 pub async fn fetch_calendar(
   email: String,
+  calendar_account_email: String,
   app_handle: tauri::AppHandle,
   connections_data: Arc<Mutex<ConnectionsData>>,
 ) -> Result<(), Error> {
-  let user_conn = match get_knapsack_api_connection(email.clone()) {
+  let _user_conn = match get_knapsack_api_connection(email.clone()) {
     Ok(connection) => connection,
-    Err(error) => {
+    Err(_error) => {
       return Err(Error::KSError("Fail to get user connection".to_string()));
     }
   };
 
-  let user_connection = match UserConnection::find_by_user_email_and_scope(
+  let user_connection = match UserConnection::find_by_user_email_scope_and_calendar_account(
     email.clone(),
     String::from(GOOGLE_CALENDAR_SCOPE),
+    calendar_account_email.clone(),
   ) {
     Ok(user_connection) => user_connection,
     Err(error) => {
-      let msg = format!("Failed to find user connection for user: {}", email);
+      let msg = format!(
+        "Failed to find calendar connection for user {} / calendar {}",
+        email, calendar_account_email
+      );
       knap_log_error(msg, Some(error), Some(true));
       return Err(Error::KSError("Fail to get user connection".to_string()));
     }
   };
+
   let access_token = match refresh_connection_token(email.clone(), user_connection.clone()).await {
     Ok(token) => token,
     Err(error) => {
       log::error!("Failed to refresh access token: {:?}", error);
-      let msg = format!("Failed to refresh access token in google calendar for user: {}", email);
+      let msg = format!(
+        "Failed to refresh access token for calendar {} (user {})",
+        calendar_account_email, email
+      );
       knap_log_error(msg, Some(error), None);
       return Err(Error::KSError("Fail to refresh access token".to_string()));
     }
@@ -89,23 +101,23 @@ pub async fn fetch_calendar(
   )
   .await;
 
+  let cal_email_clone = calendar_account_email.clone();
   tauri::async_runtime::spawn(async move {
     let hub = CalendarHub::new(
       get_https_client(),
       access_token,
     );
 
-    // NOTE: adding events from earlier than today for testing purposes.
-    // Can't hurt to store a few days' extra events.
     let two_weeks_ago = chrono::Utc::now() - chrono::Duration::days(16);
     let one_month_later = chrono::Utc::now() + chrono::Duration::days(31);
     let mut page_token: Option<String> = None;
 
     let mut event_ids_total: Vec<String> = Vec::new();
     loop {
+      // List events from the calendar identified by calendar_account_email.
       let mut request = hub
         .events()
-        .list(&email)
+        .list(&cal_email_clone)
         .single_events(true)
         .time_min(two_weeks_ago)
         .time_max(one_month_later)
@@ -189,6 +201,7 @@ pub async fn fetch_calendar(
               google_meet_url,
               recurrence_json,
               recurrence_id,
+              calendar_account_email: cal_email_clone.clone(),
             };
             if let Err(e) = calendar_event.create() {
               let msg = format!("Failed to create calendar event: {:?}", e);
@@ -203,8 +216,7 @@ pub async fn fetch_calendar(
         }
         Err(error) => {
           log::error!("Calendar sync failed {:?}", error.to_string());
-          let error_msg = format!("Fetch calendar failed: {:?}", error.to_string()
-          );
+          let error_msg = format!("Fetch calendar failed: {:?}", error.to_string());
           knap_log_error(error_msg, None, Some(true));
           ConnectionsData::lock_and_set_connection_is_syncing(
             connections_data.clone(),
@@ -217,7 +229,7 @@ pub async fn fetch_calendar(
       };
     }
     let event_count = event_ids_total.len();
-    CalendarEvent::delete_calendar_events_removed(event_ids_total);
+    CalendarEvent::delete_calendar_events_removed(event_ids_total, &cal_email_clone);
     ConnectionsData::lock_and_set_connection_is_syncing(
       connections_data,
       ConnectionsEnum::GoogleCalendar,
@@ -247,8 +259,16 @@ async fn fetch_google_calendar_api(
     actix_web::web::Query::<FetchGoogleCalendarParams>::from_query(req.query_string()).unwrap();
   let unwrapped_app_handle = app_handle.get_ref().clone();
   let unwrapped_connections_data = connections_data.get_ref().clone();
+
+  // Default calendar_account_email to the primary user email for compat.
+  let calendar_account_email = params
+    .calendar_account_email
+    .clone()
+    .unwrap_or_else(|| params.email.clone());
+
   match fetch_calendar(
     params.email.clone(),
+    calendar_account_email,
     unwrapped_app_handle,
     unwrapped_connections_data,
   )
@@ -259,8 +279,7 @@ async fn fetch_google_calendar_api(
     ),
     Err(error) => {
       log::error!("Fetch calendar failed: {:?}", error);
-      let error_msg = format!("Fetch calendar failed: {:?}", error
-      );
+      let error_msg = format!("Fetch calendar failed: {:?}", error);
       HttpResponse::BadRequest().json(
         FetchGoogleCalendarResponse { success: false, message: error_msg }
       )

--- a/src/src-tauri/src/connections/microsoft/auth.rs
+++ b/src/src-tauri/src/connections/microsoft/auth.rs
@@ -383,6 +383,7 @@ pub fn create_user_connection(
     refresh_token: refresh_token,
     connection: Some(connection),
     last_synced: None,
+    calendar_account_email: String::new(),
   };
   user_connection.upsert()
 }

--- a/src/src-tauri/src/connections/microsoft/auth.rs
+++ b/src/src-tauri/src/connections/microsoft/auth.rs
@@ -319,6 +319,7 @@ pub async fn refresh_user_connection(user_connection: UserConnection, email: Str
     refresh_token: refresh_response.refresh_token,
     connection: user_connection.connection,
     last_synced: user_connection.last_synced,
+    calendar_account_email: user_connection.calendar_account_email,
   };
   updated_user_connection.clone().update();
 

--- a/src/src-tauri/src/connections/microsoft/calendar.rs
+++ b/src/src-tauri/src/connections/microsoft/calendar.rs
@@ -324,7 +324,7 @@ async fn fetch_calendar(
   }
 
   let event_count = event_ids_total.len();
-  CalendarEvent::delete_calendar_events_removed(event_ids_total.clone());
+  CalendarEvent::delete_calendar_events_removed(event_ids_total.clone(), "");
   UserConnection::update_last_sync_by_id(user_connection.id.unwrap(), (chrono::Utc::now() + chrono::Duration::days(31)));
 
   ConnectionsData::lock_and_set_connection_is_syncing(

--- a/src/src-tauri/src/connections/microsoft/calendar.rs
+++ b/src/src-tauri/src/connections/microsoft/calendar.rs
@@ -221,6 +221,7 @@ fn create_calendar_event(event: Event) -> Result<(), Error> {
     google_meet_url,
     recurrence_json,
     recurrence_id,
+    calendar_account_email: String::new(),
   };
 
   calendar_event.create()

--- a/src/src-tauri/src/connections/utils.rs
+++ b/src/src-tauri/src/connections/utils.rs
@@ -167,8 +167,9 @@ pub fn create_knapsack_api_connection(user_email: String, refresh_internal: &str
         refresh_token: Some(refresh_internal.to_string()),
         connection: None,
         last_synced: None,
+        calendar_account_email: String::new(),
       };
-      user_connection.upsert(); 
+      user_connection.upsert();
     } else {
       let user_connection = user_conn.as_mut().unwrap();
       user_connection.token = refresh_internal.to_string();

--- a/src/src-tauri/src/db/models/calendar_event.rs
+++ b/src/src-tauri/src/db/models/calendar_event.rs
@@ -21,6 +21,8 @@ pub struct CalendarEvent {
   pub google_meet_url: Option<String>,
   pub recurrence_json: Option<String>,
   pub recurrence_id: Option<String>,
+  /// The Google account email whose calendar this event was synced from.
+  pub calendar_account_email: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -29,27 +31,22 @@ struct Participant {
     name: String,
 }
 
+const SELECT_COLS: &str = "id, event_id, title, description, creator_email, \
+  attendees_json, location, start, end, google_meet_url, recurrence_json, \
+  recurrence_id, calendar_account_email";
+
 // table calendar_events
 impl CalendarEvent {
   pub fn find_by_id(id: u64) -> Result<Option<CalendarEvent>, Error> {
     let connection = get_db_conn();
-    let mut stmt = connection.prepare("SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events WHERE id = ?1")?;
+    let query = format!(
+      "SELECT {} FROM calendar_events WHERE id = ?1",
+      SELECT_COLS
+    );
+    let mut stmt = connection.prepare(&query)?;
     let calendar_event = stmt
       .query_row(params![id], |row| {
-        Ok(CalendarEvent {
-          id: Some(row.get(0)?),
-          event_id: row.get(1)?,
-          title: row.get(2)?,
-          description: row.get(3)?,
-          creator_email: row.get(4)?,
-          attendees_json: row.get(5)?,
-          location: row.get(6)?,
-          start: row.get(7)?,
-          end: row.get(8)?,
-          google_meet_url: row.get(9)?,
-          recurrence_json: row.get(10)?,
-          recurrence_id: row.get(11)?,
-        })
+        CalendarEvent::build_struct_from_row(row)
       })
       .optional()?;
 
@@ -70,6 +67,7 @@ impl CalendarEvent {
       google_meet_url: row.get(9)?,
       recurrence_json: row.get(10)?,
       recurrence_id: row.get(11)?,
+      calendar_account_email: row.get::<_, Option<String>>(12)?.unwrap_or_default(),
     })
   }
 
@@ -99,8 +97,8 @@ impl CalendarEvent {
     let connection = get_db_conn();
     let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-      "SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events WHERE id IN ({})",
-      placeholders
+      "SELECT {} FROM calendar_events WHERE id IN ({})",
+      SELECT_COLS, placeholders
     );
     let mut stmt = connection.prepare(&query)?;
 
@@ -118,8 +116,12 @@ impl CalendarEvent {
 
   pub fn find_all() -> Vec<CalendarEvent> {
     let connection = get_db_conn();
+    let query = format!(
+      "SELECT {} FROM calendar_events ORDER BY start",
+      SELECT_COLS
+    );
     let mut stmt = connection
-      .prepare("SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events ORDER BY start")
+      .prepare(&query)
       .expect("could not prepare query get calendar events");
     let rows = stmt
       .query_map([], |row| CalendarEvent::build_struct_from_row(row))
@@ -137,8 +139,12 @@ impl CalendarEvent {
 
   pub fn find_by_timestamp_range(start: u64, end: u64) -> Vec<CalendarEvent> {
     let connection = get_db_conn();
+    let query = format!(
+      "SELECT {} FROM calendar_events WHERE start >= ?1 AND start <= ?2 ORDER BY start",
+      SELECT_COLS
+    );
     let mut stmt = connection
-      .prepare("SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events WHERE start >= ?1 AND start <= ?2 ORDER BY start")
+      .prepare(&query)
       .expect("could not prepare query get calendar events");
     let rows = stmt
       .query_map([start, end], |row| {
@@ -169,8 +175,18 @@ impl CalendarEvent {
     let connection = get_db_conn();
     let result = connection
       .execute(
-        "INSERT INTO calendar_events (id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12) ON CONFLICT(event_id) DO UPDATE SET title = ?3, description = ?4, creator_email = ?5, attendees_json = ?6, location = ?7, start = ?8, end = ?9, google_meet_url = ?10",
-        (&self.id, &self.event_id, &self.title, &self.description, &self.creator_email, &self.attendees_json, &self.location, &self.start, &self.end, &self.google_meet_url, &self.recurrence_json, &self.recurrence_id),
+        "INSERT INTO calendar_events \
+          (id, event_id, title, description, creator_email, attendees_json, location, \
+           start, end, google_meet_url, recurrence_json, recurrence_id, calendar_account_email) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+         ON CONFLICT(event_id, calendar_account_email) DO UPDATE SET \
+           title = ?3, description = ?4, creator_email = ?5, attendees_json = ?6, \
+           location = ?7, start = ?8, end = ?9, google_meet_url = ?10",
+        (
+          &self.id, &self.event_id, &self.title, &self.description, &self.creator_email,
+          &self.attendees_json, &self.location, &self.start, &self.end, &self.google_meet_url,
+          &self.recurrence_json, &self.recurrence_id, &self.calendar_account_email,
+        ),
       )
       .map_err(|e| e.into());
     match result {
@@ -183,9 +199,16 @@ impl CalendarEvent {
     let connection = get_db_conn();
     connection
       .execute(
-        "UPDATE calendar_events SET event_id = ?2, title = ?3, description = ?4, creator_email = ?5, attendees_json = ?6, location = ?7, start = ?8, end = ?9, google_meet_url = ?10, recurrence_json =11?, recurrence_id =12? WHERE id = ?1",
-        (&self.id, &self.event_id, &self.title, &self.description, &self.creator_email, &self.attendees_json, &self.location, &self.start, &self.end, &self.google_meet_url, &self.recurrence_json, &self.recurrence_id),
-        )
+        "UPDATE calendar_events SET event_id = ?2, title = ?3, description = ?4, \
+         creator_email = ?5, attendees_json = ?6, location = ?7, start = ?8, end = ?9, \
+         google_meet_url = ?10, recurrence_json = ?11, recurrence_id = ?12, \
+         calendar_account_email = ?13 WHERE id = ?1",
+        (
+          &self.id, &self.event_id, &self.title, &self.description, &self.creator_email,
+          &self.attendees_json, &self.location, &self.start, &self.end, &self.google_meet_url,
+          &self.recurrence_json, &self.recurrence_id, &self.calendar_account_email,
+        ),
+      )
       .expect("Could not update calendar event");
     Ok(())
   }
@@ -203,8 +226,12 @@ impl CalendarEvent {
     to_timestamp: i64,
   ) -> Result<Vec<CalendarEvent>, Error> {
     let connection = get_db_conn();
+    let query = format!(
+      "SELECT {} FROM calendar_events WHERE start >= ?1 and start <= ?2 ORDER BY start ASC",
+      SELECT_COLS
+    );
     let mut stmt = connection
-      .prepare("SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events WHERE start >= ?1 and start <= ?2  ORDER BY start ASC")
+      .prepare(&query)
       .map_err(|error| {
         log::error!("Failed to prepare calendar events query: {:?}", error);
         Error::KSError(format!(
@@ -236,86 +263,60 @@ impl CalendarEvent {
   }
 
   pub fn get_recent_calendar_events(limit: usize) -> Vec<CalendarEvent> {
-    // Opportunistically clean up stale events before querying
     let _ = Self::cleanup_stale_events();
     let connection = get_db_conn();
     let now_epoch = std::time::SystemTime::now()
       .duration_since(std::time::UNIX_EPOCH)
       .unwrap()
       .as_secs() as i64;
+    let query = format!(
+      "SELECT {} FROM calendar_events WHERE start > ?1 ORDER BY start ASC LIMIT ?2",
+      SELECT_COLS
+    );
     let mut stmt = connection
-      .prepare("SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events WHERE start > ?1 ORDER BY start ASC LIMIT ?2")
+      .prepare(&query)
       .expect("could not prepare query emails");
     let rows = stmt
       .query_map(rusqlite::params![now_epoch, limit], |row| {
-        Ok((
-          row.get::<_, u64>(0),
-          row.get::<_, String>(1),
-          row.get::<_, Option<String>>(2),
-          row.get::<_, Option<String>>(3),
-          row.get::<_, Option<String>>(4),
-          row.get::<_, Option<String>>(5),
-          row.get::<_, Option<String>>(6),
-          row.get::<_, Option<i64>>(7),
-          row.get::<_, Option<i64>>(8),
-          row.get::<_, Option<String>>(9),
-          row.get::<_, Option<String>>(10),
-          row.get::<_, Option<String>>(11),
-        ))
+        CalendarEvent::build_struct_from_row(row)
       })
       .expect("could not execute query");
-    let mut calendar_events = Vec::new();
-    for row in rows {
-      let (
-        id,
-        event_id,
-        title,
-        description,
-        creator_email,
-        attendees_json,
-        location,
-        start,
-        end,
-        google_meet_url,
-        recurrence_json,
-        recurrence_id,
-      ) = row.unwrap();
-      calendar_events.push(CalendarEvent {
-        id: Some(id.unwrap()),
-        event_id: event_id.unwrap(),
-        title: title.unwrap(),
-        description: description.unwrap(),
-        creator_email: creator_email.unwrap(),
-        attendees_json: attendees_json.unwrap(),
-        location: location.unwrap(),
-        start: start.unwrap(),
-        end: end.unwrap(),
-        google_meet_url: google_meet_url.unwrap(),
-        recurrence_json: recurrence_json.unwrap(),
-        recurrence_id: recurrence_id.unwrap(),
-      });
-    }
-    return calendar_events;
+    rows.filter_map(Result::ok).collect()
   }
 
-  pub fn delete_calendar_events_removed(calendar_events: Vec<String>) -> Result<(), Error> {
-    if calendar_events.is_empty() {
+  /// Delete events for a specific calendar account that were not returned in the
+  /// latest sync. Events from other accounts are left untouched.
+  pub fn delete_calendar_events_removed(
+    event_ids: Vec<String>,
+    calendar_account_email: &str,
+  ) -> Result<(), Error> {
+    let connection = get_db_conn();
+
+    if event_ids.is_empty() {
+      // No events synced — remove all events for this account.
+      connection
+        .execute(
+          "DELETE FROM calendar_events WHERE calendar_account_email = ?1",
+          params![calendar_account_email],
+        )
+        .map_err(|e| {
+          log::error!("Failed to delete all events for account {}: {:?}", calendar_account_email, e);
+          Error::KSError(format!("Failed to delete calendar events: {:?}", e))
+        })?;
       return Ok(());
     }
 
-    let connection = get_db_conn();
-
-    let id_list = calendar_events
+    let id_list = event_ids
       .iter()
       .map(|id| format!("\"{}\"", id))
       .collect::<Vec<String>>()
       .join(",");
     let query = format!(
-      "DELETE FROM calendar_events WHERE event_id NOT IN ({})",
+      "DELETE FROM calendar_events WHERE calendar_account_email = ?1 AND event_id NOT IN ({})",
       id_list
     );
     connection
-      .execute(&query, [])
+      .execute(&query, params![calendar_account_email])
       .map_err(|e| {
         log::error!("Failed to batch delete removed calendar events: {:?}", e);
         Error::KSError(format!("Failed to delete removed calendar events: {:?}", e))
@@ -325,14 +326,13 @@ impl CalendarEvent {
   }
 
   /// Delete calendar events whose end time is more than 24 hours in the past.
-  /// This prevents stale events from accumulating and triggering repeat notifications.
   pub fn cleanup_stale_events() -> Result<usize, Error> {
     let connection = get_db_conn();
     let cutoff = std::time::SystemTime::now()
       .duration_since(std::time::UNIX_EPOCH)
       .unwrap()
       .as_secs() as i64
-      - 86400; // 24 hours ago
+      - 86400;
     let deleted = connection
       .execute(
         "DELETE FROM calendar_events WHERE end IS NOT NULL AND end < ?1",
@@ -350,59 +350,18 @@ impl CalendarEvent {
 
   pub fn get_calendar_event_by_recurrence_id(recurrence_id: String) -> Vec<CalendarEvent> {
     let connection = get_db_conn();
+    let query = format!(
+      "SELECT {} FROM calendar_events WHERE recurrence_id = ?1",
+      SELECT_COLS
+    );
     let mut stmt = connection
-      .prepare("SELECT id, event_id, title, description, creator_email, attendees_json, location, start, end, google_meet_url, recurrence_json, recurrence_id FROM calendar_events WHERE recurrence_id = ?1")
+      .prepare(&query)
       .expect("could not prepare query emails");
     let rows = stmt
       .query_map([recurrence_id], |row| {
-        Ok((
-          row.get::<_, u64>(0),
-          row.get::<_, String>(1),
-          row.get::<_, Option<String>>(2),
-          row.get::<_, Option<String>>(3),
-          row.get::<_, Option<String>>(4),
-          row.get::<_, Option<String>>(5),
-          row.get::<_, Option<String>>(6),
-          row.get::<_, Option<i64>>(7),
-          row.get::<_, Option<i64>>(8),
-          row.get::<_, Option<String>>(9),
-          row.get::<_, Option<String>>(10),
-          row.get::<_, Option<String>>(11),
-        ))
+        CalendarEvent::build_struct_from_row(row)
       })
       .expect("could not execute query");
-
-    let mut calendar_events = Vec::new();
-    for row in rows {
-      let (
-        id,
-        event_id,
-        title,
-        description,
-        creator_email,
-        attendees_json,
-        location,
-        start,
-        end,
-        google_meet_url,
-        recurrence_json,
-        recurrence_id,
-      ) = row.unwrap();
-      calendar_events.push(CalendarEvent {
-        id: Some(id.unwrap()),
-        event_id: event_id.unwrap(),
-        title: title.unwrap(),
-        description: description.unwrap(),
-        creator_email: creator_email.unwrap(),
-        attendees_json: attendees_json.unwrap(),
-        location: location.unwrap(),
-        start: start.unwrap(),
-        end: end.unwrap(),
-        google_meet_url: google_meet_url.unwrap(),
-        recurrence_json: recurrence_json.unwrap(),
-        recurrence_id: recurrence_id.unwrap(),
-      });
-    }
-    return calendar_events;
+    rows.filter_map(Result::ok).collect()
   }
 }

--- a/src/src-tauri/src/db/models/user_connection.rs
+++ b/src/src-tauri/src/db/models/user_connection.rs
@@ -23,6 +23,9 @@ pub struct UserConnection {
   pub refresh_token: Option<String>,
   pub connection: Option<Connection>,
   pub last_synced: Option<u64>,
+  /// For google_calendar_read connections this holds the Google account email
+  /// whose calendar is synced. Empty string for all other connection types.
+  pub calendar_account_email: String,
 }
 
 impl UserConnection {
@@ -35,8 +38,10 @@ impl UserConnection {
     let connection = get_db_conn();
 
     connection.execute(
-      "INSERT INTO user_connections (user_id, connection_id, token, refresh_token) VALUES (?1, ?2, ?3, ?4) ON CONFLICT (user_id, connection_id) DO UPDATE SET token = ?3",
-      (&self.user_id, &self.connection_id, &self.token, &self.refresh_token),
+      "INSERT INTO user_connections (user_id, connection_id, token, refresh_token, calendar_account_email) \
+       VALUES (?1, ?2, ?3, ?4, ?5) \
+       ON CONFLICT (user_id, connection_id, calendar_account_email) DO UPDATE SET token = ?3",
+      (&self.user_id, &self.connection_id, &self.token, &self.refresh_token, &self.calendar_account_email),
     )?;
     Ok(())
   }
@@ -74,8 +79,7 @@ impl UserConnection {
   ) -> Result<UserConnection, Error> {
     let connection = get_db_conn();
     let mut stmt = connection.prepare(
-      "
-      SELECT
+      "SELECT
         user_connections.id,
         user_connections.user_id,
         user_connections.connection_id,
@@ -84,11 +88,13 @@ impl UserConnection {
         user_connections.last_synced,
         scope,
         provider,
-        email
+        email,
+        user_connections.calendar_account_email
       FROM user_connections
       LEFT JOIN connections on connection_id = connections.id
       LEFT JOIN users on user_id = users.id
-      WHERE users.email = ?1 and scope = ?2",
+      WHERE users.email = ?1 and scope = ?2
+      LIMIT 1",
     )?;
     let row = stmt.query_row(params![user_email, scope], |row| {
       Ok((
@@ -101,6 +107,7 @@ impl UserConnection {
         row.get::<_, String>(6)?,
         row.get::<_, String>(7)?,
         row.get::<_, String>(8)?,
+        row.get::<_, String>(9)?,
       ))
     })?;
     let (
@@ -113,6 +120,7 @@ impl UserConnection {
       scope,
       provider,
       _email,
+      calendar_account_email,
     ) = row;
     let connection_instance = Connection {
       id: Some(connection_id),
@@ -126,9 +134,131 @@ impl UserConnection {
       token,
       refresh_token,
       connection: Some(connection_instance),
-      last_synced: last_synced,
+      last_synced,
+      calendar_account_email,
     };
     Ok(user_connection)
+  }
+
+  /// Find the calendar connection for a specific Google calendar account email.
+  pub fn find_by_user_email_scope_and_calendar_account(
+    user_email: String,
+    scope: String,
+    calendar_account_email: String,
+  ) -> Result<UserConnection, Error> {
+    let connection = get_db_conn();
+    let mut stmt = connection.prepare(
+      "SELECT
+        user_connections.id,
+        user_connections.user_id,
+        user_connections.connection_id,
+        user_connections.token,
+        user_connections.refresh_token,
+        user_connections.last_synced,
+        scope,
+        provider,
+        email,
+        user_connections.calendar_account_email
+      FROM user_connections
+      LEFT JOIN connections on connection_id = connections.id
+      LEFT JOIN users on user_id = users.id
+      WHERE users.email = ?1 AND scope = ?2 AND user_connections.calendar_account_email = ?3",
+    )?;
+    let row = stmt.query_row(params![user_email, scope, calendar_account_email], |row| {
+      Ok((
+        row.get::<_, u64>(0)?,
+        row.get::<_, u64>(1)?,
+        row.get::<_, u64>(2)?,
+        row.get::<_, String>(3)?,
+        row.get::<_, Option<String>>(4)?,
+        row.get::<_, Option<u64>>(5)?,
+        row.get::<_, String>(6)?,
+        row.get::<_, String>(7)?,
+        row.get::<_, String>(8)?,
+        row.get::<_, String>(9)?,
+      ))
+    })?;
+    let (
+      user_connections_id,
+      user_id,
+      connection_id,
+      token,
+      refresh_token,
+      last_synced,
+      scope,
+      provider,
+      _email,
+      cal_email,
+    ) = row;
+    let connection_instance = Connection {
+      id: Some(connection_id),
+      scope,
+      provider,
+    };
+    Ok(UserConnection {
+      id: Some(user_connections_id),
+      user_id,
+      connection_id,
+      token,
+      refresh_token,
+      connection: Some(connection_instance),
+      last_synced,
+      calendar_account_email: cal_email,
+    })
+  }
+
+  /// Return all calendar connections for a user (one per linked Google account).
+  pub fn find_calendar_connections_by_user_email(
+    user_email: String,
+    calendar_scope: String,
+  ) -> Result<Vec<UserConnection>, Error> {
+    let connection = get_db_conn();
+    let mut stmt = connection.prepare(
+      "SELECT
+        user_connections.id,
+        user_connections.user_id,
+        user_connections.connection_id,
+        user_connections.token,
+        user_connections.last_synced,
+        scope,
+        provider,
+        user_connections.refresh_token,
+        user_connections.calendar_account_email
+      FROM user_connections
+      LEFT JOIN connections on connection_id = connections.id
+      LEFT JOIN users on user_id = users.id
+      WHERE users.email = ?1 AND scope = ?2",
+    )?;
+    let rows = stmt.query_map(params![user_email, calendar_scope], |row| {
+      let user_connections_id = row.get::<_, u64>(0)?;
+      let user_id = row.get::<_, u64>(1)?;
+      let connection_id = row.get::<_, u64>(2)?;
+      let token = row.get::<_, String>(3)?;
+      let last_synced = row.get::<_, Option<u64>>(4)?;
+      let scope = row.get::<_, String>(5)?;
+      let provider = row.get::<_, String>(6)?;
+      let refresh_token = row.get::<_, Option<String>>(7)?;
+      let calendar_account_email = row.get::<_, String>(8)?;
+
+      let connection_instance = Connection {
+        id: Some(connection_id),
+        scope,
+        provider,
+      };
+
+      Ok(UserConnection {
+        id: Some(user_connections_id),
+        user_id,
+        connection_id,
+        token,
+        refresh_token,
+        connection: Some(connection_instance),
+        last_synced,
+        calendar_account_email,
+      })
+    })?;
+    let result = rows.into_iter().collect::<Result<_, _>>()?;
+    Ok(result)
   }
 
   pub fn update_last_sync_by_id(
@@ -147,8 +277,7 @@ impl UserConnection {
   pub fn find_by_user_email(user_email: String) -> Result<Vec<UserConnection>, Error> {
     let connection = get_db_conn();
     let mut stmt = connection.prepare(
-      "
-      SELECT
+      "SELECT
         user_connections.id,
         user_connections.user_id,
         user_connections.connection_id,
@@ -156,7 +285,8 @@ impl UserConnection {
         user_connections.last_synced,
         scope,
         provider,
-        user_connections.refresh_token
+        user_connections.refresh_token,
+        user_connections.calendar_account_email
       FROM user_connections
       LEFT JOIN connections on connection_id = connections.id
       LEFT JOIN users on user_id = users.id
@@ -171,6 +301,7 @@ impl UserConnection {
       let scope = row.get::<_, String>(5)?;
       let provider = row.get::<_, String>(6)?;
       let refresh_token = row.get::<_, Option<String>>(7)?;
+      let calendar_account_email = row.get::<_, String>(8)?;
 
       let connection_instance = Connection {
         id: Some(connection_id),
@@ -185,7 +316,8 @@ impl UserConnection {
         token,
         refresh_token,
         connection: Some(connection_instance),
-        last_synced: last_synced,
+        last_synced,
+        calendar_account_email,
       })
     })?;
     let result = user_connections.into_iter().collect::<Result<_, _>>()?;
@@ -213,8 +345,7 @@ impl UserConnection {
   pub fn find_by_id(id: u64) -> Result<UserConnection, Error> {
     let connection = get_db_conn();
     let mut stmt = connection.prepare(
-      "
-      SELECT
+      "SELECT
         user_connections.id,
         user_connections.user_id,
         user_connections.connection_id,
@@ -223,7 +354,8 @@ impl UserConnection {
         user_connections.last_synced,
         scope,
         provider,
-        email
+        email,
+        user_connections.calendar_account_email
       FROM user_connections
       LEFT JOIN connections on connection_id = connections.id
       LEFT JOIN users on user_id = users.id
@@ -240,6 +372,7 @@ impl UserConnection {
         row.get::<_, String>(6)?,
         row.get::<_, String>(7)?,
         row.get::<_, String>(8)?,
+        row.get::<_, String>(9)?,
       ))
     })?;
     let (
@@ -252,6 +385,7 @@ impl UserConnection {
       scope,
       provider,
       _email,
+      calendar_account_email,
     ) = row;
     let connection_instance = Connection {
       id: Some(connection_id),
@@ -265,7 +399,8 @@ impl UserConnection {
       token,
       refresh_token,
       connection: Some(connection_instance),
-      last_synced: last_synced,
+      last_synced,
+      calendar_account_email,
     };
     Ok(user_connection)
   }

--- a/src/src-tauri/src/migrations/2026-04-21-000001_multi_google_calendar/down.sql
+++ b/src/src-tauri/src/migrations/2026-04-21-000001_multi_google_calendar/down.sql
@@ -1,0 +1,44 @@
+-- Reverse: drop calendar_account_email from both tables and restore original constraints.
+
+CREATE TABLE user_connections_old (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  connection_id INTEGER NOT NULL,
+  token TEXT NOT NULL,
+  last_synced INTEGER,
+  refresh_token TEXT,
+  UNIQUE(user_id, connection_id)
+);
+
+INSERT INTO user_connections_old
+  SELECT id, user_id, connection_id, token, last_synced, refresh_token
+  FROM user_connections
+  WHERE calendar_account_email = '' OR connection_id != (
+    SELECT id FROM connections WHERE scope = 'google_calendar_read'
+  );
+
+DROP TABLE user_connections;
+ALTER TABLE user_connections_old RENAME TO user_connections;
+
+CREATE TABLE calendar_events_old (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id VARCHAR(30) NOT NULL UNIQUE,
+  title TEXT,
+  description TEXT,
+  creator_email TEXT,
+  attendees_json TEXT,
+  location TEXT,
+  start INT,
+  end INT,
+  google_meet_url TEXT,
+  recurrence_json TEXT,
+  recurrence_id VARCHAR(100)
+);
+
+INSERT OR IGNORE INTO calendar_events_old
+  SELECT id, event_id, title, description, creator_email, attendees_json,
+         location, start, end, google_meet_url, recurrence_json, recurrence_id
+  FROM calendar_events;
+
+DROP TABLE calendar_events;
+ALTER TABLE calendar_events_old RENAME TO calendar_events;

--- a/src/src-tauri/src/migrations/2026-04-21-000001_multi_google_calendar/up.sql
+++ b/src/src-tauri/src/migrations/2026-04-21-000001_multi_google_calendar/up.sql
@@ -1,0 +1,61 @@
+-- Add calendar_account_email to user_connections so multiple Google Calendar
+-- accounts can be linked per user. Existing calendar connections are populated
+-- with the user's own email; all other connection types keep the default ''.
+
+ALTER TABLE user_connections ADD COLUMN calendar_account_email TEXT NOT NULL DEFAULT '';
+
+UPDATE user_connections
+SET calendar_account_email = (
+  SELECT email FROM users WHERE users.id = user_connections.user_id
+)
+WHERE connection_id = (
+  SELECT id FROM connections WHERE scope = 'google_calendar_read'
+);
+
+-- Recreate user_connections with the new unique constraint.
+-- SQLite does not support altering constraints in place.
+CREATE TABLE user_connections_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  connection_id INTEGER NOT NULL,
+  token TEXT NOT NULL,
+  last_synced INTEGER,
+  refresh_token TEXT,
+  calendar_account_email TEXT NOT NULL DEFAULT '',
+  UNIQUE(user_id, connection_id, calendar_account_email)
+);
+
+INSERT INTO user_connections_new
+  SELECT id, user_id, connection_id, token, last_synced, refresh_token, calendar_account_email
+  FROM user_connections;
+
+DROP TABLE user_connections;
+ALTER TABLE user_connections_new RENAME TO user_connections;
+
+-- Recreate calendar_events with a per-account unique constraint so that the
+-- same Google event ID can exist for two different calendar accounts (shared
+-- events).  Existing rows all get calendar_account_email = ''.
+CREATE TABLE calendar_events_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id VARCHAR(30) NOT NULL,
+  title TEXT,
+  description TEXT,
+  creator_email TEXT,
+  attendees_json TEXT,
+  location TEXT,
+  start INT,
+  end INT,
+  google_meet_url TEXT,
+  recurrence_json TEXT,
+  recurrence_id VARCHAR(100),
+  calendar_account_email TEXT NOT NULL DEFAULT '',
+  UNIQUE(event_id, calendar_account_email)
+);
+
+INSERT INTO calendar_events_new
+  SELECT id, event_id, title, description, creator_email, attendees_json,
+         location, start, end, google_meet_url, recurrence_json, recurrence_id, ''
+  FROM calendar_events;
+
+DROP TABLE calendar_events;
+ALTER TABLE calendar_events_new RENAME TO calendar_events;

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -48,6 +48,10 @@ import { BaseException } from './utils/exceptions/base'
 import KNAnalytics from './utils/KNAnalytics'
 import { KNLocalStorage, RECONNECT_DISMISSED_AT } from './utils/KNLocalStorage'
 import { isSharingEnabled } from './utils/settings'
+import {
+  consumePendingCalendarAddEmail,
+} from './utils/permissions/google'
+import { hasGoogleCalendar, getGoogleCalendarConnections } from 'src/api/connections'
 
 export type CreateAutomationProps = {
   uuid?: string
@@ -483,6 +487,30 @@ function App() {
         if (!hasOnboarded) {
           return
         }
+
+        // Check if this is an "add calendar" flow triggered from settings.
+        const pendingPrimaryEmail = consumePendingCalendarAddEmail()
+        if (pendingPrimaryEmail) {
+          getCompleteGoogleSignIn(
+            event.payload.code,
+            event.payload.raw_scopes,
+            pendingPrimaryEmail,
+          )
+            .then(() => {
+              // Refresh the connections list so the new calendar appears.
+              fetchConnections(pendingPrimaryEmail).then(updatedConnections => {
+                syncConnections(pendingPrimaryEmail, updatedConnections)
+              })
+            })
+            .catch(error => {
+              logError(new Error('Failed to add Google Calendar account'), {
+                additionalInfo: '',
+                error,
+              })
+            })
+          return
+        }
+
         getCompleteGoogleSignIn(event.payload.code, event.payload.raw_scopes)
           .then(async response => {
             auth.updateProfile({
@@ -553,7 +581,7 @@ function App() {
         if (event.payload.success) {
           KNAnalytics.trackEvent('CalendarSynced', {
             synced_events_count: event.payload.synced_events_count || 0,
-            source: connections[ConnectionKeys.GOOGLE_CALENDAR] ? 'google' : 'microsoft',
+            source: hasGoogleCalendar(connections) ? 'google' : 'microsoft',
             success: true,
           })
 
@@ -588,9 +616,16 @@ function App() {
           })
         }
 
+        // Build a sync-target map: all google calendar accounts + ms + gmail.
+        const calendarEntries = Object.fromEntries(
+          getGoogleCalendarConnections(connections).map(c => {
+            const k = `${ConnectionKeys.GOOGLE_CALENDAR}|${c.calendarAccountEmail}`
+            return [k, c]
+          }),
+        )
         const CalendarConnection = Object.fromEntries(
           Object.entries({
-            [ConnectionKeys.GOOGLE_CALENDAR]: connections[ConnectionKeys.GOOGLE_CALENDAR],
+            ...calendarEntries,
             [ConnectionKeys.MICROSOFT_CALENDAR]: connections[ConnectionKeys.MICROSOFT_CALENDAR],
             [ConnectionKeys.GOOGLE_GMAIL]: connections[ConnectionKeys.GOOGLE_GMAIL],
             [ConnectionKeys.MICROSOFT_OUTLOOK]: connections[ConnectionKeys.MICROSOFT_OUTLOOK],

--- a/src/src/api/connections.tsx
+++ b/src/src/api/connections.tsx
@@ -35,7 +35,24 @@ export type Connection = {
   state: ConnectionStates
   lastSynced?: Date | string
   syncedSince?: Date | string
+  /** Set for google_calendar_read connections — the Google account email whose
+   *  calendar this connection syncs.  Empty string for all other types. */
+  calendarAccountEmail?: string
 }
+
+/** Record key used for a Google Calendar connection given its account email. */
+export const calendarConnectionKey = (calendarAccountEmail: string): string =>
+  `${ConnectionKeys.GOOGLE_CALENDAR}|${calendarAccountEmail}`
+
+/** All Google Calendar connections in the connections map. */
+export const getGoogleCalendarConnections = (
+  connections: Record<string, Connection>,
+): Connection[] =>
+  Object.values(connections).filter(c => c.key === ConnectionKeys.GOOGLE_CALENDAR)
+
+/** True if at least one Google Calendar account is connected. */
+export const hasGoogleCalendar = (connections: Record<string, Connection>): boolean =>
+  getGoogleCalendarConnections(connections).length > 0
 
 export const isConnectionReadyToSync = (connection?: Connection) => {
   return connection?.state && connection.state !== ConnectionStates.SYNCING
@@ -195,19 +212,34 @@ export async function getConnections(email: string): Promise<Record<string, Conn
         connection: { scope: string; id: number }
         lastSynced?: number
         syncedSince?: number
+        calendarAccountEmail?: string
       },
-    ) => ({
-      ...acc,
-      [userConnection.connection.scope]: {
-        id: userConnection.id,
-        key: userConnection.connection.scope,
-        state: ConnectionStates.IDLE,
-        lastSynced: userConnection.lastSynced ? new Date(userConnection.lastSynced * 1000) : null,
-        syncedSince: userConnection.syncedSince
-          ? new Date(userConnection.syncedSince * 1000)
-          : null,
-      } as Connection,
-    }),
+    ) => {
+      const scope = userConnection.connection.scope
+      const calendarAccountEmail = userConnection.calendarAccountEmail || ''
+      // Calendar connections are keyed as "scope|accountEmail" so that
+      // multiple linked calendars can coexist in the same record.
+      const recordKey =
+        scope === ConnectionKeys.GOOGLE_CALENDAR && calendarAccountEmail
+          ? calendarConnectionKey(calendarAccountEmail)
+          : scope
+
+      return {
+        ...acc,
+        [recordKey]: {
+          id: userConnection.id,
+          key: scope,
+          state: ConnectionStates.IDLE,
+          lastSynced: userConnection.lastSynced
+            ? new Date(userConnection.lastSynced * 1000)
+            : null,
+          syncedSince: userConnection.syncedSince
+            ? new Date(userConnection.syncedSince * 1000)
+            : null,
+          calendarAccountEmail,
+        } as Connection,
+      }
+    },
     {},
   )
 }
@@ -280,8 +312,11 @@ export async function syncGoogleGmailAPI(email: string) {
   return !!data?.success
 }
 
-export async function syncGoogleCalendarAPI(email: string) {
-  const response = await fetch(`${KN_API_GOOGLE_CALENDAR}?email=${email}`, {
+export async function syncGoogleCalendarAPI(email: string, calendarAccountEmail?: string) {
+  const accountParam = calendarAccountEmail
+    ? `&calendar_account_email=${encodeURIComponent(calendarAccountEmail)}`
+    : ''
+  const response = await fetch(`${KN_API_GOOGLE_CALENDAR}?email=${email}${accountParam}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -292,7 +327,7 @@ export async function syncGoogleCalendarAPI(email: string) {
     throw new Error('400 - ' + data.message)
   }
   if (response.status != 200) {
-    throw new Error('Failed to sync local files')
+    throw new Error('Failed to sync Google Calendar')
   }
   return !!data?.success
 }
@@ -487,13 +522,23 @@ export async function getAccessToken(userEmail: string, scope: string) {
   return data.access_token
 }
 
-export async function getCompleteGoogleSignIn(code: string, scope: string) {
-  const response = await fetch(`${KN_API_COMPLETE_GOOGLE_SIGN_IN}?code=${code}&scope=${scope}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
+export async function getCompleteGoogleSignIn(
+  code: string,
+  scope: string,
+  primaryEmail?: string,
+) {
+  const primaryParam = primaryEmail
+    ? `&primary_email=${encodeURIComponent(primaryEmail)}`
+    : ''
+  const response = await fetch(
+    `${KN_API_COMPLETE_GOOGLE_SIGN_IN}?code=${code}&scope=${scope}${primaryParam}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
     },
-  })
+  )
 
   const data = await response.json()
   if (!response.ok) {

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/tauri'
 
 import { IThread, ThreadType } from 'src/api/threads'
-import { Connection, ConnectionKeys } from 'src/api/connections'
+import { Connection, ConnectionKeys, hasGoogleCalendar } from 'src/api/connections'
 import { LLMParams } from 'src/App'
 import { IFeed } from 'src/hooks/feed/useFeed'
 import { Meeting } from 'src/hooks/dataSources/useCalendar'
@@ -330,7 +330,7 @@ const MeetingsTabView = ({
                   </button>
                 </div>
                 {/* Calendar connection prompt */}
-                {connections && !connections[ConnectionKeys.GOOGLE_CALENDAR] && !connections[ConnectionKeys.MICROSOFT_CALENDAR] && onConnectCalendar && (
+                {connections && !hasGoogleCalendar(connections) && !connections[ConnectionKeys.MICROSOFT_CALENDAR] && onConnectCalendar && (
                   <div className="MeetingsTabView__calendar-prompt MeetingsTabView__calendar-prompt--notetaker">
                     <div className="MeetingsTabView__calendar-prompt-content">
                       <img src={CalendarIcon} alt="Calendar" className="MeetingsTabView__calendar-prompt-icon" />

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -6,7 +6,7 @@ import { IFeed, STATIONARY_ITEMS } from 'src/hooks/feed/useFeed'
 import KNDateUtils from 'src/utils/KNDateUtils'
 import { ThreadType } from 'src/api/threads'
 import { getAppVersion } from 'src/utils/app'
-import { Connection, ConnectionKeys } from 'src/api/connections'
+import { Connection, ConnectionKeys, hasGoogleCalendar } from 'src/api/connections'
 import { TabChoices } from 'src/components/TabBar'
 import { listWorkspaces, Workspace } from 'src/api/workspaces'
 
@@ -58,7 +58,7 @@ function NotetakerSidebar({
   }, [])
 
   const hasCalendarConnected = useMemo(
-    () => !!(connections[ConnectionKeys.GOOGLE_CALENDAR] || connections[ConnectionKeys.MICROSOFT_CALENDAR]),
+    () => !!(hasGoogleCalendar(connections) || connections[ConnectionKeys.MICROSOFT_CALENDAR]),
     [connections],
   )
 

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 
-import { Connection, ConnectionKeys, connectionsMap } from 'src/api/connections'
+import {
+  Connection,
+  ConnectionKeys,
+  connectionsMap,
+  getGoogleCalendarConnections,
+} from 'src/api/connections'
+import { openAddGoogleCalendarScreen } from 'src/utils/permissions/google'
 import { useChannelStatus } from 'src/hooks/channels/useChannelStatus'
 import KNAnalytics from 'src/utils/KNAnalytics'
 import { logError } from 'src/utils/errorHandling'
@@ -944,18 +950,21 @@ export const SettingsDialog = ({
           <Typography weight={TypographyWeight.medium}>Permissions</Typography>
 
           <div className="PermissionContent flex flex-col gap-2">
+            {/* Non-calendar connections */}
             {Object.values(connections)
-              .filter(item => connectionsKey.includes(item.key as ConnectionKeys))
+              .filter(
+                item =>
+                  connectionsKey.includes(item.key as ConnectionKeys) &&
+                  item.key !== ConnectionKeys.GOOGLE_CALENDAR &&
+                  item.key !== ConnectionKeys.MICROSOFT_CALENDAR,
+              )
               .map(item => (
                 <div
                   className="flex justify-between h-[36px] items-center"
                   key={`${item.key}-${item.id}`}
                 >
                   <Typography>
-                    {connectionsMap[item.key].label}
-                    {connectionsKey.includes(item.key as ConnectionKeys)
-                      ? `, ${email}`
-                      : ''}
+                    {connectionsMap[item.key]?.label ?? item.key}, {email}
                   </Typography>
                   <Typography
                     className={`cursor-pointer ${styles.link}`}
@@ -965,31 +974,86 @@ export const SettingsDialog = ({
                   </Typography>
                 </div>
               ))}
+
+            {/* Google Calendar — one row per linked account */}
+            {getGoogleCalendarConnections(connections).map(item => (
+              <div
+                className="flex justify-between h-[36px] items-center"
+                key={`cal-${item.id}-${item.calendarAccountEmail}`}
+              >
+                <Typography>
+                  Calendar, {item.calendarAccountEmail || email}
+                </Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => handleDeleteConnection(item)}
+                >
+                  Remove
+                </Typography>
+              </div>
+            ))}
+
+            {/* Microsoft Calendar */}
+            {connections[ConnectionKeys.MICROSOFT_CALENDAR] && (
+              <div className="flex justify-between h-[36px] items-center">
+                <Typography>Outlook Calendar, {email}</Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => handleDeleteConnection(connections[ConnectionKeys.MICROSOFT_CALENDAR])}
+                >
+                  Remove
+                </Typography>
+              </div>
+            )}
           </div>
         </div>
         <div className="AddAccountContainer p-6 pt-4 flex flex-col gap-4">
           <Typography weight={TypographyWeight.medium}>Add an account</Typography>
           <div className="PermissionContent flex flex-col gap-2">
-            {
-              connectionsKey
-              .filter( ( key: ConnectionKeys ) =>
-                !Object.keys(connections).includes(key as ConnectionKeys)
-                && Object.keys(PERMISSION_NAME_LIST).includes(key as ConnectionKeys)
+            {/* Standard non-calendar permissions that aren't yet connected */}
+            {connectionsKey
+              .filter(
+                (key: ConnectionKeys) =>
+                  key !== ConnectionKeys.GOOGLE_CALENDAR &&
+                  key !== ConnectionKeys.MICROSOFT_CALENDAR &&
+                  !Object.keys(connections).includes(key as string) &&
+                  Object.keys(PERMISSION_NAME_LIST).includes(key as string),
               )
-              .map(( connectionKey: ConnectionKeys ) =>{
-                  return (
-                    <div key={connectionKey} className="flex justify-between h-[36px] items-center">
-                    <Typography>{ Object.keys(PERMISSION_NAME_LIST).includes(connectionKey) ? PERMISSION_NAME_LIST[connectionKey] : ""}</Typography>
-                    <Typography
-                      className={`cursor-pointer ${styles.link}`}
-                      onClick={() => onConnectAccountClick([connectionKey])}
-                    >
-                      Add
-                    </Typography>
-                  </div>
-                  )
-              })
-            }
+              .map((connectionKey: ConnectionKeys) => (
+                <div key={connectionKey} className="flex justify-between h-[36px] items-center">
+                  <Typography>
+                    {PERMISSION_NAME_LIST[connectionKey] ?? ''}
+                  </Typography>
+                  <Typography
+                    className={`cursor-pointer ${styles.link}`}
+                    onClick={() => onConnectAccountClick([connectionKey])}
+                  >
+                    Add
+                  </Typography>
+                </div>
+              ))}
+
+            {/* Add Google Calendar (always available for Google users) */}
+            {profile?.provider === ConnectionKeys.GOOGLE_PROFILE && (
+              <div className="flex justify-between h-[36px] items-center">
+                <Typography>Google Calendar</Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => {
+                    if (email) {
+                      openAddGoogleCalendarScreen(
+                        email,
+                        'https://www.googleapis.com/auth/calendar.readonly',
+                      )
+                    }
+                  }}
+                >
+                  {getGoogleCalendarConnections(connections).length > 0
+                    ? 'Add another'
+                    : 'Add'}
+                </Typography>
+              </div>
+            )}
           </div>
         </div>
         <hr className="border-zinc-200" />

--- a/src/src/hooks/connections/useConnections.tsx
+++ b/src/src/hooks/connections/useConnections.tsx
@@ -7,7 +7,7 @@ import {
   dateFormat,
   getConnections,
   getConnectionsStatus,
-  syncedMessage
+  syncedMessage,
 } from 'src/api/connections'
 
 import KNDateUtils from 'src/utils/KNDateUtils'
@@ -99,36 +99,38 @@ export const useConnections = (initialState: Record<string, Connection> = {}) =>
   const fetchConnections = useCallback(
     async (email: string) => {
       const cloudConnections = await getConnections(email)
-      // const localConnections = await getLocalConnections()
       const updatedConnections: Record<string, Connection> = {}
-      for (const { id, key, state, lastSynced, syncedSince } of [
-        ...Object.values(cloudConnections),
-        // ...Object.values(localConnections),
-      ]) {
-        updatedConnections[key] =
-          connections[key]?.state === ConnectionStates.UP_TO_DATE ||
-          connections[key]?.state === ConnectionStates.SYNCING
-            ? connections[key]
-            : { id, key, state }
+
+      // cloudConnections is keyed by record key (scope, or scope|calEmail for
+      // calendar connections).  We must iterate by record key — not by the
+      // connection.key field — so multiple calendar accounts are preserved.
+      for (const [recordKey, connection] of Object.entries(cloudConnections)) {
+        const { id, key, state, lastSynced, syncedSince, calendarAccountEmail } = connection
+
+        updatedConnections[recordKey] =
+          connections[recordKey]?.state === ConnectionStates.UP_TO_DATE ||
+          connections[recordKey]?.state === ConnectionStates.SYNCING
+            ? connections[recordKey]
+            : { id, key, state, calendarAccountEmail }
 
         if (lastSynced != null) {
           if (typeof lastSynced === 'string') {
-            updatedConnections[key].lastSynced = lastSynced
+            updatedConnections[recordKey].lastSynced = lastSynced
           } else {
             let lastSyncedDate = lastSynced as Date
             let syncedSinceDate = syncedSince as Date
 
-            updatedConnections[key].lastSynced = syncedMessage[key as ConnectionKeys]
+            updatedConnections[recordKey].lastSynced = syncedMessage[key as ConnectionKeys]
             if (key !== ConnectionKeys.LOCAL_FILES) {
-              updatedConnections[key].lastSynced += KNDateUtils.formatDate(
+              updatedConnections[recordKey].lastSynced += KNDateUtils.formatDate(
                 syncedSinceDate ? syncedSinceDate : lastSyncedDate,
-                dateFormat[key as ConnectionKeys]
+                dateFormat[key as ConnectionKeys],
               )
             }
           }
         }
-
       }
+
       setConnections(updatedConnections)
       return updatedConnections
     },
@@ -145,22 +147,25 @@ export const useConnections = (initialState: Record<string, Connection> = {}) =>
     if (syncingConnections.length) {
       interval = setInterval(async () => {
         const connectionsStatus = await getConnectionsStatus()
-        const finishedConnections = Object.entries(connectionsStatus)
-          .filter(([key, value]) => syncingConnections.includes(key) && !value)
-          .reduce(
-            (acc: Record<string, Connection>, [key]) => ({
-              ...acc,
-              [key]: {
-                ...connections[key],
-                state: ConnectionStates.UP_TO_DATE,
-              },
-            }),
-            {},
-          )
-        setConnections(prev => ({
-          ...prev,
-          ...finishedConnections,
-        }))
+        const finishedConnections: Record<string, Connection> = {}
+
+        for (const syncingKey of syncingConnections) {
+          // Calendar connections have keys like "google_calendar_read|email".
+          // The backend status is still keyed by the base scope.
+          const baseScope = syncingKey.split('|')[0]
+          const backendIsDone = connectionsStatus[baseScope] === false
+
+          if (backendIsDone) {
+            finishedConnections[syncingKey] = {
+              ...connections[syncingKey],
+              state: ConnectionStates.UP_TO_DATE,
+            }
+          }
+        }
+
+        if (Object.keys(finishedConnections).length > 0) {
+          setConnections(prev => ({ ...prev, ...finishedConnections }))
+        }
       }, 3000)
     }
     return () => {

--- a/src/src/hooks/connections/useGoogleConnections.tsx
+++ b/src/src/hooks/connections/useGoogleConnections.tsx
@@ -4,7 +4,8 @@ import {
   Connection,
   ConnectionKeys,
   ConnectionStates,
-  googleConnections,
+  calendarConnectionKey,
+  getGoogleCalendarConnections,
   isConnectionReadyToSync,
   syncGoogleCalendarAPI,
   syncGoogleDriveAPI,
@@ -22,7 +23,7 @@ export const useGoogleConnections = (
   const authFailureCounts = useRef<Record<string, number>>({})
 
   const handleSyncError = useCallback(
-    (error: unknown, connectionKey: ConnectionKeys) => {
+    (error: unknown, connectionKey: string) => {
       console.error(error)
       const err = error as Error
       if (err.message.includes('400')) {
@@ -30,10 +31,8 @@ export const useGoogleConnections = (
         authFailureCounts.current[connectionKey] = count
 
         if (count >= AUTH_FAILURE_THRESHOLD) {
-          // Only trigger reconnect after repeated auth failures
-          removeConnection?.(connectionKey)
+          removeConnection?.(connectionKey as ConnectionKeys)
         } else {
-          // First failure: mark as failed but don't trigger reconnect dialog
           setConnectionState?.(connectionKey, ConnectionStates.FAILED)
         }
         return
@@ -43,7 +42,7 @@ export const useGoogleConnections = (
     [setConnectionState, removeConnection],
   )
 
-  const resetAuthFailure = useCallback((connectionKey: ConnectionKeys) => {
+  const resetAuthFailure = useCallback((connectionKey: string) => {
     authFailureCounts.current[connectionKey] = 0
   }, [])
 
@@ -73,14 +72,16 @@ export const useGoogleConnections = (
     [setConnectionState, handleSyncError, resetAuthFailure],
   )
 
+  /** Sync a single Google Calendar account identified by calendarAccountEmail. */
   const syncGoogleCalendar = useCallback(
-    async (emailAddress: string) => {
-      setConnectionState?.(ConnectionKeys.GOOGLE_CALENDAR, ConnectionStates.SYNCING)
+    async (primaryEmail: string, calendarAccountEmail: string) => {
+      const recordKey = calendarConnectionKey(calendarAccountEmail)
+      setConnectionState?.(recordKey, ConnectionStates.SYNCING)
       try {
-        await syncGoogleCalendarAPI(emailAddress)
-        resetAuthFailure(ConnectionKeys.GOOGLE_CALENDAR)
+        await syncGoogleCalendarAPI(primaryEmail, calendarAccountEmail)
+        resetAuthFailure(recordKey)
       } catch (error) {
-        handleSyncError(error, ConnectionKeys.GOOGLE_CALENDAR)
+        handleSyncError(error, recordKey)
       }
     },
     [setConnectionState, handleSyncError, resetAuthFailure],
@@ -96,26 +97,32 @@ export const useGoogleConnections = (
         await syncGoogleGmail(email)
         return
       }
-      if (connectionKey === ConnectionKeys.GOOGLE_CALENDAR) {
-        await syncGoogleCalendar(email)
-        return
-      }
     },
-    [syncGoogleCalendar, syncGoogleDrive, syncGoogleGmail],
+    [syncGoogleDrive, syncGoogleGmail],
   )
 
   const syncConnections = useCallback(
     async (email: string, connections: Record<string, Connection>) => {
-      const promises = []
-      for (const connectionKey of Object.keys(googleConnections)) {
+      const promises: Promise<void>[] = []
+
+      // Sync Drive and Gmail using the base scope keys.
+      for (const connectionKey of [ConnectionKeys.GOOGLE_DRIVE, ConnectionKeys.GOOGLE_GMAIL]) {
         if (isConnectionReadyToSync(connections[connectionKey])) {
-          promises.push(syncByConnectionKey(email, connectionKey as ConnectionKeys))
+          promises.push(syncByConnectionKey(email, connectionKey))
         }
       }
+
+      // Sync every linked Google Calendar account independently.
+      for (const calConn of getGoogleCalendarConnections(connections)) {
+        if (isConnectionReadyToSync(calConn) && calConn.calendarAccountEmail) {
+          promises.push(syncGoogleCalendar(email, calConn.calendarAccountEmail))
+        }
+      }
+
       await Promise.all(promises)
     },
-    [syncByConnectionKey],
+    [syncByConnectionKey, syncGoogleCalendar],
   )
 
-  return { syncByConnectionKey, syncConnections }
+  return { syncByConnectionKey, syncConnections, syncGoogleCalendar }
 }

--- a/src/src/utils/permissions/google.tsx
+++ b/src/src/utils/permissions/google.tsx
@@ -10,6 +10,23 @@ export class GoogleAuthError extends Error {
   }
 }
 
+// Module-level flag.  Set before opening the OAuth browser window so the
+// signin_success listener in App.tsx knows to treat this as an "add calendar"
+// flow rather than a primary login.
+let _pendingCalendarAddEmail: string | null = null
+
+/** Store the primary user email before triggering the add-calendar OAuth flow. */
+export const setPendingCalendarAddEmail = (email: string): void => {
+  _pendingCalendarAddEmail = email
+}
+
+/** Consume (read + clear) the pending calendar-add email. */
+export const consumePendingCalendarAddEmail = (): string | null => {
+  const email = _pendingCalendarAddEmail
+  _pendingCalendarAddEmail = null
+  return email
+}
+
 export const openGoogleAuthScreen = (scope: string) => {
   const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID
 
@@ -38,11 +55,8 @@ export const openGoogleAuthScreen = (scope: string) => {
   console.log('[Google OAuth] Opening URL:', fullUrl)
   console.log('[Google OAuth] redirect_uri:', KN_API_GOOGLE_SIGNIN_REDIRECT)
 
-  // window.open with _blank causes Tauri/WebView2 to route to the system browser,
-  // which avoids Google blocking OAuth inside embedded webviews.
   const popup = window.open(fullUrl, '_blank', 'noopener,noreferrer')
   if (!popup) {
-    // Fallback for environments where window.open is blocked
     try {
       open(fullUrl)
     } catch (error: any) {
@@ -54,4 +68,15 @@ export const openGoogleAuthScreen = (scope: string) => {
       throw error
     }
   }
+}
+
+/** Open the OAuth flow to add an additional Google Calendar account.
+ *  The resulting signin_success event will be handled as an add-calendar
+ *  flow (not a full re-login) because we store the primary email here. */
+export const openAddGoogleCalendarScreen = (
+  primaryEmail: string,
+  calendarScope: string,
+): void => {
+  setPendingCalendarAddEmail(primaryEmail)
+  openGoogleAuthScreen(calendarScope)
 }


### PR DESCRIPTION
## Summary
This PR adds support for linking multiple Google Calendar accounts to a single Knapsack user. Previously, users could only sync one Google Calendar. Now they can connect multiple Google accounts and sync calendars from each independently.

## Key Changes

### Database Schema
- Added `calendar_account_email` column to both `user_connections` and `calendar_events` tables
- Updated unique constraints to allow multiple calendar connections per user (keyed by `user_id, connection_id, calendar_account_email`)
- Created migration `2026-04-21-000001_multi_google_calendar` with up/down scripts

### Backend (Rust)
- **Calendar sync**: Modified `fetch_calendar()` to accept and use `calendar_account_email` parameter; updated `UserConnection::find_by_user_email_scope_and_calendar_account()` to query by specific calendar account
- **OAuth flow**: Added `primary_email` parameter to `SigninParams` to support "add calendar" flows for already-logged-in users; new `create_additional_calendar_connection()` function handles linking secondary calendar accounts
- **Event storage**: Updated `CalendarEvent` model to include `calendar_account_email` field; modified INSERT/UPDATE queries to handle per-account event uniqueness
- **Query refactoring**: Extracted repeated SELECT column lists into `SELECT_COLS` constant to reduce duplication and ensure consistency

### Frontend (React/TypeScript)
- **Connection management**: Added `calendarConnectionKey()` helper to generate unique keys for calendar connections (`scope|accountEmail`); new `getGoogleCalendarConnections()` and `hasGoogleCalendar()` utilities
- **Settings UI**: Refactored permissions display to show one row per linked Google Calendar account (with account email); added "Add Calendar" button separate from standard permission flows
- **OAuth handling**: Added `setPendingCalendarAddEmail()` / `consumePendingCalendarAddEmail()` to track add-calendar flows; modified `getCompleteGoogleSignIn()` to accept optional `primary_email` parameter
- **Sync logic**: Updated `useGoogleConnections` hook to sync individual calendar accounts; modified `syncGoogleCalendarAPI()` to accept optional `calendarAccountEmail` parameter

### UI/UX
- Settings dialog now displays each linked calendar account separately with individual remove buttons
- "Add an account" section includes dedicated "Add Calendar" button for linking additional Google accounts
- Calendar connections are keyed by account email to maintain separate sync state per account

## Implementation Details
- Backward compatible: existing single-calendar setups automatically populate `calendar_account_email` with the user's own email during migration
- Event deduplication: same Google event ID can now exist for different calendar accounts (shared events)
- Connection record keys: calendar connections use composite key format `google_calendar_read|account@email.com` to coexist with other connection types in the same record map
- Sync filtering: `delete_calendar_events_removed()` now scopes deletions to specific calendar accounts, preventing cross-account event loss

https://claude.ai/code/session_01ENMT4Jb3hwpQGRpvsK7u12