### PR TITLE
Fix gateway restart race conditions and improve error handling

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -3087,10 +3087,25 @@ pub async fn chat(
     .or_insert_with(|| load_history_from_transcript(&session_id, 20));
 
   // Memory section — inject persistent notes from previous sessions.
+  // Cap to the 10 most-recent notes and 2 000 chars total to prevent context overflow.
+  // Notes arrive oldest-first from the frontend; take from the end to get the most recent.
+  const MEMORY_MAX_NOTES: usize = 10;
+  const MEMORY_MAX_CHARS: usize = 2000;
   let memory_section = if !memory_notes.is_empty() {
+    let recent: Vec<&String> = memory_notes.iter().rev().take(MEMORY_MAX_NOTES).collect::<Vec<_>>().into_iter().rev().collect();
+    let joined = recent.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n");
+    // Truncate by chars (not bytes) to avoid splitting UTF-8 sequences.
+    let char_count = joined.chars().count();
+    let capped = if char_count > MEMORY_MAX_CHARS {
+      let tail: String = joined.chars().skip(char_count - MEMORY_MAX_CHARS).collect();
+      // Drop any partial first line produced by the truncation.
+      tail.find('\n').map(|i| tail[i + 1..].to_string()).unwrap_or(tail)
+    } else {
+      joined
+    };
     format!(
       "\n\n## MEMORY FROM PREVIOUS SESSIONS\nThe following are summaries of previous conversations. Use them for context but do not repeat them verbatim:\n{}\n",
-      memory_notes.join("\n")
+      capped
     )
   } else {
     String::new()

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -3087,25 +3087,11 @@ pub async fn chat(
     .or_insert_with(|| load_history_from_transcript(&session_id, 20));
 
   // Memory section — inject persistent notes from previous sessions.
-  // Cap to the 10 most-recent notes and 2 000 chars total to prevent context overflow.
-  // Notes arrive oldest-first from the frontend; take from the end to get the most recent.
-  const MEMORY_MAX_NOTES: usize = 10;
-  const MEMORY_MAX_CHARS: usize = 2000;
+  // The frontend already caps this at 10 entries × 500 chars each (agentMemory.ts).
   let memory_section = if !memory_notes.is_empty() {
-    let recent: Vec<&String> = memory_notes.iter().rev().take(MEMORY_MAX_NOTES).collect::<Vec<_>>().into_iter().rev().collect();
-    let joined = recent.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n");
-    // Truncate by chars (not bytes) to avoid splitting UTF-8 sequences.
-    let char_count = joined.chars().count();
-    let capped = if char_count > MEMORY_MAX_CHARS {
-      let tail: String = joined.chars().skip(char_count - MEMORY_MAX_CHARS).collect();
-      // Drop any partial first line produced by the truncation.
-      tail.find('\n').map(|i| tail[i + 1..].to_string()).unwrap_or(tail)
-    } else {
-      joined
-    };
     format!(
       "\n\n## MEMORY FROM PREVIOUS SESSIONS\nThe following are summaries of previous conversations. Use them for context but do not repeat them verbatim:\n{}\n",
-      capped
+      memory_notes.join("\n")
     )
   } else {
     String::new()
@@ -4020,18 +4006,21 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         let dropped: Vec<_> = history.drain(0..drain).collect();
         // Summarize dropped messages so the model knows what was discussed,
         // rather than silently losing that context.
-        let summary_lines: Vec<String> = dropped.iter().filter_map(|msg| match msg {
-          chat_agent::OaiMessage::User { content, .. } => {
-            let snip = if content.len() > 200 { format!("{}…", &content[..200]) } else { content.clone() };
-            Some(format!("User: {}", snip))
+        let summary_lines: Vec<String> = dropped.iter().filter_map(|msg| {
+          // Truncate by char count, not byte length, to avoid panicking on
+          // multi-byte UTF-8 characters (emoji, CJK, etc.).
+          fn snip200(s: &str) -> String {
+            let mut chars = s.chars();
+            let head: String = chars.by_ref().take(200).collect();
+            if chars.next().is_some() { format!("{}…", head) } else { head }
           }
-          chat_agent::OaiMessage::Assistant { content, .. } => {
-            content.as_ref().map(|c| {
-              let snip = if c.len() > 200 { format!("{}…", &c[..200]) } else { c.clone() };
-              format!("Assistant: {}", snip)
-            })
+          match msg {
+            chat_agent::OaiMessage::User { content, .. } =>
+              Some(format!("User: {}", snip200(content))),
+            chat_agent::OaiMessage::Assistant { content, .. } =>
+              content.as_ref().map(|c| format!("Assistant: {}", snip200(c))),
+            _ => None,
           }
-          _ => None,
         }).collect();
         if !summary_lines.is_empty() {
           history.insert(0, chat_agent::OaiMessage::System {

--- a/src/src-tauri/src/clawd/gateway_supervisor.rs
+++ b/src/src-tauri/src/clawd/gateway_supervisor.rs
@@ -40,7 +40,12 @@ pub async fn is_gateway_healthy(token: &str) -> bool {
   };
 
   match client.get(gateway_health_url()).bearer_auth(token).send().await {
-    Ok(resp) => resp.status().is_success() || resp.status().as_u16() == 404,
+    // Any HTTP response (200, 401, 404, 500 …) means the gateway process is
+    // listening on the port.  Only a connection error means it is truly down.
+    // Treating 401 as "unhealthy" caused a restart loop: the supervisor would
+    // kickstart the gateway even though it was running, and the new instance
+    // would fail with EADDRINUSE.
+    Ok(_) => true,
     Err(_) => false,
   }
 }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1844,6 +1844,8 @@ fn classify_gateway_crash(log_tail: &str) -> &'static str {
     "gatekeeper_blocked"
   } else if lower.contains("missing-meta-before-write") || lower.contains("config write anomaly") {
     "config_anomaly"
+  } else if lower.contains("enotempty") || lower.contains("stage bundled runtime deps") || (lower.contains("plugin") && (lower.contains("npm install failed") || lower.contains("failed to install"))) {
+    "plugin_install_fail"
   } else {
     "unknown"
   }
@@ -1924,7 +1926,10 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         eprintln!("[clawd/service] gateway recovered — resetting browser nudge flag");
         BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
         // Allow a fresh Sentry alert if the gateway goes down again.
-        GATEWAY_DOWN_SENTRY_ALERTED.store(false, Ordering::Relaxed);
+        // Also send a recovery event so outage durations are visible in Sentry.
+        if GATEWAY_DOWN_SENTRY_ALERTED.swap(false, Ordering::Relaxed) {
+          sentry::capture_message("[gateway] recovered after outage", sentry::Level::Info);
+        }
         // Kill stale managed Chrome processes from the previous gateway
         // session.  They may still hold the CDP port (18800), preventing
         // the new gateway from launching its own browser.
@@ -1944,6 +1949,9 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     // We guard with GATEWAY_RESTART_IN_PROGRESS to prevent concurrent restarts.
     if !gateway_ok && !GATEWAY_RESTART_IN_PROGRESS.swap(true, Ordering::Relaxed) {
       let token = tokens.gateway_token.clone();
+      // Pre-compute paths before the spawn (app_handle can't cross async boundaries cheaply).
+      let restart_clawdbot_home = app_clawdbot_home(&app_handle);
+      let restart_bundle_ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
       eprintln!("[clawd/service] gateway not reachable — attempting background restart");
       tokio::spawn(async move {
         // Kill stale managed Chrome processes before restarting the gateway.
@@ -2023,6 +2031,26 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
           }
           eprintln!("[clawd/service] Windows background restart: no saved setup — use Enable in UI");
         }
+
+        // macOS: clear any zombie process holding port 18789.
+        // Without this, kickstart fails with EADDRINUSE when a crashed gateway
+        // process lingers on the port without responding to HTTP health checks.
+        #[cfg(not(target_os = "windows"))]
+        kill_process_on_port(18789);
+
+        // Remove stale plugin-runtime-deps locks and old versioned dirs.
+        // These are cleaned during initial enable but NOT during auto-restart,
+        // leaving ENOTEMPTY traps that cause bonjour (and other plugins) to
+        // fail their npm install on every subsequent gateway start.
+        remove_stale_plugin_runtime_deps_locks(&restart_clawdbot_home);
+        remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, &restart_bundle_ver);
+
+        // Sentry: record that a self-heal cycle ran so we can see frequency in
+        // the dashboard even when the gateway ultimately recovers cleanly.
+        sentry::capture_message(
+          "[gateway] auto-restart: port cleared + plugin-runtime-deps cleaned",
+          sentry::Level::Info,
+        );
 
         use crate::clawd::gateway_supervisor;
         let result = gateway_supervisor::ensure_gateway_running(LAUNCH_AGENT_LABEL, &token).await;

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -318,57 +318,80 @@ fn kill_stale_clawdbot_chromes() {
   }
 }
 
-/// Stop and remove the standalone OpenClaw gateway LaunchAgent if present.
+/// Boot out and delete any LaunchAgent plist that competes with our gateway on
+/// port 18789.  Returns the list of labels that were evicted.
 ///
-/// When a user previously installed standalone OpenClaw (`ai.openclaw.gateway`)
-/// and then switches to Knapsack Desktop (`ai.knap.knapsack.clawdbot`), both
-/// services compete for port 18789.  The standalone gateway may also use a
-/// different device token, causing "device token mismatch" errors.
+/// Catches two cases:
+///   1. Known labels (fast path): `ai.openclaw.gateway` (standalone openclaw
+///      CLI) and other variants seen in the wild.
+///   2. Dynamic scan: any `*.plist` in ~/Library/LaunchAgents whose filename
+///      contains "openclaw" or "clawdbot" but is NOT our own label.  This
+///      catches old Knapsack betas, future label renames, and unknown forks.
 ///
-/// This function is best-effort: if the plist doesn't exist or bootout fails,
-/// we silently continue.
+/// Called during initial enable/auto_enable AND during background auto-restart
+/// so that a competing service cannot prevent recovery after a gateway crash.
 #[cfg(target_os = "macos")]
-fn remove_stale_standalone_gateway() {
-  const STANDALONE_LABEL: &str = "ai.openclaw.gateway";
-  let home = match dirs::home_dir() {
-    Some(h) => h,
-    None => return,
-  };
-  let plist_path = home
-    .join("Library")
-    .join("LaunchAgents")
-    .join(format!("{}.plist", STANDALONE_LABEL));
+fn evict_competing_gateway_plists() -> Vec<String> {
+  const KNOWN_COMPETING_LABELS: &[&str] = &[
+    "ai.openclaw.gateway",
+    "com.openclaw.gateway",
+    "ai.knap.openclaw.gateway",
+    "ai.knap.knapsack.gateway",
+  ];
 
-  if !plist_path.exists() {
-    return;
-  }
-
-  eprintln!(
-    "[clawd/service] Found standalone OpenClaw gateway plist at {}; removing to avoid port conflict",
-    plist_path.display()
-  );
-
+  let home = match dirs::home_dir() { Some(h) => h, None => return vec![] };
+  let agents_dir = home.join("Library").join("LaunchAgents");
   let uid = unsafe { libc::getuid() };
   let domain = format!("gui/{}", uid);
+  let mut evicted: Vec<String> = Vec::new();
 
-  // Try to unload the service first
-  let _ = std::process::Command::new("launchctl")
-    .args(["bootout", &domain, plist_path.to_string_lossy().as_ref()])
-    .status();
+  // Inner closure can't borrow `evicted` mutably while captured immutably,
+  // so we collect candidates first and process them in a loop.
+  let mut candidates: Vec<(String, std::path::PathBuf)> = Vec::new();
 
-  // Remove the plist file so it doesn't get reloaded on login
-  if let Err(e) = std::fs::remove_file(&plist_path) {
-    eprintln!(
-      "[clawd/service] Failed to remove standalone plist {}: {}",
-      plist_path.display(),
-      e
-    );
-  } else {
-    eprintln!("[clawd/service] Removed standalone OpenClaw gateway plist");
+  for label in KNOWN_COMPETING_LABELS {
+    let plist = agents_dir.join(format!("{}.plist", label));
+    if plist.exists() {
+      candidates.push((label.to_string(), plist));
+    }
+  }
+  if let Ok(entries) = std::fs::read_dir(&agents_dir) {
+    for entry in entries.flatten() {
+      let fname = entry.file_name().to_string_lossy().to_string();
+      if !fname.ends_with(".plist") { continue; }
+      let lower = fname.to_lowercase();
+      if !lower.contains("openclaw") && !lower.contains("clawdbot") { continue; }
+      let label = fname.trim_end_matches(".plist").to_string();
+      if label == LAUNCH_AGENT_LABEL { continue; }
+      if candidates.iter().any(|(l, _)| l == &label) { continue; }
+      candidates.push((label, entry.path()));
+    }
   }
 
-  // Give the old gateway a moment to exit
-  std::thread::sleep(std::time::Duration::from_millis(1000));
+  for (label, plist) in &candidates {
+    eprintln!(
+      "[clawd/service] evicting competing gateway plist (label={} path={})",
+      label, plist.display()
+    );
+    let _ = std::process::Command::new("launchctl")
+      .args(["bootout", &domain, plist.to_string_lossy().as_ref()])
+      .status();
+    match std::fs::remove_file(plist) {
+      Ok(_) => {
+        eprintln!("[clawd/service] removed competing plist: {}", plist.display());
+        evicted.push(label.clone());
+      }
+      Err(e) => eprintln!(
+        "[clawd/service] WARNING: could not remove competing plist {}: {}",
+        plist.display(), e
+      ),
+    }
+  }
+
+  if !evicted.is_empty() {
+    std::thread::sleep(std::time::Duration::from_millis(800));
+  }
+  evicted
 }
 
 #[cfg(target_os = "windows")]
@@ -385,8 +408,13 @@ fn kill_stale_clawdbot_chromes() {
 }
 
 #[cfg(not(target_os = "macos"))]
+fn evict_competing_gateway_plists() -> Vec<String> {
+  vec![]
+}
+
+/// Thin shim kept for existing call sites that don't need the return value.
 fn remove_stale_standalone_gateway() {
-  // No-op on other platforms
+  evict_competing_gateway_plists();
 }
 
 /// Remove stale `.openclaw-runtime-deps.lock` directories left behind when a
@@ -2030,6 +2058,26 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
             return;
           }
           eprintln!("[clawd/service] Windows background restart: no saved setup — use Enable in UI");
+        }
+
+        // Evict any competing openclaw/clawdbot LaunchAgent plists before
+        // clearing the port.  A competing plist (standalone openclaw CLI,
+        // old Knapsack beta, etc.) re-launches a new process on port 18789
+        // immediately after kill_process_on_port, causing an instant EADDRINUSE
+        // on kickstart.  Removing the plist + booting out the service first
+        // prevents that race.
+        #[cfg(not(target_os = "windows"))]
+        {
+          let evicted = evict_competing_gateway_plists();
+          if !evicted.is_empty() {
+            sentry::with_scope(
+              |scope| scope.set_tag("competing_labels", &evicted.join(",")),
+              || sentry::capture_message(
+                &format!("[gateway] auto-restart: evicted competing plist(s): {:?}", evicted),
+                sentry::Level::Warning,
+              ),
+            );
+          }
         }
 
         // macOS: clear any zombie process holding port 18789.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1980,6 +1980,12 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       // Pre-compute paths before the spawn (app_handle can't cross async boundaries cheaply).
       let restart_clawdbot_home = app_clawdbot_home(&app_handle);
       let restart_bundle_ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
+      let restart_node_path = resource_path(&app_handle, if cfg!(target_os = "windows") {
+        "resources/node/node.exe"
+      } else {
+        "resources/node/node"
+      });
+      let restart_extensions_dir = resource_path(&app_handle, "resources/clawdbot/dist/extensions");
       eprintln!("[clawd/service] gateway not reachable — attempting background restart");
       tokio::spawn(async move {
         // Kill stale managed Chrome processes before restarting the gateway.
@@ -2092,6 +2098,14 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         // fail their npm install on every subsequent gateway start.
         remove_stale_plugin_runtime_deps_locks(&restart_clawdbot_home);
         remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, &restart_bundle_ver);
+
+        // Re-run plugin dep installs for any extension whose node_modules are
+        // missing (fast no-op when all deps are already present).  This is how
+        // playwright-core for the browser extension gets installed — if the
+        // initial enable-time install failed (ENOTEMPTY, npm unavailable, etc.)
+        // the gateway silently starts without it and every snapshot() call
+        // returns "Playwright is not available in this gateway build".
+        install_bundled_plugin_runtime_deps(&restart_node_path, &restart_extensions_dir);
 
         // Sentry: record that a self-heal cycle ran so we can see frequency in
         // the dashboard even when the gateway ultimately recovers cleanly.

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -502,6 +502,11 @@ function App() {
               // Refresh the connections list so the new account appears.
               fetchConnections(pendingFlow.primaryEmail).then(updatedConnections => {
                 syncConnections(pendingFlow.primaryEmail, updatedConnections)
+                setIsSignInDialogOpened(false)
+                cleanReconnectKeys()
+                reconnectDismissedRef.current = false
+                reconnectDismissCheckDone.current = false
+                KNLocalStorage.setItem(RECONNECT_DISMISSED_AT, undefined)
               })
             })
             .catch(error => {

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -242,8 +242,11 @@ function friendlyError(raw: string, activeModel?: string): string {
     return '🌐 **Browser failed to start.** Chrome could not launch. Check the logs for details or try restarting.'
   }
   // Network / connection errors
+  // WebKit raises "TypeError: Load failed" when the AI request is blocked
+  // (context window overflow, oversized payload, or DNS/network hang).
+  // The most common cause is a conversation that's grown too long for the model.
   if (lower.includes('load failed') && !lower.includes('model')) {
-    return `🌐 **Request too large** (active: \`${activeModel}\`). The message or attachment was too large to send. Try removing any image attachments, or start a new conversation to reduce context size.`
+    return `⚠️ **Message too large** (active: \`${activeModel}\`). The conversation or payload exceeded what this model can handle. Start a new conversation to reduce context size${activeModel ? `, or switch to a larger-context model in Settings → Provider` : ''}.\n\n${switchProviderAction}`
   }
   if (lower.includes('network') || lower.includes('econnrefused') || lower.includes('fetch failed')) {
     return `🌐 **Connection error** (active: \`${activeModel}\`). Unable to reach the AI service. Check your internet connection and try again.`

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -220,6 +220,14 @@ function friendlyError(raw: string, activeModel?: string): string {
   if (lower.includes('model_not_found') || lower.includes('does not exist') || lower.includes('no access')) {
     return `⚠️ **Model not available** (active: \`${activeModel}\`). Your API key may not have access to this model. Try switching to a different model in Settings.\n\n${switchProviderAction}`
   }
+  // Playwright / snapshot not available in gateway build
+  if (lower.includes('playwright') || lower.includes('snapshot() is unsupported') || lower.includes('not available in this gateway build')) {
+    return '📸 **Screenshot unavailable.** The browser screenshot feature (Playwright) is not installed in the current gateway build. Reinstall Knapsack to get the latest gateway version, then try again.'
+  }
+  // Context / prompt too large for model
+  if (lower.includes('context overflow') || lower.includes('prompt too large') || (lower.includes('too large') && lower.includes('model'))) {
+    return `⚠️ **Context overflow** (active: \`${activeModel}\`). The conversation is too long for this model. Start a new conversation to reduce context size, or switch to a model with a larger context window in Settings → Provider.\n\n${switchProviderAction}`
+  }
   // Browser automation errors
   if (lower.includes('browser control server') || lower.includes('browser not running') || lower.includes('clawdbot base_url is not configured')) {
     return '🌐 **Browser not available.** The browser assistant is not running. Go to Settings and enable Clawd, then try again.'


### PR DESCRIPTION
## Summary
This PR addresses critical issues with gateway auto-restart reliability, improves error classification and user messaging, and fixes a sign-in flow bug. The main focus is preventing race conditions during background gateway restarts and ensuring competing LaunchAgent services don't interfere with port binding.

## Key Changes

### Gateway Restart & Port Management
- **Refactored `remove_stale_standalone_gateway()` → `evict_competing_gateway_plists()`**: Now performs a comprehensive scan for competing openclaw/clawdbot LaunchAgent plists (both known labels and dynamic filesystem scan) and returns a list of evicted labels for telemetry
- **Added pre-restart cleanup in background restart flow**: Before attempting to restart the gateway, now:
  - Evicts competing LaunchAgent plists to prevent immediate re-launch race conditions
  - Kills zombie processes holding port 18789
  - Cleans stale plugin runtime dependency locks and versioned directories
  - Re-runs plugin dependency installs for missing node_modules
  - Sends Sentry events for observability
- **Fixed gateway health check logic**: Changed `is_gateway_healthy()` to treat any HTTP response (200, 401, 404, 500) as "healthy" since a response means the process is listening. Previously treating 401 as unhealthy caused restart loops when the gateway was actually running

### Error Classification & User Messaging
- **Added `plugin_install_fail` crash classification**: Detects ENOTEMPTY, plugin npm install failures, and bundled runtime staging errors
- **Improved error messages in ClawdChat**:
  - Added Playwright/screenshot unavailability message
  - Added context overflow detection and guidance
  - Clarified "Load failed" message to explain it's often a context window overflow issue
  - All error messages now include actionable recovery steps

### Browser History Truncation Fix
- **Fixed UTF-8 safety in message summarization**: Changed from byte-based string slicing (`&content[..200]`) to character-based iteration to prevent panicking on multi-byte UTF-8 characters (emoji, CJK, etc.)

### Sign-In Flow Fix
- **Fixed post-sign-in state cleanup**: After successfully signing in and refreshing connections, now properly clears the sign-in dialog, reconnect dismissal state, and related localStorage flags

## Implementation Details
- The `evict_competing_gateway_plists()` function uses a two-phase approach: fast path for known competing labels, then dynamic scan of `~/Library/LaunchAgents` for any plist containing "openclaw" or "clawdbot" (excluding our own label)
- Pre-computes app paths before spawning the async restart task to avoid expensive app_handle operations across async boundaries
- Adds 800ms sleep only if plists were actually evicted (vs. unconditional 1000ms)
- Comprehensive Sentry instrumentation for gateway recovery events and self-heal cycle tracking

https://claude.ai/code/session_01TJi9DosctJ2dx478XdK8Mb