### PR TITLE
Fix live log streaming and improve command handling

### DIFF
--- a/src/src-tauri/Cargo.lock
+++ b/src/src-tauri/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "knapsack"
-version = "0.9.610"
+version = "1.7.6"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/src/src-tauri/Cargo.toml
+++ b/src/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "knapsack"
-version = "0.9.610"
+version = "1.7.6"
 description = "Knapsack"
 authors = ["you"]
 license = "AGPL-3.0"

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -3167,7 +3167,8 @@ When a user asks about ANY topic (a person, a project, a trip, a deal, an event)
 
 ### CREATIVE PROBLEM SOLVING
 - If a direct search yields nothing, think laterally: search for related people, dates, locations, or keywords
-- If a service is not logged in, try another service that might have the same info
+- If a service shows a "Continue as [name]" sign-in prompt, click it to authenticate — do not switch to a different browser window or profile
+- If a service is not logged in and no sign-in prompt is available, try another service that might have the same info
 - If one search query fails, try 3-5 alternative queries before moving on
 - If the obvious path is blocked, find a creative workaround — use JavaScript, try different URLs, use alternative navigation
 
@@ -3813,7 +3814,9 @@ When your response includes recommended actions the user can take (e.g. "reply t
 Example:
 [Reply to Sarah's email](knapsack://prompt/Open Gmail and draft a reply to Sarah's latest email about the Q4 report, acknowledging receipt and confirming the Friday deadline)
 
-These links are rendered as red clickable buttons in the UI. Include them whenever you have specific, actionable recommendations — especially after checking email, calendar, or summarizing tasks.
+These links are rendered as red clickable buttons in the UI, appearing **below** your message text. Include them whenever you have specific, actionable recommendations — especially after checking email, calendar, or summarizing tasks.
+
+**IMPORTANT:** Buttons always appear below the text, never above. If you refer to an action button in your message, say "click the button below" — never "click the button above".
 
 **Remember**: You are PERSISTENT. When given a complex task, work through it systematically. Try multiple approaches if one fails. Don't stop until the job is FULLY DONE or you've exhausted reasonable options."#,
     tone_section,

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -649,6 +649,14 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
     }
   }
 
+  // Ensure `ignore` is present — used by the openclaw CLI for .gitignore-style
+  // file filtering.  Like jiti, it is not committed to the repo and must be
+  // npm-installed at runtime.
+  if !root_nm.join("ignore").exists() && !missing_root.iter().any(|s| s.starts_with("ignore")) {
+    eprintln!("[clawd/service] `ignore` package missing — queuing ignore@^7.0.0 for install");
+    missing_root.push("ignore@^7.0.0".to_string());
+  }
+
   // Always recreate the openclaw self-symlink regardless of whether any deps
   // need installing — it must survive app updates where the bundle is replaced.
   ensure_openclaw_self_link(&root_nm);
@@ -6844,6 +6852,11 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
       .map(|s| s.success())
       .unwrap_or(false);
     if is_loaded {
+      // Gateway is already running — still apply the allowlist auto-heal so
+      // that a bad config (e.g. WhatsApp dmPolicy="allowlist" with no senders)
+      // is fixed on disk before the *next* gateway restart.
+      let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+      sanitize_config_file_allowlist(&config_path);
       return;
     }
     eprintln!("[clawd/service] auto_enable: plist exists but service not loaded — re-bootstrapping");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -460,7 +460,22 @@ fn install_bundled_plugin_runtime_deps(node_path: &std::path::Path, extensions_d
       } else {
         node_dir.join("npm")
       };
-      NpmRunner::NpmBin(if bin.exists() { bin } else { PathBuf::from("npm") })
+      if bin.exists() {
+        NpmRunner::NpmBin(bin)
+      } else {
+        // LaunchAgent environments have a stripped PATH that excludes Homebrew and nvm.
+        // Search well-known npm locations before falling back to bare "npm".
+        let fallback_npm = [
+          "/opt/homebrew/bin/npm",
+          "/usr/local/bin/npm",
+          "/usr/bin/npm",
+        ]
+        .iter()
+        .map(PathBuf::from)
+        .find(|p| p.exists())
+        .unwrap_or_else(|| PathBuf::from("npm"));
+        NpmRunner::NpmBin(fallback_npm)
+      }
     }
   } else {
     NpmRunner::NpmBin(PathBuf::from("npm"))

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -6857,6 +6857,10 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
       // is fixed on disk before the *next* gateway restart.
       let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
       sanitize_config_file_allowlist(&config_path);
+      // Also remove any stale standalone OpenClaw plist — it could be competing
+      // on port 18789 and causing the connect/disconnect instability even though
+      // our own service is "loaded."
+      remove_stale_standalone_gateway();
       return;
     }
     eprintln!("[clawd/service] auto_enable: plist exists but service not loaded — re-bootstrapping");

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -765,6 +765,66 @@ async fn kn_read_logs(app: AppHandle, log_type: String, max_lines: Option<usize>
     Ok(lines[start..].to_vec())
 }
 
