### PR TITLE
Add auto-generated meeting brief and inline recording insights

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -187,6 +187,12 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   const [showCalendarPicker, setShowCalendarPicker] = useState(false)
   const calendarPickerRef = useRef<HTMLDivElement>(null)
 
+  const [inlineInsights, setInlineInsights] = useState<Array<{id: number; mins: number; text: string}>>([])
+  const [briefPrepContent, setBriefPrepContent] = useState('')
+  const [isBriefPrepGenerating, setIsBriefPrepGenerating] = useState(false)
+  const [briefPrepDismissed, setBriefPrepDismissed] = useState(false)
+  const briefPrepTriggeredRef = useRef(false)
+
   const sameDayMeetings = useMemo(() => {
     if (!feed.meetings || meeting) return []
     const day = dayjs(timestamp).format('YYYY-MM-DD')
@@ -393,21 +399,22 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
       // wasRecording to be false inside stopRecording, preventing note generation.
       handleStopRecording('Automatic')
     })
-    // Listen for 15-minute heartbeat insights during recording (proactive mode only)
+    // Listen for heartbeat insights during recording — always show inline, notify if proactive mode on
     const unlistenHeartbeatPromise = listen(
       'meeting_heartbeat',
       async (event: Event<{ threadId: number; insight: string; elapsedMinutes: number }>) => {
-        const isProactive = localStorage.getItem('moltbot_proactive_mode') === 'true'
-        if (!isProactive) return
-
         const { insight, elapsedMinutes } = event.payload
         const mins = Math.round(elapsedMinutes)
-        invoke('show_notification_window', {
-          eventId: null,
-          buttonConfigs: [{ buttonText: 'Dismiss', buttonHandler: 'dismiss_notification_handler' }],
-          title: `Meeting insight (${mins} min)`,
-          time: insight,
-        }).catch(e => console.error('Failed to show meeting insight notification:', e))
+        setInlineInsights(prev => [...prev, { id: Date.now(), mins, text: insight }])
+        const isProactive = localStorage.getItem('moltbot_proactive_mode') === 'true'
+        if (isProactive) {
+          invoke('show_notification_window', {
+            eventId: null,
+            buttonConfigs: [{ buttonText: 'Dismiss', buttonHandler: 'dismiss_notification_handler' }],
+            title: `Meeting insight (${mins} min)`,
+            time: insight,
+          }).catch(e => console.error('Failed to show meeting insight notification:', e))
+        }
       },
     )
     return () => {
@@ -496,6 +503,34 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
       }
     }
   }, [recordingHandlers.hasSynthesized(thread.id)])
