### PR TITLE
Fix unhandled rejection handler registration in bonjour extension

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/extensions/bonjour/index.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/bonjour/index.js
@@ -1,5 +1,5 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
+import { isTruthyEnvValue, registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
 //#region extensions/bonjour/src/errors.ts
 function formatBonjourError(err) {
 	if (err instanceof Error) {
@@ -150,7 +150,7 @@ async function startGatewayBonjourAdvertiser(opts, deps = {}) {
 			return {
 				responder,
 				services,
-				cleanupUnhandledRejection: services.length > 0 && deps.registerUnhandledRejectionHandler ? deps.registerUnhandledRejectionHandler(handleCiaoUnhandledRejection) : void 0
+				cleanupUnhandledRejection: services.length > 0 ? (deps.registerUnhandledRejectionHandler ?? registerUnhandledRejectionHandler)(handleCiaoUnhandledRejection) : void 0
 			};
 		}
 		async function stopCycle(cycle) {


### PR DESCRIPTION
## Summary
Updated the bonjour extension to properly handle unhandled rejection registration by importing the handler function and using a fallback pattern when the dependency is not provided.

## Key Changes
- Added `registerUnhandledRejectionHandler` to the imports from `openclaw/plugin-sdk/runtime-env`
- Updated the unhandled rejection handler registration logic to use the nullish coalescing operator (`??`) as a fallback to the imported function when `deps.registerUnhandledRejectionHandler` is not available
- Simplified the conditional logic by removing the redundant check for `deps.registerUnhandledRejectionHandler` existence in the ternary operator

## Implementation Details
The change improves the robustness of the handler registration by:
1. Ensuring the function is always available (either from dependencies or from the direct import)
2. Using the nullish coalescing operator to provide a sensible default when the dependency is not injected
3. Maintaining the original behavior where the handler is only registered when `services.length > 0`

https://claude.ai/code/session_01SxEpmZSKBLEC2obB36zHEy