### PR TITLE
fix(calendar): include userinfo.email scope in add-calendar OAuth flow

### DIFF
--- a/src/src/utils/permissions/google.tsx
+++ b/src/src/utils/permissions/google.tsx
@@ -78,5 +78,8 @@ export const openAddGoogleCalendarScreen = (
   calendarScope: string,
 ): void => {
   setPendingCalendarAddEmail(primaryEmail)
-  openGoogleAuthScreen(calendarScope)
+  // userinfo.email is required so the backend can identify which Google account
+  // was just authorized and store it as the calendar_account_email.
+  const scopeWithEmail = `${calendarScope} https://www.googleapis.com/auth/userinfo.email`
+  openGoogleAuthScreen(scopeWithEmail)
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The "Add another calendar" button in Settings triggered a Google OAuth flow requesting only `calendar.readonly` scope
- `complete_google_signin` calls `fetch_google_profile` (Google's userinfo endpoint) to identify which account was just authorized — but that call requires `userinfo.email` scope
- Without it, the backend returned a 403 error and the connection was silently dropped, so the new calendar never appeared in Settings

## Fix

Include `https://www.googleapis.com/auth/userinfo.email` alongside `calendar.readonly` when opening the add-calendar OAuth flow in `openAddGoogleCalendarScreen`. No backend changes needed.

## Test plan

- [ ] Click "Add another" under Google Calendar in Settings
- [ ] Complete Google OAuth with a different Google account
- [ ] Confirm the new calendar appears in the Permissions list
- [ ] Confirm events from both calendars are synced

https://claude.ai/code/session_01ENMT4Jb3hwpQGRpvsK7u12
EOF
)