### PR TITLE
Improve notarization polling resilience with notarytool info

### DIFF
--- a/src/scripts/sign-and-notarize.sh
+++ b/src/scripts/sign-and-notarize.sh
@@ -281,19 +281,22 @@ if [ "$DO_NOTARIZE" = true ]; then
   fi
   echo "[notarize] Submission ID: $SUBMISSION_ID"
 
-  # Wait for result; retry up to 5 times on transient network failures
-  NOTARY_STATUS=""; _WAIT_DELAY=30
-  for _attempt in 1 2 3 4 5; do
-    echo "[notarize] Polling .app notarization status (attempt $_attempt/5)..."
-    _WAIT_OUTPUT=$(xcrun notarytool wait "$SUBMISSION_ID" \
+  # Poll using `notarytool info` so a network blip only loses one cycle,
+  # not the entire blocking `notarytool wait` call.
+  NOTARY_STATUS=""; _POLL_DELAY=30; _POLL_MAX=40
+  echo "[notarize] Polling .app notarization status (up to ${_POLL_MAX} attempts)..."
+  for _attempt in $(seq 1 "$_POLL_MAX"); do
+    _INFO_OUTPUT=$(xcrun notarytool info "$SUBMISSION_ID" \
       --apple-id "$APPLE_ID" \
       --team-id "$APPLE_TEAM_ID" \
       --password "$APPLE_APP_PASSWORD" 2>&1) || true
-    echo "$_WAIT_OUTPUT"
-    NOTARY_STATUS=$(echo "$_WAIT_OUTPUT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
-    [ -n "$NOTARY_STATUS" ] && break
-    echo "[notarize] No status received (network error?); retrying in ${_WAIT_DELAY}s..."
-    sleep "$_WAIT_DELAY"; _WAIT_DELAY=$((_WAIT_DELAY * 2))
+    NOTARY_STATUS=$(echo "$_INFO_OUTPUT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
+    echo "[notarize] Attempt $_attempt/${_POLL_MAX}: status=${NOTARY_STATUS:-<network error>}"
+    if [ "$NOTARY_STATUS" = "Accepted" ] || [ "$NOTARY_STATUS" = "Invalid" ]; then
+      break
+    fi
+    # In Progress or empty (network blip) — wait and retry
+    sleep "$_POLL_DELAY"
   done
 
   if [ "$NOTARY_STATUS" != "Accepted" ]; then
@@ -355,18 +358,20 @@ if [ "$DO_NOTARIZE" = true ]; then
       fi
       echo "[notarize] DMG submission ID: $DMG_SUBMISSION_ID"
 
-      DMG_STATUS=""; _DMG_DELAY=30
-      for _attempt in 1 2 3 4 5; do
-        echo "[notarize] Polling DMG notarization status (attempt $_attempt/5)..."
-        _DMG_WAIT=$(xcrun notarytool wait "$DMG_SUBMISSION_ID" \
+      # Poll using `notarytool info` so a network blip only loses one cycle.
+      DMG_STATUS=""; _DMG_POLL_DELAY=30; _DMG_POLL_MAX=40
+      echo "[notarize] Polling DMG notarization status (up to ${_DMG_POLL_MAX} attempts)..."
+      for _attempt in $(seq 1 "$_DMG_POLL_MAX"); do
+        _DMG_INFO=$(xcrun notarytool info "$DMG_SUBMISSION_ID" \
           --apple-id "$APPLE_ID" \
           --team-id "$APPLE_TEAM_ID" \
           --password "$APPLE_APP_PASSWORD" 2>&1) || true
-        echo "$_DMG_WAIT"
-        DMG_STATUS=$(echo "$_DMG_WAIT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
-        [ -n "$DMG_STATUS" ] && break
-        echo "[notarize] No status received (network error?); retrying in ${_DMG_DELAY}s..."
-        sleep "$_DMG_DELAY"; _DMG_DELAY=$((_DMG_DELAY * 2))
+        DMG_STATUS=$(echo "$_DMG_INFO" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
+        echo "[notarize] Attempt $_attempt/${_DMG_POLL_MAX}: status=${DMG_STATUS:-<network error>}"
+        if [ "$DMG_STATUS" = "Accepted" ] || [ "$DMG_STATUS" = "Invalid" ]; then
+          break
+        fi
+        sleep "$_DMG_POLL_DELAY"
       done
 
       if [ "$DMG_STATUS" = "Accepted" ]; then


### PR DESCRIPTION
## Summary
Refactored the notarization status polling logic to use `notarytool info` instead of `notarytool wait`, improving resilience to transient network failures during the Apple notarization process.

## Key Changes
- **Replaced blocking `notarytool wait` with polling `notarytool info`**: The `wait` command would fail entirely on network errors, whereas `info` allows individual poll cycles to fail gracefully without losing progress.
- **Increased polling attempts from 5 to 40**: With the more resilient polling approach, we can afford more attempts with shorter delays (30s fixed vs. exponential backoff).
- **Simplified retry logic**: Removed exponential backoff delay strategy in favor of a fixed 30-second delay between polls, since individual network blips no longer abort the entire operation.
- **Improved status reporting**: Added clearer per-attempt logging showing the current status or `<network error>` placeholder, making it easier to diagnose polling issues.
- **Applied changes to both .app and DMG notarization flows**: Consistent improvements across both code paths.

## Implementation Details
- Status extraction logic remains unchanged (grep for `status:` line and extract second field)
- Early exit conditions now explicitly check for terminal states: `Accepted` or `Invalid`
- `In Progress` status or empty results (network errors) trigger a sleep and retry
- The polling loop will now complete faster on success while being more tolerant of transient failures

https://claude.ai/code/session_01RNrW7mP3muFj5r71r33bAr