### PR TITLE
fix: resolve enable "Load failed", bonjour staging failure, and misleading token refresh errors

### DIFF
--- a/src/scripts/install-bundled-plugin-deps.cjs
+++ b/src/scripts/install-bundled-plugin-deps.cjs
@@ -134,18 +134,37 @@ if (missingFromRoot.length === 0) {
   process.exit(0);
 }
 
+// Read root package.json overrides — packages listed there cannot be installed
+// as direct deps (npm throws EOVERRIDE).  Skip them; they're already managed.
+let rootOverrides = new Set();
+try {
+  const rootPkg = JSON.parse(fs.readFileSync(path.join(CLAWDBOT_DIR, 'package.json'), 'utf8'));
+  for (const key of Object.keys(rootPkg.overrides || {})) rootOverrides.add(key);
+  for (const key of Object.keys(rootPkg.pnpm?.overrides || {})) rootOverrides.add(key);
+} catch { /* ignore */ }
+
 console.log(
   `[install-bundled-plugin-deps] Pass 2: installing ${missingFromRoot.length} dep(s) into root node_modules: ${missingFromRoot.join(', ')}...`,
 );
-try {
-  execSync(
-    `npm install ${missingFromRoot.join(' ')} --no-save --omit=dev --ignore-scripts --no-audit --no-fund`,
-    { cwd: CLAWDBOT_DIR, stdio: 'inherit' },
-  );
-  console.log('[install-bundled-plugin-deps] Pass 2: done.');
-} catch (err) {
-  console.warn(`[install-bundled-plugin-deps] WARNING: Pass 2 root npm install failed: ${err.message}`);
+let pass2Installed = 0;
+let pass2Skipped = 0;
+for (const dep of missingFromRoot) {
+  if (rootOverrides.has(dep)) {
+    console.log(`[install-bundled-plugin-deps] Pass 2: skipping ${dep} (managed by overrides)`);
+    pass2Skipped++;
+    continue;
+  }
+  try {
+    execSync(
+      `npm install ${dep} --no-save --omit=dev --ignore-scripts --no-audit --no-fund`,
+      { cwd: CLAWDBOT_DIR, stdio: 'inherit' },
+    );
+    pass2Installed++;
+  } catch (err) {
+    console.warn(`[install-bundled-plugin-deps] WARNING: Pass 2 install failed for ${dep}: ${err.message.split('\n')[0]}`);
+  }
 }
+console.log(`[install-bundled-plugin-deps] Pass 2: done (installed=${pass2Installed} skipped=${pass2Skipped}).`);
 
 // Create a self-referencing symlink so that bundled extensions can resolve
 // `openclaw/plugin-sdk/*` imports.  The clawdbot package IS the openclaw

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -4610,29 +4610,35 @@ pub async fn set_service_enabled(
         }
       }
 
