### PR TITLE
fix(windows): switch release build to MSI+tar, fix MAX_PATH failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Windows — MSI + NSIS installer
+  # Windows — MSI installer (WiX, 64-bit) + lightweight NSIS web-setup stub
   # ---------------------------------------------------------------------------
   build-windows:
     needs: bump-version
@@ -200,7 +200,17 @@ jobs:
         working-directory: src
         run: Copy-Item .env.example .env
 
+      - name: Cache clawdbot node_modules
+        id: cache-clawdbot-nm
+        uses: actions/cache@v4
+        with:
+          path: src/src-tauri/resources/clawdbot/node_modules
+          key: clawdbot-nm-windows-${{ hashFiles('src/src-tauri/resources/clawdbot/package-lock.json') }}
+          restore-keys: |
+            clawdbot-nm-windows-
+
       - name: Install clawdbot dependencies
+        if: steps.cache-clawdbot-nm.outputs.cache-hit != 'true'
         working-directory: src/src-tauri/resources/clawdbot
         run: npm ci --ignore-scripts
 
@@ -241,16 +251,59 @@ jobs:
         working-directory: src
         run: node scripts/verify-clawdbot-bundle.cjs
 
-      - name: Clean Tauri NSIS cache and stale bundle artifacts
+      - name: Build frontend
+        # Must run BEFORE Pack (below) — the prebuild hook calls
+        # verify-clawdbot-bundle.cjs which requires node_modules to exist.
+        working-directory: src
+        run: npm run build
+        env:
+          VITE_KN_API_SERVER: https://api.knapsack.ai
+          MICROSOFT_CLIENT_ID: unused
+          VITE_GOOGLE_CLIENT_ID: "963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com"
+          VITE_GOOGLE_DEVELOPER_KEY: ""
+
+      - name: Pack node_modules into tar for WiX
+        # Run from within the clawdbot dir so tar needs no path juggling.
+        # WiX candle.exe chokes generating XML for ~13k node_modules files;
+        # packing into one tar reduces the WiX input to ~3k files.
+        working-directory: src/src-tauri/resources/clawdbot
+        shell: pwsh
         run: |
-          if (Test-Path "$env:LOCALAPPDATA\tauri\NSIS") {
-            Remove-Item -Recurse -Force "$env:LOCALAPPDATA\tauri\NSIS"
-            Write-Host "Cleared stale NSIS toolchain cache"
+          if (-not (Test-Path "node_modules")) {
+            Write-Error "node_modules not found in clawdbot — was npm ci run?"
+            exit 1
           }
+          Write-Host "Packing node_modules..."
+          tar -cf node_modules.tar node_modules
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "tar failed (exit $LASTEXITCODE)"
+            exit 1
+          }
+          Remove-Item -Recurse -Force node_modules
+          $mb = [math]::Round((Get-Item node_modules.tar).Length / 1MB, 1)
+          $n  = (Get-ChildItem -Recurse . | Measure-Object).Count
+          Write-Host "node_modules.tar: $mb MB. WiX will see $n files."
+
+      - name: Disable beforeBuildCommand in tauri.conf.json
+        # The frontend is already compiled above. Remove beforeBuildCommand so
+        # Tauri doesn't re-run npm run build — after Pack, node_modules is gone
+        # and the prebuild hook (verify-clawdbot-bundle.cjs) would fail.
+        shell: pwsh
+        run: |
+          $confPath = "src/src-tauri/tauri.conf.json"
+          $conf = Get-Content $confPath -Raw | ConvertFrom-Json
+          $conf.build.PSObject.Properties.Remove('beforeBuildCommand')
+          $conf | ConvertTo-Json -Depth 20 | Set-Content $confPath -Encoding UTF8
+          Write-Host "Removed beforeBuildCommand from tauri.conf.json"
+
+      - name: Clean stale bundle artifacts and show disk space
+        shell: pwsh
+        run: |
           if (Test-Path "src\src-tauri\target\release\bundle") {
             Remove-Item -Recurse -Force "src\src-tauri\target\release\bundle"
             Write-Host "Cleared stale bundle artifacts"
           }
+          Get-PSDrive C | Select-Object Used, Free | ForEach-Object { Write-Host "Disk: used=$([math]::Round($_.Used/1GB,1))GB free=$([math]::Round($_.Free/1GB,1))GB" }
 
       - name: Install AzureSignTool
         if: env.AZURE_KEY_VAULT_URI != ''
@@ -310,7 +363,13 @@ jobs:
 
       - name: Build Tauri app
         working-directory: src
