### PR TITLE
Fix Sentry high-priority issues: IPC race conditions, port conflicts, and xlrd support

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2278,6 +2278,7 @@ pub async fn chat(
               "beautifulsoup4",
               "lxml",
               "openpyxl",
+              "xlrd",
               "scikit-learn",
               "sklearn",
               "sympy",

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -37,8 +37,8 @@ fn kill_process_on_port(port: u16) {
   use std::os::windows::process::CommandExt;
   const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-  // Try up to 3 times to kill the process and verify port is free
-  for attempt in 1..=3 {
+  // Try up to 5 times to kill the process and verify port is free
+  for attempt in 1..=5 {
     let output = std::process::Command::new("netstat")
       .args(["-ano", "-p", "tcp"])
       .creation_flags(CREATE_NO_WINDOW)
@@ -58,8 +58,8 @@ fn kill_process_on_port(port: u16) {
                   .args(["/PID", &pid.to_string(), "/F", "/T"])
                   .creation_flags(CREATE_NO_WINDOW)
                   .status();
-                // Wait for process to fully terminate
-                std::thread::sleep(std::time::Duration::from_millis(500));
+                // Wait for process to fully terminate with longer delay
+                std::thread::sleep(std::time::Duration::from_millis(800));
               }
             }
           }
@@ -72,21 +72,22 @@ fn kill_process_on_port(port: u16) {
       return;
     }
 
-    // Brief pause before retry
-    if attempt < 3 {
-      std::thread::sleep(std::time::Duration::from_millis(300));
+    // Brief pause before retry with exponential backoff
+    if attempt < 5 {
+      let delay = 300 * attempt as u64;
+      std::thread::sleep(std::time::Duration::from_millis(delay));
     }
   }
 
-  eprintln!("[clawd/service] WARNING: Failed to free port {} after 3 attempts", port);
+  eprintln!("[clawd/service] WARNING: Failed to free port {} after 5 attempts", port);
 }
 
 /// On Unix/macOS, kill a process listening on the given TCP port.
 /// Enhanced with retry logic to ensure the port is actually freed.
 #[cfg(not(target_os = "windows"))]
 fn kill_process_on_port(port: u16) {
-  // Try up to 3 times to kill the process and verify port is free
-  for attempt in 1..=3 {
+  // Try up to 5 times to kill the process and verify port is free
+  for attempt in 1..=5 {
     let output = std::process::Command::new("lsof")
       .args(["-ti", &format!(":{}", port)])
       .output();
@@ -102,8 +103,8 @@ fn kill_process_on_port(port: u16) {
             let _ = std::process::Command::new("kill")
               .args(["-9", &pid.to_string()])
               .status();
-            // Wait for process to fully terminate
-            std::thread::sleep(std::time::Duration::from_millis(500));
+            // Wait for process to fully terminate with longer delay
+            std::thread::sleep(std::time::Duration::from_millis(800));
           }
         }
       }
@@ -114,13 +115,14 @@ fn kill_process_on_port(port: u16) {
       return;
     }
 
-    // Brief pause before retry
-    if attempt < 3 {
-      std::thread::sleep(std::time::Duration::from_millis(300));
+    // Brief pause before retry with exponential backoff
+    if attempt < 5 {
+      let delay = 300 * attempt as u64;
+      std::thread::sleep(std::time::Duration::from_millis(delay));
     }
   }
 
-  eprintln!("[clawd/service] WARNING: Failed to free port {} after 3 attempts", port);
+  eprintln!("[clawd/service] WARNING: Failed to free port {} after 5 attempts", port);
 }
 
 /// Check if a process with the given PID is still running (Windows).

--- a/src/src/utils/tauriIpcBridge.ts
+++ b/src/src/utils/tauriIpcBridge.ts
@@ -4,13 +4,13 @@ import { invoke } from '@tauri-apps/api/tauri'
  * Waits for the Tauri IPC bridge to be ready before attempting to invoke commands.
  * This prevents 'command not found' errors during app initialization race conditions.
  *
- * @param maxRetries Maximum number of retry attempts (default: 10)
- * @param retryDelay Delay between retries in milliseconds (default: 100ms)
+ * @param maxRetries Maximum number of retry attempts (default: 20)
+ * @param retryDelay Delay between retries in milliseconds (default: 150ms)
  * @returns Promise that resolves when bridge is ready, rejects if max retries exceeded
  */
 export async function waitForTauriIpcBridge(
-  maxRetries: number = 10,
-  retryDelay: number = 100
+  maxRetries: number = 20,
+  retryDelay: number = 150
 ): Promise<void> {
   let attempts = 0
 
@@ -27,8 +27,9 @@ export async function waitForTauriIpcBridge(
           `Tauri IPC bridge not ready after ${maxRetries} attempts. Last error: ${error}`
         )
       }
-      // Wait before retrying
-      await new Promise(resolve => setTimeout(resolve, retryDelay))
+      // Wait before retrying with exponential backoff
+      const delay = retryDelay * Math.min(attempts, 3)
+      await new Promise(resolve => setTimeout(resolve, delay))
     }
   }
 }
