### PR TITLE
Add AI-powered workspace summarization and recording indicators

### DIFF
--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -7,6 +7,7 @@ import { LLMParams } from 'src/App'
 import { IFeed } from 'src/hooks/feed/useFeed'
 import { Meeting } from 'src/hooks/dataSources/useCalendar'
 import { MeetingTemplatePrompt } from 'src/utils/template_prompts'
+import { Workspace } from 'src/api/workspaces'
 
 import { Button, ButtonVariant } from 'src/components/atoms/button'
 import MeetingNotesMode from 'src/components/organisms/MeetingNotesMode'
@@ -55,6 +56,7 @@ interface MeetingsTabViewProps {
   onChatClick?: () => void
   onEmailClick?: (notesMarkdown: string, meeting?: Meeting) => void
   onAttendeeClick?: (email: string, name: string) => void
+  onLibraryWorkspaceOpen?: (ws: Workspace) => void
 }
 
 const MeetingsTabView = ({
@@ -69,6 +71,7 @@ const MeetingsTabView = ({
   onChatClick,
   onEmailClick,
   onAttendeeClick,
+  onLibraryWorkspaceOpen,
 }: MeetingsTabViewProps) => {
   const [micPermission, setMicPermission] = useState(localStorage.getItem('micPermissionGranted') === 'true')
   const [screenPermission, setScreenPermission] = useState(localStorage.getItem('screenPermissionGranted') === 'true')
@@ -382,6 +385,7 @@ const MeetingsTabView = ({
                       onChatClick={onChatClick}
                       onEmailClick={onEmailClick}
                       onAttendeeClick={onAttendeeClick}
+                      onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
                     />
                   ) : null
                 })()}

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -9,6 +9,7 @@ import { getAppVersion } from 'src/utils/app'
 import { Connection, ConnectionKeys, hasGoogleCalendar } from 'src/api/connections'
 import { TabChoices } from 'src/components/TabBar'
 import { listWorkspaces, Workspace } from 'src/api/workspaces'
+import { RecordingContextProps } from 'src/components/organisms/MeetingNotesMode/RecordingContext'
 
 import './style.scss'
 
@@ -22,6 +23,7 @@ interface NotetakerSidebarProps {
   onMeetingSelect?: () => void
   activeView?: 'home' | 'chat'
   onLibraryWorkspaceOpen?: (ws: Workspace) => void
+  recordingHandlers?: RecordingContextProps
 }
 
 function NotetakerSidebar({
@@ -34,6 +36,7 @@ function NotetakerSidebar({
   onMeetingSelect,
   activeView = 'home',
   onLibraryWorkspaceOpen,
+  recordingHandlers,
 }: NotetakerSidebarProps) {
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -451,10 +454,14 @@ function NotetakerSidebar({
                             typeof item.getTitle === 'function'
                               ? item.getTitle()
                               : item.title || ''
+                          const isActivelyRecording = recordingHandlers != null &&
+                            item.threads?.some(
+                              t => t.threadType === ThreadType.MEETING_NOTES && t.id != null && recordingHandlers.isRecording(t.id)
+                            )
                           return (
                             <div
                               key={item.id ?? `cal-${item.calendarEvent?.id ?? title}`}
-                              className={`notetaker-sidebar__calendar-event ${isNow ? 'notetaker-sidebar__calendar-event--now' : ''}`}
+                              className={`notetaker-sidebar__calendar-event ${isNow ? 'notetaker-sidebar__calendar-event--now' : ''} ${isActivelyRecording ? 'notetaker-sidebar__calendar-event--recording' : ''}`}
                               onClick={() => {
                                 if (item.id != null) {
                                   feed.selectFeedItem(key, item.id)
@@ -465,21 +472,31 @@ function NotetakerSidebar({
                                 onTabChange(TabChoices.Meeting, 'meetings')
                               }}
                             >
-                              <div className="notetaker-sidebar__calendar-event-bar" />
+                              <div className={`notetaker-sidebar__calendar-event-bar ${isActivelyRecording ? 'notetaker-sidebar__calendar-event-bar--recording' : ''}`} />
                               <div className="notetaker-sidebar__calendar-event-content">
                                 <div className="notetaker-sidebar__calendar-event-title">
                                   {title}
                                 </div>
                                 <div className="notetaker-sidebar__calendar-event-time">
-                                  {isNow && (
+                                  {isActivelyRecording ? (
+                                    <span className="notetaker-sidebar__recording-label">
+                                      <span className="notetaker-sidebar__recording-dot-pulse" />
+                                      Recording
+                                    </span>
+                                  ) : isNow ? (
                                     <span className="notetaker-sidebar__now-label">
                                       Now &middot;{' '}
                                     </span>
+                                  ) : null}
+                                  {!isActivelyRecording && formatTimeRange(item)}
+                                  {isActivelyRecording && (
+                                    <span className="notetaker-sidebar__recording-time">
+                                      {' '}&middot; {formatTimeRange(item)}
+                                    </span>
                                   )}
-                                  {formatTimeRange(item)}
                                 </div>
                               </div>
-                              {item.threads?.some(
+                              {!isActivelyRecording && item.threads?.some(
                                 t => t.threadType === ThreadType.MEETING_NOTES && t.recorded,
                               ) && (
                                 <svg
@@ -500,7 +517,7 @@ function NotetakerSidebar({
                                   <line x1="16" y1="17" x2="8" y2="17" />
                                 </svg>
                               )}
-                              {isNow && (
+                              {isNow && !isActivelyRecording && (
                                 <button
                                   className="notetaker-sidebar__start-now-btn"
                                   onClick={async e => {

--- a/src/src/components/organisms/NotetakerSidebar/style.scss
+++ b/src/src/components/organisms/NotetakerSidebar/style.scss
@@ -386,12 +386,21 @@ $ks-red: #C14841;
     }
   }
 
+  &__calendar-event--recording {
+    background: rgba(220, 38, 38, 0.06);
+    border-radius: 6px;
+  }
+
   &__calendar-event-bar {
     width: 3px;
     height: 28px;
     border-radius: 2px;
     background: $ks-accent;
     flex-shrink: 0;
+
+    &--recording {
+      background: #dc2626;
+    }
   }
 
   &__calendar-event-content {
@@ -414,6 +423,32 @@ $ks-red: #C14841;
   &__now-label {
     color: $ks-red;
     font-weight: 600;
+  }
+
+  &__recording-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: #dc2626;
+    font-weight: 600;
+  }
+
+  &__recording-dot-pulse {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #dc2626;
+    animation: sidebar-rec-pulse 1.2s ease-in-out infinite;
+  }
+
+  &__recording-time {
+    color: $ks-text-muted;
+  }
+
+  @keyframes sidebar-rec-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(0.8); }
   }
 
   &__start-now-btn {

--- a/src/src/components/organisms/WorkspaceView/index.tsx
+++ b/src/src/components/organisms/WorkspaceView/index.tsx
@@ -9,8 +9,10 @@ import {
   removeDocumentFromWorkspace,
   parseTags,
 } from '../../../api/workspaces'
+import { KN_API_STREAM_LLM_COMPLETE, KN_API_GET_USER_EMAIL } from '../../../utils/constants'
 
 const SUMMARY_CACHE_PREFIX = 'knap.library.summary.'
+const DOC_SUMMARY_CACHE_PREFIX = 'knap.library.docsummary.'
 
 interface WorkspaceViewProps {
   workspace: Workspace
@@ -27,6 +29,19 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
   const [editName, setEditName] = useState(workspace.name)
   const [editDescription, setEditDescription] = useState(workspace.description ?? '')
   const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null)
+  const [isSummarizing, setIsSummarizing] = useState(false)
+  const [overallSummary, setOverallSummary] = useState<string | null>(() => {
+    try {
+      const raw = localStorage.getItem(SUMMARY_CACHE_PREFIX + workspace.uuid + '.overall')
+      return raw ? raw : null
+    } catch { return null }
+  })
+  const [docSummaries, setDocSummaries] = useState<Record<number, string>>(() => {
+    try {
+      const raw = localStorage.getItem(DOC_SUMMARY_CACHE_PREFIX + workspace.uuid)
+      return raw ? JSON.parse(raw) : {}
+    } catch { return {} }
+  })
   const dropRef = useRef<HTMLDivElement>(null)
 
   // Load AI-generated card summary from localStorage (written by WorkspacesList).
@@ -151,6 +166,71 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
   const handleClearSearch = () => {
     setSearchQuery('')
     setActiveSearchQuery('')
+  }
+
+  const streamLLM = async (prompt: string): Promise<string> => {
+    let userEmail = ''
+    try {
+      const r = await fetch(KN_API_GET_USER_EMAIL)
+      if (r.ok) userEmail = (await r.json()).email ?? ''
+    } catch { /* no-op */ }
+
+    const response = await fetch(KN_API_STREAM_LLM_COMPLETE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_email: userEmail, user_name: '', prompt, semantic_search_query: null, documents: [], is_local: false }),
+    })
+    if (!response.ok || !response.body) return ''
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let text = ''
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      for (const line of decoder.decode(value, { stream: true }).split('\n')) {
+        if (!line.startsWith('data: ') || line.trim() === 'data: [DONE]') continue
+        try { text += JSON.parse(line.slice(6)).choices[0].text } catch { /* malformed */ }
+      }
+    }
+    return text.trim()
+  }
+
+  const handleSummarize = async () => {
+    if (isSummarizing || documents.length === 0) return
+    setIsSummarizing(true)
+    try {
+      const docList = documents.map(d => `- ${d.documentName}`).join('\n')
+
+      // Overall 2-sentence summary
+      const overallText = await streamLLM(
+        `You are summarizing a collection called "${currentWorkspace.name}".\n` +
+        `It contains these documents:\n${docList}\n\n` +
+        `Write exactly 2 sentences summarizing what this collection is about and why it matters. ` +
+        `Be specific and concise. Reply with only the 2 sentences, no preamble.`
+      )
+      if (overallText) {
+        setOverallSummary(overallText)
+        localStorage.setItem(SUMMARY_CACHE_PREFIX + workspace.uuid + '.overall', overallText)
+      }
+
+      // Per-document 1-sentence summaries
+      const newDocSummaries: Record<number, string> = { ...docSummaries }
+      for (const doc of documents) {
+        if (!doc.id) continue
+        const hint = [doc.documentName, doc.summary, doc.documentPath].filter(Boolean).join(' | ')
+        const oneSentence = await streamLLM(
+          `Write exactly 1 sentence summarizing this document: "${hint}". ` +
+          `Be specific. Reply with only the sentence, no preamble.`
+        )
+        if (oneSentence && doc.id) {
+          newDocSummaries[doc.id] = oneSentence
+        }
+      }
+      setDocSummaries(newDocSummaries)
+      localStorage.setItem(DOC_SUMMARY_CACHE_PREFIX + workspace.uuid, JSON.stringify(newDocSummaries))
+    } finally {
+      setIsSummarizing(false)
+    }
   }
 
   const handleSaveEdit = async () => {
@@ -287,12 +367,17 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
               Edit
             </button>
           </div>
+          {currentWorkspace.entityType === 'person' && currentWorkspace.entityKey && (
+            <p className="text-sm text-gray-400 mt-0.5 ml-10">
+              {currentWorkspace.entityKey}
+            </p>
+          )}
           {currentWorkspace.description && (
             <p className="text-sm text-gray-500 mt-1 ml-10">
               {currentWorkspace.description}
             </p>
           )}
-          {aiSummary && (
+          {aiSummary && !overallSummary && (
             <div className="ml-10 mt-2">
               <p className="text-sm text-gray-700">{aiSummary.summary}</p>
               {aiSummary.nextAction && (
@@ -314,6 +399,11 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
                   → {aiSummary.nextAction}
                 </button>
               )}
+            </div>
+          )}
+          {overallSummary && (
+            <div className="ml-10 mt-2">
+              <p className="text-sm text-gray-700">{overallSummary}</p>
             </div>
           )}
         </div>
@@ -394,6 +484,13 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
           onClick={handleAddFolder}
         >
           + Add Folder
+        </button>
+        <button
+          className="px-4 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+          onClick={handleSummarize}
+          disabled={isSummarizing || documents.length === 0}
+        >
+          {isSummarizing ? 'Summarizing…' : '✦ Summarize'}
         </button>
       </div>
 
@@ -502,10 +599,10 @@ function WorkspaceView({ workspace, onBack }: WorkspaceViewProps) {
                     </div>
                   )}
 
-                  {/* Summary — shown inline when available */}
-                  {doc.summary && (
+                  {/* Summary — per-doc AI summary takes priority, fallback to stored summary */}
+                  {(doc.id && docSummaries[doc.id] ? docSummaries[doc.id] : doc.summary) && (
                     <div className="mt-2 ml-8 text-xs text-gray-600">
-                      {doc.summary}
+                      {doc.id && docSummaries[doc.id] ? docSummaries[doc.id] : doc.summary}
                     </div>
                   )}
                 </div>

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -505,6 +505,7 @@ function Home({
                   : 'home'
                 : 'home'
             }
+            recordingHandlers={recordingHandlers}
           />
           <div data-tauri-drag-region className="overflow-hidden w-full h-full">
             <div className="KNWorkspace overflow-hidden w-full h-full bg-ks-bg-main relative">
@@ -645,6 +646,10 @@ function Home({
                   onAttendeeClick={(email, name) => {
                     setChatInitialInput(`Tell me about ${name || email}`)
                     setMeetingSubView('chat')
+                  }}
+                  onLibraryWorkspaceOpen={(ws) => {
+                    setCurrentTab(TabChoices.Library)
+                    setSelectedWorkspace(ws)
                   }}
                   onEmailClick={(notesMarkdown, meeting) => {
                     const participants = meeting?.participants ?? []


### PR DESCRIPTION
## Summary
This PR adds AI-powered summarization capabilities to workspaces and enhances the meeting sidebar with visual indicators for active recordings.

## Key Changes

### Workspace Summarization
- Added `streamLLM()` function to call the LLM API for generating summaries via streaming
- Implemented `handleSummarize()` to generate:
  - Overall 2-sentence workspace summary
  - Per-document 1-sentence summaries for each document
- Added state management for `isSummarizing`, `overallSummary`, and `docSummaries` with localStorage caching
- Added "✦ Summarize" button in the workspace toolbar
- Display AI-generated summaries in the workspace header and document list, with per-doc summaries taking priority over stored summaries
- Added display of `entityKey` for person-type workspaces

### Recording Indicators
- Enhanced `NotetakerSidebar` to accept `recordingHandlers` prop from `RecordingContext`
- Added visual indicators for actively recording calendar events:
  - Red background highlight on recording events
  - Red accent bar instead of default color
  - Animated pulsing red dot with "Recording" label
  - Recording time display with separator
- Hide "Start Now" button and recorded icon when actively recording
- Updated styling with new CSS classes and keyframe animation for pulse effect

### Integration
- Passed `recordingHandlers` through component hierarchy (Home → NotetakerSidebar)
- Added `onLibraryWorkspaceOpen` callback to MeetingsTabView for workspace navigation

## Implementation Details
- LLM streaming uses standard fetch API with line-by-line JSON parsing
- Summaries are cached in localStorage with workspace-specific prefixes to persist across sessions
- Per-document summaries use document ID as key for reliable caching
- Recording state is checked via `recordingHandlers.isRecording(threadId)` for each meeting thread

https://claude.ai/code/session_01CWcJWSznZdGTmD8Wg5wzYf