### PR TITLE
Cap Telegram long-poll timeout to prevent shutdown stalls

### DIFF
--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -984,6 +984,34 @@ async fn apply_runtime_browser_config(token: &str) {
     eprintln!("[gateway_client] agents.defaults.model updated: {:?} → '{}' in runtime patch", existing_model, model);
   }
 
+  // Cap Telegram long-poll timeout if Telegram is configured but no explicit
+  // timeout is set.  Grammy's default is 500s (≈8 min): getUpdates blocks for
+  // the entire duration, and when the gateway receives a SIGUSR1 (e.g. from a
+  // config.patch), it cannot cancel the in-flight poll → shutdown times out →
+  // gateway exits ungracefully and orphans its Chrome child process, which then
+  // holds the CDP port (18800) and prevents the restarted gateway from
+  // launching a new browser.  60s is long enough for reliable delivery and
+  // short enough that a clean shutdown always completes within the Node default
+  // graceful-shutdown window.
+  let tg_has_token = config_inner
+    .pointer("/channels/telegram/botToken")
+    .and_then(|v| v.as_str())
+    .map(|s| !s.trim().is_empty())
+    .unwrap_or(false);
+  if tg_has_token {
+    let tg_has_timeout = config_inner
+      .pointer("/channels/telegram/timeoutSeconds")
+      .and_then(|v| v.as_u64())
+      .is_some();
+    if !tg_has_timeout {
+      patch_obj.as_object_mut().unwrap().insert(
+        "channels".to_string(),
+        serde_json::json!({"telegram": {"timeoutSeconds": 60}}),
+      );
+      eprintln!("[gateway_client] Adding channels.telegram.timeoutSeconds=60 to runtime patch (Grammy default 500s causes shutdown stall)");
+    }
+  }
+
   let raw_patch = patch_obj.to_string();
 
   let patch_id = next_request_id();


### PR DESCRIPTION
## Summary
Add automatic configuration of Telegram's long-poll timeout to prevent gateway shutdown hangs that can orphan Chrome processes and block port reuse.

## Changes
- Added runtime configuration patch that automatically sets `channels.telegram.timeoutSeconds` to 60 seconds when Telegram is configured but no explicit timeout is set
- This prevents Grammy's default 500-second timeout from blocking graceful shutdown when the gateway receives a SIGUSR1 signal
- The 60-second timeout is long enough for reliable message delivery while ensuring clean shutdown completes within Node's graceful-shutdown window

## Implementation Details
- The patch only applies when:
  - Telegram bot token is configured and non-empty
  - No explicit `timeoutSeconds` value is already set
- Includes diagnostic logging to indicate when the timeout is automatically applied
- Solves the issue where long-running `getUpdates` polls prevent signal handling, causing timeouts and ungraceful exits that leave Chrome processes holding the CDP port (18800)

https://claude.ai/code/session_01Gj89m26i6D4mXAjrjfsfzR