### PR TITLE
Fix meeting title editing to sync external changes and reset on cancel

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -163,6 +163,15 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     }
   }, [isEditingTitle])
 
+  // Keep editableTitle in sync with the prop when not actively editing (handles
+  // external changes like auto-title from notes synthesis or calendar auto-attach)
+  useEffect(() => {
+    if (!isEditingTitle) {
+      setEditableTitle(thread.subtitle || '')
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [thread.subtitle])
+
   const saveTitleEdit = () => {
     const trimmed = editableTitle.trim()
     if (trimmed && trimmed !== thread.subtitle) {
@@ -772,7 +781,7 @@ Output only the 3 sentences, nothing else.`,
                     onBlur={saveTitleEdit}
                     onKeyDown={e => {
                       if (e.key === 'Enter') { e.preventDefault(); saveTitleEdit() }
-                      else if (e.key === 'Escape') setIsEditingTitle(false)
+                      else if (e.key === 'Escape') { setEditableTitle(thread.subtitle || ''); setIsEditingTitle(false) }
                     }}
                     placeholder="Meeting title..."
                   />
@@ -782,7 +791,7 @@ Output only the 3 sentences, nothing else.`,
                     onClick={() => { setIsEditingTitle(true) }}
                     title="Click to edit title"
                   >
-                    {thread.subtitle}
+                    {editableTitle || thread.subtitle}
                   </h1>
                 )}
                 <div className="notetaker-note__meta">
@@ -1011,7 +1020,7 @@ Be direct, specific, and concise. No filler text.`
                   onBlur={saveTitleEdit}
                   onKeyDown={e => {
                     if (e.key === 'Enter') { e.preventDefault(); saveTitleEdit() }
-                    else if (e.key === 'Escape') setIsEditingTitle(false)
+                    else if (e.key === 'Escape') { setEditableTitle(thread.subtitle || ''); setIsEditingTitle(false) }
                   }}
                   placeholder="Meeting title..."
                 />
@@ -1021,7 +1030,7 @@ Be direct, specific, and concise. No filler text.`
                   onClick={() => { setIsEditingTitle(true) }}
                   title="Click to edit title"
                 >
-                  {thread.subtitle}
+                  {editableTitle || thread.subtitle}
                 </h1>
               )}
               {/* Metadata row */}


### PR DESCRIPTION
## Summary
This PR improves the meeting title editing experience by ensuring the editable title state stays synchronized with external changes and properly resets when the user cancels editing.

## Key Changes
- **Added effect hook** to sync `editableTitle` with `thread.subtitle` when not actively editing, allowing external updates (e.g., from auto-title synthesis or calendar auto-attach) to be reflected in the UI
- **Enhanced Escape key handling** to reset `editableTitle` to the original `thread.subtitle` before exiting edit mode, preventing stale state from persisting
- **Updated display logic** to show `editableTitle` as fallback when available, ensuring the UI reflects the current editing state while maintaining the original subtitle as a safety net

## Implementation Details
- The new effect hook only updates `editableTitle` when `isEditingTitle` is false, preventing interference with active user edits
- Both edit mode locations (appears to be two different UI layouts) were updated consistently for the Escape key behavior and display logic
- The eslint disable comment on the effect hook is intentional, as `thread.subtitle` is the only external dependency that should trigger the sync

https://claude.ai/code/session_01XnRjA3nVJNskqSBv3zas8K