@@ -45,16 +46,29 @@ export async function waitForTauriIpcBridge(
 export async function safeInvoke<T>(
   command: string,
   args?: Record<string, unknown>,
-  maxRetries: number = 10
+  maxRetries: number = 20
 ): Promise<T> {
-  try {
-    return await invoke<T>(command, args)
-  } catch (error: any) {
-    // If the error is 'command not found', wait for bridge and retry
-    if (error?.toString().includes('not found')) {
-      await waitForTauriIpcBridge(maxRetries)
+  let attempts = 0
+
+  while (attempts < maxRetries) {
+    try {
       return await invoke<T>(command, args)
+    } catch (error: any) {
+      const errorStr = error?.toString() || ''
+      const isNotFoundError = errorStr.includes('not found') || errorStr.includes('command')
+
+      if (isNotFoundError && attempts < maxRetries - 1) {
+        attempts++
+        // Exponential backoff: 150ms, 300ms, 450ms, then 450ms for remaining attempts
+        const delay = 150 * Math.min(attempts, 3)
+        await new Promise(resolve => setTimeout(resolve, delay))
+        continue
+      }
+
+      // If not a 'not found' error, or we've exhausted retries, throw
+      throw error
     }
-    throw error
   }
+
+  throw new Error(`Failed to invoke command '${command}' after ${maxRetries} attempts`)
 }


### PR DESCRIPTION
## Summary
This PR resolves three critical issues identified in Sentry that have been causing user experience degradation:

1. **Frontend Initialization Race Condition** - Fixed `command kn_init_app not found` errors
2. **Gateway Zombie Process** - Resolved port 10048 `AddrInUse` fatal panics  
3. **Missing xlrd Dependency** - Added support for legacy Excel file processing

## Changes

### 1. Frontend Initialization Race Condition (kn_init_app not found)
**File:** `src/utils/tauriIpcBridge.ts`

- Enhanced `safeInvoke()` with more aggressive retry logic (20 attempts vs 10)
- Implemented exponential backoff (150ms → 300ms → 450ms intervals)
- Improved error detection to catch all 'command not found' error variations
- **Impact:** Prevents "command kn_init_app not found" errors on `/onboard` and `/home` routes during app startup

### 2. Gateway Zombie Process (Port 10048 AddrInUse)
**File:** `src-tauri/src/clawd/service.rs`

- Increased `kill_process_on_port()` retry attempts from 3 to 5
- Extended process termination wait time from 500ms to 800ms
- Added exponential backoff to retry delays (300ms → 600ms → 900ms → 1200ms)
- Applied to both Windows (netstat/taskkill) and Unix (lsof/kill) code paths
- **Impact:** Prevents "Unable to spawn server: Os { code: 10048, kind: AddrInUse }" fatal crashes

### 3. Missing xlrd Dependency Support
**File:** `src-tauri/src/clawd/browser.rs`

- Added `xlrd` to Python module auto-install allowlist
- Enables automatic installation when Python scripts import xlrd
- **Impact:** Supports legacy Excel file (.xls) document extraction, complementing existing openpyxl (.xlsx) support

## Testing
- ✅ Verified xlrd is now in the allowed packages list
- ✅ Confirmed exponential backoff logic in both IPC bridge and port cleanup
- ✅ Reviewed retry attempt limits and delay calculations

## Related Issues
Addresses Sentry issues:
- Frontend race condition: 50+ events of "UnhandledRejection: command kn_init_app not found"
- Gateway crashes: Fatal panics on port binding
- Document extraction: ModuleNotFoundError for xlrd imports

## Notes
- OAuth token refresh errors (Microsoft, Google, Zoho) already have exponential backoff retry logic in knapsack-studio-backend via `oauth_retry_utils.py`
- No changes needed for OAuth refresh - existing implementation is robust