### PR TITLE
Add live recording banner and auto-attach to calendar events

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -148,6 +148,7 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
       setPersonWorkspaces(map)
     }).catch(() => {})
   }, [])
+  const [showLiveBanner, setShowLiveBanner] = useState(false)
   const [isTitleSet, setIsTitleSet] = useState(thread.subtitle !== 'Untitled Meeting')
   const [isEditingTitle, setIsEditingTitle] = useState(
     !thread.recorded && thread.subtitle === 'Untitled Meeting',
@@ -605,6 +606,34 @@ Output only the 3 sentences, nothing else.`,
         getEventUrl(meeting),
         isStart,
       )
+      // Show the live recording banner on first start
+      setShowLiveBanner(true)
+      // Auto-attach to the calendar event that best overlaps with the current time
+      if (!meeting && feed.meetings && feedItemId != null) {
+        const nowMs = Date.now()
+        const WINDOW_MS = 15 * 60 * 1000
+        let bestMatch: Meeting | null = null
+        let bestDist = Infinity
+        for (const m of Object.values(feed.meetings)) {
+          const startMs = m.start * 1000
+          const endMs = m.end * 1000
+          if (nowMs >= startMs - WINDOW_MS && nowMs <= endMs + WINDOW_MS) {
+            const dist = Math.abs(startMs - nowMs)
+            if (dist < bestDist) {
+              bestDist = dist
+              bestMatch = m
+            }
+          }
+        }
+        if (bestMatch) {
+          feed.attachNotesToCalendarEvent(feedItemId, bestMatch)
+          if (!isTitleSet) {
+            feed.renameMeeting(thread.id, bestMatch.title, feedItemId)
+            setEditableTitle(bestMatch.title)
+            setIsTitleSet(true)
+          }
+        }
+      }
     } catch (err: any) {
       const msg: string = err?.message || ''
       const isPermissionIssue = msg.includes('permission') || msg.includes('Permission') || msg.includes('Recording requires')
@@ -748,9 +777,9 @@ Output only the 3 sentences, nothing else.`,
                   />
                 ) : (
                   <h1
-                    className="notetaker-note__title"
-                    onClick={!thread.recorded ? () => { setIsEditingTitle(true) } : undefined}
-                    style={!thread.recorded ? { cursor: 'text' } : undefined}
+                    className="notetaker-note__title notetaker-note__title--editable"
+                    onClick={() => { setIsEditingTitle(true) }}
+                    title="Click to edit title"
                   >
                     {thread.subtitle}
                   </h1>
@@ -985,9 +1014,9 @@ Be direct, specific, and concise. No filler text.`
                 />
               ) : (
                 <h1
-                  className="notetaker-note__title"
-                  onClick={!thread.recorded ? () => { setIsEditingTitle(true) } : undefined}
-                  style={!thread.recorded ? { cursor: 'text' } : undefined}
+                  className="notetaker-note__title notetaker-note__title--editable"
+                  onClick={() => { setIsEditingTitle(true) }}
+                  title="Click to edit title"
                 >
                   {thread.subtitle}
                 </h1>
@@ -1106,6 +1135,37 @@ Be direct, specific, and concise. No filler text.`
         {/* Recording notice */}
         {recordingHandlers.isRecording(thread.id) && (
           <MeetingChatNotice meetingPlatform={meeting?.meeting_platform} />
+        )}
+
+        {/* Live recording welcome banner */}
+        {recordingHandlers.isRecording(thread.id) && showLiveBanner && (
+          <div className="notetaker-note__live-banner">
+            <div className="notetaker-note__live-banner-title">Live meeting</div>
+            <p className="notetaker-note__live-banner-line">
+              <span className="notetaker-note__live-banner-waveform" aria-hidden="true">
+                <span style={{animationDelay: '0ms'}} />
+                <span style={{animationDelay: '150ms'}} />
+                <span style={{animationDelay: '300ms'}} />
+                <span style={{animationDelay: '450ms'}} />
+              </span>
+              Knapsack is <span className="notetaker-note__live-banner-em">transcribing</span> your meeting.
+            </p>
+            <p className="notetaker-note__live-banner-line">
+              Write notes as you normally would. When the meeting ends, Knapsack will{' '}
+              <span className="notetaker-note__live-banner-em">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" style={{display:'inline',verticalAlign:'middle',marginRight:2}}>
+                  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
+                </svg>
+                enhance your notes
+              </span>.
+            </p>
+            <button
+              className="notetaker-note__live-banner-ok"
+              onClick={() => setShowLiveBanner(false)}
+            >
+              Okay
+            </button>
+          </div>
         )}
 
         {/* Attach-to-calendar-event prompt */}

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -276,6 +276,14 @@ html, body {
   line-height: 1.3;
 }
 
+.notetaker-note__title--editable {
+  cursor: text;
+}
+
+.notetaker-note__title--editable:hover {
+  color: #555555;
+}
+
 .notetaker-note__title-input {
   font-family: 'Lora', serif;
   font-size: 24px;
@@ -938,4 +946,82 @@ html, body {
   color: #2C3A6E;
   line-height: 1.55;
   margin: 0;
+}
+
+/* Live recording welcome banner */
+.notetaker-note__live-banner {
+  background: #ffffff;
+  border: 1px solid #e8e8e8;
+  border-radius: 14px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
+  padding: 28px 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 4px 0 8px;
+}
+
+.notetaker-note__live-banner-title {
+  font-family: 'Lora', serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 2px;
+}
+
+.notetaker-note__live-banner-line {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  color: #444444;
+  line-height: 1.55;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.notetaker-note__live-banner-em {
+  color: #6474AC;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.notetaker-note__live-banner-waveform {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 16px;
+  margin-right: 4px;
+  flex-shrink: 0;
+}
+
+.notetaker-note__live-banner-waveform span {
+  display: block;
+  width: 3px;
+  border-radius: 2px;
+  background: #6474AC;
+  animation: waveform-bounce 1.2s ease-in-out infinite;
+}
+
+.notetaker-note__live-banner-ok {
+  align-self: flex-start;
+  margin-top: 8px;
+  padding: 8px 22px;
+  border-radius: 8px;
+  border: 1px solid #d0d0d0;
+  background: #f7f7f7;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333333;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.notetaker-note__live-banner-ok:hover {
+  background: #eeeeee;
+  border-color: #bbbbbb;
 }


### PR DESCRIPTION
## Summary
This PR adds a welcome banner that displays when a live meeting recording starts, and implements automatic attachment of notes to the most relevant calendar event based on time overlap.

## Key Changes

- **Live Recording Banner**: Added a new dismissible banner that appears when recording starts, informing users that Knapsack is transcribing their meeting and will enhance notes when the meeting ends. The banner includes an animated waveform visualization and an "Okay" button to dismiss it.

- **Auto-Attach to Calendar Events**: Implemented logic to automatically attach notes to the calendar event that best overlaps with the current time (within a 15-minute window). If a matching event is found and the meeting title hasn't been set, the notes are automatically renamed to match the calendar event title.

- **Title Editing UX Improvements**: 
  - Moved cursor and hover styling from inline styles to a new `.notetaker-note__title--editable` CSS class
  - Made title editing always available (removed conditional check for `!thread.recorded`)
  - Added a "Click to edit title" tooltip for better discoverability

## Implementation Details

- The live banner state is managed with a `showLiveBanner` state variable that's set to `true` when recording starts
- Calendar event matching uses a 15-minute window (`WINDOW_MS`) on both sides of the current time to find the best overlapping event
- The banner includes an animated waveform with staggered animation delays for visual interest
- All new styles follow the existing design system with proper spacing, typography, and hover states

https://claude.ai/code/session_01L7weKi7Xp1bwpPHf7iraVS