### PR TITLE
Add OAuth support for OpenRouter and Google Gemini authentication

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5806,6 +5806,286 @@ pub async fn skills_update(
   }
 }
 
+// ── OAuth provider login ───────────────────────────────────────────────────
+//
+// Supports browser-based OAuth flows for providers that offer them.
+// Currently: OpenRouter (PKCE, callback on our local Actix port).
+//
+// Flow:
+//   1. Frontend POST /api/clawd/service/oauth-start → gets back a URL
+//   2. Frontend opens URL in system browser (tauri shell.open)
+//   3. Provider redirects to /api/clawd/oauth/callback?code=...
+//   4. Callback exchanges code for API key, saves to tokens.json, restarts gateway
+
+static PENDING_OAUTH: once_cell::sync::Lazy<std::sync::Mutex<Option<PendingOAuthState>>> =
+  once_cell::sync::Lazy::new(|| std::sync::Mutex::new(None));
+
+struct PendingOAuthState {
+  provider: String,
+  state: String,
+  created_at: std::time::Instant,
+}
+
+fn generate_oauth_random(len: usize) -> String {
+  use rand::Rng;
+  rand::thread_rng()
+    .sample_iter(&rand::distributions::Alphanumeric)
+    .take(len)
+    .map(char::from)
+    .collect()
+}
+
+fn pkce_challenge(verifier: &str) -> String {
+  use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+  use sha2::Digest;
+  let hash = sha2::Sha256::digest(verifier.as_bytes());
+  URL_SAFE_NO_PAD.encode(hash)
+}
+
+const OAUTH_CALLBACK_URL: &str = "http://127.0.0.1:8897/api/clawd/oauth/callback";
+
+#[derive(Debug, Deserialize)]
+pub struct StartOAuthLoginRequest {
+  pub provider: String,
+}
+
+#[derive(Serialize)]
+struct StartOAuthLoginResponse {
+  url: String,
+}
+
+#[post("/api/clawd/service/oauth-start")]
+pub async fn start_oauth_login(
+  _app_handle: web::Data<tauri::AppHandle>,
+  payload: web::Json<StartOAuthLoginRequest>,
+) -> impl Responder {
+  match payload.provider.as_str() {
+    "openrouter" => {
+      let verifier = generate_oauth_random(64);
+      let challenge = pkce_challenge(&verifier);
+      let state = generate_oauth_random(32);
+
+      *PENDING_OAUTH.lock().unwrap() = Some(PendingOAuthState {
+        provider: "openrouter".to_string(),
+        state: state.clone(),
+        created_at: std::time::Instant::now(),
+      });
+
+      let callback_encoded = urlencoding::encode(OAUTH_CALLBACK_URL);
+      let url = format!(
+        "https://openrouter.ai/auth?callback_url={}&code_challenge={}&code_challenge_method=S256&state={}",
+        callback_encoded, challenge, state
+      );
+
+      HttpResponse::Ok().json(StartOAuthLoginResponse { url })
+    }
+    _ => HttpResponse::BadRequest().json(serde_json::json!({
+      "error": format!("Provider '{}' does not support OAuth login", payload.provider)
+    })),
+  }
+}
+
+#[derive(Deserialize)]
+pub struct OAuthCallbackQuery {
+  pub code: Option<String>,
+  pub state: Option<String>,
+  pub error: Option<String>,
+}
+
+#[get("/api/clawd/oauth/callback")]
+pub async fn oauth_callback(
+  app_handle: web::Data<tauri::AppHandle>,
+  query: web::Query<OAuthCallbackQuery>,
+) -> impl Responder {
+  if let Some(ref err) = query.error {
+    return oauth_html_page(false, &format!("Authorization denied: {}", err));
+  }
+
+  let code = match query.code.as_deref().filter(|c| !c.is_empty()) {
+    Some(c) => c.to_string(),
+    None => return oauth_html_page(false, "Missing authorization code."),
+  };
+
+  let pending = PENDING_OAUTH.lock().unwrap().take();
+  let pending = match pending {
+    Some(p) => p,
+    None => return oauth_html_page(false, "No pending OAuth request — please try again from Knapsack."),
+  };
+
+  if pending.created_at.elapsed().as_secs() > 300 {
+    return oauth_html_page(false, "OAuth request timed out. Please try again.");
+  }
+
+  if let Some(ref returned_state) = query.state {
+    if returned_state != &pending.state {
+      return oauth_html_page(false, "Invalid OAuth state. Please try again.");
+    }
+  }
+
+  let provider = pending.provider.clone();
+
+  match provider.as_str() {
+    "openrouter" => {
+      let key = match exchange_openrouter_code(&code).await {
+        Ok(k) => k,
+        Err(e) => return oauth_html_page(false, &format!("Failed to get API key: {}", e)),
+      };
+
+      match save_and_restart_for_oauth(&app_handle, "openrouter", &key) {
+        Ok(_) => {
+          eprintln!("[clawd/service] OpenRouter OAuth: key saved, gateway restarting");
+          oauth_html_page(true, "OpenRouter")
+        }
+        Err(e) => oauth_html_page(false, &format!("Failed to save key: {}", e)),
+      }
+    }
+    _ => oauth_html_page(false, "Unknown OAuth provider."),
+  }
+}
+
+async fn exchange_openrouter_code(code: &str) -> Result<String, String> {
+  let client = reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(30))
+    .build()
+    .map_err(|e| e.to_string())?;
+
+  let resp = client
+    .post("https://openrouter.ai/api/v1/auth/keys")
+    .header("Content-Type", "application/json")
+    .json(&serde_json::json!({ "code": code }))
+    .send()
+    .await
+    .map_err(|e| format!("Network error: {}", e))?;
+
+  if !resp.status().is_success() {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    return Err(format!("OpenRouter returned {}: {}", status, body));
+  }
+
+  let json: serde_json::Value = resp.json().await.map_err(|e| format!("Parse error: {}", e))?;
+  json
+    .get("key")
+    .and_then(|v| v.as_str())
+    .map(|s| s.to_string())
+    .ok_or_else(|| "Missing 'key' in OpenRouter response".to_string())
+}
+
+fn save_and_restart_for_oauth(
+  app_handle: &tauri::AppHandle,
+  provider: &str,
+  key: &str,
+) -> Result<(), String> {
+  let mut tokens = load_or_create_tokens(app_handle)?;
+
+  match provider {
+    "openrouter" => {
+      tokens.openrouter_api_key = Some(key.to_string());
+    }
+    _ => return Err(format!("Unsupported OAuth provider: {}", provider)),
+  }
+  tokens.active_provider = Some(provider.to_string());
+  save_tokens(app_handle, &tokens)?;
+
+  // Propagate to environment immediately
+  std::env::set_var("OPENROUTER_API_KEY", key);
+  std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", provider);
+  std::env::remove_var("OLLAMA_API_KEY");
+
+  // Restart gateway (same logic as set_api_key)
+  crate::clawd::gateway_client::invalidate();
+
+  #[cfg(target_os = "windows")]
+  {
+    kill_process_on_port(18789);
+  }
+
+  #[cfg(target_os = "macos")]
+  {
+    if let Ok(plist_path) = launch_agent_plist_path() {
+      regenerate_macos_plist_with_current_env(&plist_path);
+      let uid = unsafe { libc::getuid() };
+      let domain = format!("gui/{}", uid);
+      let _ = std::process::Command::new("launchctl")
+        .args(["bootout", &domain, plist_path.to_string_lossy().as_ref()])
+        .status();
+      std::thread::sleep(std::time::Duration::from_millis(500));
+      let _ = std::process::Command::new("launchctl")
+        .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
+        .status();
+      let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
+      let _ = std::process::Command::new("launchctl")
+        .args(["kickstart", "-k", &service])
+        .status();
+    }
+  }
+
+  Ok(())
+}
+
+fn oauth_html_page(success: bool, message: &str) -> HttpResponse {
+  let (title, icon, color, body) = if success {
+    (
+      format!("Connected to {} — Knapsack", message),
+      "✓",
+      "#16a34a",
+      format!(
+        "<strong>{}</strong> connected to Knapsack.<br><br>You can close this tab and return to Knapsack.",
+        message
+      ),
+    )
+  } else {
+    (
+      "Authentication Failed — Knapsack".to_string(),
+      "✗",
+      "#dc2626",
+      format!(
+        "{}<br><br>You can close this tab and try again in Knapsack.",
+        message
+      ),
+    )
+  };
+
+  let html = format!(
+    r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+           display: flex; align-items: center; justify-content: center;
+           min-height: 100vh; margin: 0; background: #f8fafc; color: #1e293b; }}
+    .card {{ text-align: center; padding: 48px 40px; background: white;
+             border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,.08);
+             max-width: 400px; width: 90%; }}
+    .icon {{ font-size: 48px; color: {color}; margin-bottom: 16px; line-height: 1; }}
+    h1 {{ font-size: 20px; font-weight: 700; margin: 0 0 12px; color: #1e293b; }}
+    p {{ font-size: 15px; line-height: 1.6; color: #64748b; margin: 0; }}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">{icon}</div>
+    <h1>{title}</h1>
+    <p>{body}</p>
+  </div>
+</body>
+</html>"#,
+    title = title,
+    icon = icon,
+    color = color,
+    body = body,
+  );
+
+  HttpResponse::Ok()
+    .content_type("text/html; charset=utf-8")
+    .body(html)
+}
+
+// ── End OAuth provider login ───────────────────────────────────────────────
+
 /// On macOS, automatically register the LaunchAgent on first launch so the
 /// user never sees "LaunchAgent plist not found — try toggling Enable in Settings."
 ///

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2228,11 +2228,13 @@ pub struct ApiKeyStatusResponse {
   pub has_gemini_key: bool,
   pub has_groq_key: bool,
   pub has_openrouter_key: bool,
+  pub has_gemini_cli_key: bool,
   pub openai_key_hint: Option<String>,
   pub anthropic_key_hint: Option<String>,
   pub gemini_key_hint: Option<String>,
   pub groq_key_hint: Option<String>,
   pub openrouter_key_hint: Option<String>,
+  pub gemini_cli_email: Option<String>,
   // Ollama (local LLM) status
   pub ollama_enabled: bool,
   pub ollama_model: Option<String>,
@@ -2266,11 +2268,13 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         has_gemini_key: false,
         has_groq_key: false,
         has_openrouter_key: false,
+        has_gemini_cli_key: false,
         openai_key_hint: None,
         anthropic_key_hint: None,
         gemini_key_hint: None,
         groq_key_hint: None,
         openrouter_key_hint: None,
+        gemini_cli_email: None,
         ollama_enabled: false,
         ollama_model: None,
         ollama_base_url: None,
@@ -2285,7 +2289,8 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
   let has_groq = tokens.groq_api_key.as_ref().map(|k| !k.trim().is_empty()).unwrap_or(false);
   let has_openrouter = tokens.openrouter_api_key.as_ref().map(|k| !k.trim().is_empty()).unwrap_or(false);
   let ollama_enabled = tokens.ollama_enabled.unwrap_or(false);
-  let has_key = has_openai || has_anthropic || has_gemini || has_groq || has_openrouter || ollama_enabled;
+  let (has_gemini_cli, gemini_cli_email) = read_gemini_cli_auth(&app_handle);
+  let has_key = has_openai || has_anthropic || has_gemini || has_groq || has_openrouter || ollama_enabled || has_gemini_cli;
 
   let model = tokens.openai_model.clone();
   let active_provider = tokens.active_provider.clone();
@@ -2334,11 +2339,13 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     has_gemini_key: has_gemini,
     has_groq_key: has_groq,
     has_openrouter_key: has_openrouter,
+    has_gemini_cli_key: has_gemini_cli,
     openai_key_hint: openai_hint,
     anthropic_key_hint: anthropic_hint,
     gemini_key_hint: gemini_hint,
     groq_key_hint: groq_hint,
     openrouter_key_hint: openrouter_hint,
+    gemini_cli_email,
     ollama_enabled,
     ollama_model: tokens.ollama_model.clone(),
     ollama_base_url: tokens.ollama_base_url.clone(),
@@ -5826,6 +5833,238 @@ struct PendingOAuthState {
   created_at: std::time::Instant,
 }
 
+/// Returns `(has_gemini_cli_auth, email_or_none)` by reading auth-profiles.json.
+fn read_gemini_cli_auth(app_handle: &tauri::AppHandle) -> (bool, Option<String>) {
+  let path = app_clawdbot_home(app_handle)
+    .join("agents").join("main").join("agent")
+    .join("auth-profiles.json");
+  let content = match std::fs::read_to_string(&path) {
+    Ok(c) => c,
+    Err(_) => return (false, None),
+  };
+  let json: serde_json::Value = match serde_json::from_str(&content) {
+    Ok(v) => v,
+    Err(_) => return (false, None),
+  };
+  if let Some(profiles) = json.get("profiles").and_then(|v| v.as_object()) {
+    for (key, profile) in profiles {
+      if key.starts_with("google-gemini-cli:") {
+        let email = profile.get("email").and_then(|v| v.as_str()).map(|s| s.to_string());
+        return (true, email);
+      }
+    }
+  }
+  (false, None)
+}
+
+/// Write Google OAuth tokens to auth-profiles.json for the google-gemini-cli provider.
+fn write_gemini_cli_auth(
+  app_handle: &tauri::AppHandle,
+  access: &str,
+  refresh: &str,
+  expires_at: u64,
+  email: &str,
+) -> Result<(), String> {
+  let path = app_clawdbot_home(app_handle)
+    .join("agents").join("main").join("agent")
+    .join("auth-profiles.json");
+  if let Some(parent) = path.parent() {
+    std::fs::create_dir_all(parent)
+      .map_err(|e| format!("Failed to create agent dir: {}", e))?;
+  }
+  let profile_id = format!("google-gemini-cli:{}", email);
+  let profiles = serde_json::json!({
+    "profiles": {
+      profile_id: {
+        "type": "oauth",
+        "provider": "google-gemini-cli",
+        "access": access,
+        "refresh": refresh,
+        "expires": expires_at,
+        "email": email,
+      }
+    }
+  });
+  std::fs::write(
+    &path,
+    serde_json::to_string_pretty(&profiles).map_err(|e| e.to_string())?,
+  ).map_err(|e| format!("Failed to write auth-profiles.json: {}", e))
+}
+
+async fn exchange_google_code_for_gemini(code: &str) -> Result<(String, String, u64), String> {
+  let secret = std::env::var("GOOGLE_CLIENT_SECRET").unwrap_or_default();
+  if !secret.is_empty() {
+    return exchange_google_code_gemini_locally(code, &secret).await;
+  }
+  exchange_google_code_gemini_via_backend(code).await
+}
+
+async fn exchange_google_code_gemini_locally(code: &str, client_secret: &str) -> Result<(String, String, u64), String> {
+  let client_id = option_env!("VITE_GOOGLE_CLIENT_ID").unwrap_or("");
+  if client_id.is_empty() {
+    return Err("Google OAuth client not configured (VITE_GOOGLE_CLIENT_ID missing)".to_string());
+  }
+  let client = reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(30))
+    .build()
+    .map_err(|e| e.to_string())?;
+  let params = [
+    ("code", code),
+    ("client_id", client_id),
+    ("client_secret", client_secret),
+    ("redirect_uri", "http://localhost:8897/api/knapsack/google/signin"),
+    ("grant_type", "authorization_code"),
+  ];
+  let resp = client
+    .post("https://oauth2.googleapis.com/token")
+    .form(&params)
+    .send()
+    .await
+    .map_err(|e| format!("Network error: {}", e))?;
+  if !resp.status().is_success() {
+    let body = resp.text().await.unwrap_or_default();
+    return Err(format!("Token exchange failed: {}", body));
+  }
+  let json: serde_json::Value = resp.json().await.map_err(|e| format!("Parse error: {}", e))?;
+  let access = json.get("access_token").and_then(|v| v.as_str())
+    .ok_or("Missing access_token")?.to_string();
+  let refresh = json.get("refresh_token").and_then(|v| v.as_str())
+    .ok_or("Missing refresh_token — use prompt=consent&access_type=offline")?.to_string();
+  let expires_in = json.get("expires_in").and_then(|v| v.as_u64()).unwrap_or(3600);
+  Ok((access, refresh, expires_in))
+}
+
+async fn exchange_google_code_gemini_via_backend(code: &str) -> Result<(String, String, u64), String> {
+  let api_server = option_env!("VITE_KN_API_SERVER").unwrap_or("");
+  if api_server.is_empty() {
+    return Err("No backend server configured and GOOGLE_CLIENT_SECRET is not set".to_string());
+  }
+  let client = reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(30))
+    .build()
+    .map_err(|e| e.to_string())?;
+  let resp = client
+    .get(format!(
+      "{}/api/authentication/google/signin/app?code={}",
+      api_server,
+      urlencoding::encode(code)
+    ))
+    .send()
+    .await
+    .map_err(|e| format!("Network error: {}", e))?;
+  if !resp.status().is_success() {
+    let body = resp.text().await.unwrap_or_default();
+    return Err(format!("Backend token exchange failed: {}", body));
+  }
+  #[derive(serde::Deserialize)]
+  struct BackendResp { access_token: String, refresh_token: String }
+  let data: BackendResp = resp.json().await.map_err(|e| format!("Parse error: {}", e))?;
+  Ok((data.access_token, data.refresh_token, 3600))
+}
+
+async fn get_google_email_from_token(access_token: &str) -> Result<String, String> {
+  let client = reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(10))
+    .build()
+    .map_err(|e| e.to_string())?;
+  let resp = client
+    .get("https://www.googleapis.com/oauth2/v1/userinfo?alt=json")
+    .header("Authorization", format!("Bearer {}", access_token))
+    .send()
+    .await
+    .map_err(|e| format!("Network error: {}", e))?;
+  let json: serde_json::Value = resp.json().await.map_err(|e| format!("Parse error: {}", e))?;
+  json.get("email").and_then(|v| v.as_str())
+    .map(|s| s.to_string())
+    .ok_or_else(|| "No email in userinfo response".to_string())
+}
+
+#[derive(Deserialize)]
+pub struct GeminiConnectRequest {
+  pub code: String,
+}
+
+#[derive(Serialize)]
+struct GeminiConnectResponse {
+  success: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  email: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  error: Option<String>,
+}
+
+#[post("/api/clawd/service/gemini-connect")]
+pub async fn gemini_connect(
+  app_handle: web::Data<tauri::AppHandle>,
+  payload: web::Json<GeminiConnectRequest>,
+) -> impl Responder {
+  match do_gemini_connect(&app_handle, &payload.code).await {
+    Ok(email) => HttpResponse::Ok().json(GeminiConnectResponse {
+      success: true,
+      email: Some(email),
+      error: None,
+    }),
+    Err(e) => {
+      eprintln!("[clawd/service] Gemini OAuth connect failed: {}", e);
+      HttpResponse::InternalServerError().json(GeminiConnectResponse {
+        success: false,
+        email: None,
+        error: Some(e),
+      })
+    }
+  }
+}
+
+async fn do_gemini_connect(app_handle: &tauri::AppHandle, code: &str) -> Result<String, String> {
+  let (access, refresh, expires_in) = exchange_google_code_for_gemini(code).await?;
+  let email = get_google_email_from_token(&access).await?;
+
+  // millis since epoch with 5-min safety buffer
+  let expires_at = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map(|d| d.as_millis() as u64)
+    .unwrap_or(0)
+    + expires_in * 1000
+    - 300_000;
+
+  write_gemini_cli_auth(app_handle, &access, &refresh, expires_at, &email)?;
+
+  let mut tokens = load_or_create_tokens(app_handle)
+    .map_err(|e| format!("Failed to load tokens: {}", e))?;
+  tokens.active_provider = Some("google-gemini-cli".to_string());
+  save_tokens(app_handle, &tokens)
+    .map_err(|e| format!("Failed to save tokens: {}", e))?;
+
+  std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "google-gemini-cli");
+  crate::clawd::gateway_client::invalidate();
+
+  #[cfg(target_os = "windows")]
+  { kill_process_on_port(18789); }
+
+  #[cfg(target_os = "macos")]
+  {
+    if let Ok(plist_path) = launch_agent_plist_path() {
+      regenerate_macos_plist_with_current_env(&plist_path);
+      let uid = unsafe { libc::getuid() };
+      let domain = format!("gui/{}", uid);
+      let _ = std::process::Command::new("launchctl")
+        .args(["bootout", &domain, plist_path.to_string_lossy().as_ref()])
+        .status();
+      std::thread::sleep(std::time::Duration::from_millis(500));
+      let _ = std::process::Command::new("launchctl")
+        .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
+        .status();
+      let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
+      let _ = std::process::Command::new("launchctl")
+        .args(["kickstart", "-k", &service])
+        .status();
+    }
+  }
+
+  eprintln!("[clawd/service] Gemini CLI OAuth: auth written, gateway restarting");
+  Ok(email)
+}
+
 fn generate_oauth_random(len: usize) -> String {
   use rand::Rng;
   rand::thread_rng()
@@ -5877,6 +6116,30 @@ pub async fn start_oauth_login(
         callback_encoded, challenge, state
       );
 
+      HttpResponse::Ok().json(StartOAuthLoginResponse { url })
+    }
+    "google-gemini" => {
+      let client_id = option_env!("VITE_GOOGLE_CLIENT_ID").unwrap_or("");
+      if client_id.is_empty() {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+          "error": "Google OAuth not configured for this build"
+        }));
+      }
+      let state = generate_oauth_random(32);
+      *PENDING_OAUTH.lock().unwrap() = Some(PendingOAuthState {
+        provider: "google-gemini".to_string(),
+        state: state.clone(),
+        created_at: std::time::Instant::now(),
+      });
+      let scope = "openid email profile https://www.googleapis.com/auth/cloud-platform";
+      let redirect_uri = "http://localhost:8897/api/knapsack/google/signin";
+      let url = format!(
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id={}&redirect_uri={}&response_type=code&scope={}&access_type=offline&prompt=consent&state={}",
+        urlencoding::encode(client_id),
+        urlencoding::encode(redirect_uri),
+        urlencoding::encode(scope),
+        urlencoding::encode(&state),
+      );
       HttpResponse::Ok().json(StartOAuthLoginResponse { url })
     }
     _ => HttpResponse::BadRequest().json(serde_json::json!({

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -287,6 +287,9 @@ pub async fn start_server<'a>(
       .service(clawd::service::set_api_key)
       .service(clawd::service::delete_extra_provider_key)
       .service(clawd::service::get_api_key)
+      // OAuth provider login (OpenRouter browser-based auth)
+      .service(clawd::service::start_oauth_login)
+      .service(clawd::service::oauth_callback)
       // Ollama (local LLM) endpoints
       .service(clawd::service::ollama_status)
       .service(clawd::service::ollama_models)

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -290,6 +290,7 @@ pub async fn start_server<'a>(
       // OAuth provider login (OpenRouter browser-based auth)
       .service(clawd::service::start_oauth_login)
       .service(clawd::service::oauth_callback)
+      .service(clawd::service::gemini_connect)
       // Ollama (local LLM) endpoints
       .service(clawd::service::ollama_status)
       .service(clawd::service::ollama_models)

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
+import { open as openExternalUrl } from '@tauri-apps/api/shell'
 
 import {
   Typography,
@@ -159,6 +160,9 @@ export const ProviderSignInDialog = ({
   const [keyStatus, setKeyStatus] = useState<ApiKeyStatusResponse | null>(null)
   const [validation, setValidation] = useState<ValidationState>('idle')
   const [validationMsg, setValidationMsg] = useState('')
+  const [oauthPending, setOauthPending] = useState(false)
+  const oauthPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const oauthTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const validateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -244,22 +248,93 @@ export const ProviderSignInDialog = ({
     }
   }, [selectedProvider, validateKey])
 
-  // Cleanup timer on unmount
+  // Cleanup timers on unmount
   useEffect(() => {
     return () => {
       if (validateTimerRef.current) clearTimeout(validateTimerRef.current)
       if (extraValidateTimerRef.current) clearTimeout(extraValidateTimerRef.current)
+      if (oauthPollRef.current) clearInterval(oauthPollRef.current)
+      if (oauthTimeoutRef.current) clearTimeout(oauthTimeoutRef.current)
     }
   }, [])
 
+  const handleOAuthLogin = useCallback(async (provider: Provider) => {
+    if (oauthPollRef.current) clearInterval(oauthPollRef.current)
+    if (oauthTimeoutRef.current) clearTimeout(oauthTimeoutRef.current)
+
+    setOauthPending(true)
+    setError('')
+    setSuccess('')
+
+    try {
+      const res = await fetch(`${API_BASE}/api/clawd/service/oauth-start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider }),
+      })
+      const data = await res.json()
+
+      if (!data.url) {
+        setError(data.error || 'Failed to start OAuth flow.')
+        setOauthPending(false)
+        return
+      }
+
+      await openExternalUrl(data.url)
+      KNAnalytics.trackEvent('oauth_started', { provider, app_version: KNAnalytics.APP_VERSION })
+
+      // Poll api-key-status until the key appears (max 5 min)
+      oauthPollRef.current = setInterval(async () => {
+        try {
+          const statusRes = await fetch(`${API_BASE}/api/clawd/service/api-key-status`)
+          const statusData: ApiKeyStatusResponse = await statusRes.json()
+          const connected =
+            provider === 'openrouter' ? statusData.has_openrouter_key :
+            provider === 'openai' ? statusData.has_openai_key :
+            provider === 'anthropic' ? statusData.has_anthropic_key : false
+
+          if (connected) {
+            clearInterval(oauthPollRef.current!)
+            clearTimeout(oauthTimeoutRef.current!)
+            oauthPollRef.current = null
+            oauthTimeoutRef.current = null
+            setOauthPending(false)
+            setSuccess(`${PROVIDER_CONFIGS.find(p => p.id === provider)?.name} connected successfully!`)
+            KNAnalytics.trackEvent('oauth_completed', { provider, app_version: KNAnalytics.APP_VERSION })
+            await fetchKeyStatus()
+            setTimeout(() => handleClose(), 1500)
+          }
+        } catch { /* ignore transient errors */ }
+      }, 1500)
+
+      oauthTimeoutRef.current = setTimeout(() => {
+        clearInterval(oauthPollRef.current!)
+        oauthPollRef.current = null
+        oauthTimeoutRef.current = null
+        setOauthPending(false)
+        setError('OAuth timed out. Please try again.')
+      }, 300_000)
+    } catch (e: any) {
+      setOauthPending(false)
+      setError(e?.message || 'Failed to start OAuth flow.')
+    }
+  }, [fetchKeyStatus, handleClose])
+
   // Fetch current status when dialog opens
   useEffect(() => {
-    if (!isOpen) return
+    if (!isOpen) {
+      // Cancel any in-flight OAuth when dialog closes
+      if (oauthPollRef.current) { clearInterval(oauthPollRef.current); oauthPollRef.current = null }
+      if (oauthTimeoutRef.current) { clearTimeout(oauthTimeoutRef.current); oauthTimeoutRef.current = null }
+      setOauthPending(false)
+      return
+    }
     setApiKey('')
     setError('')
     setSuccess('')
     setValidation('idle')
     setValidationMsg('')
+    setOauthPending(false)
     setEditingExtraId(null)
     setExtraKey('')
     setExtraSuccess('')
@@ -293,6 +368,9 @@ export const ProviderSignInDialog = ({
     setSuccess('')
     setValidation('idle')
     setValidationMsg('')
+    if (oauthPollRef.current) { clearInterval(oauthPollRef.current); oauthPollRef.current = null }
+    if (oauthTimeoutRef.current) { clearTimeout(oauthTimeoutRef.current); oauthTimeoutRef.current = null }
+    setOauthPending(false)
   }, [selectedProvider])
 
   const handleSave = useCallback(async () => {
@@ -525,6 +603,25 @@ export const ProviderSignInDialog = ({
         </div>
 
         <div className={styles.providerSignInForm}>
+          {selectedProvider === 'openrouter' && (
+            <div className={styles.oauthSection}>
+              <button
+                className={styles.oauthButton}
+                onClick={() => handleOAuthLogin('openrouter')}
+                disabled={saving || oauthPending}
+              >
+                {oauthPending ? (
+                  <><span className={styles.oauthSpinner} /> Waiting for authorization…</>
+                ) : (
+                  'Sign in with OpenRouter'
+                )}
+              </button>
+              <div className={styles.oauthDivider}>
+                <span>or paste your API key below</span>
+              </div>
+            </div>
+          )}
+
           <label className={styles.formLabel}>
             {providerConfig.name} API Key
           </label>

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { open as openExternalUrl } from '@tauri-apps/api/shell'
+import { listen } from '@tauri-apps/api/event'
 
 import {
   Typography,
@@ -12,7 +13,7 @@ import styles from './styles.module.scss'
 
 const API_BASE = 'http://127.0.0.1:8897'
 
-type Provider = 'openai' | 'anthropic' | 'openrouter'
+type Provider = 'openai' | 'anthropic' | 'openrouter' | 'gemini'
 
 type ProviderConfig = {
   id: Provider
@@ -77,6 +78,19 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
     ],
     defaultModel: 'meta-llama/llama-3.3-70b-instruct:free',
   },
+  {
+    id: 'gemini',
+    name: 'Gemini',
+    description: 'Gemini 2.5 Pro, Flash — sign in with Google',
+    keyPrefix: 'AIza',
+    helpUrl: 'https://aistudio.google.com/apikey',
+    helpLabel: 'aistudio.google.com/apikey',
+    models: [
+      { id: 'gemini/gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Most capable, best for complex tasks' },
+      { id: 'gemini/gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Fast and affordable' },
+    ],
+    defaultModel: 'gemini/gemini-2.5-pro',
+  },
 ]
 
 // Extra providers that OpenClaw supports via env vars.
@@ -132,9 +146,13 @@ type ApiKeyStatusResponse = {
   has_openai_key?: boolean
   has_anthropic_key?: boolean
   has_openrouter_key?: boolean
+  has_gemini_key?: boolean
+  has_gemini_cli_key?: boolean
   openai_key_hint?: string
   anthropic_key_hint?: string
   openrouter_key_hint?: string
+  gemini_key_hint?: string
+  gemini_cli_email?: string
   extra_providers?: ExtraProviderStatusItem[]
 }
 
@@ -161,8 +179,11 @@ export const ProviderSignInDialog = ({
   const [validation, setValidation] = useState<ValidationState>('idle')
   const [validationMsg, setValidationMsg] = useState('')
   const [oauthPending, setOauthPending] = useState(false)
+  const [geminiOAuthPending, setGeminiOAuthPending] = useState(false)
+  const geminiOAuthPendingRef = useRef(false)
   const oauthPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const oauthTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const geminiUnlistenRef = useRef<(() => void) | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const validateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -184,6 +205,7 @@ export const ProviderSignInDialog = ({
     if (provider === 'openai') return keyStatus.openai_key_hint
     if (provider === 'anthropic') return keyStatus.anthropic_key_hint
     if (provider === 'openrouter') return keyStatus.openrouter_key_hint
+    if (provider === 'gemini') return keyStatus.gemini_key_hint
     return undefined
   }
 
@@ -255,6 +277,7 @@ export const ProviderSignInDialog = ({
       if (extraValidateTimerRef.current) clearTimeout(extraValidateTimerRef.current)
       if (oauthPollRef.current) clearInterval(oauthPollRef.current)
       if (oauthTimeoutRef.current) clearTimeout(oauthTimeoutRef.current)
+      if (geminiUnlistenRef.current) { geminiUnlistenRef.current(); geminiUnlistenRef.current = null }
     }
   }, [])
 
@@ -320,13 +343,90 @@ export const ProviderSignInDialog = ({
     }
   }, [fetchKeyStatus, handleClose])
 
+  const handleGeminiOAuth = useCallback(async () => {
+    if (geminiUnlistenRef.current) { geminiUnlistenRef.current(); geminiUnlistenRef.current = null }
+
+    setGeminiOAuthPending(true)
+    geminiOAuthPendingRef.current = true
+    setError('')
+    setSuccess('')
+
+    try {
+      const res = await fetch(`${API_BASE}/api/clawd/service/oauth-start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'google-gemini' }),
+      })
+      const data = await res.json()
+      if (!data.url) {
+        setError(data.error || 'Failed to start Google sign-in.')
+        setGeminiOAuthPending(false)
+        geminiOAuthPendingRef.current = false
+        return
+      }
+
+      await openExternalUrl(data.url)
+      KNAnalytics.trackEvent('oauth_started', { provider: 'google-gemini', app_version: KNAnalytics.APP_VERSION })
+
+      // Listen for the signin_success event emitted by the existing Google callback handler
+      const unlisten = await listen<{ code: string; raw_scopes: string }>('signin_success', async (event) => {
+        if (!geminiOAuthPendingRef.current) return
+        const { code, raw_scopes } = event.payload
+        if (!raw_scopes.includes('cloud-platform')) return
+
+        geminiOAuthPendingRef.current = false
+        if (geminiUnlistenRef.current) { geminiUnlistenRef.current(); geminiUnlistenRef.current = null }
+
+        try {
+          const connectRes = await fetch(`${API_BASE}/api/clawd/service/gemini-connect`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code }),
+          })
+          const connectData = await connectRes.json()
+          if (connectData.success) {
+            KNAnalytics.trackEvent('oauth_completed', { provider: 'google-gemini', app_version: KNAnalytics.APP_VERSION })
+            setGeminiOAuthPending(false)
+            const emailLabel = connectData.email ? ` (${connectData.email})` : ''
+            setSuccess(`Google account${emailLabel} connected for Gemini!`)
+            await fetchKeyStatus()
+            setTimeout(() => handleClose(), 1500)
+          } else {
+            setGeminiOAuthPending(false)
+            setError(connectData.error || 'Failed to complete Gemini sign-in.')
+          }
+        } catch (e: any) {
+          setGeminiOAuthPending(false)
+          setError(e?.message || 'Failed to complete Gemini sign-in.')
+        }
+      })
+      geminiUnlistenRef.current = unlisten
+
+      // 5-minute hard timeout
+      oauthTimeoutRef.current = setTimeout(() => {
+        if (!geminiOAuthPendingRef.current) return
+        geminiOAuthPendingRef.current = false
+        if (geminiUnlistenRef.current) { geminiUnlistenRef.current(); geminiUnlistenRef.current = null }
+        setGeminiOAuthPending(false)
+        setError('Sign-in timed out. Please try again.')
+      }, 300_000)
+    } catch (e: any) {
+      setGeminiOAuthPending(false)
+      geminiOAuthPendingRef.current = false
+      setError(e?.message || 'Failed to start Google sign-in.')
+    }
+  }, [fetchKeyStatus, handleClose])
+
   // Fetch current status when dialog opens
   useEffect(() => {
     if (!isOpen) {
       // Cancel any in-flight OAuth when dialog closes
       if (oauthPollRef.current) { clearInterval(oauthPollRef.current); oauthPollRef.current = null }
       if (oauthTimeoutRef.current) { clearTimeout(oauthTimeoutRef.current); oauthTimeoutRef.current = null }
+      if (geminiUnlistenRef.current) { geminiUnlistenRef.current(); geminiUnlistenRef.current = null }
       setOauthPending(false)
+      setGeminiOAuthPending(false)
+      geminiOAuthPendingRef.current = false
       return
     }
     setApiKey('')
@@ -349,7 +449,10 @@ export const ProviderSignInDialog = ({
         setSelectedProvider(initialProvider)
         const config = PROVIDER_CONFIGS.find(p => p.id === initialProvider)!
         setSelectedModel(config.defaultModel)
-      } else if (data.active_provider === 'openai' || data.active_provider === 'anthropic' || data.active_provider === 'openrouter') {
+      } else if (data.active_provider === 'google-gemini-cli') {
+        setSelectedProvider('gemini')
+        setSelectedModel('gemini/gemini-2.5-pro')
+      } else if (data.active_provider === 'openai' || data.active_provider === 'anthropic' || data.active_provider === 'openrouter' || data.active_provider === 'gemini') {
         setSelectedProvider(data.active_provider as Provider)
         const config = PROVIDER_CONFIGS.find(p => p.id === data.active_provider)!
         setSelectedModel(data.model || config.defaultModel)
@@ -370,7 +473,10 @@ export const ProviderSignInDialog = ({
     setValidationMsg('')
     if (oauthPollRef.current) { clearInterval(oauthPollRef.current); oauthPollRef.current = null }
     if (oauthTimeoutRef.current) { clearTimeout(oauthTimeoutRef.current); oauthTimeoutRef.current = null }
+    if (geminiUnlistenRef.current) { geminiUnlistenRef.current(); geminiUnlistenRef.current = null }
     setOauthPending(false)
+    setGeminiOAuthPending(false)
+    geminiOAuthPendingRef.current = false
   }, [selectedProvider])
 
   const handleSave = useCallback(async () => {
@@ -443,10 +549,14 @@ export const ProviderSignInDialog = ({
     if (provider === 'openai') return !!keyStatus.has_openai_key
     if (provider === 'anthropic') return !!keyStatus.has_anthropic_key
     if (provider === 'openrouter') return !!keyStatus.has_openrouter_key
+    if (provider === 'gemini') return !!keyStatus.has_gemini_key || !!keyStatus.has_gemini_cli_key
     return false
   }
 
   const isActiveProvider = (provider: Provider): boolean => {
+    if (provider === 'gemini') {
+      return keyStatus?.active_provider === 'gemini' || keyStatus?.active_provider === 'google-gemini-cli'
+    }
     return keyStatus?.active_provider === provider
   }
 
@@ -588,6 +698,12 @@ export const ProviderSignInDialog = ({
                     <path d="M10 7h4M7 10v4M17 10v4M10 17h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
                   </svg>
                 )}
+                {config.id === 'gemini' && (
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z" fill="currentColor" opacity="0.3"/>
+                    <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 100-16 8 8 0 000 16zm0-3l-4-4h2.5V7h3v6H16l-4 4z" fill="currentColor"/>
+                  </svg>
+                )}
               </div>
               <div className={styles.providerTabContent}>
                 <span className={styles.providerTabName}>{config.name}</span>
@@ -618,6 +734,38 @@ export const ProviderSignInDialog = ({
               </button>
               <div className={styles.oauthDivider}>
                 <span>or paste your API key below</span>
+              </div>
+            </div>
+          )}
+
+          {selectedProvider === 'gemini' && (
+            <div className={styles.oauthSection}>
+              <button
+                className={styles.oauthButton}
+                onClick={handleGeminiOAuth}
+                disabled={saving || geminiOAuthPending}
+              >
+                {geminiOAuthPending ? (
+                  <><span className={styles.oauthSpinner} /> Waiting for Google sign-in…</>
+                ) : keyStatus?.has_gemini_cli_key ? (
+                  <>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z" fill="#4285F4"/><path d="M12 11.5v1h4.9c-.2 1.1-.9 2-1.9 2.6l1.5 1.2c.9-.8 1.5-2.1 1.5-3.7 0-.4 0-.7-.1-1H12z" fill="white"/><path d="M7.5 14.1l1.7-1.3c-.3-.8-.3-1.7 0-2.5L7.5 9c-.7 1.5-.7 3.2 0 5.1z" fill="white"/><path d="M12 7c1.3 0 2.5.5 3.4 1.3L17 6.7C15.6 5.4 13.9 4.5 12 4.5c-2.8 0-5.2 1.6-6.5 4L7.1 10c.8-1.7 2.6-3 4.9-3z" fill="white"/><path d="M12 17c-2.2 0-4.1-1.2-5-3l-1.6 1.2C6.7 17.4 9.2 19 12 19c1.9 0 3.7-.7 5-1.9l-1.5-1.2c-.9.7-2.1 1.1-3.5 1.1z" fill="white"/></svg>
+                    Sign in with a different Google account
+                  </>
+                ) : (
+                  <>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z" fill="#4285F4"/><path d="M12 11.5v1h4.9c-.2 1.1-.9 2-1.9 2.6l1.5 1.2c.9-.8 1.5-2.1 1.5-3.7 0-.4 0-.7-.1-1H12z" fill="white"/><path d="M7.5 14.1l1.7-1.3c-.3-.8-.3-1.7 0-2.5L7.5 9c-.7 1.5-.7 3.2 0 5.1z" fill="white"/><path d="M12 7c1.3 0 2.5.5 3.4 1.3L17 6.7C15.6 5.4 13.9 4.5 12 4.5c-2.8 0-5.2 1.6-6.5 4L7.1 10c.8-1.7 2.6-3 4.9-3z" fill="white"/><path d="M12 17c-2.2 0-4.1-1.2-5-3l-1.6 1.2C6.7 17.4 9.2 19 12 19c1.9 0 3.7-.7 5-1.9l-1.5-1.2c-.9.7-2.1 1.1-3.5 1.1z" fill="white"/></svg>
+                    Sign in with Google
+                  </>
+                )}
+              </button>
+              {keyStatus?.gemini_cli_email && (
+                <p style={{ margin: '6px 0 0', fontSize: 12, color: '#64748b', textAlign: 'center' }}>
+                  Connected as {keyStatus.gemini_cli_email}
+                </p>
+              )}
+              <div className={styles.oauthDivider}>
+                <span>or use a Gemini API key</span>
               </div>
             </div>
           )}

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/styles.module.scss
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/styles.module.scss
@@ -467,3 +467,63 @@
 .extraProviderForm {
   padding: 0 0 12px 0;
 }
+
+/* ── OAuth sign-in section ─────────────────────────────────────────────── */
+
+.oauthSection {
+  margin-bottom: 16px;
+}
+
+.oauthButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 11px 18px;
+  border-radius: 8px;
+  border: 2px solid #c54841;
+  background: white;
+  color: #c54841;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(197, 72, 65, 0.06);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.oauthSpinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(197, 72, 65, 0.3);
+  border-top-color: #c54841;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+.oauthDivider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 14px 0 0;
+  color: #94a3b8;
+  font-size: 12px;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #e2e8f0;
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds browser-based OAuth authentication flows for OpenRouter and Google Gemini, allowing users to sign in without manually copying API keys. The implementation includes OAuth state management, token exchange, and automatic gateway restart on successful authentication.

## Key Changes

### Backend (Rust/Tauri)
- **OAuth flow endpoints**: Added `/api/clawd/service/oauth-start` to initiate OAuth flows and `/api/clawd/oauth/callback` to handle provider redirects
- **OpenRouter OAuth**: Implements PKCE-based authorization code flow with token exchange via OpenRouter's API
- **Google Gemini OAuth**: Supports Google OAuth 2.0 with local or backend-based token exchange, stores credentials in `auth-profiles.json` for CLI compatibility
- **Token management**: 
  - `read_gemini_cli_auth()` reads Google OAuth tokens from `auth-profiles.json`
  - `write_gemini_cli_auth()` persists Google OAuth tokens with email and expiration tracking
  - `exchange_google_code_for_gemini()` handles both local and backend token exchange
- **API key status**: Extended `ApiKeyStatusResponse` to include `has_gemini_cli_key` and `gemini_cli_email` fields
- **Gateway restart**: Automatically restarts the gateway on Windows (kill port 18789) and macOS (launchctl bootstrap/kickstart) after successful OAuth
- **HTML callback page**: Returns styled success/error pages to users after OAuth completion

### Frontend (React/TypeScript)
- **Provider config**: Added Gemini to provider list with models (Gemini 2.5 Pro, Flash)
- **OAuth UI**: 
  - New "Sign in with OpenRouter" and "Sign in with Google" buttons with loading states
  - OAuth divider showing "or paste your API key below" for manual entry fallback
  - Animated spinner during authorization wait
- **OAuth flow handling**:
  - `handleOAuthLogin()` for OpenRouter: opens browser, polls API status until key appears (5-min timeout)
  - `handleGeminiOAuth()` for Google: opens browser, listens for `signin_success` event from existing Google callback handler, exchanges code via `/api/clawd/service/gemini-connect`
- **State management**: Tracks OAuth pending state, cleans up timers/listeners on dialog close or unmount
- **Analytics**: Tracks `oauth_started` and `oauth_completed` events per provider
- **Styling**: Added `.oauthButton`, `.oauthSpinner`, and `.oauthDivider` styles with hover effects and animations

### Server Integration
- Registered new OAuth endpoints in Actix web server configuration

## Notable Implementation Details
- OAuth state is stored in a static `PENDING_OAUTH` mutex with 5-minute expiration validation
- Google Gemini uses existing `signin_success` event listener pattern rather than polling
- Token exchange supports both local (with `GOOGLE_CLIENT_SECRET` env var) and backend-based flows
- Gemini CLI auth stored separately in `auth-profiles.json` to maintain compatibility with CLI tools
- Environment variables (`KNAPSACK_ACTIVE_PROVIDER`, provider-specific keys) are updated immediately after OAuth success
- All OAuth operations include proper error handling with user-friendly HTML error pages

https://claude.ai/code/session_0189tSi7Y8nD2amjKRUiYftu