### PR TITLE
Add self-healing for gateway port conflicts and stale plugin deps

### DIFF
--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -1414,6 +1414,17 @@ fn invalidate_client() {
 static RECONNECT_IN_PROGRESS: std::sync::atomic::AtomicBool =
   std::sync::atomic::AtomicBool::new(false);
 
+/// Total number of self-heal attempts triggered in this process lifetime.
+/// Capped to prevent infinite kill/restart loops if the user has a genuinely
+/// misconfigured environment that the self-heal can't fix.
+static SELF_HEAL_ATTEMPTS: std::sync::atomic::AtomicUsize =
+  std::sync::atomic::AtomicUsize::new(0);
+const MAX_SELF_HEAL_ATTEMPTS_PER_SESSION: usize = 3;
+/// Trigger self-heal after this many consecutive handshake failures while
+/// the gateway port is responding (i.e. something is on 18789 but it's not
+/// answering our handshake correctly — likely a competing gateway).
+const SELF_HEAL_AFTER_CONSECUTIVE_FAILURES: usize = 3;
+
 /// Spawn a background task that retries the WebSocket connection with
 /// exponential backoff (1 s → 2 s → 4 s → 8 s → 15 s cap).
 ///
@@ -1433,6 +1444,12 @@ fn spawn_reconnect_task(token: String) {
     let backoff_steps: &[u64] = &[1000, 2000, 4000, 8000, 15000];
     let mut step_idx = 0usize;
     let max_attempts = 20usize;
+    // Tracks consecutive handshake failures where the port WAS open.  This
+    // is the signature of a competing gateway responding to HTTP probes but
+    // rejecting our auth.  If we hit this signature repeatedly, run the
+    // self-heal to evict competing plists + clear the port + restart our
+    // own gateway.
+    let mut consecutive_handshake_failures: usize = 0;
 
     for attempt in 0..max_attempts {
       let delay_ms = backoff_steps[step_idx.min(backoff_steps.len() - 1)];
@@ -1484,7 +1501,36 @@ fn spawn_reconnect_task(token: String) {
           return;
         }
         Err(e) => {
-          eprintln!("[gateway_client] reconnect task: attempt {} failed ({}), backing off {}ms", attempt + 1, e, delay_ms);
+          // Port was open (we passed the is_gateway_port_open check above) but
+          // the handshake failed.  Track this as a "competing gateway"
+          // signature.
+          consecutive_handshake_failures += 1;
+          eprintln!(
+            "[gateway_client] reconnect task: attempt {} failed ({}), consecutive_handshake_failures={}, backing off {}ms",
+            attempt + 1, e, consecutive_handshake_failures, delay_ms
+          );
+
+          if consecutive_handshake_failures >= SELF_HEAL_AFTER_CONSECUTIVE_FAILURES {
+            let prior = SELF_HEAL_ATTEMPTS.fetch_add(1, Ordering::Relaxed);
+            if prior < MAX_SELF_HEAL_ATTEMPTS_PER_SESSION {
+              eprintln!(
+                "[gateway_client] reconnect task: triggering self-heal (attempt {}/{} this session)",
+                prior + 1, MAX_SELF_HEAL_ATTEMPTS_PER_SESSION
+              );
+              crate::clawd::service::self_heal_gateway_conflict(&token).await;
+              // Reset so we don't immediately self-heal again on the next failure.
+              consecutive_handshake_failures = 0;
+              // Reset backoff so the next attempt happens quickly after the
+              // self-heal restarts our gateway.
+              step_idx = 0;
+            } else {
+              // Already burned our self-heal budget — fall through to backoff.
+              eprintln!(
+                "[gateway_client] reconnect task: self-heal budget exhausted ({} attempts), continuing with backoff",
+                MAX_SELF_HEAL_ATTEMPTS_PER_SESSION
+              );
+            }
+          }
         }
       }
     }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -554,6 +554,43 @@ fn remove_stale_plugin_runtime_deps_versions(clawdbot_home: &std::path::Path, cu
   }
 }
 