-        run: npx tauri build --bundles nsis
+        shell: pwsh
+        # --bundles msi uses Tauri v1's WiX-based MSI bundler (64-bit light.exe),
+        # which handles the large clawdbot resource set without NSIS (32-bit) OOM.
+        run: |
+          $log = "$env:RUNNER_TEMP\tauri-build.log"
+          npx tauri build --bundles msi --verbose 2>&1 | Tee-Object -FilePath $log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
@@ -320,6 +379,38 @@ jobs:
           VITE_GOOGLE_DEVELOPER_KEY: ""
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Show disk space after build
+        if: always()
+        shell: pwsh
+        run: |
+          Get-PSDrive C | Select-Object Used, Free | ForEach-Object { Write-Host "Disk after build: used=$([math]::Round($_.Used/1GB,1))GB free=$([math]::Round($_.Free/1GB,1))GB" }
+
+      - name: Post build log to PR on failure
+        if: failure() && github.event.pull_request.number != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $pr   = "${{ github.event.pull_request.number }}"
+          $repo = "${{ github.repository }}"
+          $run  = "${{ github.run_id }}"
+          $log  = "$env:RUNNER_TEMP\tauri-build.log"
+          if (Test-Path $log) {
+            $tail = (Get-Content $log -Tail 100) -join "`n"
+            $body = "**[Windows CI] build-windows failed (run $run)**`n``````text`n$tail`n``````"
+          } else {
+            $body = "**[Windows CI] build-windows failed before Build step (run $run). No build log captured.**"
+          }
+          gh pr comment $pr --body $body --repo $repo
+
+      - name: Upload Tauri build log on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: tauri-build-log
+          path: ${{ runner.temp }}/tauri-build.log
+          if-no-files-found: ignore
 
       - name: Build web installer stub
         shell: pwsh