+
+  // Auto-generate brief meeting prep when a calendar meeting opens for the first time
+  useEffect(() => {
+    if (!meeting?.event_id || thread.recorded || briefPrepTriggeredRef.current) return
+    briefPrepTriggeredRef.current = true
+    setIsBriefPrepGenerating(true)
+    const participantList = meeting.participants
+      .map(p => p.name ? `${p.name} (${p.email})` : p.email)
+      .join(', ')
+    const desc = meeting.description ? ` Context: ${meeting.description}.` : ''
+    addToLLMQueue({
+      prompt: `You are preparing someone for a meeting. Write exactly 3 sentences of plain text — no bullet points, no headers, no markdown formatting. Sentence 1: explain the real reason this meeting is happening and what's at stake. Sentence 2: what the person should focus on or do to make this meeting successful. Sentence 3: the single most important thing to watch out for or remember going in. Be sharp and specific.
+
+Meeting: ${meeting.title || thread.subtitle || 'Meeting'}
+Participants: ${participantList}${desc}
+
+Output only the 3 sentences, nothing else.`,
+      semanticSearchQuery: `meeting purpose ${meeting.title || thread.subtitle || ''}`,
+      documents: [],
+      messageStreamCallback: (chunk) => setBriefPrepContent(prev => prev + chunk),
+      messageFinishCallback: async (response) => {
+        setBriefPrepContent(response)
+        setIsBriefPrepGenerating(false)
+        return undefined
+      },
+      errorCallback: () => setIsBriefPrepGenerating(false),
+    })
+  }, [meeting?.event_id])
 
   const getRunParamObject = () => {
     if (runParam) {
@@ -1153,6 +1188,57 @@ Be direct, specific, and concise. No filler text.`
             isEditing={isEditing}
             onEditClick={onEditClick}
           />
+        )}
+
+        {/* Brief meeting prep — auto-generated on open, hidden once recording starts, dismissable */}
+        {meeting && !thread.recorded && !recordingHandlers.isRecording(thread.id) && !briefPrepDismissed && (briefPrepContent || isBriefPrepGenerating) && (
+          <div className="notetaker-note__brief-prep-card">
+            <div className="notetaker-note__brief-prep-card-header">
+              <span className="notetaker-note__brief-prep-card-label">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
+                </svg>
+                Meeting Brief
+              </span>
+              <button
+                className="notetaker-note__brief-prep-card-dismiss"
+                onClick={() => setBriefPrepDismissed(true)}
+                title="Dismiss"
+              >
+                <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                  <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                </svg>
+              </button>
+            </div>
+            {isBriefPrepGenerating && !briefPrepContent ? (
+              <p className="notetaker-note__brief-prep-card-loading">Preparing your meeting brief...</p>
+            ) : (
+              <p className="notetaker-note__brief-prep-card-text">{briefPrepContent}</p>
+            )}
+          </div>
+        )}
+
+        {/* Inline insights — collected from heartbeat during recording, dismissable */}
+        {inlineInsights.length > 0 && (
+          <div className="notetaker-note__insights-inline">
+            {inlineInsights.map(insight => (
+              <div key={insight.id} className="notetaker-note__insight-card">
+                <div className="notetaker-note__insight-card-header">
+                  <span className="notetaker-note__insight-card-badge">{insight.mins} min</span>
+                  <button
+                    className="notetaker-note__insight-card-dismiss"
+                    onClick={() => setInlineInsights(prev => prev.filter(i => i.id !== insight.id))}
+                    title="Dismiss"
+                  >
+                    <svg width="11" height="11" viewBox="0 0 14 14" fill="none">
+                      <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                    </svg>
+                  </button>
+                </div>
+                <p className="notetaker-note__insight-card-text">{insight.text}</p>
+              </div>
+            ))}
+          </div>
         )}
 
         {/* Editor - always shown, focused during recording */}

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -823,3 +823,119 @@ html, body {
   background: #D8D6FF;
   color: #4A4A9A;
 }
+
+/* Brief meeting prep card — auto-generated on open */
+.notetaker-note__brief-prep-card {
+  background: #FFFBEF;
+  border: 1px solid #E5D585;
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.notetaker-note__brief-prep-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.notetaker-note__brief-prep-card-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  color: #8A6B10;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.notetaker-note__brief-prep-card-dismiss {
+  background: none;
+  border: none;
+  color: #A68C30;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  transition: background 0.1s ease;
+}
+
+.notetaker-note__brief-prep-card-dismiss:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #6A5210;
+}
+
+.notetaker-note__brief-prep-card-loading {
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  color: #A68C30;
+  font-style: italic;
+  margin: 0;
+}
+
+.notetaker-note__brief-prep-card-text {
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  color: #4A3808;
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* Inline insight cards — collected during recording, dismissable */
+.notetaker-note__insights-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.notetaker-note__insight-card {
+  background: #F0F4FF;
+  border: 1px solid #C5CCEC;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.notetaker-note__insight-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.notetaker-note__insight-card-badge {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  color: #C05A1E;
+  background: rgba(192, 90, 30, 0.1);
+  padding: 2px 8px;
+  border-radius: 20px;
+}
+
+.notetaker-note__insight-card-dismiss {
+  background: none;
+  border: none;
+  color: #8A95C4;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  transition: background 0.1s ease;
+}
+
+.notetaker-note__insight-card-dismiss:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #5A65A0;
+}
+
+.notetaker-note__insight-card-text {
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  color: #2C3A6E;
+  line-height: 1.55;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
This PR adds two new features to the meeting notes interface: an auto-generated meeting brief that appears when opening a calendar meeting, and inline insight cards that surface during recording.

## Key Changes

- **Auto-generated Meeting Brief**: When a calendar meeting opens for the first time, an LLM-generated brief is automatically created and displayed in a dismissable card. The brief contains 3 focused sentences covering the meeting's purpose, success factors, and key risks. It disappears once recording starts.

- **Inline Recording Insights**: Meeting heartbeat insights are now collected and displayed as dismissable cards during recording, showing the elapsed time when each insight was captured. Proactive mode notifications are still sent when enabled, but insights are always shown inline.

- **UI Components**: Added styled cards for both the brief prep and inline insights with:
  - Warm beige styling for the meeting brief card
  - Blue styling for insight cards
  - Dismiss buttons with hover states
  - Loading state for brief generation
  - Time badges for insights

- **State Management**: Added state tracking for:
  - `inlineInsights`: Array of insights collected during recording
  - `briefPrepContent`: Generated brief text
  - `isBriefPrepGenerating`: Loading state for brief generation
  - `briefPrepDismissed`: User dismissal state
  - `briefPrepTriggeredRef`: Ref to prevent duplicate generation

## Implementation Details

- Brief generation is triggered once per meeting open via a ref guard (`briefPrepTriggeredRef`)
- The brief prompt is carefully crafted to produce exactly 3 sentences of plain text without markdown
- Insights are always collected from the heartbeat event, but notifications only show in proactive mode
- Both cards are dismissable and have appropriate visibility conditions (brief hides when recording starts)

https://claude.ai/code/session_011SepMYDq5Y79Ehijxf1L2s