### PR TITLE
Add email composition handler for meeting follow-ups

### DIFF
--- a/src/src/components/organisms/CenterWorkspace/index.tsx
+++ b/src/src/components/organisms/CenterWorkspace/index.tsx
@@ -355,6 +355,19 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
                       recordingHandlers={recordingHandlers}
                       handleOpenTasks={handleOpenTasks}
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
+                      onEmailClick={(notesMarkdown, meeting) => {
+                        const participants = meeting?.participants ?? []
+                        const toEmails = participants
+                          .filter(p => p.email && p.email !== userEmail)
+                          .map(p => p.email)
+                          .join(', ')
+                        const subject = meeting?.title ? `Follow up: ${meeting.title}` : 'Meeting Follow Up'
+                        const escapedNotes = notesMarkdown
+                          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                          .replace(/\n/g, '<br>')
+                        const body = `<p>Hi,</p><p>Thank you for our meeting${meeting?.title ? ` — ${meeting.title}` : ''}. Here's a summary of what we discussed:</p><p>${escapedNotes}</p><p>Please let me know if you have any questions!</p><p>Best,<br>${userName || ''}</p>`
+                        feed.setComposedEmailDraft({ to: toEmails, subject, body })
+                      }}
                     />
                   </div>
                   )


### PR DESCRIPTION
## Summary
Added functionality to compose and draft email follow-ups directly from meeting notes in the CenterWorkspace component.

## Key Changes
- Implemented `onEmailClick` handler that automatically generates a follow-up email draft with:
  - **Recipients**: All meeting participants except the current user
  - **Subject**: Auto-formatted as "Follow up: [Meeting Title]" or generic "Meeting Follow Up"
  - **Body**: Pre-formatted HTML email with meeting summary, notes, and professional closing
  - **HTML Escaping**: Properly escapes special characters in notes and converts newlines to `<br>` tags for HTML rendering

## Implementation Details
- Extracts participant emails from the meeting object, filtering out the current user's email
- Generates a professional email template with greeting, meeting context, notes summary, and signature
- Integrates with the existing `feed.setComposedEmailDraft()` method to populate the email composer
- Handles edge cases where meeting title may not be present

https://claude.ai/code/session_01BtT9JXS6Z1WTXV7FuMBu2c