-      // Run "openclaw doctor --fix" to auto-migrate config for the new
-      // version (e.g. WhatsApp allowFrom validation, Telegram streaming rename).
+      // Run "openclaw doctor --fix" in a background thread — same reason as
+      // macOS: Node.js can hang on DNS failure, which would block the HTTP
+      // response and cause WebKit to report "TypeError: Load failed".
       {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW_DOCTOR: u32 = 0x08000000;
-        let mut doctor_cmd = std::process::Command::new(&setup.program_args[0]);
-        doctor_cmd
-          .arg(&setup.program_args[1])
-          .args(["doctor", "--fix"])
-          .envs(setup.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
-          .current_dir(&setup.working_dir)
-          .creation_flags(CREATE_NO_WINDOW_DOCTOR);
-        match doctor_cmd.output() {
-          Ok(out) => {
-            if !out.status.success() {
-              let stderr = String::from_utf8_lossy(&out.stderr);
-              eprintln!("[clawd/service] openclaw doctor --fix exited with {}: {}", out.status, stderr.chars().take(500).collect::<String>());
-            } else {
-              eprintln!("[clawd/service] openclaw doctor --fix completed successfully");
+        let doctor_args = setup.program_args.clone();
+        let doctor_env_map: Vec<(String, String)> = setup.env.clone();
+        let doctor_dir = setup.working_dir.clone();
+        std::thread::spawn(move || {
+          let mut doctor_cmd = std::process::Command::new(&doctor_args[0]);
+          doctor_cmd
+            .arg(&doctor_args[1])
+            .args(["doctor", "--fix"])
+            .envs(doctor_env_map.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .current_dir(&doctor_dir)
+            .creation_flags(CREATE_NO_WINDOW_DOCTOR);
+          match doctor_cmd.output() {
+            Ok(out) => {
+              if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                eprintln!("[clawd/service] openclaw doctor --fix exited with {}: {}", out.status, stderr.chars().take(500).collect::<String>());
+              } else {
+                eprintln!("[clawd/service] openclaw doctor --fix completed successfully");
+              }
             }
+            Err(e) => eprintln!("[clawd/service] WARNING: failed to run openclaw doctor --fix: {}", e),
           }
-          Err(e) => eprintln!("[clawd/service] WARNING: failed to run openclaw doctor --fix: {}", e),
-        }
+        });
       }
 
       // Spawn the gateway process
@@ -5695,29 +5701,36 @@ pub async fn set_service_enabled(
       // Save for plist regeneration when the API key changes later.
       *LAST_MACOS_PLIST_ARGS.lock().unwrap() = Some((program_args.clone(), env.clone()));
 
-      // Run "openclaw doctor --fix" to auto-migrate config for the new
-      // version (e.g. WhatsApp allowFrom validation, Telegram streaming rename).
-      // This is a quick, idempotent command that exits immediately.
+      // Run "openclaw doctor --fix" in a background thread so it never blocks
+      // the HTTP response.  On machines with DNS issues Node.js can hang for
+      // 30+ seconds while the runtime attempts an update check, which would
+      // cause WebKit to drop the connection and report "TypeError: Load failed".
+      // Doctor is idempotent; the gateway takes a few seconds to start, so
+      // any config migration it writes will be in place before the first read.
       {
+        let doctor_node = node_path.clone();
+        let doctor_entry = clawdbot_entry.clone();
         let doctor_env: Vec<(String, String)> = env.clone();
-        let mut doctor_cmd = std::process::Command::new(node_path.as_os_str());
-        doctor_cmd
-          .arg(clawdbot_entry.as_os_str())
-          .args(["doctor", "--fix"]);
-        for (k, v) in &doctor_env {
-          doctor_cmd.env(k, v);
-        }
-        match doctor_cmd.output() {
-          Ok(out) => {
-            if !out.status.success() {
-              let stderr = String::from_utf8_lossy(&out.stderr);
-              eprintln!("[clawd/service] openclaw doctor --fix exited with {}: {}", out.status, stderr.chars().take(500).collect::<String>());
-            } else {
-              eprintln!("[clawd/service] openclaw doctor --fix completed successfully");
-            }
+        std::thread::spawn(move || {
+          let mut doctor_cmd = std::process::Command::new(doctor_node.as_os_str());
+          doctor_cmd
+            .arg(doctor_entry.as_os_str())
+            .args(["doctor", "--fix"]);
+          for (k, v) in &doctor_env {
+            doctor_cmd.env(k, v);
           }
-          Err(e) => eprintln!("[clawd/service] WARNING: failed to run openclaw doctor --fix: {}", e),
-        }
+          match doctor_cmd.output() {
+            Ok(out) => {
+              if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                eprintln!("[clawd/service] openclaw doctor --fix exited with {}: {}", out.status, stderr.chars().take(500).collect::<String>());
+              } else {
+                eprintln!("[clawd/service] openclaw doctor --fix completed successfully");
+              }
+            }
+            Err(e) => eprintln!("[clawd/service] WARNING: failed to run openclaw doctor --fix: {}", e),
+          }
+        });
       }
 
       // Kill any stale Chrome processes from a previous clawdbot session so

--- a/src/src-tauri/src/connections/google/auth.rs
+++ b/src/src-tauri/src/connections/google/auth.rs
@@ -628,8 +628,7 @@ pub async fn refresh_connection_token(email: String, user_connection: UserConnec
   match google_refresh_token(email, user_connection.clone().token).await {
     Ok(access_token) => Ok(access_token),
     Err(err) => {
-      knap_log_error("Failed to refresh connection token".to_string(), Some(err), None);
-      Err(Error::KSError(format!("Invalid refresh token")))
+      Err(knap_log_error("Failed to refresh connection token".to_string(), Some(err), None))
     }
   }
 }

--- a/src/src-tauri/src/connections/microsoft/auth.rs
+++ b/src/src-tauri/src/connections/microsoft/auth.rs
@@ -307,8 +307,7 @@ pub async fn refresh_user_connection(user_connection: UserConnection, email: Str
   ).await {
     Ok(response) => response,
     Err(err) => {
-      knap_log_error("Failed to refresh connection token".to_string(), Some(err), None);
-      return Err(Error::KSError(format!("Invalid refresh token")))
+      return Err(knap_log_error("Failed to refresh connection token".to_string(), Some(err), None))
     }
   };
   let updated_user_connection = UserConnection {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **"TypeError: Load failed" when clicking `enable` in Terminal** — `openclaw doctor --fix` was blocking the async HTTP handler. On machines with DNS issues (like the bankaya tester), Node.js hangs 30+ seconds doing network ops, causing WebKit to drop the connection. Now runs in a detached background thread on both macOS and Windows.

- **Bonjour plugin stuck in announcing loop** — `@homebridge/ciao` (required by the bonjour plugin) was never making it into the `.app` bundle. The Pass 2 bulk install in `install-bundled-plugin-deps.cjs` was aborting entirely due to an `EOVERRIDE` conflict with `@anthropic-ai/sdk` in the root `package.json`. Fixed by installing packages one-by-one and skipping those managed by overrides. Next CI build will bundle the dep so the gateway no longer tries (and fails) to `npm install` into the read-only app bundle at runtime.

- **"Invalid refresh token" masking network errors** — Google/Microsoft token refresh failures caused by DNS/network outages were being logged with the real error but then discarded and replaced with the generic `"Invalid refresh token"`. Callers now receive the actual error so logs correctly distinguish network failures from credential problems.

## Test plan

- [ ] On a machine with intermittent network, click `enable` in the Clawd Terminal — should succeed without "Load failed"
- [ ] Check gateway logs after enable — bonjour plugin should initialize without "failed to stage bundled runtime deps" error
- [ ] Trigger a Google Calendar sync while offline — system logs should show the real network error, not "Invalid refresh token"
- [ ] CI macOS build should include `@homebridge/ciao` in the bonjour plugin's `node_modules`

https://claude.ai/code/session_01DfkAQicxzyvQ4tvzyD2Nox
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfkAQicxzyvQ4tvzyD2Nox)_