### PR TITLE
Add Knapsack 7B to Ollama suggested models list

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -461,6 +461,7 @@ const OPENROUTER_MODELS: OpenRouterModelOption[] = [
 // Recommended models to offer for download when Ollama has none installed
 type OllamaModelSuggestion = { id: string; name: string; description: string; size: string }
 const OLLAMA_SUGGESTED_MODELS: OllamaModelSuggestion[] = [
+  { id: 'hf.co/tunedailabs/knapsack-causal-7b-merged', name: 'Knapsack 7B', description: 'Knapsack-tuned causal model, optimized for this app', size: '~4.1 GB' },
   { id: 'llama3.1:8b', name: 'Llama 3.1 8B', description: 'Great all-rounder, fast on most hardware', size: '~4.7 GB' },
   { id: 'gemma3:4b', name: 'Gemma 3 4B', description: 'Google model, compact and capable', size: '~3.3 GB' },
   { id: 'mistral:7b', name: 'Mistral 7B', description: 'Excellent reasoning, low resource usage', size: '~4.1 GB' },


### PR DESCRIPTION
## Summary
Added Knapsack 7B, a custom-tuned causal language model, to the list of recommended Ollama models offered for download when users have no models installed.

## Changes
- Added Knapsack 7B (`hf.co/tunedailabs/knapsack-causal-7b-merged`) as the first suggested model in the `OLLAMA_SUGGESTED_MODELS` array
- Model is positioned at the top of the recommendations with a description indicating it's optimized for this application
- Specified model size as ~4.1 GB to match other similarly-sized models in the list

## Details
The Knapsack model is a specialized variant designed and tuned for optimal performance with this application. By adding it as the first suggestion, users will see it as a primary recommendation when setting up Ollama for the first time.

https://claude.ai/code/session_016vQ3xY9C3Md8doGR1T68Xb