### PR TITLE
Improve error logging and user messaging for API failures

### DIFF
--- a/src/src-tauri/src/connections/google/calendar.rs
+++ b/src/src-tauri/src/connections/google/calendar.rs
@@ -75,7 +75,6 @@ pub async fn fetch_calendar(
   let access_token = match refresh_connection_token(email.clone(), user_connection.clone()).await {
     Ok(token) => token,
     Err(error) => {
-      log::error!("Failed to refresh access token: {:?}", error);
       let msg = format!(
         "Failed to refresh access token for calendar {} (user {})",
         calendar_account_email, email
@@ -286,7 +285,7 @@ async fn fetch_google_calendar_api(
       FetchGoogleCalendarResponse { success: true, message: "Fetching calendar data".to_string() }
     ),
     Err(error) => {
-      log::error!("Fetch calendar failed: {:?}", error);
+      log::warn!("Fetch calendar failed: {:?}", error);
       let error_msg = format!("Fetch calendar failed: {:?}", error);
       HttpResponse::BadRequest().json(
         FetchGoogleCalendarResponse { success: false, message: error_msg }

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -235,7 +235,7 @@ function friendlyError(raw: string, activeModel?: string): string {
   }
   // Network / connection errors
   if (lower.includes('load failed') && !lower.includes('model')) {
-    return `🌐 **Request too large** (active: \`${activeModel}\`). The image attachment may be too large to send. Try a smaller image or send without the attachment.`
+    return `🌐 **Request too large** (active: \`${activeModel}\`). The message or attachment was too large to send. Try removing any image attachments, or start a new conversation to reduce context size.`
   }
   if (lower.includes('network') || lower.includes('econnrefused') || lower.includes('fetch failed')) {
     return `🌐 **Connection error** (active: \`${activeModel}\`). Unable to reach the AI service. Check your internet connection and try again.`


### PR DESCRIPTION
## Summary
This PR refines error handling and user-facing messages across the Google Calendar integration and chat components to provide better diagnostics and clearer guidance to users.

## Key Changes
- **Google Calendar error logging**: Removed redundant error log in `fetch_calendar` and changed `fetch_google_calendar_api` error log level from `error` to `warn` to better reflect the severity of non-critical failures
- **Chat error messaging**: Updated the "Request too large" error message to be more accurate and helpful, clarifying that the issue may stem from message/attachment size or accumulated context, and suggesting concrete remediation steps (removing attachments or starting a new conversation)

## Implementation Details
- The logging changes in the calendar module reduce noise from expected error conditions while maintaining appropriate visibility
- The improved error message in ClawdChat provides users with more actionable guidance when they encounter size-related request failures, addressing both immediate causes (large attachments) and underlying context accumulation issues

https://claude.ai/code/session_01GBDXyX7hpjp4fWXWdLWWmu