### PR TITLE
Fix plugin runtime deps and gateway stability issues

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,7 +2,7 @@ name: Build macOS App (Universal)
 
 on:
   push:
-    branches: [main, "release/*", "claude/*"]
+    branches: [main, "release/*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,7 +2,7 @@ name: Build Windows App
 
 on:
   push:
-    branches: [main, "release/*", "claude/*"]
+    branches: [main, "release/*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/src/scripts/sign-and-notarize.sh
+++ b/src/scripts/sign-and-notarize.sh
@@ -336,6 +336,14 @@ if [ "$DO_NOTARIZE" = true ]; then
       chmod -R a+rX "$DMG_TEMP"
 
       rm -f "$DMG_PATH"
+
+      # Detach any lingering mounts with the same volume name — a previous
+      # build step or failed run can leave /Volumes/<AppName> attached, which
+      # causes hdiutil create to fail with "Resource busy".
+      for vol in /Volumes/"$APP_NAME"*; do
+        [ -d "$vol" ] && hdiutil detach "$vol" -force 2>/dev/null || true
+      done
+
       hdiutil create -volname "$APP_NAME" -srcfolder "$DMG_TEMP" \
         -ov -format UDZO "$DMG_PATH"
       rm -rf "$DMG_TEMP"

--- a/src/src-tauri/Cargo.lock
+++ b/src/src-tauri/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "knapsack"
-version = "1.7.6"
+version = "1.8.5"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/src/src-tauri/Cargo.toml
+++ b/src/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "knapsack"
-version = "1.7.6"
+version = "1.8.5"
 description = "Knapsack"
 authors = ["you"]
 license = "AGPL-3.0"

--- a/src/src-tauri/build.rs
+++ b/src/src-tauri/build.rs
@@ -27,20 +27,25 @@ fn remove_broken_symlinks_recursive(dir: &Path) {
 }
 
 fn main() {
+    let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
     let node_modules = Path::new("resources/clawdbot/node_modules");
 
-    // Remove .pnpm virtual store — not needed at runtime with hoisted
-    // node_modules, and it contains thousands of internal symlinks that
-    // bloat the bundle and can break Tauri's resource copier.
-    let pnpm_store = node_modules.join(".pnpm");
-    if pnpm_store.exists() {
-        let _ = fs::remove_dir_all(&pnpm_store);
-    }
+    // These cleanup steps are only needed for release bundles — they're slow
+    // (can take minutes on large node_modules trees) and unnecessary for dev.
+    if is_release {
+        // Remove .pnpm virtual store — not needed at runtime with hoisted
+        // node_modules, and it contains thousands of internal symlinks that
+        // bloat the bundle and can break Tauri's resource copier.
+        let pnpm_store = node_modules.join(".pnpm");
+        if pnpm_store.exists() {
+            let _ = fs::remove_dir_all(&pnpm_store);
+        }
 
-    // Clean up any broken symlinks (e.g. in .bin/) that could cause
-    // tauri_build to fail.
-    if node_modules.exists() {
-        remove_broken_symlinks_recursive(node_modules);
+        // Clean up any broken symlinks (e.g. in .bin/) that could cause
+        // tauri_build to fail.
+        if node_modules.exists() {
+            remove_broken_symlinks_recursive(node_modules);
+        }
     }
 
     // Fail the build early if the bundled Node.js binary is missing.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -6565,12 +6565,17 @@ pub async fn skills_status(app_handle: web::Data<tauri::AppHandle>) -> impl Resp
   // Try to get live eligible state from the gateway (skills.status) and merge
   // it into the catalog as `enabled`.  Falls back to the static catalog when
   // the gateway is unavailable.  skills.status returns { skills: [{name, eligible, disabled, ...}] }.
+  // 5-second timeout so a reconnecting gateway never stalls the UI.
   if let Ok(tokens) = load_or_create_tokens(&app_handle) {
-    if let Ok(result) = super::gateway_client::gateway_request_pooled(
-      "skills.status",
-      Some(serde_json::json!({})),
-      &tokens.gateway_token,
-    ).await {
+    let gateway_result = tokio::time::timeout(
+      std::time::Duration::from_secs(5),
+      super::gateway_client::gateway_request_pooled(
+        "skills.status",
+        Some(serde_json::json!({})),
+        &tokens.gateway_token,
+      ),
+    ).await;
+    if let Ok(Ok(result)) = gateway_result {
       if let Some(live_skills) = result.get("skills").and_then(|s| s.as_array()) {
         // A skill is "enabled" (usable) when eligible=true and disabled=false.
         let mut enabled_map: std::collections::HashMap<String, bool> =

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1980,6 +1980,10 @@ fn classify_gateway_crash(log_tail: &str) -> &'static str {
     "config_anomaly"
   } else if lower.contains("enotempty") || lower.contains("stage bundled runtime deps") || (lower.contains("plugin") && (lower.contains("npm install failed") || lower.contains("failed to install"))) {
     "plugin_install_fail"
+  } else if lower.contains("cannot find module") && (lower.contains("plugin-sdk") || lower.contains("channel-config") || lower.contains("root-alias")) {
+    // Stale plugin-runtime-deps with wrong internal structure — version prefix
+    // matched so the normal cleanup skipped it, but the content is incompatible.
+    "module_resolution_fail"
   } else {
     "unknown"
   }
@@ -2203,7 +2207,23 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         // leaving ENOTEMPTY traps that cause bonjour (and other plugins) to
         // fail their npm install on every subsequent gateway start.
         remove_stale_plugin_runtime_deps_locks(&restart_clawdbot_home);
-        remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, &restart_bundle_ver);
+
+        // Check if the crash is a module-resolution failure (e.g. "Cannot find
+        // module .../plugin-sdk/root-alias.cjs/channel-config-schema-legacy").
+        // This happens when a plugin-runtime-deps dir has the correct version
+        // prefix but incompatible internal structure — the normal version-prefix
+        // cleanup skips it.  Force a full wipe so the gateway re-stages clean deps.
+        let log_lower = std::fs::read_to_string(gateway_stderr_log())
+          .unwrap_or_default()
+          .to_lowercase();
+        let is_module_resolution_crash = log_lower.contains("cannot find module")
+          && (log_lower.contains("plugin-sdk") || log_lower.contains("channel-config") || log_lower.contains("root-alias"));
+        if is_module_resolution_crash {
+          eprintln!("[clawd/service] auto-restart: module-resolution crash detected — force-wiping all plugin-runtime-deps dirs");
+          remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, "");
+        } else {
+          remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, &restart_bundle_ver);
+        }
 
         // Re-run plugin dep installs for any extension whose node_modules are
         // missing (fast no-op when all deps are already present).  This is how
@@ -7317,6 +7337,22 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
             sentry::Level::Warning,
           ),
         );
+      }
+
+      // Cache plist args so regenerate_macos_plist_with_current_env() can update
+      // the plist when the user saves an API key on subsequent launches. Without
+      // this, LAST_MACOS_PLIST_ARGS stays None (it's only set in the new-plist
+      // path below) and set_api_key silently skips the plist update, leaving the
+      // gateway running with stale or missing env vars.
+      {
+        let cfg: crate::clawd::sidecar::SharedClawdbotConfig =
+          std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::clawd::sidecar::ClawdbotConfig::default(),
+          ));
+        if let Ok(setup) = prepare_gateway_config(app_handle, &cfg).await {
+          *LAST_MACOS_PLIST_ARGS.lock().unwrap() = Some((setup.program_args, setup.env));
+          eprintln!("[clawd/service] auto_enable: cached plist args for future API key updates");
+        }
       }
       return;
     }

