### PR TITLE
fix: update Tauri updater public key to new passwordless keypair

### DIFF
--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -201,7 +201,7 @@
         "https://github.com/knap-ai/knapsack_desktop/releases/latest/download/latest.json"
       ],
       "dialog": false,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkwRDYxMTdERUZBOUU3MDIKUldRQzU2bnZmUkhXa1BOczhwVVNIVXZmcFFFOVUyNmpyMUN2RnpIMk9SM29EM28xZE00NWlDc0IK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDM3RTg2NTAzQTBCQjg0NTMKUldSVGhMdWdBMlhvTjlPTXN1RkkyY1Vhdnl2dHkrSVFxL3Y5Um4xb3puL0FMdkdicHZ4UUFINUEK"
     },
     "systemTray": {
       "iconPath": "icons/32x32.png",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updates the Tauri updater `pubkey` in `tauri.conf.json` to match a new keypair generated without a password (`37E86503A0BB8453`)
- The previous key (`90D6117DEFA9E702`) required `TAURI_KEY_PASSWORD` to be set in CI, which was missing/wrong and caused every macOS build to fail at the updater signing step with `"Wrong password for that key"`

## Required secrets update (already done)

In GitHub → Settings → Secrets and variables → Actions:
- `TAURI_PRIVATE_KEY` — updated to the new private key
- `TAURI_KEY_PASSWORD` — can be empty or removed

## Test plan

- [ ] macOS CI build completes without `incorrect updater private key password` error
- [ ] `.app.tar.gz.sig` updater signature is produced successfully

https://claude.ai/code/session_01DfkAQicxzyvQ4tvzyD2Nox
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfkAQicxzyvQ4tvzyD2Nox)_