### PR TITLE
Link recorded notes to a calendar event after the fact

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -184,6 +184,27 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   const [prepContent, setPrepContent] = useState('')
   const [isPrepGenerating, setIsPrepGenerating] = useState(false)
   const [suggestedCalendarEvent, setSuggestedCalendarEvent] = useState<Meeting | null>(null)
+  const [showCalendarPicker, setShowCalendarPicker] = useState(false)
+  const calendarPickerRef = useRef<HTMLDivElement>(null)
+
+  const sameDayMeetings = useMemo(() => {
+    if (!feed.meetings || meeting) return []
+    const day = dayjs(timestamp).format('YYYY-MM-DD')
+    return Object.values(feed.meetings).filter(
+      m => dayjs(m.start * 1000).format('YYYY-MM-DD') === day,
+    ).sort((a, b) => a.start - b.start)
+  }, [feed.meetings, timestamp, meeting])
+
+  useEffect(() => {
+    if (!showCalendarPicker) return
+    const handler = (e: MouseEvent) => {
+      if (calendarPickerRef.current && !calendarPickerRef.current.contains(e.target as Node)) {
+        setShowCalendarPicker(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [showCalendarPicker])
 
   const templatePrompt: MeetingTemplatePrompt = useMemo(() => {
     if (thread.promptTemplate) {
@@ -709,6 +730,47 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
                     </svg>
                     {dayjs(new Date()).isSame(dayjs(meeting?.start ? meeting.start * 1000 : undefined), 'day') ? 'Today' : dayjs(meeting?.start ? meeting.start * 1000 : undefined).format('MMM D')}
                   </span>
+                  {thread.recorded && !meeting && sameDayMeetings.length > 0 && (
+                    <div className="notetaker-note__link-event-wrap" ref={calendarPickerRef}>
+                      <button
+                        className="notetaker-note__link-event-btn"
+                        onClick={() => setShowCalendarPicker(v => !v)}
+                        title="Link to a calendar event"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                          <line x1="16" y1="2" x2="16" y2="6" />
+                          <line x1="8" y1="2" x2="8" y2="6" />
+                          <line x1="3" y1="10" x2="21" y2="10" />
+                        </svg>
+                        Link to calendar event
+                      </button>
+                      {showCalendarPicker && (
+                        <div className="notetaker-note__calendar-picker">
+                          {sameDayMeetings.map(m => (
+                            <button
+                              key={m.event_id}
+                              className="notetaker-note__calendar-picker-item"
+                              onClick={() => {
+                                if (feedItemId != null) {
+                                  feed.attachNotesToCalendarEvent(feedItemId, m)
+                                }
+                                setShowCalendarPicker(false)
+                                setSuggestedCalendarEvent(null)
+                              }}
+                            >
+                              <span className="notetaker-note__calendar-picker-time">
+                                {dayjs(m.start * 1000).format('h:mm A')}
+                              </span>
+                              <span className="notetaker-note__calendar-picker-title">
+                                {m.title}
+                              </span>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
               <div className="flex-shrink-0 flex items-center gap-2">
@@ -921,6 +983,47 @@ Be direct, specific, and concise. No filler text.`
                     {meeting.participants.slice(0, 3).map(p => p.name || p.email.split('@')[0]).join(', ')}
                     {meeting.participants.length > 3 && ` +${meeting.participants.length - 3}`}
                   </span>
+                )}
+                {thread.recorded && !meeting && sameDayMeetings.length > 0 && (
+                  <div className="notetaker-note__link-event-wrap" ref={calendarPickerRef}>
+                    <button
+                      className="notetaker-note__link-event-btn"
+                      onClick={() => setShowCalendarPicker(v => !v)}
+                      title="Link to a calendar event"
+                    >
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                        <line x1="16" y1="2" x2="16" y2="6" />
+                        <line x1="8" y1="2" x2="8" y2="6" />
+                        <line x1="3" y1="10" x2="21" y2="10" />
+                      </svg>
+                      Link to calendar event
+                    </button>
+                    {showCalendarPicker && (
+                      <div className="notetaker-note__calendar-picker">
+                        {sameDayMeetings.map(m => (
+                          <button
+                            key={m.event_id}
+                            className="notetaker-note__calendar-picker-item"
+                            onClick={() => {
+                              if (feedItemId != null) {
+                                feed.attachNotesToCalendarEvent(feedItemId, m)
+                              }
+                              setShowCalendarPicker(false)
+                              setSuggestedCalendarEvent(null)
+                            }}
+                          >
+                            <span className="notetaker-note__calendar-picker-time">
+                              {dayjs(m.start * 1000).format('h:mm A')}
+                            </span>
+                            <span className="notetaker-note__calendar-picker-title">
+                              {m.title}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -101,6 +101,7 @@ export interface IFeed {
     }>
   >
   feedContent: Record<string, FeedItem[]>
+  meetings: Record<string, Meeting> | undefined
   insertFeedItem: (
     timestamp: number,
     hideFollowUp: boolean,
@@ -2048,6 +2049,7 @@ export function useFeed(
 
   const feed: IFeed = {
     feedContent,
+    meetings,
     insertFeedItem,
     handleAutomationFeed,
     insertMessageToFeedItem,

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -476,6 +476,77 @@ html, body {
   background: #A23933;
 }
 
+.notetaker-note__link-event-wrap {
+  position: relative;
+}
+
+.notetaker-note__link-event-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-family: 'Inter', sans-serif;
+  color: #6474AC;
+  background: #EEF1FA;
+  border: 1px solid #C5CCEC;
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.notetaker-note__link-event-btn:hover {
+  background: #DDE2F5;
+}
+
+.notetaker-note__calendar-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 200;
+  background: #fff;
+  border: 1px solid #E3E2E2;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  min-width: 240px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.notetaker-note__calendar-picker-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+}
+
+.notetaker-note__calendar-picker-item:hover {
+  background: #F5F6FB;
+}
+
+.notetaker-note__calendar-picker-time {
+  font-size: 11px;
+  color: #969595;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.notetaker-note__calendar-picker-title {
+  font-size: 13px;
+  color: #333;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .notetaker-note__attach-banner {
   display: flex;
   align-items: center;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Exposes the full `meetings` map from `useCalendar` on the `IFeed` interface, so components can search all loaded calendar events (2 weeks back → 1 week ahead), not just today's `feedContent` placeholders
- Adds a **"Link to calendar event"** button in the `MeetingNotesMode` metadata row whenever a recorded note has no linked calendar event
- Clicking opens a dropdown of all calendar events from the **same day** as the recording, sorted by start time
- Selecting one calls `attachNotesToCalendarEvent`, updating the feed item title and calendar association in state and persisting the title change to the DB
- The button appears in both the loading/synthesis view and the main content view

## Test plan

- [ ] Record an ad-hoc meeting (no calendar event linked)
- [ ] After notes are generated, verify "Link to calendar event" button appears in metadata row
- [ ] Click it — confirm dropdown shows that day's calendar events with times
- [ ] Select one — confirm title updates to match the event and button disappears
- [ ] Open a meeting recorded yesterday — verify the same button appears and same-day events are listed correctly
- [ ] On a meeting already linked to a calendar event — confirm button does not appear

https://claude.ai/code/session_01JPqkoQM2ZdkZbVfr2f2UFg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPqkoQM2ZdkZbVfr2f2UFg)_