+/// Count plugin-runtime-deps directories whose version prefix doesn't match
+/// `current_version` — i.e. stale dirs from a prior gateway version that
+/// `remove_stale_plugin_runtime_deps_versions` would remove.
+///
+/// Used by `auto_enable_if_needed` to decide whether to force a gateway
+/// restart on startup: if stale dirs exist, the gateway will load mismatched
+/// staged plugin code (e.g. `openclaw-unknown-{hash}/dist/extensions/slack/`
+/// imports `openclaw` against a different package layout) and silently fail
+/// every channel setup.  HTTP /health still responds, so the auto-restart
+/// path never fires — we have to detect-and-restart at startup instead.
+fn count_stale_plugin_runtime_deps_versions(
+  clawdbot_home: &std::path::Path,
+  current_version: &str,
+) -> usize {
+  let base = clawdbot_home.join("plugin-runtime-deps");
+  let entries = match fs::read_dir(&base) {
+    Ok(d) => d,
+    Err(_) => return 0,
+  };
+  let expected_prefix = format!("openclaw-{}-", current_version);
+  let mut stale = 0usize;
+  for entry in entries.flatten() {
+    if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+      continue;
+    }
+    let dir_name = entry.file_name().to_string_lossy().to_string();
+    if !dir_name.starts_with("openclaw-") {
+      continue;
+    }
+    if !current_version.is_empty() && dir_name.starts_with(&expected_prefix) {
+      continue;
+    }
+    stale += 1;
+  }
+  stale
+}
+
 /// Read the bundled clawdbot version string from its package.json.
 /// Returns an empty string if the file can't be read or has no version field.
 fn read_clawdbot_bundle_version(clawdbot_dir: &std::path::Path) -> String {
@@ -7153,6 +7190,60 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
       // on port 18789 and causing the connect/disconnect instability even though
       // our own service is "loaded."
       remove_stale_standalone_gateway();
+
+      // Detect stale plugin-runtime-deps dirs from a prior gateway version
+      // (e.g. `openclaw-unknown-{hash}` left by a previous standalone openclaw
+      // install, or an older Knapsack bundle).  The gateway happily loads
+      // staged plugin code from these dirs, but the slack/telegram/whatsapp
+      // channel setups inside them import `openclaw/plugin-sdk/...` against a
+      // different package layout — every channel fails with "Cannot find
+      // module .../root-alias.cjs/channel-config-schema-legacy" or "Cannot
+      // find package 'openclaw'".  HTTP /health still responds, so the
+      // auto-restart path never fires; we have to clean + restart here at
+      // startup, before the user notices.
+      let bundle_dir = clawdbot_bundle_dir(app_handle);
+      let bundle_ver = read_clawdbot_bundle_version(&bundle_dir);
+      let clawdbot_home = app_clawdbot_home(app_handle);
+      let stale = count_stale_plugin_runtime_deps_versions(&clawdbot_home, &bundle_ver);
+      if stale > 0 {
+        eprintln!(
+          "[clawd/service] auto_enable: detected {} stale plugin-runtime-deps dir(s) (bundle ver={}) — cleaning and forcing gateway restart",
+          stale, bundle_ver
+        );
+        // Bootout first so the gateway isn't holding files we're about to delete.
+        let uid = unsafe { libc::getuid() };
+        let domain = format!("gui/{}", uid);
+        let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
+        let _ = std::process::Command::new("launchctl")
+          .args(["bootout", &service])
+          .status();
+        // Brief wait so the gateway releases file handles + port.
+        std::thread::sleep(std::time::Duration::from_millis(800));
+        kill_process_on_port(18789);
+        remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
+        remove_stale_plugin_runtime_deps_versions(&clawdbot_home, &bundle_ver);
+        // Re-bootstrap so the gateway is registered + started fresh.  The
+        // gateway will re-stage plugin runtime deps under the correct
+        // `openclaw-{bundle_ver}-{hash}` dir on first startup.
+        if let Ok(plist_path) = launch_agent_plist_path() {
+          let _ = std::process::Command::new("launchctl")
+            .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
+            .status();
+          let _ = std::process::Command::new("launchctl")
+            .args(["kickstart", "-k", &service])
+            .status();
+        }
+        sentry::with_scope(
+          |scope| {
+            scope.set_tag("stale_count", &stale.to_string());
+            scope.set_tag("bundle_ver", &bundle_ver);
+          },
+          || sentry::capture_message(
+            "[gateway] auto_enable: cleaned stale plugin-runtime-deps + restarted",
+            sentry::Level::Warning,
+          ),
+        );
+      }
       return;
     }
     eprintln!("[clawd/service] auto_enable: plist exists but service not loaded — re-bootstrapping");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -423,6 +423,58 @@ fn remove_stale_standalone_gateway() {
   }
 }
 
