### PR TITLE
Add inline confirmation for resolved prompt action buttons

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -307,6 +307,7 @@ type Msg = {
   model?: string // model used for this response (e.g. "gpt-4o-mini")
   promptActions?: PromptAction[] // pre-defined actions (skip extractPromptActions parsing)
   replyTo?: string // ID of the message this is a reply to
+  confirmedActionPrompts?: string[] // prompts whose action buttons have been resolved inline
 }
 
 type ServiceStatus = {
@@ -915,7 +916,7 @@ type ChatMessageProps = {
   mdPlugins: any[]
   mdComponents: Components
   onExampleClick?: (e: React.MouseEvent, text: string) => void
-  onAction?: (prompt: string) => void
+  onAction?: (prompt: string, srcMsgId?: string) => void
   onReply?: (msg: Msg) => void
   replyToMsg?: Msg | null
   onScrollToMsg?: (id: string) => void
@@ -987,16 +988,27 @@ const ChatMessage = memo(function ChatMessage({
         )}
         {actions.length > 0 && (
           <div className="ClawdPromptActions">
-            {actions.map((action, i) => (
-              <button
-                key={i}
-                className="ClawdPromptAction"
-                onClick={(e) => { e.stopPropagation(); onAction?.(action.prompt) }}
-              >
-                <span className="ClawdPromptActionNum">{i + 1}</span>
-                {action.label}
-              </button>
-            ))}
+            {actions.map((action, i) => {
+              const isConfirmed = m.confirmedActionPrompts?.includes(action.prompt)
+              if (isConfirmed) {
+                const isAdvancedMode = action.prompt.startsWith('__enable_advanced_and_resend__')
+                return (
+                  <div key={i} className="ClawdPromptActionConfirmed">
+                    {isAdvancedMode ? '⚡ Advanced mode enabled' : `✓ ${action.label}`}
+                  </div>
+                )
+              }
+              return (
+                <button
+                  key={i}
+                  className="ClawdPromptAction"
+                  onClick={(e) => { e.stopPropagation(); onAction?.(action.prompt, m.id) }}
+                >
+                  <span className="ClawdPromptActionNum">{i + 1}</span>
+                  {action.label}
+                </button>
+              )
+            })}
           </div>
         )}
         {m.model && m.role === 'assistant' && (
@@ -3325,7 +3337,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
   // Send with specific text (for prompt action clicks, example clicks, voice auto-send)
   // If the chat is busy (mid-inference), queue the message to send after completion.
-  const handleSendWithText = useCallback(async (text: string) => {
+  const handleSendWithText = useCallback(async (text: string, srcMsgId?: string) => {
     if (!text.trim()) return
 
     // Handle "open provider settings" action — opens the AI provider sidebar directly
@@ -3343,7 +3355,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       // Enable advanced mode directly (skip warning dialog since user clicked the suggestion)
       setAdvancedMode(true)
       localStorage.setItem(ADVANCED_MODE_STORAGE, 'true')
-      pushAssistant('⚡ **Advanced mode enabled.** Re-sending your request with shell access...')
+      // Replace the action button with an inline confirmation in the source message
+      if (srcMsgId) {
+        setMsgs(prev => prev.map(m =>
+          m.id === srcMsgId
+            ? { ...m, confirmedActionPrompts: [...(m.confirmedActionPrompts ?? []), text] }
+            : m
+        ))
+      }
       // Use doSendRef so the re-send picks up the new advancedMode=true state after re-render
       setTimeout(() => doSendRef.current?.(originalPrompt), 100)
       return

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -3344,8 +3344,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       setAdvancedMode(true)
       localStorage.setItem(ADVANCED_MODE_STORAGE, 'true')
       pushAssistant('⚡ **Advanced mode enabled.** Re-sending your request with shell access...')
-      // Small delay to let state update, then re-send original prompt
-      setTimeout(() => doSend(originalPrompt), 100)
+      // Use doSendRef so the re-send picks up the new advancedMode=true state after re-render
+      setTimeout(() => doSendRef.current?.(originalPrompt), 100)
       return
     }
 

--- a/src/src/components/organisms/ClawdChat/style.scss
+++ b/src/src/components/organisms/ClawdChat/style.scss
@@ -657,6 +657,20 @@
     border-top: 1px solid rgba(0, 0, 0, 0.06);
   }
 
+  .ClawdPromptActionConfirmed {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: rgba(34, 197, 94, 0.08);
+    border: 1px solid rgba(34, 197, 94, 0.2);
+    color: #16a34a;
+    font-weight: 500;
+    font-size: 13px;
+    font-family: inherit;
+  }
+
   .ClawdPromptAction {
     display: flex;
     align-items: center;

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -244,8 +244,9 @@ function Home({
     (connectionKeys: ConnectionKeys[]) => {
       if (auth.profile?.provider && auth.profile.provider == ConnectionKeys.MICROSOFT_PROFILE) {
         handleMicrosoftMenuItemClick(connectionKeys)
+      } else {
+        handleGoogleMenuItemClick(connectionKeys)
       }
-      handleGoogleMenuItemClick(connectionKeys)
     },
     [auth.profile],
   )

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { insertAutomationRun } from 'src/api/automations'
-import { Connection, ConnectionKeys, ConnectionStates } from 'src/api/connections'
+import { Connection, ConnectionKeys, ConnectionStates, getGoogleGmailConnections } from 'src/api/connections'
 import { getEmailThread } from 'src/api/data_source'
 import {
   deleteFeedItem,
@@ -2040,9 +2040,7 @@ export function useFeed(
   }, [feedContent])
 
   const loggedEmailAutopilot = useMemo(() => {
-    return connections[ConnectionKeys.GOOGLE_GMAIL] || connections[ConnectionKeys.MICROSOFT_OUTLOOK]
-      ? true
-      : false
+    return getGoogleGmailConnections(connections).length > 0 || !!connections[ConnectionKeys.MICROSOFT_OUTLOOK]
   }, [connections])
 
   const [composedEmailDraft, setComposedEmailDraft] = useState<ComposedEmailDraft | null>(null)


### PR DESCRIPTION
## Summary
This PR enhances the prompt action UI by displaying inline confirmations when action buttons are resolved, rather than immediately executing them. This provides better visual feedback to users about which actions have been triggered.

## Key Changes

- **Message type enhancement**: Added `confirmedActionPrompts` field to the `Msg` type to track which action prompts have been resolved inline
- **Action button rendering**: Modified `ChatMessage` component to display confirmed actions as styled badges (with checkmarks or status indicators) instead of clickable buttons
- **Handler signature update**: Updated `onAction` callback to include `srcMsgId` parameter, allowing the parent component to track which message's action was triggered
- **Advanced mode flow**: Refactored the advanced mode enable flow to:
  - Mark the action as confirmed in the source message
  - Use `doSendRef` to ensure the re-send picks up the updated `advancedMode` state
  - Remove the intermediate assistant message that was previously shown
- **Connection logic fix**: Improved `loggedEmailAutopilot` check in `useFeed` hook to use `getGoogleGmailConnections()` helper for more robust Gmail connection detection
- **Menu handler fix**: Fixed conditional logic in `Home.tsx` to properly handle both Microsoft and Google menu item clicks (was previously always calling both handlers)

## Implementation Details

- Confirmed actions are displayed with a green background badge showing either "✓ {label}" or "⚡ Advanced mode enabled" for special cases
- The action button click now passes the source message ID to enable proper state tracking
- Advanced mode enable action uses a ref-based approach to ensure state consistency during the re-send operation

https://claude.ai/code/session_018BGkApzPSKUNfZFHn3WP5W