### PR TITLE
Fix Tauri glob cycle by deferring openclaw self-link creation

### DIFF
--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -240,8 +240,24 @@ if (fs.existsSync(distExtensionsDir)) {
   } catch { /* skip */ }
 }
 
-// Step 5: Report results
-console.log('[prune-clawdbot] 5/5 Computing final sizes...');
+// Step 5: Remove the openclaw self-symlink before Tauri resource bundling.
+// install-bundled-plugin-deps.cjs creates node_modules/openclaw -> .. so the
+// CI smoke test (which runs before prune) can resolve 'openclaw/plugin-sdk/*'
+// imports.  But 'openclaw -> ..' is a cycle: Tauri's 'resources/clawdbot/**/*'
+// glob follows it and recurses into clawdbot/ infinitely, causing the macOS
+// build to spin for hours before failing.  Remove it here; service.rs recreates
+// it at runtime after Tauri has already copied resources to their final location.
+const openclawLink = path.join(nodeModules, 'openclaw');
+try {
+  const linkStat = fs.lstatSync(openclawLink);
+  if (linkStat.isSymbolicLink()) {
+    fs.unlinkSync(openclawLink);
+    console.log('[prune-clawdbot] Removed openclaw self-symlink (prevents Tauri glob cycle)');
+  }
+} catch { /* not present — nothing to do */ }
+
+// Step 6: Report results
+console.log('[prune-clawdbot] 6/6 Computing final sizes...');
 const afterNM = getDirSizeMB(nodeModules);
 const afterExt = getDirSizeMB(extensionsDir);
 const totalSaved = (beforeNM + beforeExt) - (afterNM + afterExt);

--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -129,9 +129,11 @@ if (fs.existsSync(buildInfoPath)) {
 // These are the packages required by the gateway startup path — if any are missing
 // the gateway crashes immediately with ERR_MODULE_NOT_FOUND.
 const CRITICAL_PACKAGES = [
-  // Self-link: the clawdbot package IS openclaw; extensions import openclaw/plugin-sdk/*
-  // via this symlink (node_modules/openclaw -> ..).  Missing = plugins crash on load.
-  'openclaw',
+  // NOTE: 'openclaw' self-symlink is intentionally absent.  It is created by
+  // install-bundled-plugin-deps.cjs for the CI smoke test, but prune-clawdbot.cjs
+  // removes it before the Tauri build to prevent Tauri's resources/clawdbot/**/*
+  // glob from following the cycle (openclaw -> ..) and spinning forever.
+  // service.rs recreates it at runtime after resource extraction.
   'chalk',
   'commander',
   'chokidar',

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -538,6 +538,10 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
     }
   }
 
+  // Always recreate the openclaw self-symlink regardless of whether any deps
+  // need installing — it must survive app updates where the bundle is replaced.
+  ensure_openclaw_self_link(&root_nm);
+
   if missing_root.is_empty() {
     return;
   }
@@ -581,12 +585,6 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
     ),
   }
 
-  // Pass 3: Recreate the openclaw self-symlink (node_modules/openclaw -> ..).
-  // prune-clawdbot.cjs removes this symlink before the Tauri build to prevent
-  // Tauri's resources/clawdbot/**/* glob from following the cycle and looping
-  // forever.  Bundled extensions import 'openclaw/plugin-sdk/*' at runtime, so
-  // the symlink must exist in the deployed node_modules directory.
-  ensure_openclaw_self_link(&root_nm);
 }
 
 /// Create `node_modules/openclaw -> ..` (or a junction on Windows) so that

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -580,6 +580,53 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
       e
     ),
   }
+
+  // Pass 3: Recreate the openclaw self-symlink (node_modules/openclaw -> ..).
+  // prune-clawdbot.cjs removes this symlink before the Tauri build to prevent
+  // Tauri's resources/clawdbot/**/* glob from following the cycle and looping
+  // forever.  Bundled extensions import 'openclaw/plugin-sdk/*' at runtime, so
+  // the symlink must exist in the deployed node_modules directory.
+  ensure_openclaw_self_link(&root_nm);
+}
+
+/// Create `node_modules/openclaw -> ..` (or a junction on Windows) so that
+/// bundled extensions can resolve `openclaw/plugin-sdk/*` imports at runtime.
+/// This symlink is removed by prune-clawdbot.cjs before the Tauri build (to
+/// avoid an infinite glob cycle), so it must be recreated here at startup.
+fn ensure_openclaw_self_link(root_nm: &std::path::Path) {
+  let link_path = root_nm.join("openclaw");
+  if link_path.exists() || link_path.symlink_metadata().is_ok() {
+    return; // already present
+  }
+
+  #[cfg(target_os = "windows")]
+  {
+    // Use mklink /J to create a directory junction — no elevation required.
+    // Symlinks (mklink /D) require SeCreateSymbolicLinkPrivilege; junctions don't.
+    let parent = root_nm.parent().unwrap_or(root_nm);
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let status = std::process::Command::new("cmd")
+      .args(["/c", "mklink", "/J"])
+      .arg(&link_path)
+      .arg(parent)
+      .creation_flags(CREATE_NO_WINDOW)
+      .status();
+    match status {
+      Ok(s) if s.success() => eprintln!("[clawd/service] Created openclaw junction in node_modules"),
+      Ok(s) => eprintln!("[clawd/service] WARNING: mklink /J for openclaw exited {}", s),
+      Err(e) => eprintln!("[clawd/service] WARNING: mklink /J for openclaw failed: {}", e),
+    }
+  }
+
+  #[cfg(not(target_os = "windows"))]
+  {
+    match std::os::unix::fs::symlink("..", &link_path) {
+      Ok(()) => eprintln!("[clawd/service] Created openclaw self-link in node_modules"),
+      Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+      Err(e) => eprintln!("[clawd/service] WARNING: could not create openclaw self-link: {}", e),
+    }
+  }
 }
 
 /// Check if the gateway Node.js binary or the bundled clawdbot directory is


### PR DESCRIPTION
## Summary
Resolves an infinite glob cycle during the Tauri build process by moving the creation of the `node_modules/openclaw` self-link from the bundling phase to runtime. The symlink is now removed before Tauri's resource bundling and recreated by the service at startup.

## Key Changes
- **service.rs**: Added `ensure_openclaw_self_link()` function that recreates the `node_modules/openclaw -> ..` symlink at service startup
  - Uses directory junctions (`mklink /J`) on Windows to avoid requiring elevated privileges
  - Uses standard symlinks on Unix-like systems
  - Gracefully handles cases where the link already exists
  
- **prune-clawdbot.cjs**: Added Step 5 to explicitly remove the `openclaw` self-symlink before Tauri resource bundling
  - Prevents Tauri's `resources/clawdbot/**/*` glob from following the cyclic symlink and recursing infinitely
  - Includes detailed comments explaining why this is necessary
  
- **verify-clawdbot-bundle.cjs**: Updated to remove `openclaw` from the `CRITICAL_PACKAGES` check
  - Added explanatory comment documenting the intentional absence and its lifecycle

## Implementation Details
- The symlink is created during the CI smoke test phase (before Tauri build) to allow bundled extensions to resolve `openclaw/plugin-sdk/*` imports
- It is removed by `prune-clawdbot.cjs` immediately before Tauri's resource bundling to prevent the infinite glob cycle
- It is recreated by `service.rs` at runtime after Tauri has already extracted resources to their final location, ensuring extensions can still resolve their imports
- Platform-specific handling: Windows uses junctions (no elevation required), Unix uses symlinks

https://claude.ai/code/session_01DfkAQicxzyvQ4tvzyD2Nox