--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -131,6 +131,7 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   onAttendeeClick,
 }) => {
   const [isInitialLoading, setIsInitialLoading] = useState(true)
+  const initialLoadingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [disableIsRecording, setDisableIsRecording] = useState(false)
   const [permissionError, setPermissionError] = useState<string | null>(null)
   const [notesMarkdown, setNotesMarkdown] = useState<string>('')
@@ -380,8 +381,15 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     }
 
     if (thread.id) {
+      // Safety timeout: if fetchNotes hangs (e.g. server temporarily busy),
+      // clear the skeleton after 8 seconds so the view isn't stuck forever.
+      if (initialLoadingTimerRef.current) clearTimeout(initialLoadingTimerRef.current)
+      initialLoadingTimerRef.current = setTimeout(() => setIsInitialLoading(false), 8000)
       fetchNotes()
       refreshStatus()
+    }
+    return () => {
+      if (initialLoadingTimerRef.current) clearTimeout(initialLoadingTimerRef.current)
     }
   }, [thread.id, isLLMLoading, synthesisState])
 
@@ -519,6 +527,8 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     if (!meeting?.event_id || thread.recorded || briefPrepTriggeredRef.current) return
     briefPrepTriggeredRef.current = true
     setIsBriefPrepGenerating(true)
+    // Safety timeout: if the gateway doesn't respond within 30s, clear the spinner
+    const briefPrepTimeout = setTimeout(() => setIsBriefPrepGenerating(false), 30000)
     const participantList = meeting.participants
       .map(p => p.name ? `${p.name} (${p.email})` : p.email)
       .join(', ')
