### PR TITLE
Improve gateway service startup and health check handling

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5913,6 +5913,12 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   }
   eprintln!("[clawd/service] auto_enable: wrote plist to {}", plist_path.display());
 
+  // Save args so regenerate_macos_plist_with_current_env() can update the plist
+  // later when the user saves or changes an API key (e.g. GOOGLE_API_KEY).
+  // Without this, the regeneration call from set_api_key() finds LAST_MACOS_PLIST_ARGS=None
+  // and silently skips the update, leaving the gateway subprocess running without the key.
+  *LAST_MACOS_PLIST_ARGS.lock().unwrap() = Some((setup.program_args.clone(), setup.env.clone()));
+
   let uid = unsafe { libc::getuid() };
   let domain = format!("gui/{}", uid);
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2170,6 +2170,7 @@ pub async fn service_status() -> impl Responder {
     // code=1006 "closed before connect" WS errors in the gateway log).
     // This handles the case where the gateway is running from a prior session
     // but the plist is missing or launchctl hasn't registered it yet.
+    // 401 is treated as "running": gateway requires auth but is listening.
     let port_ok = if !launchctl_running {
       let probe = reqwest::Client::builder()
         .timeout(std::time::Duration::from_millis(800))
@@ -2177,7 +2178,7 @@ pub async fn service_status() -> impl Responder {
         .ok()
         .map(|c| c.get("http://127.0.0.1:18789/health").send());
       match probe {
-        Some(fut) => fut.await.map(|r| r.status().is_success() || r.status().as_u16() == 404).unwrap_or(false),
+        Some(fut) => fut.await.map(|r| r.status().is_success() || r.status().as_u16() == 401 || r.status().as_u16() == 404).unwrap_or(false),
         None => false,
       }
     } else {
@@ -5851,14 +5852,28 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   };
 
   if plist_path.exists() {
-    return; // Already registered — nothing to do.
+    // Plist exists — check if the service is actually loaded.  If it is,
+    // there's nothing to do.  If it isn't (e.g. bootstrap failed on a prior
+    // launch, the service was manually unregistered, or the app was reinstalled
+    // without deleting the plist), fall through and re-bootstrap so the gateway
+    // starts without the user having to toggle Enable in Settings.
+    let uid = unsafe { libc::getuid() };
+    let domain = format!("gui/{}/{}", uid, LAUNCH_AGENT_LABEL);
+    let is_loaded = std::process::Command::new("launchctl")
+      .args(["print", &domain])
+      .status()
+      .map(|s| s.success())
+      .unwrap_or(false);
+    if is_loaded {
+      return;
+    }
+    eprintln!("[clawd/service] auto_enable: plist exists but service not loaded — re-bootstrapping");
   }
 
-  // Signal to the health endpoint that first-time setup is in progress so it
-  // can show a cleaner "starting for the first time" message rather than
-  // "service is registering — please retry".
+  // Signal to the health endpoint that setup is in progress so it can show a
+  // cleaner message rather than "service is registering — please retry".
   AUTO_ENABLE_STARTED.store(true, Ordering::Relaxed);
-  eprintln!("[clawd/service] auto_enable: plist not found, registering LaunchAgent for first launch");
+  eprintln!("[clawd/service] auto_enable: registering LaunchAgent");
 
   // Build a default config (base_url is set inside prepare_gateway_config's
   // return value; we only need the Arc wrapper to satisfy the signature).


### PR DESCRIPTION
## Summary
This PR improves the reliability of the gateway service startup process by enhancing health checks to recognize authenticated endpoints and implementing smarter auto-enable logic that re-bootstraps the service when the plist exists but the service isn't actually loaded.

## Key Changes
- **Health check enhancement**: Modified the `/health` endpoint probe to treat HTTP 401 (Unauthorized) as a success indicator, since a 401 response means the gateway is running and listening but requires authentication
- **Auto-enable logic improvement**: Changed `auto_enable_if_needed()` to check if the LaunchAgent service is actually loaded when the plist file exists, rather than assuming the plist's existence means the service is registered. If the plist exists but the service isn't loaded (e.g., due to a failed bootstrap, manual unregistration, or app reinstall), the function now re-bootstraps the service automatically
- **Updated logging**: Clarified log messages to reflect that auto-enable handles both first-time setup and recovery scenarios

## Implementation Details
- Uses `launchctl print` command to verify if the service is actually loaded in the user's LaunchAgent domain
- Retrieves the current user ID via `libc::getuid()` to construct the correct domain path
- Falls through to re-bootstrap only when necessary, avoiding redundant operations when the service is already properly loaded

https://claude.ai/code/session_011tWhpoiCWfy7XyKcDDYZGx