### PR TITLE
Add responsive sidebar collapse on window resize

### DIFF
--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -47,6 +47,16 @@ function NotetakerSidebar({
   }, [])
 
   useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 900) {
+        setIsCollapsed(true)
+      }
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault()


### PR DESCRIPTION
## Summary
Added automatic sidebar collapse functionality that triggers when the window is resized below 900px width, improving the responsive behavior of the NotetakerSidebar component.

## Key Changes
- Added a new `useEffect` hook that listens to window resize events
- Automatically collapses the sidebar (`setIsCollapsed(true)`) when viewport width drops below 900px
- Properly cleans up the event listener on component unmount to prevent memory leaks

## Implementation Details
- The resize event listener is attached to the window object and removed in the cleanup function
- The effect has an empty dependency array, ensuring it only runs once on component mount
- This complements existing responsive design patterns and improves mobile/tablet usability

https://claude.ai/code/session_0134GCveHytqif56ERytosMy