+/// Streaming variant for live log tailing.  Returns only the bytes after
+/// `since_offset` (a byte position in the file) plus the new file size so the
+/// caller can pass it back on the next poll.  If the file has been rotated
+/// (new size < since_offset), we reset and return the full tail instead.
+#[tauri::command]
+async fn kn_read_logs_since(
+    app: AppHandle,
+    log_type: String,
+    since_offset: u64,
+) -> Result<(Vec<String>, u64), String> {
+    let log_dir = app
+        .path_resolver()
+        .app_log_dir()
+        .ok_or("Could not resolve log directory")?;
+
+    let log_path = match log_type.as_str() {
+        "error" => log_dir.join("ks_error.log"),
+        "clawdbot_err" => crate::clawd::service::gateway_stderr_log(),
+        "clawdbot_out" => crate::clawd::service::gateway_stdout_log(),
+        _ => log_dir.join("ks.log"),
+    };
+
+    let metadata = std::fs::metadata(&log_path)
+        .map_err(|e| format!("Failed to stat log file: {}", e))?;
+    let file_size = metadata.len();
+
+    // When since_offset exceeds the file size (first poll uses a large sentinel,
+    // or the file was rotated/truncated), start from a reasonable tail so we
+    // show recent context without dumping the whole file.
+    let read_from = if since_offset > file_size {
+        file_size.saturating_sub(32 * 1024) // last 32 KB
+    } else {
+        since_offset
+    };
+
+    if read_from >= file_size {
+        return Ok((vec![], file_size));
+    }
+
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(&log_path)
+        .map_err(|e| format!("Failed to open log file: {}", e))?;
+    f.seek(SeekFrom::Start(read_from))
+        .map_err(|e| format!("Seek failed: {}", e))?;
+
+    let mut buf = String::new();
+    f.read_to_string(&mut buf)
+        .map_err(|e| format!("Read failed: {}", e))?;
+
+    // If we seeked into the middle of a line, skip to the first newline.
+    let content = if read_from > 0 {
+        buf.find('\n').map(|i| &buf[i + 1..]).unwrap_or("")
+    } else {
+        &buf
+    };
+
+    let lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
+    Ok((lines, file_size))
+}
+
 #[tauri::command]
 async fn kn_get_openclaw_version(app: AppHandle) -> Result<String, String> {
     let pkg_path = app
@@ -1571,6 +1631,7 @@ async fn main() {
       update_tray_menu,
       update_tray_title,
       kn_read_logs,
+      kn_read_logs_since,
       kn_get_log_path,
       kn_get_openclaw_version,
       kn_execute_command,

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -1257,6 +1257,7 @@ function App() {
         meetingId: meetingId,
       })
       await invoke('activate_main_window')
+      window.dispatchEvent(new CustomEvent('clawd-open-meeting'))
       try {
         await startRecordingExistingMeeting(meetingId, openUrl, startRecord)
       } catch (error) {

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -249,6 +249,7 @@ function App() {
     hasSynthesized,
   } = useRecording()
   const isAnyRecordingRef = useRef(isAnyRecording)
+  const suppressMicNotificationRef = useRef(false)
 
   useEffect(() => {
     const email = auth.profile?.email ?? ''
@@ -1049,11 +1050,21 @@ function App() {
     }
   }, [])
 
+  // Suppress mic-activated notification briefly when the user explicitly starts a quick note,
+  // so the "You're on a call" popup doesn't appear redundantly alongside the recording UI.
+  useEffect(() => {
+    const unlistenPromise = listen('create_quick_note', () => {
+      suppressMicNotificationRef.current = true
+      setTimeout(() => { suppressMicNotificationRef.current = false }, 10000)
+    })
+    return () => { unlistenPromise.then(unlisten => unlisten()) }
+  }, [])
+
   // Listen for mic-activated events emitted by the Rust mic monitor.
   // Show a "Take Notes" prompt when any app activates the mic (unscheduled calls).
   useEffect(() => {
     const unlistenPromise = listen('mic-activated', async () => {
-      if (isAnyRecordingRef.current) return
+      if (isAnyRecordingRef.current || suppressMicNotificationRef.current) return
       try {
         await openNotificationWindow(
           undefined,

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -1650,7 +1650,8 @@ const TerminalView: React.FC = () => {
             updateSession(activeSession.id, s => ({ ...s, lines: [] }))
             if (liveLogsSession === activeSession.id) {
               setLiveLogsSession(null)
-              lastLogLineCountRef.current = 0
+              lastLogOffsetRef.current = 0
+              lastGwOffsetRef.current = 0
             }
           }}
         >

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -870,7 +870,8 @@ const TerminalView: React.FC = () => {
 
   // Live log streaming state
   const [liveLogsSession, setLiveLogsSession] = useState<string | null>(null)
-  const lastLogLineCountRef = useRef<number>(0)
+  const lastLogOffsetRef = useRef<number>(0)
+  const lastGwOffsetRef = useRef<number>(0)
   const clawdbotInitRef = useRef(false)
 
   // Auto-fetch backend status when Clawdbot session first opens
@@ -902,18 +903,42 @@ const TerminalView: React.FC = () => {
     fetchStatus()
   }, [sessions, addLine])
 
-  // Live log polling
+  // Live log polling — uses byte-offset tracking so we only fetch new content
+  // on each poll.  The old line-count approach broke once the count hit maxLines
+  // (500): lines.slice(500) was always [] and no new lines ever appeared.
+  //
+  // Number.MAX_SAFE_INTEGER is used as the sentinel for the first poll,
+  // which tells the Rust side to start from the last 32 KB of the file
+  // (recent context without dumping the whole file).
   useEffect(() => {
     if (!liveLogsSession) return
-    lastLogLineCountRef.current = 0
+    // Large sentinel → Rust will start from the last 32 KB of each file,
+    // giving recent context without dumping the full history.
+    lastLogOffsetRef.current = Number.MAX_SAFE_INTEGER
+    lastGwOffsetRef.current = Number.MAX_SAFE_INTEGER
 
     const poll = async () => {
       try {
-        const lines: string[] = await invoke('kn_read_logs', { logType: 'all', maxLines: 500 })
-        const newLines = lines.slice(lastLogLineCountRef.current)
-        if (newLines.length > 0) {
-          lastLogLineCountRef.current = lines.length
-          newLines.forEach(line => addLine(liveLogsSession, 'stdout', line))
+        // Poll app log and gateway stderr in parallel; interleave results.
+        const [appResult, gwResult] = await Promise.allSettled([
+          invoke<[string[], number]>('kn_read_logs_since', {
+            logType: 'all',
+            sinceOffset: lastLogOffsetRef.current,
+          }),
+          invoke<[string[], number]>('kn_read_logs_since', {
+            logType: 'clawdbot_err',
+            sinceOffset: lastGwOffsetRef.current,
+          }),
+        ])
+        if (appResult.status === 'fulfilled') {
+          const [lines, newOffset] = appResult.value
+          lines.forEach(line => addLine(liveLogsSession, 'stdout', `[app] ${line}`))
+          lastLogOffsetRef.current = newOffset
+        }
+        if (gwResult.status === 'fulfilled') {
+          const [lines, newOffset] = gwResult.value
+          lines.forEach(line => addLine(liveLogsSession, 'stderr', `[gw] ${line}`))
+          lastGwOffsetRef.current = newOffset
         }
       } catch {
         // Log reading may fail if files don't exist yet

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -1133,6 +1133,7 @@ const TerminalView: React.FC = () => {
       const session = sessions.find(s => s.id === sessionId)
       if (!session) return
       const trimmed = command.trim()
+      const cmd = trimmed.toLowerCase()
 
       // For PTY sessions, always forward Enter (even when empty) so that
       // interactive TUI prompts (e.g. Claude Code selection menus) receive
@@ -1152,12 +1153,12 @@ const TerminalView: React.FC = () => {
       }))
       addLine(sessionId, 'command', `$ ${trimmed}`)
 
-      if (trimmed === 'clear') {
+      if (cmd === 'clear') {
         updateSession(sessionId, s => ({ ...s, lines: [] }))
         return
       }
 
-      if (trimmed === 'help') {
+      if (cmd === 'help') {
         addLine(sessionId, 'system', [
           'Built-in commands:',
           '  clear              Clear terminal output',
@@ -1178,7 +1179,7 @@ const TerminalView: React.FC = () => {
       }
 
       // Live logs toggle command
-      if (trimmed === 'live logs' || trimmed === 'logs' || trimmed === 'live' || trimmed === 'tail') {
+      if (cmd === 'live logs' || cmd === 'logs' || cmd === 'live' || cmd === 'tail') {
         if (liveLogsSession === sessionId) {
           setLiveLogsSession(null)
           addLine(sessionId, 'system', 'Live log streaming stopped.')
@@ -1190,7 +1191,7 @@ const TerminalView: React.FC = () => {
       }
 
       // Service status command
-      if (trimmed === 'status' || trimmed === 'service status') {
+      if (cmd === 'status' || cmd === 'service status') {
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
           const [statusRes, healthRes] = await Promise.all([
@@ -1213,8 +1214,8 @@ const TerminalView: React.FC = () => {
       }
 
       // enable / disable — register or remove the LaunchAgent
-      if (trimmed === 'enable' || trimmed === 'disable') {
-        const enabling = trimmed === 'enable'
+      if (cmd === 'enable' || cmd === 'disable') {
+        const enabling = cmd === 'enable'
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         addLine(sessionId, 'system', enabling ? 'Registering LaunchAgent and starting gateway...' : 'Stopping gateway and removing LaunchAgent...')
         try {
@@ -1249,10 +1250,10 @@ const TerminalView: React.FC = () => {
 
       // gateway restart — re-run enable to restart the gateway LaunchAgent
       if (
-        trimmed === 'gateway restart' ||
-        trimmed === 'restart' ||
-        trimmed === 'openclaw gateway restart' ||
-        trimmed === 'openclaw restart'
+        cmd === 'gateway restart' ||
+        cmd === 'restart' ||
+        cmd === 'openclaw gateway restart' ||
+        cmd === 'openclaw restart'
       ) {
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         addLine(sessionId, 'system', 'Restarting gateway (re-registering LaunchAgent)...')
@@ -1282,18 +1283,18 @@ const TerminalView: React.FC = () => {
       }
 
       // openclaw install — openclaw is embedded; guide user to enable/doctor instead
-      if (trimmed === 'openclaw install' || trimmed === 'openclaw setup') {
+      if (cmd === 'openclaw install' || cmd === 'openclaw setup') {
         addLine(sessionId, 'system', 'openclaw is bundled inside Knapsack — no separate install needed.\nTry: "enable" to start the gateway, or "doctor" to diagnose issues.')
         return
       }
 
       // Skills CLI commands — intercept and call the backend API
-      if (trimmed === 'skills' || trimmed === 'skills help') {
+      if (cmd === 'skills' || cmd === 'skills help') {
         addLine(sessionId, 'system', 'Usage: skills <command>\n\n  skills list       List all skills with status\n  skills install    Install a skill (e.g. skills install GitHub)\n  skills enable     Enable a skill (e.g. skills enable GitHub)\n  skills disable    Disable a skill (e.g. skills disable GitHub)\n  skills help       Show this help')
         return
       }
 
-      if (trimmed === 'skills list' || trimmed === 'skills status' || trimmed === 'skills check') {
+      if (cmd === 'skills list' || cmd === 'skills status' || cmd === 'skills check') {
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
           const resp = await fetch('http://127.0.0.1:8897/api/clawd/skills/status')
@@ -1414,7 +1415,7 @@ const TerminalView: React.FC = () => {
 
       // ── Legacy pipe-based execution (non-PTY fallback) ──
 
-      if (trimmed.startsWith('cd ')) {
+      if (cmd.startsWith('cd ')) {
         const dir = trimmed.slice(3).trim()
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
@@ -1437,18 +1438,18 @@ const TerminalView: React.FC = () => {
 
       // openclaw doctor — run as a streaming process for real-time self-heal output
       if (
-        trimmed === 'doctor' ||
-        trimmed === 'doctor --fix' ||
-        trimmed === 'openclaw doctor' ||
-        trimmed === 'openclaw doctor --fix'
+        cmd === 'doctor' ||
+        cmd === 'doctor --fix' ||
+        cmd === 'openclaw doctor' ||
+        cmd === 'openclaw doctor --fix'
       ) {
-        const isFixMode = trimmed.includes('--fix')
-        const cmd = isFixMode ? 'openclaw doctor --fix' : 'openclaw doctor'
+        const isFixMode = cmd.includes('--fix')
+        const doctorCmd = isFixMode ? 'openclaw doctor --fix' : 'openclaw doctor'
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
           addLine(sessionId, 'system', isFixMode ? 'Running openclaw doctor --fix...' : 'Running openclaw doctor...')
           const processId: string = await invoke('kn_spawn_streaming_command', {
-            command: cmd,
+            command: doctorCmd,
             cwd: session.cwd || undefined,
             sessionId,
           })
@@ -1461,7 +1462,7 @@ const TerminalView: React.FC = () => {
       }
 
       // Claude Code CLI — run as a streaming process so output appears in real-time
-      if (trimmed === 'claude' || trimmed.startsWith('claude ')) {
+      if (cmd === 'claude' || cmd.startsWith('claude ')) {
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
           addLine(sessionId, 'system', 'Starting Claude Code...')

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -2898,7 +2898,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         pushAssistant(`Great! I'm all set up with ${providerInfo?.name || selectedProvider} (${modelName}) and ready to help. Try asking me to browse a website!`)
       } catch (e: any) {
         pushAssistant(
-          'API key saved! You can now enable the browser assistant using the Enable button above.',
+          'API key saved! You can now enable the browser assistant using the Enable button below.',
         )
       }
     } catch (e: any) {

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -205,11 +205,17 @@ function Home({
       setCurrentTab(TabChoices.Openclaw)
     }
     const handleFocusChat = () => setCurrentTab(TabChoices.Openclaw)
+    const handleOpenMeeting = () => {
+      setCurrentTab(TabChoices.Meeting)
+      setMeetingSubView('meetings')
+    }
     window.addEventListener('clawd-email-draft-ready', handleEmailDraftReady)
     window.addEventListener('clawd-focus-chat', handleFocusChat)
+    window.addEventListener('clawd-open-meeting', handleOpenMeeting)
     return () => {
       window.removeEventListener('clawd-email-draft-ready', handleEmailDraftReady)
       window.removeEventListener('clawd-focus-chat', handleFocusChat)
+      window.removeEventListener('clawd-open-meeting', handleOpenMeeting)
     }
   }, [feed.loggedEmailAutopilot, feed.setComposedEmailDraft])
 


### PR DESCRIPTION
## Summary
This PR fixes live log streaming in the Activity Panel by switching from line-count tracking to byte-offset tracking, and improves command parsing consistency throughout the terminal interface.

## Key Changes

### Live Log Streaming Fix
- **Replaced line-count tracking with byte-offset tracking** in `TerminalView` to fix a critical bug where logs stopped appearing after reaching the 500-line limit
  - Old approach: `lastLogLineCountRef` tracked line count, but `lines.slice(500)` always returned empty array once limit was hit
  - New approach: `lastLogOffsetRef` and `lastGwOffsetRef` track byte positions in files, allowing continuous polling
- **Added new Rust backend command** `kn_read_logs_since()` that:
  - Returns only new content since a given byte offset plus the new file size
  - Handles file rotation by detecting when file size shrinks below the offset
  - Uses `Number.MAX_SAFE_INTEGER` as a sentinel for first poll to start from last 32 KB of file
- **Separated app and gateway logs** into parallel polling with proper interleaving and prefixes (`[app]` and `[gw]`)

### Command Parsing Improvements
- **Normalized command comparison** by converting trimmed input to lowercase once (`const cmd = trimmed.toLowerCase()`) and using it consistently throughout command handlers
- Applies to: `clear`, `help`, `live logs`/`logs`/`live`/`tail`, `status`, `enable`/`disable`, `gateway restart`, `openclaw install`, `skills`, `doctor`, and `claude` commands
- Improves robustness against case variations in user input

### Additional Fixes
- **NPM resolution in LaunchAgent environments**: Added fallback search for npm in well-known locations (`/opt/homebrew/bin/npm`, `/usr/local/bin/npm`, `/usr/bin/npm`) when the bundled npm is unavailable, since LaunchAgent has a stripped PATH
- **Added `ignore` package installation**: Ensures the `ignore` package (used by openclaw CLI for .gitignore-style filtering) is npm-installed at runtime
- **Gateway auto-heal improvements**: When gateway is already running during `auto_enable_if_needed()`, now applies allowlist config sanitization and removes stale standalone OpenClaw plist that could cause port conflicts
- **Mic notification suppression**: Added `suppressMicNotificationRef` to prevent redundant "You're on a call" popup when user explicitly starts a quick note
- **Meeting tab navigation**: Added `clawd-open-meeting` event listener to navigate to Meeting tab when a meeting is opened
- **Browser assistant prompt clarification**: Updated instructions to clarify that sign-in prompts should be clicked and that action buttons appear below message text

## Implementation Details
- The byte-offset approach uses `Promise.allSettled()` to poll both app and gateway logs in parallel, gracefully handling failures in either stream
- File seeking skips partial lines at the start of a read to ensure clean line boundaries
- The 32 KB tail on first poll provides recent context without dumping entire file history

https://claude.ai/code/session_01LkojWCNDnm23fU8UVHgwqr