### PR TITLE
Improve rate-limit handling and first-run curator behavior

### DIFF
--- a/src/src-tauri/src/db/models/workspace.rs
+++ b/src/src-tauri/src/db/models/workspace.rs
@@ -587,6 +587,17 @@ impl WorkspaceDocument {
         Ok(docs)
     }
 
+    /// Count documents whose `auto_tags` is null — used to detect first-run scenarios.
+    pub fn count_untagged() -> Result<i64, Error> {
+        let connection = get_db_conn();
+        let count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM workspace_documents WHERE auto_tags IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
     /// Update tags for a document.
     pub fn update_tags(id: u64, tags: Option<String>) -> Result<(), Error> {
         let connection = get_db_conn();

--- a/src/src-tauri/src/library_curator/mod.rs
+++ b/src/src-tauri/src/library_curator/mod.rs
@@ -21,9 +21,10 @@ use crate::error::Error;
 /// How often the curator wakes up to look for new data to ingest.
 const CURATOR_INTERVAL_SECS: u64 = 30 * 60; // 30 minutes
 
-/// How long to wait after app startup before the first run, so we don't fight
-/// the sync pipeline for connections that are still authenticating.
-const CURATOR_STARTUP_DELAY_SECS: u64 = 60;
+/// How long to wait after app startup before the first run. 120s gives email
+/// sync time to settle before the curator's LLM calls begin, avoiding overlap
+/// that would cause rate-limit errors on first launch.
+const CURATOR_STARTUP_DELAY_SECS: u64 = 120;
 
 /// Drive the curator forever from a dedicated tokio runtime. Call this from
 /// inside `Runtime::block_on(...)` on a worker thread spawned at startup.

--- a/src/src-tauri/src/library_curator/retag.rs
+++ b/src/src-tauri/src/library_curator/retag.rs
@@ -16,7 +16,15 @@ use crate::error::Error;
 use crate::llm::types::{Message as LlmMessage, MessageSender};
 use crate::llm::use_cases::complete::multi_provider_completion;
 
+/// Normal per-pass cap.
 const MAX_PER_PASS: i64 = 25;
+/// Reduced cap when many untagged docs exist (first-run / large initial sync).
+/// Spreads the work across curator intervals instead of blasting the API at launch.
+const MAX_PER_PASS_FIRST_RUN: i64 = 5;
+/// If more than this many docs need tagging we treat it as a first-run scenario.
+const FIRST_RUN_THRESHOLD: i64 = 10;
+/// Pause between LLM calls to avoid rate-limit bursts.
+const INTER_CALL_DELAY_MS: u64 = 500;
 const MAX_BODY_CHARS: usize = 4_000;
 
 #[derive(Debug, Deserialize)]
@@ -28,7 +36,18 @@ struct TagResponse {
 }
 
 pub async fn retag_stale() -> Result<(), Error> {
-    let docs = WorkspaceDocument::find_untagged(MAX_PER_PASS)?;
+    let total_untagged = WorkspaceDocument::count_untagged().unwrap_or(0);
+    let limit = if total_untagged > FIRST_RUN_THRESHOLD {
+        log::info!(
+            "[library_curator/retag] {} untagged docs — first-run mode, capping at {}",
+            total_untagged, MAX_PER_PASS_FIRST_RUN
+        );
+        MAX_PER_PASS_FIRST_RUN
+    } else {
+        MAX_PER_PASS
+    };
+
+    let docs = WorkspaceDocument::find_untagged(limit)?;
     if docs.is_empty() {
         log::info!("[library_curator/retag] no stale documents");
         return Ok(());
@@ -63,6 +82,7 @@ pub async fn retag_stale() -> Result<(), Error> {
                 // On failure, leave auto_tags NULL so we retry next pass.
             }
         }
+        tokio::time::sleep(tokio::time::Duration::from_millis(INTER_CALL_DELAY_MS)).await;
     }
     Ok(())
 }

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -314,6 +314,24 @@ fn is_retryable_status(status: reqwest::StatusCode) -> bool {
     || status == reqwest::StatusCode::GATEWAY_TIMEOUT
 }
 
+/// Parse the wait time from a 429 response body.
+/// Providers embed text like "Please try again in 4.183s" or "retry in 60 seconds".
+/// Falls back to exponential backoff when the body doesn't contain a clear value.
+fn parse_retry_after(text: &str, attempt: u32) -> f64 {
+  let patterns = ["try again in ", "retry in ", "wait "];
+  for pattern in patterns {
+    if let Some(idx) = text.find(pattern) {
+      let rest = &text[idx + pattern.len()..];
+      let num_str: String = rest.chars().take_while(|c| c.is_numeric() || *c == '.').collect();
+      if let Ok(secs) = num_str.parse::<f64>() {
+        return (secs + 1.0).max(1.0); // small buffer above the stated window
+      }
+    }
+  }
+  // Default: exponential backoff capped at 60s
+  (2u64.pow(attempt + 1) as f64).min(60.0)
+}
+
 /// Call an OpenAI-compatible chat completions endpoint (works for OpenAI, Groq, Gemini).
 /// Retries up to 3 times on transient failures with exponential backoff.
 async fn openai_compatible_completion(
@@ -377,9 +395,9 @@ async fn openai_compatible_completion(
       Err(e) => {
         last_error = format!("{} request failed: {}", provider.name, e);
         if attempt < max_retries - 1 {
-          let wait = 2u64.pow(attempt as u32 + 1);
-          log::warn!("[completion] {} (attempt {}/{}), retrying in {}s...", last_error, attempt + 1, max_retries, wait);
-          tokio::time::sleep(tokio::time::Duration::from_secs(wait)).await;
+          let wait = parse_retry_after(&last_error, attempt as u32);
+          log::warn!("[completion] {} (attempt {}/{}), retrying in {:.1}s...", last_error, attempt + 1, max_retries, wait);
+          tokio::time::sleep(tokio::time::Duration::from_secs_f64(wait)).await;
           continue;
         }
         return Err(LLMError::ChatCompletionFailed(last_error));
@@ -415,12 +433,12 @@ async fn openai_compatible_completion(
 
     // Retry on transient errors (429, 500, 502, 503, 504)
     if is_retryable_status(status) && attempt < max_retries - 1 {
-      let wait = 2u64.pow(attempt as u32 + 1);
+      let wait = parse_retry_after(&text, attempt as u32);
       log::warn!(
-        "[completion] {} error {} (attempt {}/{}), retrying in {}s...",
+        "[completion] {} error {} (attempt {}/{}), retrying in {:.1}s...",
         provider.name, status, attempt + 1, max_retries, wait
       );
-      tokio::time::sleep(tokio::time::Duration::from_secs(wait)).await;
+      tokio::time::sleep(tokio::time::Duration::from_secs_f64(wait)).await;
       last_error = format!("{} error ({}): {}", provider.name, status, text);
       continue;
     }
@@ -493,9 +511,9 @@ async fn anthropic_completion(
       Err(e) => {
         last_error = format!("Anthropic request failed: {}", e);
         if attempt < max_retries - 1 {
-          let wait = 2u64.pow(attempt as u32 + 1);
-          log::warn!("[completion] {} (attempt {}/{}), retrying in {}s...", last_error, attempt + 1, max_retries, wait);
-          tokio::time::sleep(tokio::time::Duration::from_secs(wait)).await;
+          let wait = parse_retry_after(&last_error, attempt as u32);
+          log::warn!("[completion] {} (attempt {}/{}), retrying in {:.1}s...", last_error, attempt + 1, max_retries, wait);
+          tokio::time::sleep(tokio::time::Duration::from_secs_f64(wait)).await;
           continue;
         }
         return Err(LLMError::ChatCompletionFailed(last_error));
@@ -531,12 +549,12 @@ async fn anthropic_completion(
 
     // Retry on transient errors
     if is_retryable_status(status) && attempt < max_retries - 1 {
-      let wait = 2u64.pow(attempt as u32 + 1);
+      let wait = parse_retry_after(&text, attempt as u32);
       log::warn!(
-        "[completion] Anthropic error {} (attempt {}/{}), retrying in {}s...",
+        "[completion] Anthropic error {} (attempt {}/{}), retrying in {:.1}s...",
         status, attempt + 1, max_retries, wait
       );
-      tokio::time::sleep(tokio::time::Duration::from_secs(wait)).await;
+      tokio::time::sleep(tokio::time::Duration::from_secs_f64(wait)).await;
       last_error = format!("Anthropic error ({}): {}", status, text);
       continue;
     }

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -831,7 +831,7 @@ export function useFeed(
         const batch = newMessages.slice(i, i + BATCH_SIZE)
         executeClassification(batch)
 
-        await new Promise(resolve => setTimeout(resolve, 100))
+        await new Promise(resolve => setTimeout(resolve, 1000))
       }
 
       setTimeout(() => {


### PR DESCRIPTION
## Summary
This PR enhances rate-limit resilience and optimizes the library curator's behavior during initial setup by implementing smarter retry logic and adaptive workload distribution.

## Key Changes

**Rate-Limit Handling (`complete.rs`)**
- Added `parse_retry_after()` function to extract wait times from 429 response bodies (e.g., "retry in 60 seconds")
- Falls back to exponential backoff (capped at 60s) when providers don't specify a wait time
- Updated both OpenAI-compatible and Anthropic completion endpoints to use the new parser
- Changed sleep calls to use `from_secs_f64()` to support fractional second delays
- Improved logging to show precise wait times with one decimal place

**First-Run Curator Optimization (`retag.rs` & `workspace.rs`)**
- Added `count_untagged()` database method to detect first-run scenarios (many untagged documents)
- Implemented adaptive rate limiting: reduces per-pass document limit from 25 to 5 when >10 untagged docs exist
- Added 500ms inter-call delay between LLM requests to avoid burst rate-limiting
- Logs first-run detection to help with debugging

**Curator Startup Timing (`mod.rs`)**
- Increased initial startup delay from 60s to 120s to allow email sync to settle before LLM calls begin
- Updated comment to clarify the rationale: prevents overlap that causes rate-limit errors on first launch

**Frontend Batching (`useFeed.tsx`)**
- Increased batch processing delay from 100ms to 1000ms to reduce classification request frequency

## Implementation Details
- The retry parser handles multiple common patterns: "try again in", "retry in", "wait"
- Adds a 1-second buffer above stated wait times for safety
- First-run detection is automatic and transparent—no configuration needed
- All changes maintain backward compatibility with existing retry logic

https://claude.ai/code/session_01MvJNpc56rceyyBVKUzpfR8