### PR TITLE
Upgrade GitHub Actions artifact upload/download to v6

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -76,14 +76,14 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: knapsack-macos-dmg
           path: src/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
           if-no-files-found: warn
 
       - name: Upload updater artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: knapsack-macos-updater
           path: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload Tauri build log on failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: tauri-build-log
           path: ${{ runner.temp }}/tauri-build.log
@@ -220,21 +220,21 @@ jobs:
           Write-Host "Signed: Knapsack-web-setup.exe"
 
       - name: Upload MSI artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: knapsack-windows-msi
           path: src/src-tauri/target/release/bundle/msi/*.msi
           if-no-files-found: warn
 
       - name: Upload NSIS artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: knapsack-windows-nsis
           path: src/src-tauri/target/release/bundle/nsis/*.exe
           if-no-files-found: warn
 
       - name: Upload web installer stub artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: knapsack-windows-web-setup
           path: src/installer/Knapsack-web-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         run: bash scripts/recreate-updater-archive.sh
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: macos-artifacts
           path: |
@@ -332,7 +332,7 @@ jobs:
           Write-Host "Signed: Knapsack-web-setup.exe"
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-artifacts
           path: |
@@ -355,7 +355,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
This PR upgrades the `actions/upload-artifact` and `actions/download-artifact` GitHub Actions from v5 to v6 across all CI/CD workflows.

## Key Changes
- Updated `actions/upload-artifact@v5` to `actions/upload-artifact@v6` in:
  - `.github/workflows/build-windows.yml` (4 occurrences)
  - `.github/workflows/build-macos.yml` (2 occurrences)
  - `.github/workflows/release.yml` (2 occurrences)
- Updated `actions/download-artifact@v5` to `actions/download-artifact@v6` in:
  - `.github/workflows/release.yml` (1 occurrence)

## Details
This is a routine dependency update for GitHub Actions used in the CI/CD pipeline. The v6 release of these actions includes improvements and bug fixes for artifact handling in GitHub Actions workflows. All artifact upload and download operations across the build and release workflows now use the latest stable version.

https://claude.ai/code/session_01AeWWRZxNNYJHDd5MFgue3u