+/// Self-heal a gateway connectivity issue by clearing competing LaunchAgent
+/// plists, killing any process holding port 18789, and restarting our own
+/// gateway via the supervisor.
+///
+/// Called when gateway_client repeatedly fails its WS handshake even though
+/// port 18789 is responding to HTTP.  The most likely cause is a competing
+/// gateway (standalone openclaw, manual `openclaw gateway start`, old beta
+/// install) that owns the port.  Knapsack's HTTP health probe treats it as
+/// healthy, so the auto-restart path never fires — but our handshake fails
+/// because the auth token doesn't match.
+///
+/// This function unconditionally kills whatever holds port 18789.  If it was
+/// our own gateway in a bad state, the supervisor restarts it.  If it was a
+/// non-LaunchAgent process, the kill is the only way to clear the port.
+#[cfg(target_os = "macos")]
+pub async fn self_heal_gateway_conflict(token: &str) {
+  let evicted = evict_competing_gateway_plists();
+  eprintln!(
+    "[clawd/service] self-heal: evicted competing plists: {:?}",
+    evicted
+  );
+  kill_process_on_port(18789);
+
+  // Wait for LaunchAgent throttle / for the supervisor to be willing to
+  // kickstart again.  Also gives mDNS/Bonjour time to release its bindings.
+  tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+
+  let result =
+    crate::clawd::gateway_supervisor::ensure_gateway_running(LAUNCH_AGENT_LABEL, token).await;
+  eprintln!(
+    "[clawd/service] self-heal: restart {} ({})",
+    result.message,
+    if result.running { "running" } else { "not running" }
+  );
+
+  sentry::with_scope(
+    |scope| scope.set_tag("evicted_count", &evicted.len().to_string()),
+    || {
+      sentry::capture_message(
+        &format!("[gateway] self-heal triggered (evicted={:?})", evicted),
+        sentry::Level::Warning,
+      )
+    },
+  );
+}
+
+#[cfg(not(target_os = "macos"))]
+pub async fn self_heal_gateway_conflict(_token: &str) {
+  // No-op on non-macOS: the LaunchAgent + standalone-gateway scenario is
+  // macOS-specific.  Windows uses a different supervision model.
+}
+
 /// Remove stale `.openclaw-runtime-deps.lock` directories left behind when a
 /// previous gateway process was killed (e.g. via `launchctl bootout` or SIGTERM)
 /// while holding the lock during plugin runtime-deps installation.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -413,8 +413,14 @@ fn evict_competing_gateway_plists() -> Vec<String> {
 }
 
 /// Thin shim kept for existing call sites that don't need the return value.
+/// After evicting competing LaunchAgent plists, also kills any process still
+/// holding port 18789 — `launchctl bootout` removes launchd management but
+/// leaves the process alive, so without the kill it keeps blocking the port.
 fn remove_stale_standalone_gateway() {
-  evict_competing_gateway_plists();
+  let evicted = evict_competing_gateway_plists();
+  if !evicted.is_empty() {
+    kill_process_on_port(18789);
+  }
 }
 
 /// Remove stale `.openclaw-runtime-deps.lock` directories left behind when a


### PR DESCRIPTION
## Summary
This PR adds automatic detection and recovery mechanisms for two gateway connectivity issues that can occur on macOS:
1. **Port conflicts**: When a competing gateway (standalone openclaw, manual start, old beta install) holds port 18789 but fails our WebSocket handshake
2. **Stale plugin dependencies**: When outdated plugin-runtime-deps directories from prior gateway versions cause channel setup failures

## Key Changes

- **New `self_heal_gateway_conflict()` function**: Detects repeated handshake failures while port 18789 is responding, then evicts competing LaunchAgent plists, kills the blocking process, and restarts the gateway via supervisor. Includes safeguards to prevent infinite restart loops (max 3 attempts per session).

- **Enhanced `remove_stale_standalone_gateway()`**: Now kills any process still holding port 18789 after evicting competing plists, since `launchctl bootout` removes launchd management but leaves the process alive.

- **New `count_stale_plugin_runtime_deps_versions()` function**: Counts stale plugin-runtime-deps directories from prior gateway versions to detect version mismatches.

- **Startup cleanup in `auto_enable_if_needed()`**: Detects stale plugin-runtime-deps directories at startup and proactively cleans them before the user notices channel setup failures. Performs a full gateway bootout/cleanup/bootstrap cycle to ensure fresh state.

- **Reconnect task improvements**: Tracks consecutive handshake failures while the port is open (signature of a competing gateway) and triggers self-heal after 3 consecutive failures. Resets backoff after self-heal to retry quickly.

## Implementation Details

- Self-heal is macOS-specific (no-op on other platforms) since the LaunchAgent + standalone-gateway scenario is unique to macOS
- Includes 1.5s sleep after killing processes to allow LaunchAgent throttle recovery and mDNS/Bonjour binding release
- Sends Sentry warnings with context (evicted plist count, bundle version, stale directory count) for monitoring
- Gracefully handles missing files/directories and command failures

https://claude.ai/code/session_01WZrj4djbEhHW3yjpYaUNBb