### PR TITLE
Upgrade Node.js version to 22.19.0

### DIFF
--- a/src/scripts/prepare-node.cjs
+++ b/src/scripts/prepare-node.cjs
@@ -6,7 +6,7 @@
  * Runs automatically via the npm `prebuild` hook (before `tsc && vite build`),
  * so every `tauri build` gets the right binary without manual intervention.
  *
- * Override the version:  NODE_VERSION=22.15.0 node scripts/prepare-node.js
+ * Override the version:  NODE_VERSION=22.19.0 node scripts/prepare-node.js
  */
 const fs = require('fs');
 const path = require('path');
@@ -15,7 +15,7 @@ const { execSync } = require('child_process');
 const https = require('https');
 const http = require('http');
 
-const NODE_VERSION = process.env.NODE_VERSION || '22.16.0';
+const NODE_VERSION = process.env.NODE_VERSION || '22.19.0';
 const SCRIPT_DIR = __dirname;
 const PROJECT_DIR = path.resolve(SCRIPT_DIR, '..');
 const TARGET_DIR = path.join(PROJECT_DIR, 'src-tauri', 'resources', 'node');

--- a/src/scripts/prepare-node.sh
+++ b/src/scripts/prepare-node.sh
@@ -5,11 +5,11 @@
 # Runs automatically via the npm `prebuild` hook (before `tsc && vite build`),
 # so every `tauri build` gets the right binary without manual intervention.
 #
-# Override the version:  NODE_VERSION=22.15.0 bash scripts/prepare-node.sh
+# Override the version:  NODE_VERSION=22.19.0 bash scripts/prepare-node.sh
 #
 set -euo pipefail
 
-NODE_VERSION="${NODE_VERSION:-22.14.0}"
+NODE_VERSION="${NODE_VERSION:-22.19.0}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
## Summary
Updates the default Node.js version used in the build preparation scripts from 22.16.0 (and 22.14.0 in the shell script) to 22.19.0.

## Changes
- **prepare-node.cjs**: Updated default `NODE_VERSION` from `22.16.0` to `22.19.0` and updated the documentation example from `22.15.0` to `22.19.0`
- **prepare-node.sh**: Updated default `NODE_VERSION` from `22.14.0` to `22.19.0` and updated the documentation example from `22.15.0` to `22.19.0`

## Details
These scripts automatically download and prepare the Node.js binary during the `prebuild` npm hook, which runs before the TypeScript compilation and Vite build process. The version can be overridden via the `NODE_VERSION` environment variable. This update ensures that all Tauri builds will use the latest stable Node.js 22.x release.

https://claude.ai/code/session_01378sTkdSsEASZBo3z1iryD