### PR TITLE
Add support for multiple coding agents (Codex, Gemini CLI)

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2618,7 +2618,7 @@ pub async fn chat(
       let process_id = uuid::Uuid::new_v4().to_string();
 
       // Select which coding CLI to use: check user preference first, then fall back to
-      // whichever API key is available (Anthropic → claude, OpenAI → codex).
+      // whichever API key is available. Anthropic → claude, OpenAI → codex, Google → gemini.
       let coding_agent = {
         let pref = std::env::var("KNAPSACK_CODING_AGENT").unwrap_or_default();
         let pref = pref.trim().to_lowercase();
@@ -2628,6 +2628,7 @@ pub async fn chat(
           let has = |v: &str| std::env::var(v).map(|k| !k.trim().is_empty()).unwrap_or(false);
           if has("ANTHROPIC_API_KEY") { "claude".to_string() }
           else if has("OPENAI_API_KEY") { "codex".to_string() }
+          else if has("GEMINI_API_KEY") || has("GOOGLE_API_KEY") { "gemini".to_string() }
           else { "claude".to_string() }
         }
       };
@@ -2644,7 +2645,8 @@ pub async fn chat(
       // Build the command string for the chosen CLI.
       // claude: --yes auto-accepts tool use so it can read/write files without prompting.
       // codex:  --approval-mode auto-edit allows file edits non-interactively.
-      // agy:    Google Antigravity CLI (agy); launched with the prompt as a positional arg.
+      // gemini: -p (--prompt) triggers headless mode, returning stdout output without TTY UI.
+      //         Note: Antigravity (`agy`) is an IDE, not a headless CLI — use `gemini` instead.
       // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
       let claude_cmd = match coding_agent.as_str() {
         "codex" => {
@@ -2653,11 +2655,11 @@ pub async fn chat(
           #[cfg(not(target_os = "windows"))]
           { format!("codex --approval-mode auto-edit '{}'", prompt.replace('\'', "'\\''")) }
         }
-        "agy" | "antigravity" => {
+        "gemini" => {
           #[cfg(target_os = "windows")]
-          { format!("agy \"{}\"", prompt.replace('"', "\\\"")) }
+          { format!("gemini -p \"{}\"", prompt.replace('"', "\\\"")) }
           #[cfg(not(target_os = "windows"))]
-          { format!("agy '{}'", prompt.replace('\'', "'\\''")) }
+          { format!("gemini -p '{}'", prompt.replace('\'', "'\\''")) }
         }
         _ => {
           #[cfg(target_os = "windows")]

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2644,6 +2644,7 @@ pub async fn chat(
       // Build the command string for the chosen CLI.
       // claude: --yes auto-accepts tool use so it can read/write files without prompting.
       // codex:  --approval-mode auto-edit allows file edits non-interactively.
+      // agy:    Google Antigravity CLI (agy); launched with the prompt as a positional arg.
       // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
       let claude_cmd = match coding_agent.as_str() {
         "codex" => {
@@ -2651,6 +2652,12 @@ pub async fn chat(
           { format!("codex --approval-mode auto-edit \"{}\"", prompt.replace('"', "\\\"")) }
           #[cfg(not(target_os = "windows"))]
           { format!("codex --approval-mode auto-edit '{}'", prompt.replace('\'', "'\\''")) }
+        }
+        "agy" | "antigravity" => {
+          #[cfg(target_os = "windows")]
+          { format!("agy \"{}\"", prompt.replace('"', "\\\"")) }
+          #[cfg(not(target_os = "windows"))]
+          { format!("agy '{}'", prompt.replace('\'', "'\\''")) }
         }
         _ => {
           #[cfg(target_os = "windows")]

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2617,27 +2617,47 @@ pub async fn chat(
       let session_id = "claude-code".to_string();
       let process_id = uuid::Uuid::new_v4().to_string();
 
+      // Select which coding CLI to use: check user preference first, then fall back to
+      // whichever API key is available (Anthropic → claude, OpenAI → codex).
+      let coding_agent = {
+        let pref = std::env::var("KNAPSACK_CODING_AGENT").unwrap_or_default();
+        let pref = pref.trim().to_lowercase();
+        if !pref.is_empty() {
+          pref
+        } else {
+          let has = |v: &str| std::env::var(v).map(|k| !k.trim().is_empty()).unwrap_or(false);
+          if has("ANTHROPIC_API_KEY") { "claude".to_string() }
+          else if has("OPENAI_API_KEY") { "codex".to_string() }
+          else { "claude".to_string() }
+        }
+      };
+
       // Emit a "claude-code-started" event so the frontend auto-opens the Activity Panel
       let _ = app_handle.emit_all("claude-code-started", json!({
         "processId": process_id,
         "sessionId": session_id,
         "prompt": prompt,
         "cwd": wd,
+        "agent": coding_agent,
       }));
 
-      // Build the claude command: use --yes for non-interactive mode that can still make changes.
-      // --print only outputs text without making file changes; --yes auto-accepts tool use
-      // so Claude Code can actually read/write files and run commands.
+      // Build the command string for the chosen CLI.
+      // claude: --yes auto-accepts tool use so it can read/write files without prompting.
+      // codex:  --approval-mode auto-edit allows file edits non-interactively.
       // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
-      #[cfg(target_os = "windows")]
-      let claude_cmd = {
-        let escaped = prompt.replace('"', "\\\"");
-        format!("claude --yes \"{}\"", escaped)
-      };
-      #[cfg(not(target_os = "windows"))]
-      let claude_cmd = {
-        let escaped_prompt = prompt.replace('\'', "'\\''");
-        format!("claude --yes '{}'", escaped_prompt)
+      let claude_cmd = match coding_agent.as_str() {
+        "codex" => {
+          #[cfg(target_os = "windows")]
+          { format!("codex --approval-mode auto-edit \"{}\"", prompt.replace('"', "\\\"")) }
+          #[cfg(not(target_os = "windows"))]
+          { format!("codex --approval-mode auto-edit '{}'", prompt.replace('\'', "'\\''")) }
+        }
+        _ => {
+          #[cfg(target_os = "windows")]
+          { format!("claude --yes \"{}\"", prompt.replace('"', "\\\"")) }
+          #[cfg(not(target_os = "windows"))]
+          { format!("claude --yes '{}'", prompt.replace('\'', "'\\''")) }
+        }
       };
 
       let wd_clone = wd.clone();

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -97,6 +97,8 @@ struct StoredTokens {
   ollama_base_url: Option<String>,
   #[serde(default)]
   extra_provider_keys: Option<std::collections::HashMap<String, String>>,
+  #[serde(default)]
+  preferred_coding_agent: Option<String>,
 }
 
 fn app_clawdbot_home(app_handle: &tauri::AppHandle) -> PathBuf {
@@ -161,6 +163,7 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     ollama_model: None,
     ollama_base_url: None,
     extra_provider_keys: None,
+    preferred_coding_agent: None,
   };
 
   fs::write(&path, serde_json::to_string_pretty(&t).unwrap_or_default())

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1680,6 +1680,7 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     ollama_model: None,
     ollama_base_url: None,
     extra_provider_keys: None,
+    preferred_coding_agent: None,
   };
 
   fs::write(&path, serde_json::to_string_pretty(&t).unwrap_or_default())

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1534,6 +1534,11 @@ struct StoredTokens {
   /// e.g. {"MINIMAX_API_KEY": "...", "ZAI_API_KEY": "...", "HF_TOKEN": "..."}
   #[serde(default)]
   extra_provider_keys: Option<std::collections::HashMap<String, String>>,
+
+  /// Preferred coding CLI when multiple keys are available: "claude", "codex", or "gemini".
+  /// When unset, auto-selects based on which API key is present (Anthropic → claude, OpenAI → codex).
+  #[serde(default)]
+  preferred_coding_agent: Option<String>,
 }
 
 fn tokens_path(app_handle: &tauri::AppHandle) -> PathBuf {
@@ -1718,6 +1723,10 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
   if let Some(p) = &tokens.active_provider {
     let p = p.trim();
     if !p.is_empty() { std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", p); }
+  }
+  if let Some(a) = &tokens.preferred_coding_agent {
+    let a = a.trim();
+    if !a.is_empty() { std::env::set_var("KNAPSACK_CODING_AGENT", a); }
   }
   if let Some(m) = &tokens.openai_model {
     let m = m.trim();
@@ -2757,6 +2766,9 @@ pub struct ApiKeyStatusResponse {
   /// Extra providers: list of {id, env_var, has_key, key_hint}
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub extra_providers: Vec<ExtraProviderStatus>,
+  /// User's preferred coding CLI: "claude", "codex", or "gemini".
+  /// Null means auto-select based on available API keys.
+  pub preferred_coding_agent: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2794,6 +2806,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         ollama_model: None,
         ollama_base_url: None,
         extra_providers: vec![],
+        preferred_coding_agent: None,
       })
     }
   };
@@ -2865,6 +2878,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     ollama_model: tokens.ollama_model.clone(),
     ollama_base_url: tokens.ollama_base_url.clone(),
     extra_providers,
+    preferred_coding_agent: tokens.preferred_coding_agent.clone(),
   })
 }
 
@@ -3040,6 +3054,9 @@ pub struct SetApiKeyRequest {
   /// For extra providers: the environment variable name to store the key under.
   /// e.g. "MINIMAX_API_KEY", "ZAI_API_KEY", "HF_TOKEN"
   pub env_var: Option<String>,
+  /// Preferred coding CLI agent: "claude", "codex", or "gemini".
+  /// When provided alongside or without a key change, updates the stored preference.
+  pub preferred_coding_agent: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -3296,6 +3313,15 @@ pub async fn set_api_key(
       "OpenAI"
     }
   };
+
+  // Persist coding agent preference if provided ("claude", "codex", or "gemini")
+  if let Some(agent) = &payload.preferred_coding_agent {
+    let agent = agent.trim().to_lowercase();
+    if ["claude", "codex", "gemini"].contains(&agent.as_str()) {
+      tokens.preferred_coding_agent = Some(agent.clone());
+      std::env::set_var("KNAPSACK_CODING_AGENT", &agent);
+    }
+  }
 
   if let Err(e) = save_tokens(&app_handle, &tokens) {
     return HttpResponse::InternalServerError().json(SetApiKeyResponse {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1535,7 +1535,7 @@ struct StoredTokens {
   #[serde(default)]
   extra_provider_keys: Option<std::collections::HashMap<String, String>>,
 
-  /// Preferred coding CLI when multiple keys are available: "claude", "codex", or "gemini".
+  /// Preferred coding CLI when multiple keys are available: "claude", "codex", or "agy" (Google Antigravity).
   /// When unset, auto-selects based on which API key is present (Anthropic → claude, OpenAI → codex).
   #[serde(default)]
   preferred_coding_agent: Option<String>,
@@ -3317,7 +3317,7 @@ pub async fn set_api_key(
   // Persist coding agent preference if provided ("claude", "codex", or "gemini")
   if let Some(agent) = &payload.preferred_coding_agent {
     let agent = agent.trim().to_lowercase();
-    if ["claude", "codex", "gemini"].contains(&agent.as_str()) {
+    if ["claude", "codex", "agy"].contains(&agent.as_str()) {
       tokens.preferred_coding_agent = Some(agent.clone());
       std::env::set_var("KNAPSACK_CODING_AGENT", &agent);
     }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1535,8 +1535,9 @@ struct StoredTokens {
   #[serde(default)]
   extra_provider_keys: Option<std::collections::HashMap<String, String>>,
 
-  /// Preferred coding CLI when multiple keys are available: "claude", "codex", or "agy" (Google Antigravity).
-  /// When unset, auto-selects based on which API key is present (Anthropic → claude, OpenAI → codex).
+  /// Preferred coding CLI when multiple keys are available: "claude", "codex", or "gemini" (Google Gemini CLI).
+  /// When unset, auto-selects based on which API key is present
+  /// (Anthropic → claude, OpenAI → codex, Google → gemini).
   #[serde(default)]
   preferred_coding_agent: Option<String>,
 }
@@ -3317,7 +3318,7 @@ pub async fn set_api_key(
   // Persist coding agent preference if provided ("claude", "codex", or "gemini")
   if let Some(agent) = &payload.preferred_coding_agent {
     let agent = agent.trim().to_lowercase();
-    if ["claude", "codex", "agy"].contains(&agent.as_str()) {
+    if ["claude", "codex", "gemini"].contains(&agent.as_str()) {
       tokens.preferred_coding_agent = Some(agent.clone());
       std::env::set_var("KNAPSACK_CODING_AGENT", &agent);
     }

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -1489,10 +1489,10 @@ const TerminalView: React.FC = () => {
       // Coding agent CLIs (claude, codex) — run as streaming processes so output appears in real-time
       const isCodingAgentCmd = cmd === 'claude' || cmd.startsWith('claude ')
         || cmd === 'codex' || cmd.startsWith('codex ')
-        || cmd === 'agy' || cmd.startsWith('agy ')
+        || cmd === 'gemini' || cmd.startsWith('gemini ')
       if (isCodingAgentCmd) {
         const agentLabel = cmd.startsWith('codex') ? 'Codex'
-          : cmd.startsWith('agy') ? 'Antigravity'
+          : cmd.startsWith('gemini') ? 'Gemini CLI'
           : 'Claude Code'
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -1486,11 +1486,14 @@ const TerminalView: React.FC = () => {
         return
       }
 
-      // Claude Code CLI — run as a streaming process so output appears in real-time
-      if (cmd === 'claude' || cmd.startsWith('claude ')) {
+      // Coding agent CLIs (claude, codex) — run as streaming processes so output appears in real-time
+      const isCodingAgentCmd = cmd === 'claude' || cmd.startsWith('claude ')
+        || cmd === 'codex' || cmd.startsWith('codex ')
+      if (isCodingAgentCmd) {
+        const agentLabel = cmd.startsWith('codex') ? 'Codex' : 'Claude Code'
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
-          addLine(sessionId, 'system', 'Starting Claude Code...')
+          addLine(sessionId, 'system', `Starting ${agentLabel}...`)
           const processId: string = await invoke('kn_spawn_streaming_command', {
             command: trimmed,
             cwd: session.cwd || undefined,
@@ -1498,7 +1501,7 @@ const TerminalView: React.FC = () => {
           })
           updateSession(sessionId, s => ({ ...s, streamingProcessId: processId }))
         } catch (err) {
-          addLine(sessionId, 'stderr', `Failed to start Claude Code: ${err}`)
+          addLine(sessionId, 'stderr', `Failed to start ${agentLabel}: ${err}`)
           updateSession(sessionId, s => ({ ...s, isExecuting: false }))
         }
         return

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -1489,8 +1489,11 @@ const TerminalView: React.FC = () => {
       // Coding agent CLIs (claude, codex) — run as streaming processes so output appears in real-time
       const isCodingAgentCmd = cmd === 'claude' || cmd.startsWith('claude ')
         || cmd === 'codex' || cmd.startsWith('codex ')
+        || cmd === 'agy' || cmd.startsWith('agy ')
       if (isCodingAgentCmd) {
-        const agentLabel = cmd.startsWith('codex') ? 'Codex' : 'Claude Code'
+        const agentLabel = cmd.startsWith('codex') ? 'Codex'
+          : cmd.startsWith('agy') ? 'Antigravity'
+          : 'Claude Code'
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {
           addLine(sessionId, 'system', `Starting ${agentLabel}...`)

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -370,6 +370,7 @@ type ApiKeyStatus = {
   ollama_model?: string
   ollama_base_url?: string
   extra_providers?: Array<{ env_var: string; has_key: boolean; key_hint?: string }>
+  preferred_coding_agent?: string
 }
 
 type SkillInfo = {
@@ -529,6 +530,7 @@ const PROACTIVE_MODE_STORAGE = 'moltbot_proactive_mode'
 const ADVANCED_MODE_STORAGE = 'moltbot_advanced_mode'
 const DEVELOPER_MODE_STORAGE = 'moltbot_developer_mode'
 const ACTIVE_PROVIDER_STORAGE = 'moltbot_active_provider'
+const CODING_AGENT_STORAGE = 'knapsack_coding_agent_pref'
 const ONBOARDING_VERSION_STORAGE = 'moltbot_onboarding_version'
 
 // The current app version — bump this when you want to re-show the key prompt
@@ -933,6 +935,7 @@ const FALLBACK_SKILLS: SkillInfo[] = [
   {name:"skill-creator",emoji:"🛠️",description:"Create custom skills",source:"OpenClaw",eligible:false},
   {name:"clawhub",emoji:"🏪",description:"Discover and install skills from ClawHub",source:"OpenClaw",eligible:false},
   {name:"Claude Code",emoji:"🤖",description:"Anthropic's autonomous AI coding agent — edits files, runs tests, and manages git",source:"Anthropic",eligible:false,externalApi:true,homepage:"https://claude.ai/code"},
+  {name:"Codex",emoji:"🧪",description:"OpenAI's autonomous coding agent — edits files, runs tests, and manages git",source:"OpenAI",eligible:false,externalApi:true,homepage:"https://github.com/openai/codex"},
   {name:"Claude API",emoji:"✨",description:"Use Claude models directly in your own apps and scripts via the Anthropic API",source:"Anthropic",eligible:false,externalApi:true,homepage:"https://console.anthropic.com"},
   {name:"Persistent Memory",emoji:"🧠",description:"Remember decisions, context, and past work across sessions with semantic search",source:"MCP Market",eligible:false,homepage:"https://mcpmarket.com/tools/skills/memory-search-for-claude"},
   {name:"Code Review",emoji:"🔎",description:"Severity-ranked AI code review with security, performance, and architecture findings",source:"MCP Market",eligible:false,homepage:"https://mcpmarket.com/tools/skills/advanced-code-review-agent"},
@@ -1623,9 +1626,15 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     }
   }, [])
 
-  // Claude Code activity tracking — shows indicator when Claude Code is running
+  // Claude Code / Codex activity tracking — shows indicator when a coding agent is running
   const [claudeCodeActive, setClaudeCodeActive] = useState(false)
   const [claudeCodePrompt, setClaudeCodePrompt] = useState<string | null>(null)
+  const [codingAgentName, setCodingAgentName] = useState('Claude Code')
+
+  // Preferred coding agent: "claude" | "codex" | "gemini" | "" (auto-detect from API keys)
+  const [preferredCodingAgent, setPreferredCodingAgent] = useState<string>(() => {
+    return localStorage.getItem(CODING_AGENT_STORAGE) || ''
+  })
 
   // Tone selection
   const [selectedTone, setSelectedTone] = useState<string>(() => {
@@ -1921,6 +1930,11 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         if (keyStatus.ollama_enabled && keyStatus.ollama_model) {
           setSelectedOllamaModel(keyStatus.ollama_model)
           localStorage.setItem(OLLAMA_MODEL_STORAGE, keyStatus.ollama_model)
+        }
+        // Restore coding agent preference from backend
+        if (keyStatus.preferred_coding_agent) {
+          setPreferredCodingAgent(keyStatus.preferred_coding_agent)
+          localStorage.setItem(CODING_AGENT_STORAGE, keyStatus.preferred_coding_agent)
         }
         // Fetch extra provider statuses
         if (keyStatus.extra_providers) {
@@ -2680,12 +2694,13 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     const cleanups: Array<() => void> = []
 
     ;(async () => {
-      const unlistenStarted = await tauriListen<{ processId: string; sessionId: string; prompt: string; cwd: string }>(
+      const unlistenStarted = await tauriListen<{ processId: string; sessionId: string; prompt: string; cwd: string; agent?: string }>(
         'claude-code-started',
         (event) => {
           if (cancelled) return
           setClaudeCodeActive(true)
           setClaudeCodePrompt(event.payload.prompt)
+          setCodingAgentName(event.payload.agent === 'codex' ? 'Codex' : 'Claude Code')
           // Auto-open Activity Panel if not already open
           if (!externalActivityPanelRef.current && onToggleActivityRef.current) {
             onToggleActivityRef.current()
@@ -4974,7 +4989,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
             <div className="ClawdBubble ClawdBubble--claude-code">
               <div className="ClawdClaudeCodeIndicator">
                 <span className="ClawdClaudeCodeIndicator__pulse" />
-                <span className="ClawdClaudeCodeIndicator__label">Claude Code is working</span>
+                <span className="ClawdClaudeCodeIndicator__label">{codingAgentName} is working</span>
                 {claudeCodePrompt && (
                   <span className="ClawdClaudeCodeIndicator__prompt">{claudeCodePrompt.length > 80 ? claudeCodePrompt.slice(0, 80) + '...' : claudeCodePrompt}</span>
                 )}
@@ -6819,6 +6834,35 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
                   </div>
                 )
               })}
+            </div>
+
+            {/* ── Coding Agent preference ── */}
+            <div style={{ borderTop: '1px solid #e2e8f0', marginTop: 16, paddingTop: 16 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
+                <div>
+                  <div style={{ fontWeight: 500, fontSize: 13 }}>Coding Agent</div>
+                  <div style={{ fontSize: 11, color: '#64748b', marginTop: 2, maxWidth: 280 }}>
+                    Which CLI to use for autonomous coding tasks. "Auto" picks based on which API key is saved.
+                  </div>
+                </div>
+                <select
+                  value={preferredCodingAgent}
+                  onChange={async e => {
+                    const val = e.target.value
+                    setPreferredCodingAgent(val)
+                    localStorage.setItem(CODING_AGENT_STORAGE, val)
+                    try {
+                      await apiPost('/api/clawd/service/set-api-key', { key: '', preferred_coding_agent: val || null })
+                    } catch { /* ignore — preference is still stored locally */ }
+                  }}
+                  style={{ fontSize: 12, padding: '4px 8px', borderRadius: 4, border: '1px solid #cbd5e1', background: '#fff', cursor: 'pointer' }}
+                >
+                  <option value="">Auto-detect</option>
+                  <option value="claude">Claude Code (Anthropic)</option>
+                  <option value="codex">Codex (OpenAI)</option>
+                  <option value="gemini">Gemini CLI (Google)</option>
+                </select>
+              </div>
             </div>
 
             {/* ── Background AI toggle ── */}

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -936,7 +936,7 @@ const FALLBACK_SKILLS: SkillInfo[] = [
   {name:"clawhub",emoji:"🏪",description:"Discover and install skills from ClawHub",source:"OpenClaw",eligible:false},
   {name:"Claude Code",emoji:"🤖",description:"Anthropic's autonomous AI coding agent — edits files, runs tests, and manages git",source:"Anthropic",eligible:false,externalApi:true,homepage:"https://claude.ai/code"},
   {name:"Codex",emoji:"🧪",description:"OpenAI's autonomous coding agent — edits files, runs tests, and manages git",source:"OpenAI",eligible:false,externalApi:true,homepage:"https://github.com/openai/codex"},
-  {name:"Antigravity",emoji:"🚀",description:"Google's agentic development platform — natural language coding in a VS Code-based IDE",source:"Google",eligible:false,externalApi:true,homepage:"https://antigravity.google"},
+  {name:"Gemini CLI",emoji:"♊",description:"Google's open-source terminal AI agent — headless coding with the Gemini API",source:"Google",eligible:false,externalApi:true,homepage:"https://github.com/google-gemini/gemini-cli"},
   {name:"Claude API",emoji:"✨",description:"Use Claude models directly in your own apps and scripts via the Anthropic API",source:"Anthropic",eligible:false,externalApi:true,homepage:"https://console.anthropic.com"},
   {name:"Persistent Memory",emoji:"🧠",description:"Remember decisions, context, and past work across sessions with semantic search",source:"MCP Market",eligible:false,homepage:"https://mcpmarket.com/tools/skills/memory-search-for-claude"},
   {name:"Code Review",emoji:"🔎",description:"Severity-ranked AI code review with security, performance, and architecture findings",source:"MCP Market",eligible:false,homepage:"https://mcpmarket.com/tools/skills/advanced-code-review-agent"},
@@ -2702,7 +2702,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           setClaudeCodeActive(true)
           setClaudeCodePrompt(event.payload.prompt)
           const a = event.payload.agent
-          setCodingAgentName(a === 'codex' ? 'Codex' : a === 'agy' || a === 'antigravity' ? 'Antigravity' : 'Claude Code')
+          setCodingAgentName(a === 'codex' ? 'Codex' : a === 'gemini' ? 'Gemini CLI' : 'Claude Code')
           // Auto-open Activity Panel if not already open
           if (!externalActivityPanelRef.current && onToggleActivityRef.current) {
             onToggleActivityRef.current()
@@ -6862,7 +6862,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
                   <option value="">Auto-detect</option>
                   <option value="claude">Claude Code (Anthropic)</option>
                   <option value="codex">Codex (OpenAI)</option>
-                  <option value="agy">Antigravity — agy (Google)</option>
+                  <option value="gemini">Gemini CLI (Google)</option>
                 </select>
               </div>
             </div>

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -936,6 +936,7 @@ const FALLBACK_SKILLS: SkillInfo[] = [
   {name:"clawhub",emoji:"🏪",description:"Discover and install skills from ClawHub",source:"OpenClaw",eligible:false},
   {name:"Claude Code",emoji:"🤖",description:"Anthropic's autonomous AI coding agent — edits files, runs tests, and manages git",source:"Anthropic",eligible:false,externalApi:true,homepage:"https://claude.ai/code"},
   {name:"Codex",emoji:"🧪",description:"OpenAI's autonomous coding agent — edits files, runs tests, and manages git",source:"OpenAI",eligible:false,externalApi:true,homepage:"https://github.com/openai/codex"},
+  {name:"Antigravity",emoji:"🚀",description:"Google's agentic development platform — natural language coding in a VS Code-based IDE",source:"Google",eligible:false,externalApi:true,homepage:"https://antigravity.google"},
   {name:"Claude API",emoji:"✨",description:"Use Claude models directly in your own apps and scripts via the Anthropic API",source:"Anthropic",eligible:false,externalApi:true,homepage:"https://console.anthropic.com"},
   {name:"Persistent Memory",emoji:"🧠",description:"Remember decisions, context, and past work across sessions with semantic search",source:"MCP Market",eligible:false,homepage:"https://mcpmarket.com/tools/skills/memory-search-for-claude"},
   {name:"Code Review",emoji:"🔎",description:"Severity-ranked AI code review with security, performance, and architecture findings",source:"MCP Market",eligible:false,homepage:"https://mcpmarket.com/tools/skills/advanced-code-review-agent"},
@@ -2700,7 +2701,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           if (cancelled) return
           setClaudeCodeActive(true)
           setClaudeCodePrompt(event.payload.prompt)
-          setCodingAgentName(event.payload.agent === 'codex' ? 'Codex' : 'Claude Code')
+          const a = event.payload.agent
+          setCodingAgentName(a === 'codex' ? 'Codex' : a === 'agy' || a === 'antigravity' ? 'Antigravity' : 'Claude Code')
           // Auto-open Activity Panel if not already open
           if (!externalActivityPanelRef.current && onToggleActivityRef.current) {
             onToggleActivityRef.current()
@@ -6860,7 +6862,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
                   <option value="">Auto-detect</option>
                   <option value="claude">Claude Code (Anthropic)</option>
                   <option value="codex">Codex (OpenAI)</option>
-                  <option value="gemini">Gemini CLI (Google)</option>
+                  <option value="agy">Antigravity — agy (Google)</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Extended the coding agent system to support multiple autonomous coding CLIs beyond Claude Code, including OpenAI's Codex and Google's Gemini CLI. Users can now select their preferred coding agent or let the system auto-detect based on available API keys.

## Key Changes

- **Backend (Rust)**
  - Added `preferred_coding_agent` field to `StoredTokens` to persist user preference
  - Implemented agent selection logic that checks `KNAPSACK_CODING_AGENT` env var first, then falls back to auto-detection based on available API keys (Anthropic → claude, OpenAI → codex, Google → gemini)
  - Extended command building to generate appropriate CLI flags for each agent:
    - `claude`: `--yes` flag for auto-accepting tool use
    - `codex`: `--approval-mode auto-edit` for non-interactive file edits
    - `gemini`: `-p` flag for headless mode
  - Updated `ApiKeyStatusResponse` to include `preferred_coding_agent` field
  - Modified `SetApiKeyRequest` to accept `preferred_coding_agent` parameter for updating preferences
  - Added environment variable propagation for the coding agent preference

- **Frontend (React)**
  - Added `CODING_AGENT_STORAGE` constant for persisting user preference in localStorage
  - Created new state variables: `codingAgentName` and `preferredCodingAgent`
  - Added dropdown selector in settings to choose between Auto-detect, Claude Code, Codex, and Gemini CLI
  - Updated event listener to receive and handle the `agent` field from `claude-code-started` events
  - Modified activity indicator label to dynamically display the active coding agent name
  - Added Codex and Gemini CLI to the `FALLBACK_SKILLS` list with appropriate metadata
  - Updated terminal view to recognize and handle all three coding agent commands with appropriate labels

## Notable Implementation Details

- The system maintains backward compatibility by defaulting to Claude Code when no preference is set and no API keys are available
- Platform-specific command escaping (Windows double-quotes vs Unix single-quotes) is preserved for all agents
- User preference is stored both locally (localStorage) and on the backend (StoredTokens) for consistency
- The API endpoint gracefully handles preference updates even if no API key change is provided

https://claude.ai/code/session_01B3rZ6AvHE3TkMe6zJwCdVc