### PR TITLE
Fix stale closure in recording listener and window ID mismatch

### DIFF
--- a/src/src-tauri/src/spotlight.rs
+++ b/src/src-tauri/src/spotlight.rs
@@ -87,7 +87,7 @@ fn register_shortcut(app_handle: AppHandle<Wry>) {
 
 #[tauri::command]
 pub fn kn_show_app(app_handle: AppHandle<Wry>) {
-  if let Some(window) = app_handle.get_window("main_window") {
+  if let Some(window) = app_handle.get_window("main") {
     log::debug!("show_spotlight: 1");
     // panel!(app_handle).show();
     window.show().expect("Failed to show window");
@@ -97,7 +97,7 @@ pub fn kn_show_app(app_handle: AppHandle<Wry>) {
 
 #[tauri::command]
 pub fn kn_hide_app(app_handle: AppHandle<Wry>) {
-  if let Some(window) = app_handle.get_window("main_window") {
+  if let Some(window) = app_handle.get_window("main") {
     log::debug!("hide_spotlight: 1");
     // panel!(app_handle).order_out(None);
     window.hide().expect("Failed to hide window");

--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -580,15 +580,20 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     }
   }
 
+  // Keep a ref so the listener below always calls the latest handleStopRecording
+  // without stale-closure issues (recordingHandlers changes each render when
+  // isRecordingStates updates, so capturing it in a [thread.id]-scoped effect
+  // means isRecording() always returned false and stop was silently skipped).
+  const handleStopRecordingRef = React.useRef(handleStopRecording)
+  handleStopRecordingRef.current = handleStopRecording
+
   useEffect(() => {
     const unlisten = listen('stop-recording-from-indicator', () => {
-      if (recordingHandlers.isRecording(thread.id)) {
-        handleStopRecording('Indicator')
-      }
+      handleStopRecordingRef.current('Indicator')
     })
     return () => { unlisten.then(fn => fn()) }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [thread.id])
+  }, [])
 
   const isSynthesizing = useCallback(() => {
     return recordingHandlers.isLoadingNotes(thread.id) || isLLMLoading


### PR DESCRIPTION
## Summary
This PR fixes two bugs: a stale closure issue in the meeting notes recording listener that prevented stop-recording events from being processed, and a window ID mismatch in the Tauri spotlight commands.

## Key Changes

- **Recording listener stale closure fix**: Refactored the `stop-recording-from-indicator` event listener to use a ref-based approach (`handleStopRecordingRef`) instead of capturing `recordingHandlers` in the dependency array. This ensures the listener always calls the latest `handleStopRecording` function without stale closure issues. The effect dependency array was changed from `[thread.id]` to `[]` since the ref pattern eliminates the need for re-registration.

- **Window ID correction**: Updated window identifier from `"main_window"` to `"main"` in both `kn_show_app` and `kn_hide_app` Tauri commands in `spotlight.rs` to match the actual window configuration.

## Implementation Details

The recording listener previously had a subtle bug where `recordingHandlers` was captured in a dependency array scoped to `thread.id`. Since `recordingHandlers` changes on every render when `isRecordingStates` updates, the effect would re-register frequently, but the captured `isRecording()` check would always return false due to stale state, causing stop-recording events to be silently skipped. The ref-based solution decouples the listener registration from state changes while maintaining access to the current handler.

https://claude.ai/code/session_017zgascCA7RdkkM94S6oJni