### PR TITLE
feat: context engineering improvements — compaction, feedback history, semantic search, agent memory

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -1698,6 +1698,20 @@ pub async fn chat(
     .trim()
     .to_string();
 
+  // Agent memory: previous-run summaries sent by the frontend from localStorage.
+  // Format: [{ timestamp: string, summary: string }, ...]
+  let memory_notes: Vec<String> = body
+    .get("memoryNotes")
+    .and_then(|v| v.as_array())
+    .map(|arr| {
+      arr.iter().filter_map(|entry| {
+        let ts = entry.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let summary = entry.get("summary").and_then(|v| v.as_str()).unwrap_or("");
+        if summary.is_empty() { None } else { Some(format!("- {}: {}", ts, summary)) }
+      }).collect()
+    })
+    .unwrap_or_default();
+
   let chrome = body.get("chrome").and_then(|v| v.as_bool());
   let profile = clawd_profile(chrome);
 
@@ -3072,6 +3086,16 @@ pub async fn chat(
     .entry(session_id.clone())
     .or_insert_with(|| load_history_from_transcript(&session_id, 20));
 
+  // Memory section — inject persistent notes from previous sessions.
+  let memory_section = if !memory_notes.is_empty() {
+    format!(
+      "\n\n## MEMORY FROM PREVIOUS SESSIONS\nThe following are summaries of previous conversations. Use them for context but do not repeat them verbatim:\n{}\n",
+      memory_notes.join("\n")
+    )
+  } else {
+    String::new()
+  };
+
   // System prompt - build with tone if provided
   let tone_section = if !tone_prompt.is_empty() {
     format!("\n\n## COMMUNICATION STYLE\n{}\n", tone_prompt)
@@ -3382,7 +3406,7 @@ No email account is directly connected via the send_email tool. However, you CAN
 
   let system_content = format!(
     r#"You are Openclaw, an intelligent personal assistant running inside the Knapsack desktop app with browser control capabilities.
-{}{}{}{}{}{}{}
+{}{}{}{}{}{}{}{}
 # CORE IDENTITY
 You are PROACTIVE, PERSISTENT, THOROUGH, and CREATIVE in helping users accomplish their goals. You don't give up easily and you always see tasks through to completion.
 
@@ -3799,7 +3823,8 @@ These links are rendered as red clickable buttons in the UI. Include them whenev
     advanced_section,
     skills_section,
     platform_section,
-    email_section
+    email_section,
+    memory_section
   );
 
   let system = chat_agent::OaiMessage::System {
@@ -3974,7 +3999,31 @@ These links are rendered as red clickable buttons in the UI. Include them whenev
       history.push(assistant_msg);
       if history.len() > 20 {
         let drain = history.len() - 20;
-        history.drain(0..drain);
+        let dropped: Vec<_> = history.drain(0..drain).collect();
+        // Summarize dropped messages so the model knows what was discussed,
+        // rather than silently losing that context.
+        let summary_lines: Vec<String> = dropped.iter().filter_map(|msg| match msg {
+          chat_agent::OaiMessage::User { content, .. } => {
+            let snip = if content.len() > 200 { format!("{}…", &content[..200]) } else { content.clone() };
+            Some(format!("User: {}", snip))
+          }
+          chat_agent::OaiMessage::Assistant { content, .. } => {
+            content.as_ref().map(|c| {
+              let snip = if c.len() > 200 { format!("{}…", &c[..200]) } else { c.clone() };
+              format!("Assistant: {}", snip)
+            })
+          }
+          _ => None,
+        }).collect();
+        if !summary_lines.is_empty() {
+          history.insert(0, chat_agent::OaiMessage::System {
+            content: format!(
+              "[Earlier conversation ({} messages, now summarized):\n{}]",
+              summary_lines.len(),
+              summary_lines.join("\n")
+            ),
+          });
+        }
       }
       return HttpResponse::Ok().json(serde_json::json!({"ok": true, "reply": reply}));
     }

--- a/src/src-tauri/src/clawd/dev_feedback_loop.rs
+++ b/src/src-tauri/src/clawd/dev_feedback_loop.rs
@@ -352,6 +352,13 @@ pub fn evaluate_dev_state(state: &DevState) -> FeedbackResult {
 // Feedback Loop
 // ---------------------------------------------------------------------------
 
+/// Summary of what was tried and what errors remained after a single iteration.
+struct PriorAttempt {
+    iteration: u32,
+    what_was_tried: String,
+    errors: String,
+}
+
 /// Run the full feedback loop: agent_run → capture → evaluate → repeat.
 ///
 /// `shared_state` is used to expose progress to the frontend via polling.
@@ -367,7 +374,9 @@ pub async fn run_with_feedback(
 ) -> FeedbackLoopResult {
     let profile = "openclaw";
     let mut iteration_history: Vec<LoopIteration> = Vec::new();
-    let mut accumulated_feedback = String::new();
+    // Rolling record of what was tried and what broke — passed to the model each iteration
+    // so it doesn't repeat approaches that already failed.
+    let mut prior_attempts: Vec<PriorAttempt> = Vec::new();
     let mut last_agent_reply = String::new();
     let mut last_dev_state = DevState {
         screenshot_base64: None,
@@ -379,20 +388,33 @@ pub async fn run_with_feedback(
     };
 
     for iteration in 1..=max_iterations {
-        // Build the prompt: original task + accumulated feedback
-        let full_prompt = if accumulated_feedback.is_empty() {
+        // Build the prompt: original task + full prior-attempt history so the model
+        // can avoid repeating approaches that already failed.
+        let full_prompt = if prior_attempts.is_empty() {
             task_prompt.to_string()
         } else {
+            let history_text = prior_attempts
+                .iter()
+                .map(|a| {
+                    format!(
+                        "Attempt {} of {}:\n  What was done: {}\n  Errors that remained: {}",
+                        a.iteration, max_iterations, a.what_was_tried, a.errors
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            let current_errors = &prior_attempts.last().unwrap().errors;
+            let remaining = max_iterations - iteration + 1;
             format!(
-                "{}\n\n--- FEEDBACK FROM PREVIOUS ITERATION ({}/{}) ---\n\n{}",
-                task_prompt,
-                iteration - 1,
-                max_iterations,
-                accumulated_feedback
+                "{}\n\n=== PREVIOUS ATTEMPT HISTORY ===\n{}\n\n=== CURRENT TASK ===\nYou have {} of {} attempt(s) remaining. Fix these errors without repeating previous approaches:\n{}",
+                task_prompt, history_text, remaining, max_iterations, current_errors
             )
         };
 
         // Update shared state
+        let last_feedback_preview = prior_attempts
+            .last()
+            .map(|a| truncate(&a.errors, 500));
         if let Some(ref state) = shared_state {
             let mut guard = state.lock().await;
             guard.insert(
@@ -402,11 +424,7 @@ pub async fn run_with_feedback(
                     status: LoopStatus::Running,
                     current_iteration: iteration,
                     max_iterations,
-                    last_feedback: if accumulated_feedback.is_empty() {
-                        None
-                    } else {
-                        Some(truncate(&accumulated_feedback, 500))
-                    },
+                    last_feedback: last_feedback_preview,
                     last_screenshot_base64: None,
                     error_count: 0,
                     agent_id: agent_id.to_string(),
@@ -564,8 +582,12 @@ pub async fn run_with_feedback(
             };
         }
 
-        // 5. Append feedback for next iteration
-        accumulated_feedback = feedback.feedback_prompt.clone();
+        // 5. Record this attempt so future iterations know what was already tried.
+        prior_attempts.push(PriorAttempt {
+            iteration,
+            what_was_tried: truncate(&agent_reply, 500),
+            errors: feedback.feedback_prompt.clone(),
+        });
     }
 
     // Max iterations reached

--- a/src/src-tauri/src/llm/prompt.rs
+++ b/src/src-tauri/src/llm/prompt.rs
@@ -39,30 +39,30 @@ pub async fn build_user_message(
   let mut user_prompt: String = prompt.clone();
   let mut total_doc_knowledge = "".to_string();
 
-  // let max_context_length: u64 = get_max_context_length();
-  // let maybe_locked_semantic_service = semantic_service.lock().await;
-  // let locked_semantic_service = maybe_locked_semantic_service.as_ref().unwrap();
-  // let mut ss_results = Vec::new();
-  // if semantic_search_query.is_some() {
-  //   ss_results = match locked_semantic_service
-  //     .semantic_search(
-  //       semantic_search_query.unwrap(),
-  //       5,
-  //       None,
-  //       None,
-  //       Some(false),
-  //       Some(false),
-  //       filter_documents.clone(),
-  //     )
-  //     .await
-  //   {
-  //     Ok(ss) => ss,
-  //     Err(e) => {
-  //       log::error!("------------- ss fail: {:?}", e);
-  //       Vec::new()
-  //     }
-  //   };
-  // }
+  let mut ss_results = Vec::new();
+  if let Some(query) = semantic_search_query {
+    let maybe_locked_semantic_service = semantic_service.lock().await;
+    if let Some(locked_semantic_service) = maybe_locked_semantic_service.as_ref() {
+      ss_results = match locked_semantic_service
+        .semantic_search(
+          query,
+          5,
+          None,
+          None,
+          Some(false),
+          Some(false),
+          filter_documents.clone(),
+        )
+        .await
+      {
+        Ok(ss) => ss,
+        Err(e) => {
+          log::error!("------------- ss fail: {:?}", e);
+          Vec::new()
+        }
+      };
+    }
+  }
 
   for additional_document in additional_documents.unwrap_or(vec![]) {
     // println!("############# ADDITIONAL DOC: {:?}", additional_document);
@@ -74,21 +74,21 @@ pub async fn build_user_message(
     ));
   }
 
-  // for ss_result in &ss_results {
-  //   let knowledge = convert_ids_to_knowledge(
-  //     ss_result.document_id,
-  //     Some(ss_result.chunk_ids.clone()),
-  //     Some(ss_result.payloads.clone()),
-  //   )
-  //   .unwrap_or_else(|_| {
-  //     log::error!(
-  //       "Could not convert ids to knowledge for document_id: {}",
-  //       ss_result.document_id
-  //     );
-  //     String::new()
-  //   });
-  //   total_doc_knowledge.push_str(&knowledge);
-  // }
+  for ss_result in &ss_results {
+    let knowledge = convert_ids_to_knowledge(
+      ss_result.document_id,
+      Some(ss_result.chunk_ids.clone()),
+      Some(ss_result.payloads.clone()),
+    )
+    .unwrap_or_else(|_| {
+      log::error!(
+        "Could not convert ids to knowledge for document_id: {}",
+        ss_result.document_id
+      );
+      String::new()
+    });
+    total_doc_knowledge.push_str(&knowledge);
+  }
 
   if total_doc_knowledge.len() > 0 {
     user_prompt = format!(

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -18,6 +18,7 @@ import { DeveloperModePanel } from 'src/components/organisms/DeveloperModePanel'
 import { TokenCostsView } from 'src/components/organisms/ActivityPanel'
 import { detectBuildIntent, extractProjectDescription } from 'src/utils/devIntentDetector'
 import { dispatchDevPopulate, dispatchOpenDevPanel } from 'src/utils/devModeEvents'
+import { getAgentMemory, saveAgentMemory } from 'src/automations/agentMemory'
 
 // Prompt action prefix used by the AI to embed executable actions in messages.
 // Format in raw AI text: [Label](knapsack://prompt/Detailed instruction)
@@ -4067,6 +4068,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           developerMode, // When true, enables Sentry scanning, error log analysis, and auto-PR creation
           userEmail: userEmail || '', // For direct email sending via send_email tool
           userName: userName || '', // Sender display name for emails
+          memoryNotes: getAgentMemory('knapsack-chat'), // Persistent cross-session context
         }
 
         // Add attachments if present
@@ -4206,6 +4208,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
                 ...prev,
                 { id: crypto.randomUUID(), role: 'assistant', text: out.reply!, ts: Date.now(), model: out.model },
               ])
+              // Persist a summary so future sessions have cross-session context.
+              saveAgentMemory('knapsack-chat', out.reply)
             } else {
               pushAssistant(friendlyError(out.message || out.error || 'No reply', activeModelAtSend))
             }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Conversation compaction**: when the 20-message history window fills, dropped messages are summarized into a System turn instead of being silently lost, so the model retains awareness of earlier context
- **Feedback loop iteration history**: each `dev_feedback_loop` iteration now receives the full prior-attempt history (what was tried + what errors remained) so the model avoids repeating approaches that already failed
- **Re-enable semantic search**: uncomment the `SemanticService` search path in `llm/prompt.rs`; use `if let` instead of `.unwrap()` to handle an uninitialized service gracefully
- **Agent memory injection**: the main chat frontend reads persistent notes from `localStorage` (key `knapsack-chat`) and sends them with every request; the backend injects them into the system prompt as a *MEMORY FROM PREVIOUS SESSIONS* section; successful replies are saved back for future sessions

## Files changed

| File | Change |
|---|---|
| `src-tauri/src/clawd/browser.rs` | Compaction on history drain; memory section in system prompt; `memoryNotes` extraction from request body |
| `src-tauri/src/clawd/dev_feedback_loop.rs` | `PriorAttempt` struct; rolling history passed to each iteration |
| `src-tauri/src/llm/prompt.rs` | Uncomment semantic search; safe `if let` guard |
| `src/components/organisms/ClawdChat/index.tsx` | Import `getAgentMemory`/`saveAgentMemory`; send memory notes in request; save reply after success |

## Test plan

- [ ] Send 10+ messages in a single chat session; verify the System summary message appears at the head of history once messages are drained (check via Sentry or log)
- [ ] Trigger `dev_feedback_loop` with a broken project; verify iteration 2+ logs include "PREVIOUS ATTEMPT HISTORY" in the prompt
- [ ] With a document indexed in the workspace, send a query that should match; verify semantic results are included in the response
- [ ] Send a chat message, close and reopen the app, send another message; verify the assistant references context from the previous session

https://claude.ai/code/session_01KYNtunwhBHzjWvnJHnZQ1X
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYNtunwhBHzjWvnJHnZQ1X)_