### PR TITLE
fix: loosen jiti to ^2.0.0 and use npm ci in ensure-clawdbot-deps

### DIFF
--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -27,11 +27,15 @@ const SOURCE_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources',
 const TARGET_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'target', 'debug', 'resources', 'clawdbot');
 
 function runNpmInstall(cwd, label) {
-  console.log(`[ensure-clawdbot-deps] npm install in ${label}...`);
-  execSync('npm install --omit=dev --ignore-scripts --no-audit --no-fund', {
-    cwd,
-    stdio: 'inherit',
-  });
+  // Prefer `npm ci` when a lockfile is present — it does a clean install from the
+  // lockfile and catches version mismatches that `npm install` silently ignores.
+  // Falls back to `npm install` when no lockfile exists (e.g. target debug dir).
+  const hasLockfile = fs.existsSync(path.join(cwd, 'package-lock.json'));
+  const cmd = hasLockfile
+    ? 'npm ci --ignore-scripts --no-audit --no-fund'
+    : 'npm install --omit=dev --ignore-scripts --no-audit --no-fund';
+  console.log(`[ensure-clawdbot-deps] ${hasLockfile ? 'npm ci' : 'npm install'} in ${label}...`);
+  execSync(cmd, { cwd, stdio: 'inherit' });
 }
 
 function needsMainInstall(clawdbotDir) {

--- a/src/src-tauri/resources/clawdbot/package.json
+++ b/src/src-tauri/resources/clawdbot/package.json
@@ -1618,7 +1618,7 @@
     "file-type": "22.0.1",
     "https-proxy-agent": "^9.0.0",
     "ipaddr.js": "^2.3.0",
-    "jiti": "^2.6.1",
+    "jiti": "^2.0.0",
     "json5": "^2.2.3",
     "jszip": "^3.10.1",
     "markdown-it": "14.1.1",


### PR DESCRIPTION
## Summary

- **`clawdbot/package.json`**: relax jiti from `^2.6.1` to `^2.0.0`. The tighter pin caused `npm install` to report "up to date" even when jiti v1 was present (npm considered the lockfile constraint already met), leaving the wrong version in place silently.
- **`ensure-clawdbot-deps.cjs`**: switch `runNpmInstall()` to `npm ci` when a `package-lock.json` is present. `npm ci` always does a clean install from the lockfile, catching version mismatches that `npm install` silently ignores. Falls back to `npm install` for the tauri dev target dir (no lockfile).

## Test plan

- [ ] `rm -rf node_modules && npm ci --ignore-scripts` in `clawdbot/` completes cleanly with jiti v2 installed
- [ ] `npm run dev` triggers `npm ci` (not `npm install`) for the clawdbot dir going forward
- [ ] Gateway boots without the `createJiti` SyntaxError

https://claude.ai/code/session_01KekEA4sgvTWLYnqw5Umx4a

---
_Generated by [Claude Code](https://claude.ai/code/session_01KekEA4sgvTWLYnqw5Umx4a)_