### PR TITLE
Ensure jiti v2 is installed for dynamic TypeScript plugin loading

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/ensure-clawdbot-deps.cjs && vite",
-    "prebuild": "node scripts/sync-version.cjs && node scripts/prepare-node.cjs && node scripts/prune-clawdbot.cjs && node scripts/verify-clawdbot-bundle.cjs",
+    "prebuild": "node scripts/sync-version.cjs && node scripts/prepare-node.cjs && node scripts/ensure-clawdbot-deps.cjs && node scripts/prune-clawdbot.cjs && node scripts/verify-clawdbot-bundle.cjs",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "node scripts/load-env-and-run.cjs tauri",

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -607,6 +607,28 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
     }
   }
 
+  // Ensure jiti v2 is present — it is externalized from the dist bundle and
+  // required at runtime for dynamic TypeScript plugin loading.  Unlike chalk
+  // (committed to git as a shim), jiti is installed by npm.  A missing install
+  // or a stale v1 copy causes "createJiti is not a named export" on gateway
+  // startup, preventing all plugin loading.
+  {
+    let jiti_dir = root_nm.join("jiti");
+    let installed_jiti_major: u64 = fs::read_to_string(jiti_dir.join("package.json"))
+      .ok()
+      .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+      .and_then(|v| v.get("version").and_then(|vv| vv.as_str()).map(|s| s.to_string()))
+      .and_then(|ver| ver.split('.').next().and_then(|m| m.parse::<u64>().ok()))
+      .unwrap_or(0);
+    if installed_jiti_major < 2 && !missing_root.iter().any(|s| s.starts_with("jiti")) {
+      eprintln!(
+        "[clawd/service] jiti v{} installed (need v2+) — queuing jiti@^2.0.0 for install",
+        installed_jiti_major
+      );
+      missing_root.push("jiti@^2.0.0".to_string());
+    }
+  }
+
   // Always recreate the openclaw self-symlink regardless of whether any deps
   // need installing — it must survive app updates where the bundle is replaced.
   ensure_openclaw_self_link(&root_nm);


### PR DESCRIPTION
## Summary
This PR adds runtime validation and automatic installation of jiti v2, which is required for dynamic TypeScript plugin loading in the gateway. It also ensures the dependency check runs during the prebuild phase.

## Key Changes
- **Runtime jiti version check**: Added validation in `install_bundled_plugin_runtime_deps()` to detect if jiti v1 (or missing jiti) is installed and automatically queue jiti@^2.0.0 for installation
  - Parses the installed jiti's `package.json` to extract the major version
  - Logs a warning when an outdated version is detected
  - Prevents the "createJiti is not a named export" error that blocks plugin loading on gateway startup
- **Prebuild script ordering**: Added `ensure-clawdbot-deps.cjs` to the prebuild phase to validate dependencies before the build process

## Implementation Details
- The jiti version check uses a defensive parsing chain that safely handles missing files or malformed JSON, defaulting to version 0 if jiti is not found
- Only queues jiti for installation if the major version is less than 2 AND jiti is not already in the missing dependencies list (avoiding duplicate entries)
- Unlike chalk (which is committed as a shim), jiti is installed via npm and must be present at runtime

https://claude.ai/code/session_018zVwtCYb4j7ZVwypCTf7qf