@@ -361,9 +452,6 @@ jobs:
             src/src-tauri/target/release/bundle/msi/*.msi
             src/src-tauri/target/release/bundle/msi/*.msi.zip
             src/src-tauri/target/release/bundle/msi/*.msi.zip.sig
-            src/src-tauri/target/release/bundle/nsis/*.exe
-            src/src-tauri/target/release/bundle/nsis/*.nsis.zip
-            src/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig
             src/installer/Knapsack-web-setup.exe
           if-no-files-found: error
 
@@ -404,7 +492,7 @@ jobs:
 
           WIN_SIG=""
           WIN_ZIP_NAME=""
-          for f in artifacts/windows-artifacts/**/*.nsis.zip.sig artifacts/windows-artifacts/*.nsis.zip.sig; do
+          for f in artifacts/windows-artifacts/**/*.msi.zip.sig artifacts/windows-artifacts/*.msi.zip.sig; do
             if [ -f "$f" ]; then
               WIN_SIG=$(cat "$f")
               WIN_ZIP_NAME=$(basename "${f%.sig}")
@@ -412,14 +500,14 @@ jobs:
             fi
           done
 
-          # Find the Windows NSIS setup exe (exclude the lightweight web-setup stub).
-          # This URL is used by the stub installer to download the full installer
-          # directly, without relying on the nsis.zip URL which may not always exist.
-          WIN_EXE_NAME=""
-          for f in artifacts/windows-artifacts/**/*-setup.exe artifacts/windows-artifacts/*-setup.exe; do
+          # Find the MSI installer (exclude the zip and sig variants).
+          # This URL is used by the stub installer to download and install the MSI.
+          WIN_MSI_NAME=""
+          for f in artifacts/windows-artifacts/**/*.msi artifacts/windows-artifacts/*.msi; do
             name=$(basename "$f")
-            if [ -f "$f" ] && [ "$name" != "Knapsack-web-setup.exe" ]; then
-              WIN_EXE_NAME="$name"
+            # Skip .msi.zip files
+            if [ -f "$f" ] && [[ "$name" != *.zip ]]; then
+              WIN_MSI_NAME="$name"
               break
             fi
           done
@@ -442,7 +530,7 @@ jobs:
               "windows-x86_64": {
                 "url": "$RELEASE_URL/$WIN_ZIP_NAME",
                 "signature": "$WIN_SIG",
-                "setupUrl": "$RELEASE_URL/$WIN_EXE_NAME"
+                "setupUrl": "$RELEASE_URL/$WIN_MSI_NAME"
               }
             }
           }
@@ -457,7 +545,7 @@ jobs:
           # macOS
           find artifacts/macos-artifacts -type f \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \) -exec cp {} release-files/ \;
           # Windows
-          find artifacts/windows-artifacts -type f \( -name "*.msi" -o -name "*.msi.zip" -o -name "*.msi.zip.sig" -o -name "*.exe" -o -name "*.nsis.zip" -o -name "*.nsis.zip.sig" \) -exec cp {} release-files/ \;
+          find artifacts/windows-artifacts -type f \( -name "*.msi" -o -name "*.msi.zip" -o -name "*.msi.zip.sig" -o -name "Knapsack-web-setup.exe" \) -exec cp {} release-files/ \;
           # Web installer stub (promote to top-level with a stable name)
           find artifacts/windows-artifacts -name "Knapsack-web-setup.exe" -exec cp {} release-files/ \; 2>/dev/null || true
           # Updater metadata

--- a/src/installer/stub.nsi
+++ b/src/installer/stub.nsi
@@ -1,5 +1,5 @@
 ; Knapsack Web Installer (stub)
-; Downloads the full NSIS installer from the latest GitHub release at runtime.
+; Downloads the full MSI installer from the latest GitHub release at runtime.
 ; The compiled stub is ~400 KB vs the full installer (100+ MB), giving users
 ; a fast initial download while the real payload streams in the background.
 
@@ -59,7 +59,7 @@ Section "Install" SecMain
   FileWrite $R0 'try { [System.Net.WebRequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials } catch {}$\r$\n'
   FileWrite $R0 '$ProgressPreference = "SilentlyContinue"$\r$\n'
   FileWrite $R0 '$ErrorActionPreference = "Stop"$\r$\n'
-  FileWrite $R0 '$dest   = Join-Path $env:TEMP "knapsack-setup-full.exe"$\r$\n'
+  FileWrite $R0 '$dest   = Join-Path $env:TEMP "knapsack-setup-full.msi"$\r$\n'
   FileWrite $R0 '$errLog = Join-Path $env:TEMP "knapsack-dl-error.txt"$\r$\n'
   FileWrite $R0 '$ua     = "Knapsack-Installer/1.0"$\r$\n'
   FileWrite $R0 'if (Test-Path $dest) { Remove-Item $dest -Force -ErrorAction SilentlyContinue }$\r$\n'
@@ -86,20 +86,20 @@ Section "Install" SecMain
   FileWrite $R0 '  $plat    = $meta.platforms."windows-x86_64"$\r$\n'
   FileWrite $R0 '  if (-not $plat) { throw "latest.json has no windows-x86_64 entry" }$\r$\n'
   FileWrite $R0 '  $version = $meta.version$\r$\n'
-  FileWrite $R0 '  # Prefer setupUrl (direct exe link added in release workflow).$\r$\n'
-  FileWrite $R0 '  # Fall back to deriving the exe name from the nsis.zip URL.$\r$\n'
+  FileWrite $R0 '  # Prefer setupUrl (direct MSI link added in release workflow).$\r$\n'
+  FileWrite $R0 '  # Fall back to deriving the MSI name from the msi.zip URL.$\r$\n'
   FileWrite $R0 '  if ($plat.setupUrl -and $plat.setupUrl -notmatch "/$") {$\r$\n'
-  FileWrite $R0 '    $exeUrl = $plat.setupUrl$\r$\n'
+  FileWrite $R0 '    $msiUrl = $plat.setupUrl$\r$\n'
   FileWrite $R0 '  } elseif ($plat.url -and $plat.url -notmatch "/$") {$\r$\n'
   FileWrite $R0 '    $zipUrl = $plat.url$\r$\n'
-  FileWrite $R0 '    # nsis.zip name: Knapsack_X.Y.Z_en-US.nsis.zip -> Knapsack_X.Y.Z_x64-setup.exe$\r$\n'
-  FileWrite $R0 '    $exeUrl = $zipUrl -replace "_en-US\.nsis\.zip$", "_x64-setup.exe"$\r$\n'
-  FileWrite $R0 '    if ($exeUrl -eq $zipUrl) { throw "Could not derive setup exe URL from: $zipUrl" }$\r$\n'
+  FileWrite $R0 '    # msi.zip name: Knapsack_X.Y.Z_en-US.msi.zip -> Knapsack_X.Y.Z_en-US.msi$\r$\n'
+  FileWrite $R0 '    $msiUrl = $zipUrl -replace "\.zip$", ""$\r$\n'
+  FileWrite $R0 '    if ($msiUrl -eq $zipUrl) { throw "Could not derive MSI URL from: $zipUrl" }$\r$\n'
   FileWrite $R0 '  } else {$\r$\n'
   FileWrite $R0 '    throw "latest.json windows-x86_64 entry has no usable URL"$\r$\n'
   FileWrite $R0 '  }$\r$\n'
   FileWrite $R0 '  Write-Host "Downloading Knapsack $version ..."$\r$\n'
-  FileWrite $R0 '  Write-Host "URL: $exeUrl"$\r$\n'
+  FileWrite $R0 '  Write-Host "URL: $msiUrl"$\r$\n'
 
   ; Prefer curl.exe (ships with Windows 10 1803+). It has built-in retry,
   ; picks up system proxy env vars automatically, and is far more reliable
@@ -108,11 +108,11 @@ Section "Install" SecMain
   FileWrite $R0 '  $curl = Join-Path $env:SystemRoot "System32\curl.exe"$\r$\n'
   FileWrite $R0 '  if (Test-Path $curl) {$\r$\n'
   FileWrite $R0 '    Write-Host "Using curl.exe"$\r$\n'
-  FileWrite $R0 '    & $curl --fail --location --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 30 --max-time 1800 -A $ua -o $dest $exeUrl$\r$\n'
+  FileWrite $R0 '    & $curl --fail --location --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 30 --max-time 1800 -A $ua -o $dest $msiUrl$\r$\n'
   FileWrite $R0 '    if ($LASTEXITCODE -ne 0) { throw "curl.exe failed (exit $LASTEXITCODE)" }$\r$\n'
   FileWrite $R0 '  } else {$\r$\n'
   FileWrite $R0 '    Write-Host "curl.exe not found, using Invoke-WebRequest"$\r$\n'
-  FileWrite $R0 '    Invoke-WithRetry -Label "Download" -Block { Invoke-WebRequest -Uri $exeUrl -OutFile $dest -UseBasicParsing -TimeoutSec 1800 -Headers @{ "User-Agent" = $ua } }$\r$\n'
+  FileWrite $R0 '    Invoke-WithRetry -Label "Download" -Block { Invoke-WebRequest -Uri $msiUrl -OutFile $dest -UseBasicParsing -TimeoutSec 1800 -Headers @{ "User-Agent" = $ua } }$\r$\n'
   FileWrite $R0 '  }$\r$\n'
 
   ; Validate. GitHub occasionally serves a tiny HTML redirect/error page
@@ -165,8 +165,8 @@ Section "Install" SecMain
   ${EndIf}
 
   DetailPrint "Launching installer..."
-  ExecWait '"$TEMP\knapsack-setup-full.exe"' $0
-  Delete "$TEMP\knapsack-setup-full.exe"
+  ExecWait 'msiexec /i "$TEMP\knapsack-setup-full.msi"' $0
+  Delete "$TEMP\knapsack-setup-full.msi"
 
   ${If} $0 != 0
     MessageBox MB_OK|MB_ICONEXCLAMATION \

--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -231,9 +231,11 @@ if (IS_WIN) {
 // fails with LGHT0103 on these. List the subdir to remove (not the whole package,
 // so the CJS dist/ entry point remains usable at runtime).
 const LONG_PATH_PACKAGE_SUBDIRS = [
-  // @mistralai/mistralai ESM operation files have ~100-char filenames that push
-  // the full path past 260 chars. The CJS dist/ tree is unaffected and sufficient.
+  // @mistralai/mistralai ESM and src TypeScript operation files have ~100-char
+  // filenames that push the full path past 260 chars on Windows. The CJS dist/
+  // tree is unaffected and sufficient at runtime.
   path.join('@mistralai', 'mistralai', 'esm'),
+  path.join('@mistralai', 'mistralai', 'src'),
 ];
 
 if (fs.existsSync(distExtensionsDir)) {


### PR DESCRIPTION
## Summary

- **`prune-clawdbot.cjs`**: Add `@mistralai/mistralai/src` to `LONG_PATH_PACKAGE_SUBDIRS`. The `src/` tree contains TypeScript operation files with ~100-char names that push paths past Windows MAX_PATH (260 chars) inside extension `node_modules`, causing NSIS/WiX `LGHT0103`. Only `esm/` was removed before; `src/` is also unused at runtime.

- **`release.yml`**: Switch the `build-windows` job from `--bundles nsis` to `--bundles msi --verbose`, with the same frontend-first → tar-pack → disable-`beforeBuildCommand` sequence already used in `build-windows.yml`. NSIS is 32-bit and OOMs on the large clawdbot resource set; WiX (64-bit `light.exe`) handles it correctly. The `publish-release` job now looks for `.msi.zip.sig` for the auto-updater signature and `setupUrl` in `latest.json` points to the `.msi` file.

- **`stub.nsi`**: Update the web-setup stub to save the download as `.msi` and launch it via `msiexec /i` instead of `ExecWait` on an NSIS exe, matching the new release artifact format.

## Test plan

- [ ] Windows CI build completes without MAX_PATH / LGHT0103 errors
- [ ] MSI artifact is produced and uploaded
- [ ] `latest.json` `windows-x86_64.url` points to `.msi.zip`, `setupUrl` points to `.msi`
- [ ] Web-setup stub downloads and launches the MSI correctly via `msiexec`

https://claude.ai/code/session_01TChSnT4rLQSQ7Jts5VSqfq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TChSnT4rLQSQ7Jts5VSqfq)_