@@ -534,12 +544,17 @@ Output only the 3 sentences, nothing else.`,
       documents: [],
       messageStreamCallback: (chunk) => setBriefPrepContent(prev => prev + chunk),
       messageFinishCallback: async (response) => {
+        clearTimeout(briefPrepTimeout)
         setBriefPrepContent(response)
         setIsBriefPrepGenerating(false)
         return undefined
       },
-      errorCallback: () => setIsBriefPrepGenerating(false),
+      errorCallback: () => {
+        clearTimeout(briefPrepTimeout)
+        setIsBriefPrepGenerating(false)
+      },
     })
+    return () => clearTimeout(briefPrepTimeout)
   }, [meeting?.event_id])
 
   const getRunParamObject = () => {

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -190,6 +190,7 @@ function NotetakerSidebar({
     (currentTab === TabChoices.Meeting && activeView === 'chat')
   const isEmailActive = currentTab === TabChoices.Email
   const isLibraryActive = currentTab === TabChoices.Library
+  const isGBrainActive = currentTab === TabChoices.GBrain
 
   const chatIcon = (
     <svg
@@ -235,6 +236,22 @@ function NotetakerSidebar({
     >
       <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
       <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+    </svg>
+  )
+
+  const gbrainIcon = (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.46 2.5 2.5 0 0 1-1.67-3.6A3 3 0 0 1 3 12a3 3 0 0 1 2.37-2.94A2.5 2.5 0 0 1 9.5 2z" />
+      <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.46 2.5 2.5 0 0 0 1.67-3.6A3 3 0 0 0 21 12a3 3 0 0 0-2.37-2.94A2.5 2.5 0 0 0 14.5 2z" />
     </svg>
   )
 
@@ -723,12 +740,12 @@ function NotetakerSidebar({
             <span>Email</span>
           </button>
           <button
-            className={`notetaker-sidebar__bottom-action ${isLibraryActive ? 'notetaker-sidebar__bottom-action--active' : ''}`}
-            onClick={() => onTabChange(TabChoices.Library)}
-            title="Library"
+            className={`notetaker-sidebar__bottom-action ${isGBrainActive ? 'notetaker-sidebar__bottom-action--active' : ''}`}
+            onClick={() => onTabChange(TabChoices.GBrain)}
+            title="GBrain"
           >
-            {libraryIcon}
-            <span>Library</span>
+            {gbrainIcon}
+            <span>GBrain</span>
           </button>
         </div>
         {appVersion && (

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -257,6 +257,7 @@ export const SettingsDialog = ({
     has_openai_key?: boolean
     has_anthropic_key?: boolean
     has_openrouter_key?: boolean
+    has_gemini_cli_key?: boolean
     ollama_enabled?: boolean
     ollama_model?: string
     ollama_base_url?: string
@@ -301,6 +302,7 @@ export const SettingsDialog = ({
           has_openai_key: data.has_openai_key,
           has_anthropic_key: data.has_anthropic_key,
           has_openrouter_key: data.has_openrouter_key,
+          has_gemini_cli_key: data.has_gemini_cli_key,
           ollama_enabled: data.ollama_enabled,
           ollama_model: data.ollama_model,
           ollama_base_url: data.ollama_base_url,
@@ -619,23 +621,25 @@ export const SettingsDialog = ({
               { id: 'huggingface', envVar: 'HF_TOKEN', name: 'Hugging Face' },
             ].map(ep => {
               const status = providerStatus?.extra_providers?.find(p => p.env_var === ep.envVar)
+              const isGeminiViaCli = ep.id === 'gemini' && !!providerStatus?.has_gemini_cli_key
+              const isConnected = !!status?.has_key || isGeminiViaCli
               return (
                 <ProviderAccordion
                   key={ep.id}
                   title={ep.name}
-                  isConnected={!!status?.has_key}
+                  isConnected={isConnected}
                   expanded={expandedProvider === ep.id}
                   onToggle={() => toggleProvider(ep.id)}
                 >
                   <div className={styles.providerActions}>
                     <span className={styles.providerStatus}>
-                      {status?.has_key ? 'API key configured' : 'No API key set'}
+                      {isConnected ? (isGeminiViaCli && !status?.has_key ? 'Gemini CLI auth configured' : 'API key configured') : 'No API key set'}
                     </span>
                     <button
                       className={styles.providerActionLink}
                       onClick={() => { handleClose(); onProviderSignInClick?.() }}
                     >
-                      {status?.has_key ? 'Change' : 'Add key'}
+                      {isConnected ? 'Change' : 'Add key'}
                     </button>
                   </div>
                 </ProviderAccordion>

--- a/src/src/hooks/useAppUpdate.tsx
+++ b/src/src/hooks/useAppUpdate.tsx
@@ -76,7 +76,11 @@ export function AppUpdateProvider({ children }: { children: React.ReactNode }) {
         setState({ status: 'up-to-date' })
       }
     } catch (err) {
-      setState({ status: 'error', message: String(err) })
+      const msg = String(err)
+      const friendlyMsg = msg.includes('fetch') || msg.includes('release JSON') || msg.includes('network')
+        ? 'Could not reach the update server. Check your connection and try again.'
+        : msg
+      setState({ status: 'error', message: friendlyMsg })
     }
   }, [])
 


### PR DESCRIPTION
## Summary
This PR addresses several stability issues in the gateway service and UI, including improved handling of stale plugin dependencies, better timeout management for gateway requests, and UI enhancements for the GBrain feature.

## Key Changes

### Gateway Service Improvements
- **Module resolution crash detection**: Added classification for "cannot find module" errors related to plugin-sdk, channel-config, or root-alias to detect incompatible plugin-runtime-deps structures
- **Force cleanup on module resolution failures**: When a module resolution crash is detected, force a full wipe of plugin-runtime-deps directories (by passing empty string to version filter) so the gateway re-stages clean dependencies
- **macOS plist caching**: Cache plist arguments during auto-enable so that subsequent API key updates can properly regenerate the plist with current environment variables, preventing stale env vars in the gateway

### Gateway Request Resilience
- **Skills status timeout**: Added 5-second timeout to `skills.status` gateway requests to prevent UI stalls when the gateway is reconnecting or temporarily unavailable

### UI/UX Enhancements
- **GBrain sidebar button**: Replaced Library button with GBrain button in the NotetakerSidebar with a new brain icon
- **Meeting notes loading safety**: Added 8-second timeout for initial notes fetch to prevent skeleton loader from staying indefinitely if the server is busy
- **Brief prep generation timeout**: Added 30-second safety timeout for brief preparation generation to clear the spinner if the gateway doesn't respond

### Version Bump
- Updated version from 1.7.6 to 1.8.5

## Implementation Details
- Module resolution detection logic mirrors the crash classification logic for consistency
- Timeout implementations use `tokio::time::timeout` for async operations and `setTimeout` for React components
- Cleanup functions properly handle timeout edge cases with ref-based timer management
- Gemini CLI authentication status is now properly tracked alongside API key configuration in settings

https://claude.ai/code/session_01X47LtAjNkXL4ss5zgEkVxQ