### PR TITLE
Improve gateway resilience and model selection logic

### DIFF
--- a/src/src-tauri/src/audio/audio.rs
+++ b/src/src-tauri/src/audio/audio.rs
@@ -632,16 +632,25 @@ pub async fn stop_recording(
   ) {
     Ok(_) => {
       log::info!("Successfully combined .wav/.raw files");
+      // NotFound is benign — the file may have already been cleaned up by
+      // another path (e.g. interrupted recording).  Only escalate to Sentry
+      // for real IO errors like permission-denied.
       if let Err(e) = std::fs::remove_file(&input_path) {
-        let err_msg = format!("Failed to delete input txt file: {:?}", e);
-        knap_log_error(err_msg.clone(), None, Some(true));
-        log::error!("Failed to delete input txt file: {:?}", e);
+        if e.kind() == std::io::ErrorKind::NotFound {
+          log::debug!("input txt file already gone, skipping delete: {:?}", input_path);
+        } else {
+          let err_msg = format!("Failed to delete input txt file: {:?}", e);
+          knap_log_error(err_msg, None, Some(true));
+        }
       }
       if output_path.exists() {
         if let Err(e) = std::fs::remove_file(&output_path) {
-          let err_msg = format!("Failed to delete output txt file: {:?}", e);
-          knap_log_error(err_msg.clone(), None, Some(true));
-          log::error!("Failed to delete output file: {:?}", e);
+          if e.kind() == std::io::ErrorKind::NotFound {
+            log::debug!("output txt file already gone, skipping delete: {:?}", output_path);
+          } else {
+            let err_msg = format!("Failed to delete output txt file: {:?}", e);
+            knap_log_error(err_msg, None, Some(true));
+          }
         }
       }
     }

--- a/src/src-tauri/src/audio/transcribe.rs
+++ b/src/src-tauri/src/audio/transcribe.rs
@@ -65,7 +65,10 @@ fn resolve_stt_provider() -> Result<SttProvider, LLMError> {
   }
 
   Err(LLMError::ChatCompletionFailed(
-    "No speech-to-text provider available. Please add an OpenAI or Groq API key in Settings.".into(),
+    "No speech-to-text provider available. Speech-to-text requires a Groq or OpenAI API \
+     key (Anthropic and Gemini don't expose a Whisper-compatible endpoint). Groq offers a \
+     free tier — add a key in Settings → AI Provider → Groq."
+      .into(),
   ))
 }
 

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -175,77 +175,13 @@ fn has_default_model(snapshot: &serde_json::Value) -> bool {
 
 /// Pick the best default model based on which LLM API key is available.
 ///
-/// The gateway inherits env vars from the desktop app (service.rs propagates
-/// ANTHROPIC_API_KEY, OPENAI_API_KEY, GROQ_API_KEY, GEMINI_API_KEY).
+/// Delegates to `gateway_client::resolve_default_model` so the two call
+/// sites can't drift — a previous local copy here fell back to
+/// `anthropic/claude-opus-4-6`, which itself fails when the user has no
+/// Anthropic key, whereas the gateway_client version falls back to the free
+/// Groq model.
 fn resolve_default_model() -> String {
-    // Respect the user's active provider selection so the gateway model
-    // matches what the user configured in Settings.
-    let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
-
-    match active.as_str() {
-        "openrouter" => {
-            let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
-                .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
-            return format!("openrouter/{}", model);
-        }
-        "ollama" => {
-            let model = std::env::var("KNAPSACK_OLLAMA_MODEL")
-                .unwrap_or_else(|_| "llama3.1".to_string());
-            return format!("ollama/{}", model);
-        }
-        "anthropic" if has_key("ANTHROPIC_API_KEY") => {
-            let model = std::env::var("KNAPSACK_ANTHROPIC_MODEL")
-                .unwrap_or_else(|_| "claude-opus-4-6".to_string());
-            return format!("anthropic/{}", model);
-        }
-        "openai" if has_key("OPENAI_API_KEY") => {
-            let model = std::env::var("KNAPSACK_OPENAI_MODEL")
-                .unwrap_or_else(|_| "gpt-5.4".to_string());
-            return format!("openai/{}", model);
-        }
-        "groq" if has_key("GROQ_API_KEY") => {
-            let model = std::env::var("KNAPSACK_GROQ_MODEL")
-                .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
-            return format!("groq/{}", model);
-        }
-        "gemini" if has_key("GEMINI_API_KEY") => {
-            let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-                .unwrap_or_else(|_| "gemini-2.0-flash".to_string());
-            return format!("google/{}", model);
-        }
-        _ => {}
-    }
-
-    // Fallback: try providers in preference order
-    if has_key("ANTHROPIC_API_KEY") {
-        let model = std::env::var("KNAPSACK_ANTHROPIC_MODEL")
-            .unwrap_or_else(|_| "claude-opus-4-6".to_string());
-        return format!("anthropic/{}", model);
-    }
-    if has_key("OPENAI_API_KEY") {
-        let model = std::env::var("KNAPSACK_OPENAI_MODEL")
-            .unwrap_or_else(|_| "gpt-5.4".to_string());
-        return format!("openai/{}", model);
-    }
-    if has_key("GROQ_API_KEY") { return "groq/llama-3.3-70b-versatile".to_string(); }
-    if has_key("GEMINI_API_KEY") { return "google/gemini-2.0-flash".to_string(); }
-    if has_key("OPENROUTER_API_KEY") {
-        let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
-            .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
-        return format!("openrouter/{}", model);
-    }
-    if std::env::var("OLLAMA_API_KEY").map(|k| !k.trim().is_empty()).unwrap_or(false) {
-        let model = std::env::var("KNAPSACK_OLLAMA_MODEL")
-            .unwrap_or_else(|_| "llama3.1".to_string());
-        return format!("ollama/{}", model);
-    }
-
-    // Fallback — matches the gateway's compiled default
-    "anthropic/claude-opus-4-6".to_string()
-}
-
-fn has_key(var: &str) -> bool {
-    std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false)
+    crate::clawd::gateway_client::resolve_default_model()
 }
 
 /// Check whether `browser.enabled` is already true in the config snapshot.

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -156,6 +156,52 @@ fn extract_base_hash(snapshot: &serde_json::Value) -> String {
     String::new()
 }
 
