### PR TITLE
UI fixes and skills catalog expansion

### DIFF
--- a/src/src-tauri/src/clawd/skills_catalog.json
+++ b/src/src-tauri/src/clawd/skills_catalog.json
@@ -52,6 +52,15 @@
   {"name":"goplaces","emoji":"📍","description":"Google Places search and discovery","source":"OpenClaw","eligible":false},
   {"name":"gifgrep","emoji":"🎞️","description":"GIF search and download","source":"OpenClaw","eligible":false},
 
+  {"name":"linear","emoji":"📐","description":"Linear issue tracking — create, update, and search issues and projects","source":"OpenClaw","eligible":false},
+  {"name":"sentry","emoji":"🚨","description":"Sentry error monitoring — view issues, stack traces, and release health","source":"OpenClaw","eligible":false},
+  {"name":"figma","emoji":"🎨","description":"Figma design — read files, generate designs, and implement components","source":"OpenClaw","eligible":false},
+  {"name":"jupyter-notebook","emoji":"📓","description":"Create and run Jupyter notebooks for data science and analysis","source":"OpenClaw","eligible":false},
+  {"name":"playwright","emoji":"🎭","description":"Browser automation and end-to-end testing with Playwright","source":"OpenClaw","eligible":false},
+  {"name":"vercel-deploy","emoji":"▲","description":"Deploy and manage projects on Vercel","source":"OpenClaw","eligible":false},
+  {"name":"netlify-deploy","emoji":"🌐","description":"Deploy and manage sites on Netlify","source":"OpenClaw","eligible":false},
+  {"name":"cloudflare-deploy","emoji":"🔶","description":"Deploy Workers, Pages, and resources on Cloudflare","source":"OpenClaw","eligible":false},
+
   {"name":"skill-creator","emoji":"🛠️","description":"Create custom skills","source":"OpenClaw","eligible":false},
   {"name":"clawhub","emoji":"🏪","description":"Discover and install skills from ClawHub","source":"OpenClaw","eligible":false},
   {"name":"healthcheck","emoji":"🔒","description":"Security hardening and auditing","source":"OpenClaw","eligible":false},


### PR DESCRIPTION
## Summary

- **Chat formatting**: Fixed code blocks being clipped on the right side (`overflow: hidden` → `overflow: visible` on `.ClawdBubble`)
- **Terminal formatting**: Fixed `## heading` lines causing `zsh: command not found: #` by stripping comment lines before sending to terminal; fixed PTY output line buffering so curl commands don't get word-wrapped into fragments
- **Skill discoverability**: Added contextual skill suggestions after AI responses — detects relevant skills from user message keywords and shows a nudge with one-click install or external link
- **Skills catalog — Anthropic**: Added Claude Code and Claude API as Anthropic-sourced entries
- **Skills catalog — MCP Market**: Added 10 top skills from mcpmarket.com (Persistent Memory, Code Review, Data Analyst, PDF Extractor, Web Scraper, Market Research, GitHub PR Review, Database Ops, Security Scanner, Image Generation)
- **Skills catalog — OpenAI curated**: Added 8 skills filling catalog gaps: Linear, Sentry, Figma, Jupyter Notebook, Playwright, Vercel, Netlify, Cloudflare deploy
- **Windows CI**: Fixed duplicate build runs on `claude/*` branches (push + pull_request both triggering) by adding a concurrency group; added `timeout-minutes: 240` safety cap

## Test plan

- [ ] Open chat, send a message related to a skill (e.g. "search the web for...") — skill nudge should appear after response
- [ ] Click "Install" on nudge — skill should install immediately
- [ ] Type "yes" in response to a nudge — should trigger install
- [ ] Open Skills panel — verify Anthropic and MCP Market sections appear with correct entries
- [ ] Verify code blocks in chat scroll horizontally and are not clipped
- [ ] Run a command with `## comment` lines in terminal — should not produce zsh errors
- [ ] Check Windows CI only fires one build per commit on a PR branch

https://claude.ai/code/session_01JSouuLDKC14CQCZ4QuRL7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSouuLDKC14CQCZ4QuRL7D)_