### PR TITLE
Enforce bundled Node.js only in production, reorder PATH

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3681,12 +3681,13 @@ async fn prepare_gateway_config(
       bundled_node.clone(),
     ]
   } else {
-    vec![
-      bundled_node.clone(),
-      PathBuf::from("/opt/homebrew/bin/node"),
-      PathBuf::from("/usr/local/bin/node"),
-      PathBuf::from("/usr/bin/node"),
-    ]
+    // Production (macOS/Linux): use the bundled node only — never fall back to
+    // Homebrew or system Node.js.  Mixing the app's bundled JS (with its own
+    // node_modules snapshot) against a foreign Node.js binary causes version /
+    // ABI mismatches and is exactly what "openclaw doctor" flags when it sees
+    // /opt/homebrew/... as the gateway entrypoint.  A corrupt bundle is a
+    // reinstall signal, not a silent Homebrew fallback.
+    vec![bundled_node.clone()]
   };
 
   let bundled_node_path = resource_path(app_handle, if cfg!(target_os = "windows") {
@@ -4416,7 +4417,12 @@ async fn prepare_gateway_config(
       }
     }
   } else {
-    for p in &["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"] {
+    // Standard system paths first, Homebrew last.  The bundled node directory
+    // was prepended above, so putting /opt/homebrew/bin at the end prevents
+    // Homebrew's node / npm from shadowing the bundled binary in any subprocess
+    // the gateway spawns.  Homebrew tools that have no bundled equivalent (e.g.
+    // signal-cli) are still discoverable via the trailing entry.
+    for p in &["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin", "/opt/homebrew/bin"] {
       let s = p.to_string();
       if !path_parts.contains(&s) {
         path_parts.push(s);
@@ -4914,13 +4920,9 @@ pub async fn set_service_enabled(
           bundled_node,
         ]
       } else {
-        // Production: prefer bundled node, fall back to system
-        vec![
-          bundled_node,
-          PathBuf::from("/opt/homebrew/bin/node"),
-          PathBuf::from("/usr/local/bin/node"),
-          PathBuf::from("/usr/bin/node"),
-        ]
+        // Production (macOS/Linux): bundled node only — no Homebrew / system
+        // fallback.  See comment in the synchronous path above for rationale.
+        vec![bundled_node]
       };
 
       let bundled_node_path = resource_path(&app_handle, "resources/node/node");
@@ -5619,7 +5621,9 @@ pub async fn set_service_enabled(
       if !node_dir.is_empty() {
         path_parts.push(node_dir);
       }
-      for p in &["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"] {
+      // Standard system paths first, Homebrew last — same rationale as the
+      // synchronous PATH builder above.
+      for p in &["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin", "/opt/homebrew/bin"] {
         let s = p.to_string();
         if !path_parts.contains(&s) {
           path_parts.push(s);


### PR DESCRIPTION
## Summary
This change removes fallback paths to system and Homebrew Node.js installations in production environments, enforcing the use of the bundled Node.js binary exclusively. Additionally, the PATH construction is reordered to prioritize standard system paths while moving Homebrew to the end.

## Key Changes
- **Remove Node.js fallbacks in production**: Changed from attempting multiple Node.js locations (`/opt/homebrew/bin/node`, `/usr/local/bin/node`, `/usr/bin/node`) to using only the bundled Node.js binary in both `prepare_gateway_config()` and `set_service_enabled()` functions
- **Reorder PATH construction**: Moved `/opt/homebrew/bin` from the beginning to the end of the PATH search order in two locations, ensuring standard system paths (`/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`) are checked first
- **Add clarifying comments**: Documented the rationale for these changes, explaining that mixing the bundled JavaScript with foreign Node.js binaries causes version/ABI mismatches and that a corrupt bundle should trigger a reinstall rather than silently falling back to Homebrew

## Implementation Details
- The bundled node directory is still prepended to PATH first, ensuring it takes precedence
- Homebrew tools without bundled equivalents (e.g., `signal-cli`) remain discoverable via the trailing `/opt/homebrew/bin` entry
- Changes apply to both synchronous and asynchronous code paths
- The modifications align with what the "openclaw doctor" diagnostic tool expects when validating gateway entrypoints

https://claude.ai/code/session_01GEk3xY3J5S1fCsiX4N3i5c