### PR TITLE
Add API key setup banner and suppress error banners during onboarding

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -1746,7 +1746,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     channelStatus.genericChannels.irc?.configured ||
     channelStatus.genericChannels.googlechat?.configured
   )
-  const showChannelBanner = msgs.every(m => m.id.startsWith('welcome-')) && !hasAnyChannel && !hasAnyGenericChannel
+  const showChannelBanner = hasCompletedOnboarding && msgs.every(m => m.id.startsWith('welcome-')) && !hasAnyChannel && !hasAnyGenericChannel
 
   // Build channel status tooltip and button color class
   const channelButtonInfo = useMemo(() => {
@@ -4729,6 +4729,23 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
             </div>
           </div>
         )}
+        {/* API key setup banner — shown on first launch until an API key is saved */}
+        {!hasCompletedOnboarding && msgs.every(m => m.id.startsWith('welcome-')) && (
+          <div className="ClawdMsg ClawdMsg-assistant">
+            <div className="ClawdBubble ClawdApiKeyBanner">
+              <p className="ClawdApiKeyBannerTitle">One more step to get started</p>
+              <p className="ClawdApiKeyBannerDesc">
+                Add an API key from Anthropic, OpenAI, Gemini, or another provider to start chatting. Your key is stored locally and never shared.
+              </p>
+              <button
+                className="ClawdApiKeyBannerBtn"
+                onClick={() => { setShowKeyPrompt(true); setShowSkillsPanel(false); setShowChannelsPanel(false) }}
+              >
+                Add API Key
+              </button>
+            </div>
+          </div>
+        )}
         {/* Channel connection banner — shown in welcome area when no channels are connected */}
         {showChannelBanner && (
           <div className="ClawdMsg ClawdMsg-assistant">
@@ -4761,8 +4778,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           </div>
         )}
         {/* Gateway troubleshooting banner — shown only after grace period (3 polls × 3 s = 9 s)
-            so brief restarts and sleep/wake blips don't surface a scary error. */}
-        {health && !health.gateway_ok && gatewayDownPolls >= 3 && !channelStatus.gatewayStarting && (
+            so brief restarts and sleep/wake blips don't surface a scary error.
+            Suppressed entirely until an API key is saved — the gateway status is
+            irrelevant and alarming when the user hasn't set up a key yet. */}
+        {hasCompletedOnboarding && health && !health.gateway_ok && gatewayDownPolls >= 3 && !channelStatus.gatewayStarting && (
           <div className="ClawdMsg ClawdMsg-assistant">
             <div className="ClawdBubble ClawdGatewayBanner">
               <p className="ClawdGatewayBannerTitle">Gateway connectivity issue</p>
@@ -4796,7 +4815,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           </div>
         )}
         {/* Browser-only issue banner — gateway OK but browser not responding for 60s+ */}
-        {health && health.gateway_ok && !health.browser_ok && !channelStatus.gatewayStarting && browserNotReadyPolls >= 20 && (
+        {hasCompletedOnboarding && health && health.gateway_ok && !health.browser_ok && !channelStatus.gatewayStarting && browserNotReadyPolls >= 20 && (
           <div className="ClawdMsg ClawdMsg-assistant">
             <div className="ClawdBubble ClawdGatewayBanner ClawdGatewayBanner--warn">
               <p className="ClawdGatewayBannerTitle">Browser is not responding</p>

--- a/src/src/components/organisms/ClawdChat/style.scss
+++ b/src/src/components/organisms/ClawdChat/style.scss
@@ -2668,6 +2668,47 @@
   }
 }
 
+// API key setup banner — shown on first launch before a key is saved
+.ClawdApiKeyBanner {
+  background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);
+  border: 1px solid #c4b5fd;
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.ClawdApiKeyBannerTitle {
+  font-weight: 600;
+  font-size: 14px;
+  color: #4c1d95;
+  margin: 0 0 4px;
+}
+
+.ClawdApiKeyBannerDesc {
+  font-size: 13px;
+  color: #5b21b6;
+  margin: 0 0 14px;
+  line-height: 1.45;
+}
+
+.ClawdApiKeyBannerBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  background: #7c3aed;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #6d28d9;
+  }
+}
+
 // Gateway troubleshooting banner — shown when gateway or browser is down
 .ClawdGatewayBanner {
   background: linear-gradient(135deg, #fef2f2 0%, #fff7ed 100%);


### PR DESCRIPTION
## Summary
This PR improves the first-launch experience by adding a dedicated API key setup banner and suppressing potentially confusing error messages until the user has completed initial setup.

## Key Changes
- **New API key setup banner**: Added a prominent banner that appears on first launch before an API key is saved, guiding users to add their API key from Anthropic, OpenAI, Gemini, or another provider
- **Styling for banner**: Added comprehensive SCSS styles for the banner including title, description, and button with hover effects using a purple gradient theme
- **Suppress error banners during onboarding**: Gateway and browser error banners are now hidden until `hasCompletedOnboarding` is true, preventing alarming error messages when the user hasn't yet configured an API key
- **Fixed channel banner logic**: Updated the channel connection banner condition to also check `hasCompletedOnboarding`, ensuring consistent banner behavior during the onboarding flow

## Implementation Details
- The API key banner is conditionally rendered when the user hasn't completed onboarding and only welcome messages are present
- Clicking the "Add API Key" button opens the key prompt modal and closes other panels
- Error banners (gateway connectivity and browser responsiveness) are now gated behind the `hasCompletedOnboarding` flag to reduce user confusion during initial setup
- Added clarifying comments explaining why error banners are suppressed during onboarding

https://claude.ai/code/session_01RZTYNuUzX8MLeJtGMu9F72