### PR TITLE
fix: detect jiti major-version mismatch and verify before build

### DIFF
--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -39,8 +39,23 @@ function needsMainInstall(clawdbotDir) {
   if (!fs.existsSync(nodeModules)) return true;
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(clawdbotDir, 'package.json'), 'utf8'));
-    const deps = Object.keys(pkg.dependencies || {});
-    return deps.some(dep => !fs.existsSync(path.join(nodeModules, dep)));
+    const deps = pkg.dependencies || {};
+    return Object.entries(deps).some(([dep, requiredVersion]) => {
+      const depDir = path.join(nodeModules, dep);
+      if (!fs.existsSync(depDir)) return true; // missing
+      // Check for major-version mismatch on ^-ranges (e.g. jiti@^2 installed as v1).
+      // npm install will correct it; we just need to detect it here.
+      const caretMatch = requiredVersion.match(/^\^(\d+)\./);
+      if (caretMatch) {
+        try {
+          const installed = JSON.parse(fs.readFileSync(path.join(depDir, 'package.json'), 'utf8'));
+          const installedMajor = parseInt((installed.version || '0').split('.')[0], 10);
+          const requiredMajor = parseInt(caretMatch[1], 10);
+          if (installedMajor !== requiredMajor) return true; // wrong major version
+        } catch { /* can't read version — leave it */ }
+      }
+      return false;
+    });
   } catch {
     return true;
   }

--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -159,7 +159,16 @@ const CRITICAL_PACKAGES = [
   '@modelcontextprotocol/sdk',
   '@slack/web-api',
   'file-type',
+  // jiti is used by gateway dist chunks for plugin loading.  Must be v2+
+  // (v2 exports createJiti; v1 does not, causing a runtime SyntaxError).
+  'jiti',
 ];
+
+// Packages that must be a specific minimum major version.
+// A wrong-major install (e.g. jiti v1 when v2 is required) is as bad as missing.
+const REQUIRED_MAJOR_VERSIONS = {
+  jiti: 2,
+};
 
 const nodeModulesDir = path.join(CLAWDBOT_DIR, 'node_modules');
 if (fs.existsSync(nodeModulesDir)) {
@@ -168,6 +177,21 @@ if (fs.existsSync(nodeModulesDir)) {
     const pkgJson = path.join(nodeModulesDir, pkg, 'package.json');
     if (!fs.existsSync(pkgJson)) {
       missing.push(pkg);
+      continue;
+    }
+    // Check minimum major version when required.
+    const minMajor = REQUIRED_MAJOR_VERSIONS[pkg];
+    if (minMajor !== undefined) {
+      try {
+        const installed = JSON.parse(fs.readFileSync(pkgJson, 'utf8'));
+        const installedMajor = parseInt((installed.version || '0').split('.')[0], 10);
+        if (installedMajor < minMajor) {
+          console.error(
+            `[verify-clawdbot] WRONG VERSION: node_modules/${pkg} is v${installed.version} — need v${minMajor}+`
+          );
+          errors++;
+        }
+      } catch { /* unreadable package.json — already caught as missing above */ }
     }
   }
   if (missing.length > 0) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`ensure-clawdbot-deps.cjs`**: `needsMainInstall()` now checks the installed package's major version against the `^major` range, not just directory existence. A jiti v1 install (incompatible with the v2 `createJiti` API used by the gateway) now triggers `npm install` to upgrade automatically.
- **`verify-clawdbot-bundle.cjs`**: Added `jiti` to `CRITICAL_PACKAGES` with a new `REQUIRED_MAJOR_VERSIONS` check. The CI prebuild verify step now fails explicitly if jiti is missing or the wrong major version — before `tauri build` rather than at runtime.

## Root cause

The gateway dist imports `{ createJiti }` from `jiti` (v2 API). If jiti v1 is resolved instead, Node.js throws:
```
SyntaxError: The requested module 'jiti' does not provide an export named 'createJiti'
```

CI wasn't catching this because it runs `npm ci` (which pins jiti to v2.6.1), while local dev builds go through `ensure-clawdbot-deps.cjs` which only checked `node_modules/jiti` *exists* — a v1 directory passes that check silently.

## Test plan

- [ ] `node scripts/verify-clawdbot-bundle.cjs` fails clearly if jiti is missing or v1
- [ ] `npm run dev` (which calls `ensure-clawdbot-deps.cjs`) upgrades jiti v1 → v2 automatically
- [ ] CI build passes (jiti v2.6.1 installed via `npm ci` satisfies the version check)

https://claude.ai/code/session_01KekEA4sgvTWLYnqw5Umx4a
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KekEA4sgvTWLYnqw5Umx4a)_