### PR TITLE
feat(connections): support multiple Google Drive and Gmail accounts per user

### DIFF
--- a/src/src-tauri/src/connections/google/auth.rs
+++ b/src/src-tauri/src/connections/google/auth.rs
@@ -248,9 +248,11 @@ fn create_connections_from_scopes(
       if !(scopes.contains(scope_value)) {
         continue;
       }
-      // For the calendar scope, calendar_account_email = the Google account
-      // email whose calendar we're linking.
-      let calendar_account_email = if *scope_key == GOOGLE_CALENDAR_SCOPE {
+      // For calendar, drive, and gmail the calendar_account_email identifies
+      // which Google account's data this connection syncs.
+      let calendar_account_email = if [GOOGLE_CALENDAR_SCOPE, GOOGLE_DRIVE_SCOPE, GOOGLE_GMAIL_SCOPE]
+        .contains(scope_key)
+      {
         email.clone()
       } else {
         String::new()
@@ -279,20 +281,39 @@ fn create_connections_from_scopes(
   Ok(connected_scopes)
 }
 
-/// Create a calendar connection for a *secondary* Google account.  The
-/// `primary_user_email` identifies the existing user; `calendar_email` is the
-/// new account being linked.
-fn create_additional_calendar_connection(
+/// Create connections for a *secondary* Google account.  Looks at `raw_scopes`
+/// to decide which connection types to create (calendar, drive, gmail).
+/// `primary_user_email` identifies the existing user; `new_account_email` is
+/// the email of the newly authorised Google account.
+fn create_additional_connections(
   primary_user_email: String,
-  calendar_email: String,
+  new_account_email: String,
+  raw_scopes: String,
   refresh_token: String,
-) -> Result<(), Error> {
-  create_user_connection(
-    primary_user_email,
-    refresh_token,
-    String::from(GOOGLE_CALENDAR_SCOPE),
-    calendar_email,
-  )
+) -> Result<Vec<String>, Error> {
+  let scopes = raw_scopes.split(' ').collect::<Vec<&str>>();
+
+  let scope_map: &[(&str, &[&str])] = &[
+    (GOOGLE_CALENDAR_SCOPE, &["https://www.googleapis.com/auth/calendar.readonly"]),
+    (GOOGLE_DRIVE_SCOPE,    &["https://www.googleapis.com/auth/drive.readonly"]),
+    (GOOGLE_GMAIL_SCOPE,    &["https://www.googleapis.com/auth/gmail.modify"]),
+  ];
+
+  let mut created: Vec<String> = vec![];
+  for (scope_key, scope_values) in scope_map {
+    let has_scope = scope_values.iter().any(|sv| scopes.contains(sv));
+    if !has_scope {
+      continue;
+    }
+    create_user_connection(
+      primary_user_email.clone(),
+      refresh_token.clone(),
+      String::from(*scope_key),
+      new_account_email.clone(),
+    )?;
+    created.push(String::from(*scope_key));
+  }
+  Ok(created)
 }
 
 /// Exchange OAuth code for tokens locally using Google's token endpoint.
@@ -430,32 +451,33 @@ async fn complete_google_signin(
 
   let calendar_email = profile.email.clone().unwrap();
 
-  // ── Add-calendar flow ──────────────────────────────────────────────────────
+  // ── Add-account flow ───────────────────────────────────────────────────────
   // When `primary_email` is provided the caller is already logged in as that
-  // user and just wants to link an additional Google Calendar account.
+  // user and wants to link an additional Google account (calendar, drive, or
+  // gmail depending on which scopes were granted).
   if let Some(primary_email) = params.primary_email.clone() {
-    match create_additional_calendar_connection(
+    match create_additional_connections(
       primary_email.clone(),
       calendar_email.clone(),
+      raw_scopes.clone(),
       response.refresh_token.clone(),
     ) {
-      Ok(_) => {
-        log::info!("Linked additional calendar {} to user {}", calendar_email, primary_email);
+      Ok(created_keys) => {
+        log::info!("Linked additional account {} to user {} for scopes {:?}", calendar_email, primary_email, created_keys);
+        return HttpResponse::Ok().json(json!({
+          "success": true,
+          "calendar_email": calendar_email,
+          "connection_keys": created_keys
+        }));
       }
       Err(err) => {
-        log::error!("Failed to link additional calendar: {:?}", err);
+        log::error!("Failed to link additional account: {:?}", err);
         return HttpResponse::InternalServerError().json(json!({
-          "error": format!("Failed to link additional calendar: {:?}", err),
+          "error": format!("Failed to link additional account: {:?}", err),
           "success": false
         }));
       }
     }
-
-    return HttpResponse::Ok().json(json!({
-      "success": true,
-      "calendar_email": calendar_email,
-      "connection_keys": [GOOGLE_CALENDAR_SCOPE]
-    }));
   }
 
   // ── Normal (primary) sign-in flow ──────────────────────────────────────────

--- a/src/src-tauri/src/connections/google/drive.rs
+++ b/src/src-tauri/src/connections/google/drive.rs
@@ -281,6 +281,7 @@ pub async fn get_or_create_drive_document_from_file(
   file: &File,
   temp_dir: &PathBuf,
   hub: &DriveHub<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>,
+  account_email: &str,
 ) -> DriveDocument {
   let mime_type = file.mime_type.clone().unwrap();
   let drive_id = file.id.clone().unwrap();
@@ -317,6 +318,7 @@ pub async fn get_or_create_drive_document_from_file(
     url,
     timestamp: None,
     content_chunks: maybe_content,
+    account_email: account_email.to_string(),
   };
 
   let insert_result = drive_document.create();
@@ -331,6 +333,7 @@ pub async fn fetch_drive(
   access_token: String,
   _semantic_service: Arc<Mutex<Option<SemanticService>>>,
   user_connection: UserConnection,
+  account_email: String,
 ) -> Result<(), Error> {
   let mut maybe_next_page_token: Option<String> = None;
   let hub = DriveHub::new(
@@ -378,10 +381,11 @@ pub async fn fetch_drive(
       let temp_dir_clone = temp_dir.clone();
       let hub_clone = hub.clone();
       let drive_documents_clone = drive_documents.clone();
+      let account_email_clone = account_email.clone();
       let task = tauri::async_runtime::spawn(async move {
         let _permit = semaphore_clone.acquire().await.unwrap();
         let drive_document =
-          get_or_create_drive_document_from_file(&file, &temp_dir_clone, &hub_clone).await;
+          get_or_create_drive_document_from_file(&file, &temp_dir_clone, &hub_clone, &account_email_clone).await;
         drive_documents_clone.lock().await.push(drive_document);
       });
       tasks.push(task);
@@ -453,6 +457,7 @@ async fn start_drive_data_fetching(
     }
   };
 
+  let account_email = user_connection.calendar_account_email.clone();
   tauri::async_runtime::spawn(async move {
     if ConnectionsData::lock_and_get_connection_is_syncing(
       connections_data.clone(),
@@ -468,7 +473,7 @@ async fn start_drive_data_fetching(
       true,
     )
     .await;
-    let result = fetch_drive(access_token, semantic_service, user_connection.clone()).await;
+    let result = fetch_drive(access_token, semantic_service, user_connection.clone(), account_email).await;
     if let Err(error) = result {
       let msg = format!("Failed to fetch drive files: {}", email);
       knap_log_error(msg, Some(error), Some(true));
@@ -599,7 +604,7 @@ async fn fetch_google_drive_files(
   for file in data.files.iter() {
     let (_response, file) = hub.files().get(&file.id).doit().await.unwrap();
 
-    let drive_document = get_or_create_drive_document_from_file(&file, &temp_dir, &hub).await;
+    let drive_document = get_or_create_drive_document_from_file(&file, &temp_dir, &hub, &email).await;
     let document =
       create_drive_document(drive_document.id.unwrap(), drive_document.checksum.clone());
 

--- a/src/src-tauri/src/connections/google/gmail.rs
+++ b/src/src-tauri/src/connections/google/gmail.rs
@@ -78,7 +78,7 @@ fn get_body_content(maybe_body: Option<MessagePartBody>) -> Option<String> {
   }
 }
 
-pub async fn upsert_email_by_uid(email_uid: &str, access_token: &str, flag_update: bool) -> Result<Email, Error> {
+pub async fn upsert_email_by_uid(email_uid: &str, access_token: &str, flag_update: bool, account_email: &str) -> Result<Email, Error> {
   let email_result = Email::find_by_uid(email_uid).ok().flatten();
   if let Some(email) = email_result {
     if email.thread_id.is_some() && !flag_update {
@@ -191,6 +191,7 @@ pub async fn upsert_email_by_uid(email_uid: &str, access_token: &str, flag_updat
     is_read: Some(is_read),
     is_archived: Some(is_archived),
     is_deleted: Some(false),
+    account_email: account_email.to_string(),
   };
   let email_message_creation_response = email_message.create();
   if let Err(error) = email_message_creation_response {
@@ -210,7 +211,7 @@ pub async fn embed_email(
   )?;
   let access_token = refresh_connection_token(email.clone().to_string(), user_connection.clone()).await?;
 
-  let email = upsert_email_by_uid(email_uid, &access_token, false).await?;
+  let email = upsert_email_by_uid(email_uid, &access_token, false, email).await?;
 
   let documents = email.get_documents();
 
@@ -228,6 +229,7 @@ pub async fn fetch_gmail(
   days: u16,
   embedding_priority: u16,
   flag_update: bool,
+  account_email: String,
 ) -> Result<(), Error> {
   let mut maybe_next_page_token: Option<String> = None;
   let mut all_email_uuids = Vec::new(); 
@@ -267,9 +269,10 @@ pub async fn fetch_gmail(
       let message_id = message.clone().id.unwrap();
       all_email_uuids.push(message_id.clone());
       let email_documents_clone = email_documents.clone();
+      let account_email_clone = account_email.clone();
       let task = tauri::async_runtime::spawn(async move {
         let _permit = semaphore_clone.acquire().await.unwrap();
-        let result = upsert_email_by_uid(&message_id, &access_token_clone, flag_update.clone()).await;
+        let result = upsert_email_by_uid(&message_id, &access_token_clone, flag_update.clone(), &account_email_clone).await;
         match result {
           Ok(email_message) => {
             if (older_date.timestamp() as u64 > email_message.clone().date) {
@@ -321,7 +324,7 @@ pub async fn fetch_gmail(
     }
   }
 
-  Email::mark_deleted_emails(&all_email_uuids, 3).await?;
+  Email::mark_deleted_emails(&all_email_uuids, 3, &account_email).await?;
 
   UserConnection::update_last_sync_by_id(user_connection.id.unwrap(), older_date);
   Ok(())
@@ -359,6 +362,7 @@ async fn start_gmail_data_fetching(
     }
 
   };
+  let account_email = user_connection.calendar_account_email.clone();
   tauri::async_runtime::spawn(async move {
     if ConnectionsData::lock_and_get_connection_is_syncing(
       connections_data.clone(),
@@ -380,7 +384,8 @@ async fn start_gmail_data_fetching(
       semantic_service.clone(),
       3,
       3,
-      true
+      true,
+      account_email,
     )
     .await;
 

--- a/src/src-tauri/src/connections/microsoft/outlook.rs
+++ b/src/src-tauri/src/connections/microsoft/outlook.rs
@@ -151,6 +151,7 @@ async fn upsert_email_by_uid(
     is_read: Some(email_data.isRead),
     is_archived: Some(is_archived),
     is_deleted: Some(false),
+    account_email: String::new(),
   };
 
   email_entry.create();
@@ -312,7 +313,7 @@ pub async fn fetch_outlook_emails(
     }
   }
 
-  Email::mark_deleted_emails(&all_email_uuids, 3).await?;
+  Email::mark_deleted_emails(&all_email_uuids, 3, "").await?;
 
   Ok(())
 }

--- a/src/src-tauri/src/db/models/drive_document.rs
+++ b/src/src-tauri/src/db/models/drive_document.rs
@@ -21,13 +21,14 @@ pub struct DriveDocument {
   pub url: String,
   pub timestamp: Option<u64>,
   pub content_chunks: Option<Vec<String>>,
+  pub account_email: String,
 }
 
 impl DriveDocument {
   pub fn find_by_id(id: u64) -> Result<Option<DriveDocument>, Error> {
     let connection = get_db_conn();
     let mut stmt = connection
-      .prepare("SELECT id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, timestamp FROM drive_documents WHERE id = ?1")?;
+      .prepare("SELECT id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, timestamp, account_email FROM drive_documents WHERE id = ?1")?;
 
     let drive_document = stmt
       .query_row(params![id], |row| {
@@ -43,6 +44,7 @@ impl DriveDocument {
           url: row.get(8)?,
           timestamp: row.get(9)?,
           content_chunks: None,
+          account_email: row.get(10).unwrap_or_default(),
         })
       })
       .optional()?;
@@ -53,7 +55,7 @@ impl DriveDocument {
   pub fn find_by_drive_id(drive_id: &str) -> Result<Option<DriveDocument>, Error> {
     let connection = get_db_conn();
     let mut stmt = connection
-      .prepare("SELECT id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, timestamp FROM drive_documents WHERE drive_id = ?1")?;
+      .prepare("SELECT id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, timestamp, account_email FROM drive_documents WHERE drive_id = ?1")?;
 
     let drive_document = stmt
       .query_row(params![drive_id], |row| {
@@ -69,6 +71,7 @@ impl DriveDocument {
           url: row.get(8)?,
           timestamp: row.get(9)?,
           content_chunks: None,
+          account_email: row.get(10).unwrap_or_default(),
         })
       })
       .optional()?;
@@ -85,7 +88,7 @@ impl DriveDocument {
     .collect::<Vec<_>>()
     .join(", ");
     let mut stmt = connection
-      .prepare(&format!("SELECT id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, timestamp FROM drive_documents WHERE drive_id IN ({})", 
+      .prepare(&format!("SELECT id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, timestamp, account_email FROM drive_documents WHERE drive_id IN ({})",
       formatted_ids))?;
 
     let rows = stmt
@@ -102,6 +105,7 @@ impl DriveDocument {
           url: row.get(8)?,
           timestamp: row.get(9)?,
           content_chunks: None,
+          account_email: row.get(10).unwrap_or_default(),
       })
     })?;
 
@@ -125,7 +129,7 @@ impl DriveDocument {
     let connection = get_db_conn();
     let result = connection
       .execute(
-        "INSERT INTO drive_documents (id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        "INSERT INTO drive_documents (id, drive_id, filename, file_size, date_modified, date_created, summary, checksum, url, account_email) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         (
           &self.id,
           &self.drive_id,
@@ -136,6 +140,7 @@ impl DriveDocument {
           &self.summary,
           &self.checksum,
           &self.url,
+          &self.account_email,
         ),
       )
       .map_err(|e| e.into());

--- a/src/src-tauri/src/db/models/email.rs
+++ b/src/src-tauri/src/db/models/email.rs
@@ -27,6 +27,7 @@ pub struct Email {
   pub is_read: Option<bool>,
   pub is_archived: Option<bool>,
   pub is_deleted: Option<bool>,
+  pub account_email: String,
 }
 
 impl Email {
@@ -45,6 +46,7 @@ impl Email {
       is_read: row.get(10)?,
       is_archived: row.get(11)?,
       is_deleted: Some(row.get(12)?),
+      account_email: row.get(13).unwrap_or_default(),
     })
   }
   pub fn delete(&self) -> Result<()> {
@@ -94,8 +96,8 @@ impl Email {
     let connection = get_db_conn();
     connection
       .execute(
-        "INSERT INTO emails (email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12) ON CONFLICT(email_uid) DO UPDATE SET subject = ?2, date = ?3, sender = ?4, body = ?5, recipient = ?6, cc = ?7, thread_id = ?8, is_starred = ?9,  is_read = ?10, is_archived =?11, is_deleted =?12",
-        params![self.email_uid, self.subject, self.date, self.sender, self.body, self.recipient, self.cc, self.thread_id, self.is_starred, self.is_read, self.is_archived, self.is_deleted],
+        "INSERT INTO emails (email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) ON CONFLICT(email_uid, account_email) DO UPDATE SET subject = ?2, date = ?3, sender = ?4, body = ?5, recipient = ?6, cc = ?7, thread_id = ?8, is_starred = ?9, is_read = ?10, is_archived = ?11, is_deleted = ?12",
+        params![self.email_uid, self.subject, self.date, self.sender, self.body, self.recipient, self.cc, self.thread_id, self.is_starred, self.is_read, self.is_archived, self.is_deleted, self.account_email],
       )?;
     self.id = Some(connection.last_insert_rowid() as u64);
     Ok(())
@@ -104,7 +106,7 @@ impl Email {
   pub fn find_by_id(id: u64) -> Result<Option<Email>, Error> {
     let connection = get_db_conn();
     let mut stmt = connection
-      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails WHERE id = ?1")
+      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails WHERE id = ?1")
       .expect("could not prepare query emails");
     let email = stmt
       .query_row([id], |row| Email::build_struct_from_row(row))
@@ -115,7 +117,7 @@ impl Email {
   pub fn find_by_uid(uid: &str) -> Result<Option<Email>, Error> {
     let connection = get_db_conn();
     let mut stmt = connection
-      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails WHERE email_uid = ?1")
+      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails WHERE email_uid = ?1")
       .expect("could not prepare query emails");
     let email = stmt
       .query_row([uid], |row| Email::build_struct_from_row(row))
@@ -130,7 +132,7 @@ impl Email {
     let limit_string = limit.clone().to_string();
     let limit_str = limit_string.as_str();
     let mut stmt = connection
-      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails WHERE sender LIKE ?1 OR recipient LIKE ?1 ORDER BY date DESC LIMIT ?2")
+      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails WHERE sender LIKE ?1 OR recipient LIKE ?1 ORDER BY date DESC LIMIT ?2")
       .expect("could not prepare query emails");
     let rows = stmt
       .query_map([&sender_or_recipient_query_str, &limit_str], |row| {
@@ -157,7 +159,7 @@ impl Email {
   pub fn get_email_message(email_uid: &str) -> Option<Email> {
     let connection = get_db_conn();
     let mut stmt = connection
-      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails WHERE email_uid = ?1")
+      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails WHERE email_uid = ?1")
       .expect("could not prepare query emails");
     //TODO use build_struct_from_row
     let result = stmt.query_row(&[email_uid], |row| Email::build_struct_from_row(row));
@@ -174,7 +176,7 @@ impl Email {
   pub fn get_recent_emails(limit: usize) -> Vec<Email> {
     let connection = get_db_conn();
     let mut stmt = connection
-      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails ORDER BY date DESC LIMIT ?1")
+      .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails ORDER BY date DESC LIMIT ?1")
       .expect("could not prepare query emails");
     //TODO use build_struct_from_row
     let rows = stmt
@@ -220,7 +222,7 @@ impl Email {
 
     let where_query = "WHERE sender LIKE ?1 AND date >= ?2 AND date <= ?3".to_string();
 
-    let query = format!("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails {} ORDER BY date DESC LIMIT ?4", where_query);
+    let query = format!("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails {} ORDER BY date DESC LIMIT ?4", where_query);
     let mut stmt = connection
       .prepare(&query)
       .expect("could not prepare query emails");
@@ -273,7 +275,7 @@ impl Email {
       where_query = format!("WHERE {}", where_queries.join(" and "));
     }
 
-    let query = format!("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails {} ORDER BY date DESC LIMIT ?{}", where_query, params.len() + 1);
+    let query = format!("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails {} ORDER BY date DESC LIMIT ?{}", where_query, params.len() + 1);
     params.push(limit.to_string());
     let mut stmt = connection
       .prepare(&query)
@@ -398,7 +400,7 @@ impl Email {
   pub fn get_last_email_by_thread_id(thread_id: &str) -> Result<Vec<Email>, Error> {
     let connection = get_db_conn();
     let mut stmt = connection
-        .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted FROM emails WHERE thread_id = ?1 ORDER BY date DESC")
+        .prepare("SELECT id, email_uid, subject, date, sender, body, recipient, cc, thread_id, is_starred, is_read, is_archived, is_deleted, account_email FROM emails WHERE thread_id = ?1 ORDER BY date DESC")
         .expect("could not prepare query emails by thread_id");
 
     let emails = stmt
@@ -410,30 +412,33 @@ impl Email {
     Ok(emails)
   }
 
-  pub async fn mark_deleted_emails(fetched_uuids: &[String], days: i64) -> Result<(), Error> {
+  pub async fn mark_deleted_emails(fetched_uuids: &[String], days: i64, account_email: &str) -> Result<(), Error> {
     let connection = get_db_conn();
     let days_ago = chrono::Utc::now() - chrono::Duration::days(days);
     let days_ago_timestamp = days_ago.timestamp() as u64;
     let current_timestamp = chrono::Utc::now().timestamp() as u64;
-  
+
     let placeholders: String = fetched_uuids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-        "UPDATE emails SET is_deleted = TRUE 
-        WHERE email_uid NOT IN ({}) 
-        AND date >= ? 
-        AND date <= ? 
+        "UPDATE emails SET is_deleted = TRUE
+        WHERE email_uid NOT IN ({})
+        AND account_email = ?
+        AND date >= ?
+        AND date <= ?
         AND is_deleted = FALSE",
         placeholders
     );
-  
+
     let mut stmt = connection.prepare(&query)?;
-    
+
+    let account_email_owned = account_email.to_owned();
     let mut params: Vec<&dyn rusqlite::ToSql> = fetched_uuids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+    params.push(&account_email_owned);
     params.push(&days_ago_timestamp);
     params.push(&current_timestamp);
-  
+
     stmt.execute(params.as_slice())?;
-  
+
     Ok(())
   }
 }

--- a/src/src-tauri/src/migrations/2026-04-21-000002_multi_google_drive_gmail/down.sql
+++ b/src/src-tauri/src/migrations/2026-04-21-000002_multi_google_drive_gmail/down.sql
@@ -1,0 +1,32 @@
+-- Reverse account_email backfill on user_connections
+UPDATE user_connections
+SET calendar_account_email = ''
+WHERE connection_id IN (
+  SELECT id FROM connections
+  WHERE scope IN ('google_drive_read', 'google_gmail_modify')
+);
+
+-- Recreate emails without account_email
+CREATE TABLE emails_old (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email_uid TEXT NOT NULL UNIQUE,
+  subject TEXT NOT NULL DEFAULT '',
+  date INTEGER NOT NULL DEFAULT 0,
+  sender TEXT NOT NULL DEFAULT '',
+  recipient TEXT NOT NULL DEFAULT '',
+  cc TEXT,
+  body TEXT NOT NULL DEFAULT '',
+  thread_id TEXT,
+  is_starred INTEGER,
+  is_read INTEGER,
+  is_archived INTEGER,
+  is_deleted INTEGER
+);
+
+INSERT OR IGNORE INTO emails_old
+  SELECT id, email_uid, subject, date, sender, recipient, cc, body,
+         thread_id, is_starred, is_read, is_archived, is_deleted
+  FROM emails;
+
+DROP TABLE emails;
+ALTER TABLE emails_old RENAME TO emails;

--- a/src/src-tauri/src/migrations/2026-04-21-000002_multi_google_drive_gmail/up.sql
+++ b/src/src-tauri/src/migrations/2026-04-21-000002_multi_google_drive_gmail/up.sql
@@ -1,0 +1,43 @@
+-- Add account_email to drive_documents so files from multiple Google accounts
+-- can coexist without collision.
+ALTER TABLE drive_documents ADD COLUMN account_email TEXT NOT NULL DEFAULT '';
+
+-- Recreate emails with account_email and a composite unique constraint so that
+-- the same email_uid can appear for two different Google accounts.
+CREATE TABLE emails_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email_uid TEXT NOT NULL,
+  subject TEXT NOT NULL DEFAULT '',
+  date INTEGER NOT NULL DEFAULT 0,
+  sender TEXT NOT NULL DEFAULT '',
+  recipient TEXT NOT NULL DEFAULT '',
+  cc TEXT,
+  body TEXT NOT NULL DEFAULT '',
+  thread_id TEXT,
+  is_starred INTEGER,
+  is_read INTEGER,
+  is_archived INTEGER,
+  is_deleted INTEGER,
+  account_email TEXT NOT NULL DEFAULT '',
+  UNIQUE(email_uid, account_email)
+);
+
+INSERT INTO emails_new
+  SELECT id, email_uid, subject, date, sender, recipient, cc, body,
+         thread_id, is_starred, is_read, is_archived, is_deleted, ''
+  FROM emails;
+
+DROP TABLE emails;
+ALTER TABLE emails_new RENAME TO emails;
+
+-- Backfill user_connections: Drive and Gmail connections should have
+-- calendar_account_email = the linked user's email (same pattern as Calendar).
+UPDATE user_connections
+SET calendar_account_email = (
+  SELECT email FROM users WHERE users.id = user_connections.user_id
+)
+WHERE connection_id IN (
+  SELECT id FROM connections
+  WHERE scope IN ('google_drive_read', 'google_gmail_modify')
+)
+AND calendar_account_email = '';

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -49,9 +49,9 @@ import KNAnalytics from './utils/KNAnalytics'
 import { KNLocalStorage, RECONNECT_DISMISSED_AT } from './utils/KNLocalStorage'
 import { isSharingEnabled } from './utils/settings'
 import {
-  consumePendingCalendarAddEmail,
+  consumePendingAddAccountFlow,
 } from './utils/permissions/google'
-import { hasGoogleCalendar, getGoogleCalendarConnections } from 'src/api/connections'
+import { hasGoogleCalendar, getGoogleCalendarConnections, getGoogleDriveConnections, getGoogleGmailConnections } from 'src/api/connections'
 
 export type CreateAutomationProps = {
   uuid?: string
@@ -488,23 +488,23 @@ function App() {
           return
         }
 
-        // Check if this is an "add calendar" flow triggered from settings.
-        const pendingPrimaryEmail = consumePendingCalendarAddEmail()
-        if (pendingPrimaryEmail) {
+        // Check if this is an "add account" flow (calendar / drive / gmail) triggered from settings.
+        const pendingFlow = consumePendingAddAccountFlow()
+        if (pendingFlow) {
           getCompleteGoogleSignIn(
             event.payload.code,
             event.payload.raw_scopes,
-            pendingPrimaryEmail,
+            pendingFlow.primaryEmail,
           )
             .then(() => {
-              // Refresh the connections list so the new calendar appears.
-              fetchConnections(pendingPrimaryEmail).then(updatedConnections => {
-                syncConnections(pendingPrimaryEmail, updatedConnections)
+              // Refresh the connections list so the new account appears.
+              fetchConnections(pendingFlow.primaryEmail).then(updatedConnections => {
+                syncConnections(pendingFlow.primaryEmail, updatedConnections)
               })
             })
             .catch(error => {
-              logError(new Error('Failed to add Google Calendar account'), {
-                additionalInfo: '',
+              logError(new Error('Failed to add Google account'), {
+                additionalInfo: pendingFlow.type,
                 error,
               })
             })
@@ -616,18 +616,31 @@ function App() {
           })
         }
 
-        // Build a sync-target map: all google calendar accounts + ms + gmail.
+        // Build a sync-target map: all google calendar/drive/gmail accounts + microsoft.
         const calendarEntries = Object.fromEntries(
           getGoogleCalendarConnections(connections).map(c => {
             const k = `${ConnectionKeys.GOOGLE_CALENDAR}|${c.calendarAccountEmail}`
             return [k, c]
           }),
         )
+        const driveEntries = Object.fromEntries(
+          getGoogleDriveConnections(connections).map(c => {
+            const k = `${ConnectionKeys.GOOGLE_DRIVE}|${c.calendarAccountEmail}`
+            return [k, c]
+          }),
+        )
+        const gmailEntries = Object.fromEntries(
+          getGoogleGmailConnections(connections).map(c => {
+            const k = `${ConnectionKeys.GOOGLE_GMAIL}|${c.calendarAccountEmail}`
+            return [k, c]
+          }),
+        )
         const CalendarConnection = Object.fromEntries(
           Object.entries({
             ...calendarEntries,
+            ...driveEntries,
+            ...gmailEntries,
             [ConnectionKeys.MICROSOFT_CALENDAR]: connections[ConnectionKeys.MICROSOFT_CALENDAR],
-            [ConnectionKeys.GOOGLE_GMAIL]: connections[ConnectionKeys.GOOGLE_GMAIL],
             [ConnectionKeys.MICROSOFT_OUTLOOK]: connections[ConnectionKeys.MICROSOFT_OUTLOOK],
           }).filter(([_, value]) => value !== undefined),
         )

--- a/src/src/api/connections.tsx
+++ b/src/src/api/connections.tsx
@@ -44,11 +44,31 @@ export type Connection = {
 export const calendarConnectionKey = (calendarAccountEmail: string): string =>
   `${ConnectionKeys.GOOGLE_CALENDAR}|${calendarAccountEmail}`
 
+/** Record key used for a Google Drive connection given its account email. */
+export const driveConnectionKey = (accountEmail: string): string =>
+  `${ConnectionKeys.GOOGLE_DRIVE}|${accountEmail}`
+
+/** Record key used for a Google Gmail connection given its account email. */
+export const gmailConnectionKey = (accountEmail: string): string =>
+  `${ConnectionKeys.GOOGLE_GMAIL}|${accountEmail}`
+
 /** All Google Calendar connections in the connections map. */
 export const getGoogleCalendarConnections = (
   connections: Record<string, Connection>,
 ): Connection[] =>
   Object.values(connections).filter(c => c.key === ConnectionKeys.GOOGLE_CALENDAR)
+
+/** All Google Drive connections in the connections map. */
+export const getGoogleDriveConnections = (
+  connections: Record<string, Connection>,
+): Connection[] =>
+  Object.values(connections).filter(c => c.key === ConnectionKeys.GOOGLE_DRIVE)
+
+/** All Google Gmail connections in the connections map. */
+export const getGoogleGmailConnections = (
+  connections: Record<string, Connection>,
+): Connection[] =>
+  Object.values(connections).filter(c => c.key === ConnectionKeys.GOOGLE_GMAIL)
 
 /** True if at least one Google Calendar account is connected. */
 export const hasGoogleCalendar = (connections: Record<string, Connection>): boolean =>
@@ -217,11 +237,16 @@ export async function getConnections(email: string): Promise<Record<string, Conn
     ) => {
       const scope = userConnection.connection.scope
       const calendarAccountEmail = userConnection.calendarAccountEmail || ''
-      // Calendar connections are keyed as "scope|accountEmail" so that
-      // multiple linked calendars can coexist in the same record.
+      // Calendar, Drive, and Gmail connections are keyed as "scope|accountEmail"
+      // so that multiple linked accounts can coexist in the same record.
+      const multiAccountScopes = new Set([
+        ConnectionKeys.GOOGLE_CALENDAR,
+        ConnectionKeys.GOOGLE_DRIVE,
+        ConnectionKeys.GOOGLE_GMAIL,
+      ])
       const recordKey =
-        scope === ConnectionKeys.GOOGLE_CALENDAR && calendarAccountEmail
-          ? calendarConnectionKey(calendarAccountEmail)
+        multiAccountScopes.has(scope as ConnectionKeys) && calendarAccountEmail
+          ? `${scope}|${calendarAccountEmail}`
           : scope
 
       return {
@@ -281,8 +306,11 @@ export async function getGoogleProfile(email: string) {
   } as Profile
 }
 
-export async function syncGoogleDriveAPI(email: string) {
-  const response = await fetch(`${KN_API_GOOGLE_DRIVE}?email=${email}`, {
+export async function syncGoogleDriveAPI(email: string, accountEmail?: string) {
+  const accountParam = accountEmail
+    ? `&account_email=${encodeURIComponent(accountEmail)}`
+    : ''
+  const response = await fetch(`${KN_API_GOOGLE_DRIVE}?email=${email}${accountParam}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -295,8 +323,11 @@ export async function syncGoogleDriveAPI(email: string) {
   return !!data?.success
 }
 
-export async function syncGoogleGmailAPI(email: string) {
-  const response = await fetch(`${KN_API_GOOGLE_GMAIL}?email=${email}`, {
+export async function syncGoogleGmailAPI(email: string, accountEmail?: string) {
+  const accountParam = accountEmail
+    ? `&account_email=${encodeURIComponent(accountEmail)}`
+    : ''
+  const response = await fetch(`${KN_API_GOOGLE_GMAIL}?email=${email}${accountParam}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -5,8 +5,14 @@ import {
   ConnectionKeys,
   connectionsMap,
   getGoogleCalendarConnections,
+  getGoogleDriveConnections,
+  getGoogleGmailConnections,
 } from 'src/api/connections'
-import { openAddGoogleCalendarScreen } from 'src/utils/permissions/google'
+import {
+  openAddGoogleCalendarScreen,
+  openAddGoogleDriveScreen,
+  openAddGoogleGmailScreen,
+} from 'src/utils/permissions/google'
 import { useChannelStatus } from 'src/hooks/channels/useChannelStatus'
 import KNAnalytics from 'src/utils/KNAnalytics'
 import { logError } from 'src/utils/errorHandling'
@@ -950,12 +956,14 @@ export const SettingsDialog = ({
           <Typography weight={TypographyWeight.medium}>Permissions</Typography>
 
           <div className="PermissionContent flex flex-col gap-2">
-            {/* Non-calendar connections */}
+            {/* Non-calendar, non-drive, non-gmail connections */}
             {Object.values(connections)
               .filter(
                 item =>
                   connectionsKey.includes(item.key as ConnectionKeys) &&
                   item.key !== ConnectionKeys.GOOGLE_CALENDAR &&
+                  item.key !== ConnectionKeys.GOOGLE_DRIVE &&
+                  item.key !== ConnectionKeys.GOOGLE_GMAIL &&
                   item.key !== ConnectionKeys.MICROSOFT_CALENDAR,
               )
               .map(item => (
@@ -974,6 +982,42 @@ export const SettingsDialog = ({
                   </Typography>
                 </div>
               ))}
+
+            {/* Google Drive — one row per linked account */}
+            {getGoogleDriveConnections(connections).map(item => (
+              <div
+                className="flex justify-between h-[36px] items-center"
+                key={`drive-${item.id}-${item.calendarAccountEmail}`}
+              >
+                <Typography>
+                  Drive, {item.calendarAccountEmail || email}
+                </Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => handleDeleteConnection(item)}
+                >
+                  Remove
+                </Typography>
+              </div>
+            ))}
+
+            {/* Google Gmail — one row per linked account */}
+            {getGoogleGmailConnections(connections).map(item => (
+              <div
+                className="flex justify-between h-[36px] items-center"
+                key={`gmail-${item.id}-${item.calendarAccountEmail}`}
+              >
+                <Typography>
+                  Gmail, {item.calendarAccountEmail || email}
+                </Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => handleDeleteConnection(item)}
+                >
+                  Remove
+                </Typography>
+              </div>
+            ))}
 
             {/* Google Calendar — one row per linked account */}
             {getGoogleCalendarConnections(connections).map(item => (
@@ -1010,13 +1054,15 @@ export const SettingsDialog = ({
         <div className="AddAccountContainer p-6 pt-4 flex flex-col gap-4">
           <Typography weight={TypographyWeight.medium}>Add an account</Typography>
           <div className="PermissionContent flex flex-col gap-2">
-            {/* Standard non-calendar permissions that aren't yet connected */}
+            {/* Standard permissions that aren't multi-account and aren't yet connected */}
             {connectionsKey
               .filter(
                 (key: ConnectionKeys) =>
                   key !== ConnectionKeys.GOOGLE_CALENDAR &&
+                  key !== ConnectionKeys.GOOGLE_DRIVE &&
+                  key !== ConnectionKeys.GOOGLE_GMAIL &&
                   key !== ConnectionKeys.MICROSOFT_CALENDAR &&
-                  !Object.keys(connections).includes(key as string) &&
+                  !Object.keys(connections).some(k => k === key || k.startsWith(`${key}|`)) &&
                   Object.keys(PERMISSION_NAME_LIST).includes(key as string),
               )
               .map((connectionKey: ConnectionKeys) => (
@@ -1032,6 +1078,32 @@ export const SettingsDialog = ({
                   </Typography>
                 </div>
               ))}
+
+            {/* Add Google Drive (always available for Google users) */}
+            {profile?.provider === ConnectionKeys.GOOGLE_PROFILE && (
+              <div className="flex justify-between h-[36px] items-center">
+                <Typography>Google Drive</Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => { if (email) openAddGoogleDriveScreen(email) }}
+                >
+                  {getGoogleDriveConnections(connections).length > 0 ? 'Add another' : 'Add'}
+                </Typography>
+              </div>
+            )}
+
+            {/* Add Gmail (always available for Google users) */}
+            {profile?.provider === ConnectionKeys.GOOGLE_PROFILE && (
+              <div className="flex justify-between h-[36px] items-center">
+                <Typography>Gmail</Typography>
+                <Typography
+                  className={`cursor-pointer ${styles.link}`}
+                  onClick={() => { if (email) openAddGoogleGmailScreen(email) }}
+                >
+                  {getGoogleGmailConnections(connections).length > 0 ? 'Add another' : 'Add'}
+                </Typography>
+              </div>
+            )}
 
             {/* Add Google Calendar (always available for Google users) */}
             {profile?.provider === ConnectionKeys.GOOGLE_PROFILE && (

--- a/src/src/hooks/connections/useConnections.tsx
+++ b/src/src/hooks/connections/useConnections.tsx
@@ -89,7 +89,7 @@ export const useConnections = (initialState: Record<string, Connection> = {}) =>
     })
   }, [setConnections])
 
-  const { syncByConnectionKey, syncConnections: syncGoogleConnections } =
+  const { syncConnections: syncGoogleConnections } =
     useGoogleConnections(setConnectionState, removeConnection)
   const { syncConnections: syncLocalConnections, getLocalConnections } =
     useLocalConnections(setConnectionState)
@@ -200,13 +200,14 @@ export const useConnections = (initialState: Record<string, Connection> = {}) =>
   )
 
   const syncGoogleConnectionsByKey = useCallback(
-    async (email: string, ConnectionKeys: ConnectionKeys[]) => {
-      for (const connectionKey of ConnectionKeys) {
-        setConnectionState(connectionKey, ConnectionStates.IDLE)
-        syncByConnectionKey(email, connectionKey as ConnectionKeys)
-      }
+    async (email: string, keys: ConnectionKeys[]) => {
+      const subset = Object.fromEntries(
+        keys.flatMap(k => Object.entries(connections).filter(([_, c]) => c.key === k))
+      )
+      setConnectionState(keys[0], ConnectionStates.IDLE)
+      syncGoogleConnections(email, subset)
     },
-    [setConnectionState, syncByConnectionKey],
+    [setConnectionState, syncGoogleConnections, connections],
   )
 
   const syncMicrosoftConnectionsByKey = useCallback(

--- a/src/src/hooks/connections/useGoogleConnections.tsx
+++ b/src/src/hooks/connections/useGoogleConnections.tsx
@@ -5,7 +5,11 @@ import {
   ConnectionKeys,
   ConnectionStates,
   calendarConnectionKey,
+  driveConnectionKey,
+  gmailConnectionKey,
   getGoogleCalendarConnections,
+  getGoogleDriveConnections,
+  getGoogleGmailConnections,
   isConnectionReadyToSync,
   syncGoogleCalendarAPI,
   syncGoogleDriveAPI,
@@ -46,27 +50,31 @@ export const useGoogleConnections = (
     authFailureCounts.current[connectionKey] = 0
   }, [])
 
+  /** Sync a single Google Drive account identified by accountEmail. */
   const syncGoogleDrive = useCallback(
-    async (emailAddress: string) => {
-      setConnectionState?.(ConnectionKeys.GOOGLE_DRIVE, ConnectionStates.SYNCING)
+    async (primaryEmail: string, accountEmail: string) => {
+      const recordKey = driveConnectionKey(accountEmail)
+      setConnectionState?.(recordKey, ConnectionStates.SYNCING)
       try {
-        await syncGoogleDriveAPI(emailAddress)
-        resetAuthFailure(ConnectionKeys.GOOGLE_DRIVE)
+        await syncGoogleDriveAPI(primaryEmail, accountEmail)
+        resetAuthFailure(recordKey)
       } catch (error) {
-        handleSyncError(error, ConnectionKeys.GOOGLE_DRIVE)
+        handleSyncError(error, recordKey)
       }
     },
     [setConnectionState, handleSyncError, resetAuthFailure],
   )
 
+  /** Sync a single Gmail account identified by accountEmail. */
   const syncGoogleGmail = useCallback(
-    async (emailAddress: string) => {
-      setConnectionState?.(ConnectionKeys.GOOGLE_GMAIL, ConnectionStates.SYNCING)
+    async (primaryEmail: string, accountEmail: string) => {
+      const recordKey = gmailConnectionKey(accountEmail)
+      setConnectionState?.(recordKey, ConnectionStates.SYNCING)
       try {
-        await syncGoogleGmailAPI(emailAddress)
-        resetAuthFailure(ConnectionKeys.GOOGLE_GMAIL)
+        await syncGoogleGmailAPI(primaryEmail, accountEmail)
+        resetAuthFailure(recordKey)
       } catch (error) {
-        handleSyncError(error, ConnectionKeys.GOOGLE_GMAIL)
+        handleSyncError(error, recordKey)
       }
     },
     [setConnectionState, handleSyncError, resetAuthFailure],
@@ -87,28 +95,21 @@ export const useGoogleConnections = (
     [setConnectionState, handleSyncError, resetAuthFailure],
   )
 
-  const syncByConnectionKey = useCallback(
-    async (email: string, connectionKey: ConnectionKeys) => {
-      if (connectionKey === ConnectionKeys.GOOGLE_DRIVE) {
-        await syncGoogleDrive(email)
-        return
-      }
-      if (connectionKey === ConnectionKeys.GOOGLE_GMAIL) {
-        await syncGoogleGmail(email)
-        return
-      }
-    },
-    [syncGoogleDrive, syncGoogleGmail],
-  )
-
   const syncConnections = useCallback(
     async (email: string, connections: Record<string, Connection>) => {
       const promises: Promise<void>[] = []
 
-      // Sync Drive and Gmail using the base scope keys.
-      for (const connectionKey of [ConnectionKeys.GOOGLE_DRIVE, ConnectionKeys.GOOGLE_GMAIL]) {
-        if (isConnectionReadyToSync(connections[connectionKey])) {
-          promises.push(syncByConnectionKey(email, connectionKey))
+      // Sync every linked Google Drive account independently.
+      for (const driveConn of getGoogleDriveConnections(connections)) {
+        if (isConnectionReadyToSync(driveConn) && driveConn.calendarAccountEmail) {
+          promises.push(syncGoogleDrive(email, driveConn.calendarAccountEmail))
+        }
+      }
+
+      // Sync every linked Gmail account independently.
+      for (const gmailConn of getGoogleGmailConnections(connections)) {
+        if (isConnectionReadyToSync(gmailConn) && gmailConn.calendarAccountEmail) {
+          promises.push(syncGoogleGmail(email, gmailConn.calendarAccountEmail))
         }
       }
 
@@ -121,8 +122,8 @@ export const useGoogleConnections = (
 
       await Promise.all(promises)
     },
-    [syncByConnectionKey, syncGoogleCalendar],
+    [syncGoogleDrive, syncGoogleGmail, syncGoogleCalendar],
   )
 
-  return { syncByConnectionKey, syncConnections, syncGoogleCalendar }
+  return { syncConnections, syncGoogleCalendar, syncGoogleDrive, syncGoogleGmail }
 }

--- a/src/src/utils/permissions/google.tsx
+++ b/src/src/utils/permissions/google.tsx
@@ -10,21 +10,37 @@ export class GoogleAuthError extends Error {
   }
 }
 
-// Module-level flag.  Set before opening the OAuth browser window so the
-// signin_success listener in App.tsx knows to treat this as an "add calendar"
-// flow rather than a primary login.
-let _pendingCalendarAddEmail: string | null = null
-
-/** Store the primary user email before triggering the add-calendar OAuth flow. */
-export const setPendingCalendarAddEmail = (email: string): void => {
-  _pendingCalendarAddEmail = email
+// Module-level pending-add-account state.  Set before opening the OAuth browser
+// window so the signin_success listener in App.tsx knows this is an
+// "add account" flow rather than a primary login.
+type PendingAddAccountFlow = {
+  primaryEmail: string
+  type: 'calendar' | 'drive' | 'gmail'
 }
 
-/** Consume (read + clear) the pending calendar-add email. */
+let _pendingAddAccountFlow: PendingAddAccountFlow | null = null
+
+/** Store the primary user email and connection type before triggering an add-account OAuth flow. */
+export const setPendingAddAccountFlow = (primaryEmail: string, type: 'calendar' | 'drive' | 'gmail'): void => {
+  _pendingAddAccountFlow = { primaryEmail, type }
+}
+
+/** Consume (read + clear) the pending add-account flow state. */
+export const consumePendingAddAccountFlow = (): PendingAddAccountFlow | null => {
+  const flow = _pendingAddAccountFlow
+  _pendingAddAccountFlow = null
+  return flow
+}
+
+/** @deprecated Use setPendingAddAccountFlow / consumePendingAddAccountFlow instead. */
+export const setPendingCalendarAddEmail = (email: string): void =>
+  setPendingAddAccountFlow(email, 'calendar')
+
+/** @deprecated Use consumePendingAddAccountFlow instead. */
 export const consumePendingCalendarAddEmail = (): string | null => {
-  const email = _pendingCalendarAddEmail
-  _pendingCalendarAddEmail = null
-  return email
+  const flow = consumePendingAddAccountFlow()
+  if (!flow || flow.type !== 'calendar') return null
+  return flow.primaryEmail
 }
 
 export const openGoogleAuthScreen = (scope: string) => {
@@ -70,16 +86,32 @@ export const openGoogleAuthScreen = (scope: string) => {
   }
 }
 
-/** Open the OAuth flow to add an additional Google Calendar account.
- *  The resulting signin_success event will be handled as an add-calendar
- *  flow (not a full re-login) because we store the primary email here. */
+/** Open the OAuth flow to add an additional Google Calendar account. */
 export const openAddGoogleCalendarScreen = (
   primaryEmail: string,
   calendarScope: string,
 ): void => {
-  setPendingCalendarAddEmail(primaryEmail)
+  setPendingAddAccountFlow(primaryEmail, 'calendar')
   // userinfo.email is required so the backend can identify which Google account
   // was just authorized and store it as the calendar_account_email.
   const scopeWithEmail = `${calendarScope} https://www.googleapis.com/auth/userinfo.email`
   openGoogleAuthScreen(scopeWithEmail)
+}
+
+/** Open the OAuth flow to add an additional Google Drive account. */
+export const openAddGoogleDriveScreen = (
+  primaryEmail: string,
+): void => {
+  setPendingAddAccountFlow(primaryEmail, 'drive')
+  const scope = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/userinfo.email'
+  openGoogleAuthScreen(scope)
+}
+
+/** Open the OAuth flow to add an additional Gmail account. */
+export const openAddGoogleGmailScreen = (
+  primaryEmail: string,
+): void => {
+  setPendingAddAccountFlow(primaryEmail, 'gmail')
+  const scope = 'https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/userinfo.email'
+  openGoogleAuthScreen(scope)
 }


### PR DESCRIPTION
## Summary

- **DB migration**: adds `account_email` to `drive_documents` and `emails` tables; changes `emails` UNIQUE constraint from `(email_uid)` to `(email_uid, account_email)`; backfills `calendar_account_email` for existing Drive/Gmail user_connections from the user's email
- **Backend**: `drive.rs`/`gmail.rs`/`auth.rs` now propagate `account_email` from `user_connection.calendar_account_email` to every DB write; `mark_deleted_emails` scopes deletions by account so syncing one account doesn't delete another's emails; primary sign-in sets `calendar_account_email = email` for Drive and Gmail (was calendar-only); the add-account OAuth flow is generalised to create whichever connection types match the granted scopes
- **Frontend**: Drive and Gmail connections are keyed as `scope|accountEmail` (same pattern as Calendar); Settings shows one row per linked Drive/Gmail account with Remove; "Add" / "Add another" buttons in Settings for Drive, Gmail, and Calendar; `signin_success` handler covers all three add-account types

## Test plan

- [ ] Primary Google sign-in: verify Drive and Gmail connections appear in Settings with the correct email label
- [ ] "Add another" Drive: click button → OAuth → new Drive row appears in Settings with second account's email
- [ ] "Add another" Gmail: same as above for Gmail
- [ ] Remove a Drive/Gmail account: row disappears, the other account's data is unaffected
- [ ] Gmail sync for account A does not mark account B's emails as deleted
- [ ] CI passes (macOS build)

https://claude.ai/code/session_01ENMT4Jb3hwpQGRpvsK7u12