### PR TITLE
Skip cancelled events when fetching Google Calendar

### DIFF
--- a/src/src-tauri/src/connections/google/calendar.rs
+++ b/src/src-tauri/src/connections/google/calendar.rs
@@ -132,10 +132,18 @@ pub async fn fetch_calendar(
       match result {
         Ok(response) => {
           let events = response.1.items.unwrap_or_default();
-          let event_ids: Vec<String> = events.iter().filter_map(|event| event.id.clone()).collect();
-          event_ids_total.extend(event_ids);
           for event in events {
-            let event_id = event.id.unwrap();
+            let event_id = match event.id {
+              Some(id) => id,
+              None => continue,
+            };
+            // Skip cancelled events (e.g. the original slot of a rescheduled
+            // occurrence). Excluding their IDs causes delete_calendar_events_removed
+            // to purge any previously-stored copy.
+            if event.status.as_deref() == Some("cancelled") {
+              continue;
+            }
+            event_ids_total.push(event_id.clone());
             let title = event.summary;
             let description = event.description;
             let mut creator_email = None;


### PR DESCRIPTION
## Summary
Updated the Google Calendar event fetching logic to skip cancelled events and improve event ID handling.

## Key Changes
- **Skip cancelled events**: Added a check to filter out events with `status == "cancelled"`, which typically represent original slots of rescheduled occurrences. This ensures that previously-stored copies of cancelled events are properly purged by `delete_calendar_events_removed`.
- **Improved event ID handling**: Refactored event ID extraction to use a match statement instead of `unwrap()`, providing safer handling of missing IDs with an early `continue` statement.
- **Fixed event ID collection**: Changed from pre-collecting all event IDs to pushing them individually during iteration, ensuring only non-cancelled events with valid IDs are added to `event_ids_total`.

## Implementation Details
The changes maintain the same overall flow while adding defensive checks:
- Events without IDs are skipped gracefully
- Cancelled events are explicitly filtered out before processing
- Event IDs are only collected for valid, non-cancelled events

https://claude.ai/code/session_01LaQTTuyFEgVsWUr3ZPdyqn