### PR TITLE
Fix concurrent plugin registration race condition with retry logic

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -46,6 +46,10 @@ jobs:
         working-directory: src
         run: node scripts/install-bundled-plugin-deps.cjs
 
+      - name: Smoke-test gateway plugin registration
+        working-directory: src
+        run: bash scripts/smoke-test-gateway-plugins.sh
+
       - name: Run prebuild scripts
         working-directory: src
         env:

--- a/src/scripts/smoke-test-gateway-plugins.sh
+++ b/src/scripts/smoke-test-gateway-plugins.sh
@@ -49,6 +49,7 @@ run_pass() {
   echo "[smoke-test] $pass_name: starting gateway..."
   (cd "$CLAWDBOT_DIR" && node dist/entry.js gateway run \
     --allow-unconfigured \
+    --verbose \
     --bind loopback \
     --auth token \
     --token "$GW_TOKEN" \

--- a/src/scripts/smoke-test-gateway-plugins.sh
+++ b/src/scripts/smoke-test-gateway-plugins.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# smoke-test-gateway-plugins.sh — Starts the clawdbot gateway twice (cold + warm)
+# and asserts that all plugins register without filesystem errors (ENOTEMPTY, etc.).
+#
+# Cold start: first run, no mirror dirs exist yet — exercises initial mirroring.
+# Warm start: reuses same state dir so mirror dirs already exist — exercises the
+#             rmSync + rename path that previously raced with concurrent plugins.
+#
+# Run after install-bundled-plugin-deps.cjs (plugins need their node_modules).
+# Run before prune-clawdbot.cjs (some pruned extensions may lack deps after prune).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAWDBOT_DIR="$(cd "$SCRIPT_DIR/../src-tauri/resources/clawdbot" && pwd)"
+PORT=28789
+TIMEOUT_S=90
+
+STATE_DIR=""
+LOG_FILE=""
+GW_PID=""
+
+cleanup() {
+  if [[ -n "$GW_PID" ]]; then
+    kill "$GW_PID" 2>/dev/null || true
+    wait "$GW_PID" 2>/dev/null || true
+  fi
+  [[ -n "$STATE_DIR" ]] && rm -rf "$STATE_DIR"
+  [[ -n "$LOG_FILE"  ]] && rm -f  "$LOG_FILE"
+}
+trap cleanup EXIT
+
+STATE_DIR="$(mktemp -d)"
+LOG_FILE="$(mktemp)"
+
+# Isolated state dir so the test never touches ~/.openclaw
+export OPENCLAW_STATE_DIR="$STATE_DIR"
+# Skip legacy-dir scan to speed up startup
+export OPENCLAW_TEST_FAST="1"
+# Prevent entry.js from re-spawning itself (would make the PID useless)
+export OPENCLAW_NO_RESPAWN="1"
+
+GW_TOKEN="ci-smoke-$$"
+
+run_pass() {
+  local pass_name="$1"
+  GW_PID=""
+  >"$LOG_FILE"
+
+  echo "[smoke-test] $pass_name: starting gateway..."
+  (cd "$CLAWDBOT_DIR" && node dist/entry.js gateway run \
+    --allow-unconfigured \
+    --bind loopback \
+    --auth token \
+    --token "$GW_TOKEN" \
+    --port "$PORT") >>"$LOG_FILE" 2>&1 &
+  GW_PID=$!
+
+  # Poll until "ready (" appears (emitted by server-startup-log after plugin
+  # registration completes and the WS server is listening), or bail on timeout/exit.
+  local ticks=0
+  local max_ticks=$(( TIMEOUT_S * 2 ))
+  while ! grep -qF "ready (" "$LOG_FILE" 2>/dev/null; do
+    if ! kill -0 "$GW_PID" 2>/dev/null; then
+      echo "[smoke-test] FAIL: $pass_name — gateway exited before reaching ready state"
+      echo "--- gateway output ---" >&2
+      cat "$LOG_FILE" >&2
+      exit 1
+    fi
+    if (( ticks >= max_ticks )); then
+      echo "[smoke-test] FAIL: $pass_name — gateway did not reach ready state within ${TIMEOUT_S}s"
+      echo "--- gateway output ---" >&2
+      cat "$LOG_FILE" >&2
+      exit 1
+    fi
+    sleep 0.5
+    ticks=$(( ticks + 1 ))
+  done
+
+  kill "$GW_PID" 2>/dev/null || true
+  wait "$GW_PID" 2>/dev/null || true
+  GW_PID=""
+
+  if grep -qF "plugin failed during register" "$LOG_FILE"; then
+    echo "[smoke-test] FAIL: $pass_name — plugin registration errors:"
+    grep "plugin failed during register" "$LOG_FILE" >&2
+    exit 1
+  fi
+
+  echo "[smoke-test] $pass_name: OK"
+}
+
+run_pass "cold start (no mirror dirs)"
+run_pass "warm start (mirror dirs exist from cold start)"
+
+echo "[smoke-test] All plugin registration checks passed."

--- a/src/scripts/smoke-test-gateway-plugins.sh
+++ b/src/scripts/smoke-test-gateway-plugins.sh
@@ -13,7 +13,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAWDBOT_DIR="$(cd "$SCRIPT_DIR/../src-tauri/resources/clawdbot" && pwd)"
 PORT=28789
-TIMEOUT_S=90
+# Browser plugin downloads playwright-core (~30 MB) on cold start; allow enough
+# headroom for a slow CI network while keeping the overall bound reasonable.
+TIMEOUT_S=180
 
 STATE_DIR=""
 LOG_FILE=""
@@ -50,6 +52,7 @@ run_pass() {
   (cd "$CLAWDBOT_DIR" && node dist/entry.js gateway run \
     --allow-unconfigured \
     --verbose \
+    --force \
     --bind loopback \
     --auth token \
     --token "$GW_TOKEN" \
@@ -80,6 +83,9 @@ run_pass() {
   kill "$GW_PID" 2>/dev/null || true
   wait "$GW_PID" 2>/dev/null || true
   GW_PID=""
+
+  # Brief pause to ensure the port is fully released before the next pass.
+  sleep 2
 
   if grep -qF "plugin failed during register" "$LOG_FILE"; then
     echo "[smoke-test] FAIL: $pass_name — plugin registration errors:"

--- a/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-CuaPBWeD.js
+++ b/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-CuaPBWeD.js
@@ -71,7 +71,16 @@ function mirrorBundledPluginRuntimeRoot(params) {
 			recursive: true,
 			force: true
 		});
-		fs.renameSync(stagedRoot, mirrorRoot);
+		try {
+			fs.renameSync(stagedRoot, mirrorRoot);
+		} catch (renameErr) {
+			if (renameErr.code === 'ENOTEMPTY' || renameErr.code === 'EEXIST') {
+				fs.rmSync(mirrorRoot, { recursive: true, force: true });
+				fs.renameSync(stagedRoot, mirrorRoot);
+			} else {
+				throw renameErr;
+			}
+		}
 	} finally {
 		fs.rmSync(tempDir, {
 			recursive: true,
@@ -180,10 +189,11 @@ function ensureOpenClawPluginSdkAlias(distRoot) {
 			"./plugin-sdk/*": "./plugin-sdk/*.js"
 		}
 	});
-	fs.rmSync(pluginSdkAliasDir, {
-		recursive: true,
-		force: true
-	});
+	try {
+		if (fs.existsSync(pluginSdkAliasDir) && !fs.lstatSync(pluginSdkAliasDir).isDirectory()) {
+			fs.rmSync(pluginSdkAliasDir, { recursive: true, force: true });
+		}
+	} catch {}
 	fs.mkdirSync(pluginSdkAliasDir, { recursive: true });
 	for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
 		if (!entry.isFile() || path.extname(entry.name) !== ".js") continue;

--- a/src/src-tauri/resources/clawdbot/dist/loader-NucjcOgv.js
+++ b/src/src-tauri/resources/clawdbot/dist/loader-NucjcOgv.js
@@ -2061,7 +2061,16 @@ function mirrorBundledPluginRuntimeRoot(params) {
 			recursive: true,
 			force: true
 		});
-		fs.renameSync(stagedRoot, mirrorRoot);
+		try {
+			fs.renameSync(stagedRoot, mirrorRoot);
+		} catch (renameErr) {
+			if (renameErr.code === 'ENOTEMPTY' || renameErr.code === 'EEXIST') {
+				fs.rmSync(mirrorRoot, { recursive: true, force: true });
+				fs.renameSync(stagedRoot, mirrorRoot);
+			} else {
+				throw renameErr;
+			}
+		}
 	} finally {
 		fs.rmSync(tempDir, {
 			recursive: true,


### PR DESCRIPTION
## Summary
This PR fixes a race condition that occurs during concurrent plugin registration when multiple plugins attempt to mirror bundled runtime roots simultaneously. The issue manifests as `ENOTEMPTY` or `EEXIST` errors when the `fs.renameSync()` operation fails because the target directory already exists.

## Key Changes

- **Added retry logic for `fs.renameSync()`**: When renaming the staged mirror directory fails with `ENOTEMPTY` or `EEXIST`, the code now removes the existing target directory and retries the rename operation. This handles the case where concurrent plugins have already created the mirror directory.

- **Improved `ensureOpenClawPluginSdkAlias()` safety**: Added existence and type checking before attempting to remove the plugin SDK alias directory, with error suppression for edge cases where the directory state is uncertain.

- **Added smoke test for plugin registration**: Created `smoke-test-gateway-plugins.sh` that validates plugin registration under both cold start (no mirror dirs) and warm start (mirror dirs exist) conditions. This test exercises the concurrent registration path and ensures no filesystem errors occur.

- **Integrated smoke test into CI**: Added the smoke test to the macOS build workflow to catch registration issues early.

## Implementation Details

The fix uses a try-catch pattern around `fs.renameSync()` to detect and handle the specific error codes that indicate a race condition. When detected, it cleans up the conflicting directory and retries, ensuring that the operation completes successfully regardless of which concurrent plugin wins the race to create the mirror directory first.

The smoke test runs the gateway twice with the same state directory—once to create mirror directories (cold start) and once to reuse them (warm start)—verifying that plugin registration succeeds in both scenarios.

https://claude.ai/code/session_011rDNnDQ9YxtwtZzBN6Avh3