### PR TITLE
fix(config): always write channel sanitization fixes even when gateway is live

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3950,18 +3950,26 @@ async fn prepare_gateway_config(
         // ── Auto-heal allowlist channels ──────────────────────────────
         // Must run AFTER other patches so that the in-memory cfg_val is
         // already up-to-date before we persist it.
-        if sanitize_channel_allowlist_configs(&mut cfg_val) {
+        // Track separately: channel fixes MUST always reach disk (even while
+        // the gateway is running) because an invalid channel entry causes every
+        // subsequent config reload to fail — a worse outcome than the anomaly.
+        let channels_sanitized = sanitize_channel_allowlist_configs(&mut cfg_val);
+        if channels_sanitized {
           patched = true;
         }
 
         if patched {
-          // Skip direct file write if the gateway is already running — it
-          // watches openclaw.json and treats any external write as a
-          // "Config overwrite / missing-meta-before-write" anomaly, triggering
-          // an unnecessary SIGUSR1 reload.  The config.patch RPC fired in
-          // connect_and_handshake (gateway_client.rs) pushes the same changes
-          // to the live gateway via RPC without touching the file.
-          if gateway_client::is_gateway_port_open().await {
+          // Skip direct file write if the gateway is already running AND we
+          // only have non-critical patches (browser settings, token sync, tools).
+          // The config.patch RPC in connect_and_handshake handles those via RPC
+          // without touching the file, avoiding the "Config overwrite /
+          // missing-meta-before-write" anomaly and an unnecessary SIGUSR1 reload.
+          //
+          // Exception: channel sanitization always writes — invalid channel
+          // entries cause gateway config reloads to fail entirely, so the fix
+          // must reach disk even if it triggers the anomaly.
+          let gateway_live = gateway_client::is_gateway_port_open().await;
+          if gateway_live && !channels_sanitized {
             eprintln!(
               "[clawd/service] Config needs patching but gateway is live — \
                skipping file write to avoid anomaly; config.patch RPC will apply changes"


### PR DESCRIPTION
## Summary

- **Regression fix from #314**: the "skip write when gateway is live" change inadvertently suppressed channel-sanitization writes, leaving broken `channels.telegram` (or other non-object channel entries) on disk and putting the gateway in a reload-failure loop

## What was wrong

PR #314 added a guard: skip the direct `openclaw.json` write in `prepare_gateway_config` when the gateway is already running, to avoid the "Config overwrite / missing-meta-before-write" anomaly and unnecessary SIGUSR1 restarts.

But it skipped *all* writes — including the channel-sanitization fix that removes non-object channel entries. Those entries cause every subsequent gateway config reload to fail with `"channels.telegram: invalid config: must be object"`, so the gateway gets stuck in a crash/restart loop that the skipped write was supposed to break.

## Fix

Track `channels_sanitized` separately from `patched`:

- `channels_sanitized = true` → **always write**, even while the gateway is running. A brief anomaly + reload is acceptable; a perpetual reload-failure loop is not.
- Only other patches (browser settings, token sync, tools) → skip write when gateway is live and let the `config.patch` RPC handle them.

https://claude.ai/code/session_01SZ8JGKNHqPAML9YepXym74