+/// Whether a config.patch error looks like the gateway dropped the WS
+/// mid-request (e.g. it restarted after applying a prior patch, or the
+/// pooled connection lapsed).  These are safe to retry with a fresh
+/// base_hash; RPC-level errors (rate-limit, stale hash, validation) are
+/// returned as-is because retrying with the same payload won't help.
+fn is_connection_level_error(err: &str) -> bool {
+    err.contains("connection closed")
+        || err.contains("channel closed")
+        || err.starts_with("Timeout waiting for response")
+        || err.starts_with("Failed to send request")
+}
+
+/// Call `gateway_client::config_patch` with a single retry on
+/// connection-level errors.  The `build_patch` closure returns the patch
+/// JSON given the freshly-fetched snapshot, so it can re-run
+/// `build_enable_patch` against the post-restart config (which may have
+/// moved on under our feet).  `base_hash` is refetched on the retry.
+async fn config_patch_with_reconnect<F>(
+    initial_snapshot: &serde_json::Value,
+    mut build_patch: F,
+) -> Result<serde_json::Value, String>
+where
+    F: FnMut(&serde_json::Value) -> String,
+{
+    let initial_patch = build_patch(initial_snapshot);
+    let initial_hash = extract_base_hash(initial_snapshot);
+    match gateway_client::config_patch(&initial_patch, &initial_hash, None).await {
+        Ok(v) => Ok(v),
+        Err(e) if is_connection_level_error(&e) => {
+            log::warn!(
+                "[channels] config.patch hit connection error ({}) — waiting for gateway and retrying once",
+                e
+            );
+            gateway_client::ensure_gateway_and_wait().await;
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            let fresh_snapshot = gateway_client::config_get(None)
+                .await
+                .map_err(|ge| format!("config.patch retry: config.get failed: {}", ge))?;
+            let fresh_patch = build_patch(&fresh_snapshot);
+            let fresh_hash = extract_base_hash(&fresh_snapshot);
+            gateway_client::config_patch(&fresh_patch, &fresh_hash, None).await
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Check whether `agents.defaults.model` is already set in the config snapshot.
 fn has_default_model(snapshot: &serde_json::Value) -> bool {
     let config = snapshot.get("config").unwrap_or(snapshot);
@@ -1103,18 +1149,19 @@ pub async fn telegram_enable(
 
     match config_result {
         Ok(config_snapshot) => {
-            let base_hash = extract_base_hash(&config_snapshot);
-
-            let patch = if body.enabled {
-                build_enable_patch(
-                    r#"{"channels": {"telegram": {"dmPolicy": "pairing"}}}"#,
-                    &config_snapshot,
-                )
-            } else {
-                r#"{"channels": {"telegram": null}}"#.to_string()
+            let enabled = body.enabled;
+            let build_patch = |snapshot: &serde_json::Value| {
+                if enabled {
+                    build_enable_patch(
+                        r#"{"channels": {"telegram": {"dmPolicy": "pairing"}}}"#,
+                        snapshot,
+                    )
+                } else {
+                    r#"{"channels": {"telegram": null}}"#.to_string()
+                }
             };
 
-            match gateway_client::config_patch(&patch, &base_hash, None).await {
+            match config_patch_with_reconnect(&config_snapshot, build_patch).await {
                 Ok(_) => {
                     if body.enabled {
                         // Auto-approve the first pairing request so the device
@@ -1190,8 +1237,6 @@ pub async fn telegram_configure(
 
     match config_result {
         Ok(config_snapshot) => {
-            let base_hash = extract_base_hash(&config_snapshot);
-
             let patch_value = serde_json::json!({
                 "channels": {
                     "telegram": {
@@ -1205,12 +1250,14 @@ pub async fn telegram_configure(
                     }
                 }
             });
-            let patch = build_enable_patch(
-                &serde_json::to_string(&patch_value).unwrap(),
-                &config_snapshot,
-            );
+            let build_patch = |snapshot: &serde_json::Value| {
+                build_enable_patch(
+                    &serde_json::to_string(&patch_value).unwrap(),
+                    snapshot,
+                )
+            };
 
-            match gateway_client::config_patch(&patch, &base_hash, None).await {
+            match config_patch_with_reconnect(&config_snapshot, build_patch).await {
                 Ok(_) => {
                     log::info!("[channels] Telegram bot token configured successfully");
                     // Start watching for the owner's first message so we can
@@ -1730,18 +1777,22 @@ pub async fn generic_channel_configure(
     let config_result = gateway_client::config_get(None).await;
     match config_result {
         Ok(config_snapshot) => {
-            let base_hash = extract_base_hash(&config_snapshot);
-            let patch_value = serde_json::json!({
-                "channels": {
-                    channel.clone(): channel_config
-                }
-            });
-            let patch = build_enable_patch(
-                &serde_json::to_string(&patch_value).unwrap(),
-                &config_snapshot,
-            );
+            // Clone the channel config for each closure invocation so the
+            // retry path gets its own copy — serde_json::json! moves the
+            // value into the tree.
+            let build_patch = |snapshot: &serde_json::Value| {
+                let patch_value = serde_json::json!({
+                    "channels": {
+                        channel.clone(): channel_config.clone()
+                    }
+                });
+                build_enable_patch(
+                    &serde_json::to_string(&patch_value).unwrap(),
+                    snapshot,
+                )
+            };
 
-            match gateway_client::config_patch(&patch, &base_hash, None).await {
+            match config_patch_with_reconnect(&config_snapshot, build_patch).await {
                 Ok(_) => {
                     log::info!("[channels] {} configured successfully", channel);
                     // For channels using pairing mode, auto-approve the first
@@ -4073,4 +4124,30 @@ pub async fn telegram_get_agent_bot_statuses() -> impl Responder {
         .unwrap_or_default();
 
     HttpResponse::Ok().json(entries)
+}
+
+#[cfg(test)]
+mod reconnect_retry_tests {
+    use super::is_connection_level_error;
+
+    #[test]
+    fn connection_closed_is_retryable() {
+        assert!(is_connection_level_error("Gateway connection closed"));
+        assert!(is_connection_level_error("Gateway response channel closed"));
+    }
+
+    #[test]
+    fn send_failure_and_timeout_are_retryable() {
+        assert!(is_connection_level_error("Failed to send request: broken pipe"));
+        assert!(is_connection_level_error("Timeout waiting for response"));
+    }
+
+    #[test]
+    fn rpc_level_errors_are_not_retryable() {
+        // "ok=false" responses from the gateway — retrying the same payload
+        // won't change the outcome.
+        assert!(!is_connection_level_error("rate limit exceeded"));
+        assert!(!is_connection_level_error("invalid baseHash"));
+        assert!(!is_connection_level_error("schema validation failed: channels.telegram"));
+    }
 }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3457,6 +3457,44 @@ struct ServiceSetup {
   working_dir: PathBuf,
 }
 
+/// Whether any known LLM provider env var is populated.  Used by the gateway
+/// config setup to decide whether it's safe to pin `agents.defaults.model` —
+/// if no keys are available at all, pinning any model just produces a
+/// different "No API key found" error, so we leave the field unset and let
+/// the user configure a provider first.
+fn any_provider_key_available() -> bool {
+  const VARS: &[&str] = &[
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OLLAMA_API_KEY",
+  ];
+  VARS.iter().any(|v| {
+    std::env::var(v).map(|k| !k.trim().is_empty()).unwrap_or(false)
+  })
+}
+
+/// Whether the provider prefix in a model ref (e.g. "openai/gpt-5.4",
+/// "anthropic/claude-opus-4-6") has an available API key in the environment.
+/// Unknown prefixes return `true` so we don't clobber user-configured custom
+/// providers.
+fn model_ref_has_key(model_ref: &str) -> bool {
+  let provider = model_ref.split('/').next().unwrap_or("").to_lowercase();
+  let has = |var: &str| std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false);
+  match provider.as_str() {
+    "openai" | "openai-codex" => has("OPENAI_API_KEY"),
+    "anthropic" => has("ANTHROPIC_API_KEY"),
+    "google" | "gemini" | "vertex" => has("GEMINI_API_KEY") || has("GOOGLE_API_KEY"),
+    "groq" => has("GROQ_API_KEY"),
+    "openrouter" => has("OPENROUTER_API_KEY"),
+    "ollama" => has("OLLAMA_API_KEY"),
+    _ => true,
+  }
+}
+
 /// Platform-agnostic gateway configuration setup.
 /// Finds Node.js, resolves paths, creates/patches config files, builds env vars.
 /// Returns everything needed to spawn the gateway process.
@@ -3579,7 +3617,20 @@ async fn prepare_gateway_config(
   if !config_path.exists() {
     let _ = ensure_dir(&clawdbot_home);
     harden_dir_permissions(&clawdbot_home);
-    let default_config = serde_json::json!({
+    // Pin agents.defaults.model based on the user's available provider keys.
+    // Without this, the OpenClaw gateway falls back to its compiled default
+    // (openai/gpt-5.4) and every request fails with "No API key found for
+    // provider openai" for any user who doesn't have an OpenAI key.
+    let agents_defaults = if any_provider_key_available() {
+      serde_json::json!({
+        "defaults": {
+          "model": {"primary": crate::clawd::gateway_client::resolve_default_model()}
+        }
+      })
+    } else {
+      serde_json::Value::Null
+    };
+    let mut default_config = serde_json::json!({
       "gateway": {
         "mode": "local",
         "auth": {
@@ -3622,6 +3673,12 @@ async fn prepare_gateway_config(
         }
       }
     });
+    if !agents_defaults.is_null() {
+      default_config
+        .as_object_mut()
+        .unwrap()
+        .insert("agents".to_string(), agents_defaults);
+    }
     match fs::write(&config_path, serde_json::to_string_pretty(&default_config).unwrap_or_default()) {
       Ok(_) => eprintln!("[clawd/service] Created default config at {}", config_path.display()),
       Err(e) => eprintln!("[clawd/service] WARNING: Failed to create config at {}: {}", config_path.display(), e),
@@ -3730,6 +3787,57 @@ async fn prepare_gateway_config(
               eprintln!("[clawd/service] Migrated agents.defaults.model from string to object form");
               patched = true;
             }
+          }
+        }
+
+        // Ensure agents.defaults.model.primary refers to a provider whose key
+        // is actually available.  Without this, a stored model whose provider
+        // key has been removed (or a missing model entry on first launch
+        // after the user configured a non-OpenAI key) falls through to the
+        // gateway's compiled default of openai/gpt-5.4 and every request
+        // fails with "No API key found for provider openai".
+        //
+        // Read both string and object forms (regression guard from CLAUDE.md):
+        // service.rs writes {"primary": "..."} while older code wrote a bare
+        // string.  Copy to owned string so the borrow ends before we mutate.
+        let current_primary: String = cfg_val
+          .pointer("/agents/defaults/model")
+          .and_then(|v| match v {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Object(o) => {
+              o.get("primary").and_then(|p| p.as_str()).map(|s| s.to_string())
+            }
+            _ => None,
+          })
+          .unwrap_or_default();
+        let needs_model_fix = current_primary.trim().is_empty()
+          || !model_ref_has_key(current_primary.trim());
+        if needs_model_fix && any_provider_key_available() {
+          let new_model = crate::clawd::gateway_client::resolve_default_model();
+          if new_model != current_primary {
+            // Ensure agents.defaults exists, in two separate borrows so each
+            // mutable borrow of cfg_val is released before the next starts.
+            if cfg_val.pointer("/agents").is_none() {
+              cfg_val.as_object_mut().unwrap().insert(
+                "agents".to_string(),
+                serde_json::json!({}),
+              );
+            }
+            if cfg_val.pointer("/agents/defaults").is_none() {
+              cfg_val.pointer_mut("/agents").unwrap().as_object_mut().unwrap().insert(
+                "defaults".to_string(),
+                serde_json::json!({}),
+              );
+            }
+            cfg_val.pointer_mut("/agents/defaults").unwrap().as_object_mut().unwrap().insert(
+              "model".to_string(),
+              serde_json::json!({"primary": new_model.clone()}),
+            );
+            eprintln!(
+              "[clawd/service] Patched agents.defaults.model.primary: {:?} → '{}' (provider key mismatch)",
+              current_primary, new_model
+            );
+            patched = true;
           }
         }
 
@@ -6521,4 +6629,92 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
 #[cfg(not(target_os = "macos"))]
 pub async fn auto_enable_if_needed(_app_handle: &tauri::AppHandle) {
   // No-op on non-macOS platforms.
+}
+
+#[cfg(test)]
+mod provider_key_tests {
+  use super::*;
+
+  // These tests mutate process-wide env vars, so they must run serially
+  // (cargo's default is parallel).  We guard with a mutex and always
+  // restore the prior state to avoid cross-test contamination.
+  static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+  const ALL_VARS: &[&str] = &[
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "GROQ_API_KEY", "OPENROUTER_API_KEY", "OLLAMA_API_KEY",
+  ];
+
+  fn clear_all() {
+    for v in ALL_VARS { std::env::remove_var(v); }
+  }
+
+  #[test]
+  fn no_keys_means_no_provider_available() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    assert!(!any_provider_key_available());
+  }
+
+  #[test]
+  fn anthropic_key_alone_counts_as_available() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
+    assert!(any_provider_key_available());
+    std::env::remove_var("ANTHROPIC_API_KEY");
+  }
+
+  #[test]
+  fn empty_or_whitespace_key_does_not_count() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    std::env::set_var("ANTHROPIC_API_KEY", "   ");
+    assert!(!any_provider_key_available());
+    std::env::remove_var("ANTHROPIC_API_KEY");
+  }
+
+  #[test]
+  fn model_ref_without_matching_key_is_detected() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    // User selected OpenAI model but has no OpenAI key — the stored model
+    // is stale and should be re-resolved.
+    assert!(!model_ref_has_key("openai/gpt-5.4"));
+    assert!(!model_ref_has_key("anthropic/claude-opus-4-6"));
+    assert!(!model_ref_has_key("google/gemini-2.5-pro"));
+    assert!(!model_ref_has_key("groq/llama-3.3-70b-versatile"));
+  }
+
+  #[test]
+  fn model_ref_with_matching_key_is_recognized() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
+    assert!(model_ref_has_key("anthropic/claude-opus-4-6"));
+    assert!(!model_ref_has_key("openai/gpt-5.4"));
+    std::env::remove_var("ANTHROPIC_API_KEY");
+  }
+
+  #[test]
+  fn gemini_model_ref_recognizes_either_env_var() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    std::env::set_var("GOOGLE_API_KEY", "AIzaTest");
+    assert!(model_ref_has_key("google/gemini-2.5-pro"));
+    assert!(model_ref_has_key("gemini/gemini-2.5-flash"));
+    std::env::remove_var("GOOGLE_API_KEY");
+    std::env::set_var("GEMINI_API_KEY", "AIzaTest");
+    assert!(model_ref_has_key("google/gemini-2.5-pro"));
+    std::env::remove_var("GEMINI_API_KEY");
+  }
+
+  #[test]
+  fn unknown_provider_prefix_is_trusted() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    // Don't clobber custom providers the user may have configured out-of-band.
+    assert!(model_ref_has_key("custom/my-model"));
+    assert!(model_ref_has_key("minimax/m2.5"));
+  }
 }


### PR DESCRIPTION
## Summary
This PR improves the robustness of gateway interactions and fixes model selection to respect available API keys. It introduces automatic retry logic for connection-level errors, consolidates model resolution logic, and ensures the gateway config is initialized with a valid default model.

## Key Changes

### Gateway Connection Resilience
- Added `config_patch_with_reconnect()` helper that retries `config_patch` calls once on connection-level errors (closed connections, timeouts, send failures) while treating RPC-level errors (rate limits, validation) as permanent
- Added `is_connection_level_error()` to distinguish transient connection issues from permanent API errors
- Updated `telegram_enable()`, `telegram_configure()`, and `generic_channel_configure()` to use the new retry logic
- Added unit tests for connection error detection

### Model Selection Consolidation
- Removed duplicate model resolution logic from `channels.rs` and delegated to `gateway_client::resolve_default_model()` to prevent drift between call sites
- Added `any_provider_key_available()` and `model_ref_has_key()` helpers in `service.rs` to validate that stored/default models have corresponding API keys
- Updated gateway config initialization to pin `agents.defaults.model.primary` based on available provider keys, preventing "No API key found" errors for users without OpenAI keys
- Added config patching logic to fix stale model references when provider keys change
- Added comprehensive unit tests for provider key detection

### Error Handling Improvements
- Made audio file cleanup more resilient by treating `NotFound` errors as benign (file may have been cleaned up by another path) and only escalating real IO errors to Sentry
- Improved speech-to-text error message to guide users toward free Groq tier when no STT provider is available

## Implementation Details
- The `config_patch_with_reconnect()` closure pattern allows the patch builder to re-run against a fresh config snapshot on retry, accommodating gateway state changes
- Model validation happens both at config creation (new installs) and during config patching (existing installs with changed keys)
- All provider key checks normalize whitespace to avoid treating empty/whitespace-only values as valid keys

https://claude.ai/code/session_01MDMVBMvBXJZdbv7vNPgjLH