### PR TITLE
Fix email recipient lookup and improve skill installation error handling

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -3028,11 +3028,24 @@ pub async fn chat(
       }
 
       // Phase 1: draft the email and store it as pending.
-      let to = args_map.get("to").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
+      let mut to = args_map.get("to").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
       let cc = args_map.get("cc").and_then(|v| v.as_str()).map(|s| s.trim().to_string());
       let subject = args_map.get("subject").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
       let body_html = args_map.get("body").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
       let thread_id = args_map.get("thread_id").and_then(|v| v.as_str()).map(|s| s.trim().to_string());
+
+      // When replying to an existing thread, look up the actual sender from the local DB
+      // so we don't rely on the LLM guessing the recipient's email address.
+      if let Some(ref tid) = thread_id {
+        if let Ok(thread_emails) = crate::db::models::email::Email::get_last_email_by_thread_id(tid) {
+          if let Some(most_recent) = thread_emails.first() {
+            let db_sender = most_recent.sender.trim().to_string();
+            if !db_sender.is_empty() && db_sender != user_email {
+              to = db_sender;
+            }
+          }
+        }
+      }
 
       if to.is_empty() || subject.is_empty() || body_html.is_empty() {
         anyhow::bail!("to, subject, and body are all required");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -6319,8 +6319,8 @@ pub async fn skills_install(
     Ok(result) => HttpResponse::Ok().json(serde_json::json!({"success": true, "result": result})),
     Err(e) => {
       eprintln!("[clawd/service] skills.install error: {}", e);
-      HttpResponse::BadGateway()
-        .json(serde_json::json!({"success": false, "error": "Skill installation requires the ClawdBot gateway to be running. Check the Activity panel for gateway status."}))
+      HttpResponse::Ok()
+        .json(serde_json::json!({"success": false, "error": format!("Skill installation failed: {}. Make sure the ClawdBot gateway is running — check the Activity panel.", e)}))
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR addresses two issues: improving email recipient handling when replying to threads, and providing better error feedback for skill installation failures.

## Key Changes

- **Email recipient lookup for thread replies**: When drafting a reply to an existing email thread, the system now looks up the actual sender from the local database instead of relying on the LLM to guess the recipient's email address. This ensures replies are sent to the correct person.

- **Skill installation error handling**: Changed the error response for failed skill installations from `BadGateway` (502) to `Ok` (200) with a more informative error message that includes the actual failure reason and guidance to check the gateway status.

## Implementation Details

- The email recipient lookup only applies when replying to an existing thread (`thread_id` is present)
- The database lookup retrieves the most recent email in the thread and uses its sender as the reply recipient
- The lookup is skipped if the sender is empty or matches the current user's email address
- The skill installation error message now includes the underlying error details to help with debugging

https://claude.ai/code/session_01UQxUznUwb2Gv6CQqYKP9vA