### PR TITLE
Add Knapsack cloud inference provider support

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1540,6 +1540,12 @@ struct StoredTokens {
   /// (Anthropic → claude, OpenAI → codex, Google → gemini).
   #[serde(default)]
   preferred_coding_agent: Option<String>,
+
+  // Knapsack cloud inference (no API key — uses the user's Knapsack JWT)
+  #[serde(default)]
+  knapsack_email: Option<String>,
+  #[serde(default)]
+  knapsack_model: Option<String>,
 }
 
 fn tokens_path(app_handle: &tauri::AppHandle) -> PathBuf {
@@ -1681,6 +1687,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     ollama_base_url: None,
     extra_provider_keys: None,
     preferred_coding_agent: None,
+    knapsack_email: None,
+    knapsack_model: None,
   };
 
   fs::write(&path, serde_json::to_string_pretty(&t).unwrap_or_default())
@@ -1782,6 +1790,15 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
         std::env::set_var(env_var, key);
       }
     }
+  }
+  // Propagate Knapsack cloud inference settings (active when user chose Knapsack as provider)
+  if let Some(e) = &tokens.knapsack_email {
+    let e = e.trim();
+    if !e.is_empty() { std::env::set_var("KNAPSACK_USER_EMAIL", e); }
+  }
+  if let Some(m) = &tokens.knapsack_model {
+    let m = m.trim();
+    if !m.is_empty() { std::env::set_var("KNAPSACK_KNAPSACK_MODEL", m); }
   }
 
   // Propagate gateway token so that in-process gateway RPC callers
@@ -2791,6 +2808,10 @@ pub struct ApiKeyStatusResponse {
   /// User's preferred coding CLI: "claude", "codex", or "gemini".
   /// Null means auto-select based on available API keys.
   pub preferred_coding_agent: Option<String>,
+  // Knapsack cloud inference
+  pub has_knapsack: bool,
+  pub knapsack_email: Option<String>,
+  pub knapsack_model: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2829,6 +2850,9 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         ollama_base_url: None,
         extra_providers: vec![],
         preferred_coding_agent: None,
+        has_knapsack: false,
+        knapsack_email: None,
+        knapsack_model: None,
       })
     }
   };
@@ -2840,7 +2864,8 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
   let has_openrouter = tokens.openrouter_api_key.as_ref().map(|k| !k.trim().is_empty()).unwrap_or(false);
   let ollama_enabled = tokens.ollama_enabled.unwrap_or(false);
   let (has_gemini_cli, gemini_cli_email) = read_gemini_cli_auth(&app_handle);
-  let has_key = has_openai || has_anthropic || has_gemini || has_groq || has_openrouter || ollama_enabled || has_gemini_cli;
+  let has_knapsack = tokens.knapsack_email.as_ref().map(|e| !e.trim().is_empty()).unwrap_or(false);
+  let has_key = has_openai || has_anthropic || has_gemini || has_groq || has_openrouter || ollama_enabled || has_gemini_cli || has_knapsack;
 
   let model = tokens.openai_model.clone();
   let active_provider = tokens.active_provider.clone();
@@ -2901,6 +2926,9 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     ollama_base_url: tokens.ollama_base_url.clone(),
     extra_providers,
     preferred_coding_agent: tokens.preferred_coding_agent.clone(),
+    has_knapsack,
+    knapsack_email: tokens.knapsack_email.clone(),
+    knapsack_model: tokens.knapsack_model.clone(),
   })
 }
 
@@ -3105,8 +3133,8 @@ pub async fn set_api_key(
   let key = payload.key.trim().to_string();
   let provider = payload.provider.as_deref().unwrap_or("openai").to_lowercase();
 
-  // Validate key format before storing (skip for ollama which uses a dummy key)
-  if !key.is_empty() && provider != "ollama" {
+  // Validate key format before storing (skip for ollama and knapsack which don't use API keys)
+  if !key.is_empty() && provider != "ollama" && provider != "knapsack" {
     if let Err(msg) = validate_api_key_format(&key) {
       return HttpResponse::BadRequest().json(SetApiKeyResponse {
         success: false,
@@ -3123,6 +3151,7 @@ pub async fn set_api_key(
       "groq" => tokens.groq_api_key.as_ref().map_or(false, |k| !k.is_empty()),
       "openrouter" => tokens.openrouter_api_key.as_ref().map_or(false, |k| !k.is_empty()),
       "ollama" => true,
+      "knapsack" => tokens.knapsack_email.as_ref().map_or(false, |e| !e.is_empty()),
       _ => tokens.openai_api_key.as_ref().map_or(false, |k| !k.is_empty()),
     };
     if !has_existing {
@@ -3140,6 +3169,7 @@ pub async fn set_api_key(
         "groq" => { tokens.groq_model = Some(model.trim().to_string()); }
         "openrouter" => { tokens.openrouter_model = Some(model.trim().to_string()); }
         "ollama" => { tokens.ollama_model = Some(model.trim().to_string()); }
+        "knapsack" => { tokens.knapsack_model = Some(model.trim().to_string()); }
         _ => { tokens.openai_model = Some(model.trim().to_string()); }
       }
     }
@@ -3149,6 +3179,7 @@ pub async fn set_api_key(
       "groq" => "Groq",
       "openrouter" => "OpenRouter",
       "ollama" => "Ollama",
+      "knapsack" => "Knapsack",
       _ => "OpenAI",
     };
     if let Err(e) = save_tokens(&app_handle, &tokens) {
@@ -3185,6 +3216,11 @@ pub async fn set_api_key(
       std::env::remove_var("OLLAMA_API_KEY");
       std::env::remove_var("KNAPSACK_OLLAMA_MODEL");
       std::env::remove_var("OLLAMA_HOST");
+    }
+    // Propagate Knapsack inference settings
+    if provider == "knapsack" {
+      if let Some(e) = &tokens.knapsack_email { std::env::set_var("KNAPSACK_USER_EMAIL", e); }
+      if let Some(m) = &tokens.knapsack_model { std::env::set_var("KNAPSACK_KNAPSACK_MODEL", m); }
     }
 
     // Update agents.defaults.model in the config file so the gateway uses
@@ -3298,6 +3334,15 @@ pub async fn set_api_key(
       }
       "Ollama"
     }
+    "knapsack" => {
+      // Knapsack cloud inference: key field carries the user's email (no API key needed)
+      tokens.knapsack_email = Some(key);
+      tokens.active_provider = Some("knapsack".to_string());
+      if let Some(model) = &payload.model {
+        tokens.knapsack_model = Some(model.trim().to_string());
+      }
+      "Knapsack"
+    }
     "minimax" | "zai" | "huggingface" => {
       // Extra providers: store key in extra_provider_keys map.
       // Determine the env var name from the request or derive from provider.
@@ -3386,6 +3431,11 @@ pub async fn set_api_key(
     std::env::remove_var("OLLAMA_API_KEY");
     std::env::remove_var("KNAPSACK_OLLAMA_MODEL");
     std::env::remove_var("OLLAMA_HOST");
+  }
+  // Propagate Knapsack cloud inference settings
+  if provider == "knapsack" {
+    if let Some(e) = &tokens.knapsack_email { std::env::set_var("KNAPSACK_USER_EMAIL", e); }
+    if let Some(m) = &tokens.knapsack_model { std::env::set_var("KNAPSACK_KNAPSACK_MODEL", m); }
   }
   if let Some(extra) = &tokens.extra_provider_keys {
     for (env_var, key) in extra {

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -664,6 +664,11 @@ async fn knapsack_completion(
         "Knapsack session expired — please sign in again".into(),
       ));
     }
+    if status == reqwest::StatusCode::PAYMENT_REQUIRED {
+      return Err(LLMError::ChatCompletionFailed(
+        "No Knapsack credits remaining. Sign up or top up at https://studio.knapsack.ai".into(),
+      ));
+    }
     return Err(LLMError::ChatCompletionFailed(format!(
       "Knapsack inference error ({}): {}",
       status, text

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -109,6 +109,20 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
         is_anthropic: false,
       });
     }
+    "knapsack" => {
+      let email = std::env::var("KNAPSACK_USER_EMAIL").unwrap_or_default();
+      if !email.trim().is_empty() {
+        let model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
+          .unwrap_or_else(|_| "anthropic/claude-haiku-4-5".to_string());
+        return Ok(ResolvedProvider {
+          name: "knapsack".into(),
+          api_key: email,
+          model,
+          base_url: "https://api.knapsack.ai".into(),
+          is_anthropic: false,
+        });
+      }
+    }
     "ollama" if ollama_key.is_some() => {
       let ollama_base = std::env::var("OLLAMA_HOST")
         .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string());
@@ -568,6 +582,129 @@ async fn anthropic_completion(
   Err(LLMError::ChatCompletionFailed(format!("Anthropic failed after {} retries: {}", max_retries, last_error)))
 }
 
+/// Call Knapsack's cloud inference API (`POST /api/desktop/inference`).
+/// Fetches a fresh JWT from the local gateway before each request.
+async fn knapsack_completion(
+  provider: &ResolvedProvider,
+  messages: &[LlmMessage],
+) -> Result<String, LLMError> {
+  let email = &provider.api_key;
+  let client = reqwest::Client::new();
+
+  // Fetch a fresh JWT from the local gateway
+  let token_url = format!(
+    "http://127.0.0.1:8897/api/knapsack/connections/refresh_token_api/{}",
+    email
+  );
+  let token_resp = client.get(&token_url).send().await.map_err(|e| {
+    LLMError::ChatCompletionFailed(format!("Knapsack token fetch failed: {}", e))
+  })?;
+
+  if !token_resp.status().is_success() {
+    return Err(LLMError::ChatCompletionFailed(
+      "Knapsack auth failed — please sign in to Knapsack again".into(),
+    ));
+  }
+
+  let token_json: serde_json::Value = token_resp.json().await.map_err(|e| {
+    LLMError::ChatCompletionFailed(format!("Knapsack token parse failed: {}", e))
+  })?;
+
+  let token = token_json
+    .get("token")
+    .and_then(|t| t.as_str())
+    .ok_or_else(|| {
+      LLMError::ChatCompletionFailed("Knapsack JWT not found in token response".into())
+    })?
+    .to_string();
+
+  // Separate system prompt from conversation messages
+  let system_prompt: String = messages
+    .iter()
+    .filter(|m| matches!(m.sender, MessageSender::System))
+    .map(|m| m.content.as_str())
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  let conversation: Vec<serde_json::Value> = messages
+    .iter()
+    .filter(|m| !matches!(m.sender, MessageSender::System))
+    .map(|m| {
+      let role = match m.sender {
+        MessageSender::User => "user",
+        MessageSender::Bot => "assistant",
+        _ => "user",
+      };
+      serde_json::json!({"role": role, "content": &m.content})
+    })
+    .collect();
+
+  let mut body = serde_json::json!({
+    "messages": conversation,
+    "model": &provider.model,
+  });
+  if !system_prompt.is_empty() {
+    body["system_prompt"] = serde_json::Value::String(system_prompt);
+  }
+
+  let resp = client
+    .post(format!("{}/api/desktop/inference", &provider.base_url))
+    .header("Authorization", format!("Bearer {}", token))
+    .header("Content-Type", "application/json")
+    .json(&body)
+    .send()
+    .await
+    .map_err(|e| LLMError::ChatCompletionFailed(format!("Knapsack inference request failed: {}", e)))?;
+
+  let status = resp.status();
+  if !status.is_success() {
+    let text = resp.text().await.unwrap_or_default();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+      return Err(LLMError::ChatCompletionFailed(
+        "Knapsack session expired — please sign in again".into(),
+      ));
+    }
+    return Err(LLMError::ChatCompletionFailed(format!(
+      "Knapsack inference error ({}): {}",
+      status, text
+    )));
+  }
+
+  // Consume SSE stream and concatenate content chunks
+  let body_bytes = resp.bytes().await.map_err(|e| {
+    LLMError::ChatCompletionFailed(format!("Knapsack response read failed: {}", e))
+  })?;
+  let body_str = String::from_utf8_lossy(&body_bytes);
+
+  let mut full_text = String::new();
+  for line in body_str.lines() {
+    if let Some(data) = line.strip_prefix("data: ") {
+      if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+        if json.get("done").and_then(|d| d.as_bool()).unwrap_or(false) {
+          break;
+        }
+        if let Some(content) = json.get("content").and_then(|c| c.as_str()) {
+          full_text.push_str(content);
+        }
+      }
+    }
+  }
+
+  if full_text.is_empty() {
+    return Err(LLMError::ChatCompletionFailed(
+      "Knapsack returned an empty response".into(),
+    ));
+  }
+
+  let usage = CompletionUsage {
+    input_tokens: messages.iter().map(|m| estimate_tokens(&m.content)).sum::<i64>(),
+    output_tokens: estimate_tokens(&full_text),
+  };
+  record_usage("knapsack", &provider.model, &usage, "chat");
+
+  Ok(full_text)
+}
+
 /// Complete using the best available provider. Falls back through providers on failure.
 pub async fn multi_provider_completion(
   messages: Vec<LlmMessage>,
@@ -593,7 +730,9 @@ pub async fn multi_provider_completion(
     provider.name, provider.model, key_len, key_preview
   );
 
-  let result = if provider.is_anthropic {
+  let result = if provider.name == "knapsack" {
+    knapsack_completion(&provider, &messages).await
+  } else if provider.is_anthropic {
     anthropic_completion(&provider, &messages).await
   } else {
     openai_compatible_completion(&provider, &messages).await

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -93,7 +93,7 @@ function Home({
   const [useLocalLLM, setUseLocalLLM] = useState<boolean>(false)
   const [isSettingsDialogOpened, setIsSettingsDialogOpened] = useState(false)
   const [isProviderSignInDialogOpened, setIsProviderSignInDialogOpened] = useState(false)
-  const [providerSignInInitialProvider, setProviderSignInInitialProvider] = useState<'openai' | 'anthropic' | 'openrouter' | undefined>(undefined)
+  const [providerSignInInitialProvider, setProviderSignInInitialProvider] = useState<'knapsack' | 'openai' | 'anthropic' | 'openrouter' | undefined>(undefined)
   const [openProviderPanelTrigger, setOpenProviderPanelTrigger] = useState(0)
   const [connectionsDropdownOpened, setConnectionsDropdownOpened] = useState(false)
   const [showAutomationLabModal, setShowAutomationLabModal] = useState(false)
@@ -323,7 +323,7 @@ function Home({
     }
   }
 
-  const handleOpenProviderSignIn = useCallback((provider?: 'openai' | 'anthropic' | 'openrouter') => {
+  const handleOpenProviderSignIn = useCallback((provider?: 'knapsack' | 'openai' | 'anthropic' | 'openrouter') => {
     // Close settings dialog and open the ClawdChat provider sidebar instead
     setIsSettingsDialogOpened(false)
     setProviderSignInInitialProvider(provider)
@@ -474,6 +474,7 @@ function Home({
         isOpen={isProviderSignInDialogOpened}
         handleClose={() => setIsProviderSignInDialogOpened(false)}
         initialProvider={providerSignInInitialProvider}
+        userEmail={userEmail}
       />
       <SignInDialog
         isOpen={isSignInDialogOpened}

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -13,7 +13,7 @@ import styles from './styles.module.scss'
 
 const API_BASE = 'http://127.0.0.1:8897'
 
-type Provider = 'openai' | 'anthropic' | 'openrouter' | 'gemini'
+type Provider = 'knapsack' | 'openai' | 'anthropic' | 'openrouter' | 'gemini'
 
 type ProviderConfig = {
   id: Provider
@@ -33,6 +33,20 @@ type ModelOption = {
 }
 
 const PROVIDER_CONFIGS: ProviderConfig[] = [
+  {
+    id: 'knapsack',
+    name: 'Knapsack',
+    description: 'Powered by Knapsack — no API key needed',
+    keyPrefix: '',
+    helpUrl: 'https://www.knapsack.ai',
+    helpLabel: 'knapsack.ai',
+    models: [
+      { id: 'anthropic/claude-haiku-4-5', name: 'Standard', description: 'Fast, efficient — great for everyday tasks' },
+      { id: 'anthropic/claude-sonnet-4-5', name: 'Plus', description: 'Balanced performance and capability' },
+      { id: 'anthropic/claude-opus-4-7', name: 'Premium', description: 'Most powerful — best for complex work' },
+    ],
+    defaultModel: 'anthropic/claude-haiku-4-5',
+  },
   {
     id: 'openai',
     name: 'OpenAI',
@@ -159,6 +173,9 @@ type ApiKeyStatusResponse = {
   gemini_key_hint?: string
   gemini_cli_email?: string
   extra_providers?: ExtraProviderStatusItem[]
+  has_knapsack?: boolean
+  knapsack_email?: string
+  knapsack_model?: string
 }
 
 type ValidationState = 'idle' | 'validating' | 'valid' | 'invalid'
@@ -167,14 +184,16 @@ type ProviderSignInDialogProps = {
   isOpen: boolean
   handleClose: () => void
   initialProvider?: Provider
+  userEmail?: string
 }
 
 export const ProviderSignInDialog = ({
   isOpen,
   handleClose,
   initialProvider,
+  userEmail,
 }: ProviderSignInDialogProps) => {
-  const [selectedProvider, setSelectedProvider] = useState<Provider>(initialProvider ?? 'openai')
+  const [selectedProvider, setSelectedProvider] = useState<Provider>(initialProvider ?? 'knapsack')
   const [apiKey, setApiKey] = useState('')
   const [selectedModel, setSelectedModel] = useState('')
   const [saving, setSaving] = useState(false)
@@ -457,6 +476,10 @@ export const ProviderSignInDialog = ({
       } else if (data.active_provider === 'google-gemini-cli') {
         setSelectedProvider('gemini')
         setSelectedModel('gemini/gemini-2.5-pro')
+      } else if (data.active_provider === 'knapsack') {
+        setSelectedProvider('knapsack')
+        const config = PROVIDER_CONFIGS.find(p => p.id === 'knapsack')!
+        setSelectedModel(data.knapsack_model || config.defaultModel)
       } else if (data.active_provider === 'openai' || data.active_provider === 'anthropic' || data.active_provider === 'openrouter' || data.active_provider === 'gemini') {
         setSelectedProvider(data.active_provider as Provider)
         const config = PROVIDER_CONFIGS.find(p => p.id === data.active_provider)!
@@ -483,6 +506,38 @@ export const ProviderSignInDialog = ({
     setGeminiOAuthPending(false)
     geminiOAuthPendingRef.current = false
   }, [selectedProvider])
+
+  const handleActivateKnapsack = useCallback(async () => {
+    const email = userEmail || keyStatus?.knapsack_email || ''
+    if (!email) {
+      setError('Sign in to Knapsack first to use this option.')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+    setSuccess('')
+    try {
+      const res = await fetch(`${API_BASE}/api/clawd/service/set-api-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'knapsack', key: email, model: selectedModel }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        KNAnalytics.trackEvent('knapsack_provider_activated', { model: selectedModel, app_version: KNAnalytics.APP_VERSION })
+        setSuccess('Knapsack AI activated!')
+        await fetchKeyStatus()
+        setTimeout(() => handleClose(), 1200)
+      } else {
+        setError(data.message || 'Failed to activate Knapsack.')
+      }
+    } catch (e: any) {
+      setError(e?.message || 'Failed to activate. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }, [userEmail, keyStatus, selectedModel, fetchKeyStatus, handleClose])
 
   const handleSave = useCallback(async () => {
     if (!apiKey.trim()) {
@@ -551,6 +606,7 @@ export const ProviderSignInDialog = ({
 
   const hasExistingKey = (provider: Provider): boolean => {
     if (!keyStatus) return false
+    if (provider === 'knapsack') return !!keyStatus.has_knapsack
     if (provider === 'openai') return !!keyStatus.has_openai_key
     if (provider === 'anthropic') return !!keyStatus.has_anthropic_key
     if (provider === 'openrouter') return !!keyStatus.has_openrouter_key
@@ -687,6 +743,13 @@ export const ProviderSignInDialog = ({
               disabled={saving}
             >
               <div className={styles.providerTabIcon}>
+                {config.id === 'knapsack' && (
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect x="3" y="6" width="18" height="14" rx="2" stroke="currentColor" strokeWidth="2" fill="none"/>
+                    <path d="M8 6V4a4 4 0 018 0v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                    <circle cx="12" cy="13" r="2" fill="currentColor"/>
+                  </svg>
+                )}
                 {config.id === 'openai' && (
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364l2.0201-1.1638a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4091-.6813zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0974-2.3616l2.603-1.5018 2.6032 1.5018v3.0036l-2.6032 1.5018-2.603-1.5018z" fill="currentColor"/>
@@ -724,6 +787,64 @@ export const ProviderSignInDialog = ({
         </div>
 
         <div className={styles.providerSignInForm}>
+          {selectedProvider === 'knapsack' && (
+            <div style={{ padding: '20px 24px' }}>
+              <div style={{ marginBottom: 16, padding: '12px 16px', background: '#f8fafc', borderRadius: 8, border: '1px solid #e2e8f0' }}>
+                {(userEmail || keyStatus?.knapsack_email) ? (
+                  <p style={{ margin: 0, fontSize: 13, color: '#334155' }}>
+                    Signed in as <strong>{userEmail || keyStatus?.knapsack_email}</strong>
+                  </p>
+                ) : (
+                  <p style={{ margin: 0, fontSize: 13, color: '#64748b' }}>
+                    Sign in to Knapsack to use this option.
+                  </p>
+                )}
+              </div>
+              <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: '#374151', marginBottom: 8 }}>
+                Model tier
+              </label>
+              <div style={{ display: 'flex', gap: 8, marginBottom: 20 }}>
+                {providerConfig.models.map(m => (
+                  <button
+                    key={m.id}
+                    onClick={() => setSelectedModel(m.id)}
+                    disabled={saving}
+                    style={{
+                      flex: 1,
+                      padding: '10px 8px',
+                      border: selectedModel === m.id ? '2px solid #c54841' : '2px solid #e2e8f0',
+                      borderRadius: 8,
+                      background: selectedModel === m.id ? '#fff5f5' : 'white',
+                      cursor: 'pointer',
+                      textAlign: 'center',
+                    }}
+                  >
+                    <div style={{ fontSize: 13, fontWeight: 600, color: selectedModel === m.id ? '#c54841' : '#374151' }}>{m.name}</div>
+                    <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>{m.description}</div>
+                  </button>
+                ))}
+              </div>
+              {error && <p style={{ margin: '0 0 12px', fontSize: 13, color: '#ef4444' }}>{error}</p>}
+              {success && <p style={{ margin: '0 0 12px', fontSize: 13, color: '#4caf50' }}>{success}</p>}
+              <button
+                style={{
+                  width: '100%',
+                  padding: '10px 0',
+                  background: (userEmail || keyStatus?.knapsack_email) ? '#c54841' : '#94a3b8',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: 8,
+                  fontWeight: 600,
+                  fontSize: 14,
+                  cursor: (userEmail || keyStatus?.knapsack_email) ? 'pointer' : 'not-allowed',
+                }}
+                onClick={handleActivateKnapsack}
+                disabled={saving || !(userEmail || keyStatus?.knapsack_email)}
+              >
+                {saving ? 'Activating…' : isActiveProvider('knapsack') ? 'Update model' : 'Activate Knapsack'}
+              </button>
+            </div>
+          )}
           {selectedProvider === 'openrouter' && (
             <div className={styles.oauthSection}>
               <button
@@ -775,10 +896,10 @@ export const ProviderSignInDialog = ({
             </div>
           )}
 
-          <label className={styles.formLabel}>
+          {selectedProvider !== 'knapsack' && <label className={styles.formLabel}>
             {providerConfig.name} API Key
-          </label>
-          <div className={styles.inputWrapper}>
+          </label>}
+          {selectedProvider !== 'knapsack' && <div className={styles.inputWrapper}>
             <input
               type="password"
               value={apiKey}
@@ -803,16 +924,16 @@ export const ProviderSignInDialog = ({
                 </svg>
               )}
             </div>
-          </div>
-          {validationMsg && validation === 'valid' && (
+          </div>}
+          {selectedProvider !== 'knapsack' && validationMsg && validation === 'valid' && (
             <p className={styles.validationSuccess}>{validationMsg}</p>
           )}
-          {validationMsg && validation === 'invalid' && (
+          {selectedProvider !== 'knapsack' && validationMsg && validation === 'invalid' && (
             <p className={styles.validationError}>{validationMsg}</p>
           )}
 
-          <label className={styles.formLabel}>Model</label>
-          <div className={styles.modelSelector}>
+          {selectedProvider !== 'knapsack' && <label className={styles.formLabel}>Model</label>}
+          {selectedProvider !== 'knapsack' && <div className={styles.modelSelector}>
             {providerConfig.models.map(model => (
               <button
                 key={model.id}
@@ -827,25 +948,25 @@ export const ProviderSignInDialog = ({
                 </span>
               </button>
             ))}
-          </div>
+          </div>}
 
-          {error && (
+          {selectedProvider !== 'knapsack' && error && (
             <p className={styles.errorMessage}>{error}</p>
           )}
 
-          {success && (
+          {selectedProvider !== 'knapsack' && success && (
             <p className={styles.successMessage}>{success}</p>
           )}
 
-          <button
+          {selectedProvider !== 'knapsack' && <button
             className={styles.saveButton}
             onClick={handleSave}
             disabled={saving || !apiKey.trim()}
           >
             {saving ? 'Connecting...' : `Sign in with ${providerConfig.name}`}
-          </button>
+          </button>}
 
-          <p className={styles.helpText}>
+          {selectedProvider !== 'knapsack' && <p className={styles.helpText}>
             Get your API key at{' '}
             <a
               href={providerConfig.helpUrl}
@@ -854,7 +975,7 @@ export const ProviderSignInDialog = ({
             >
               {providerConfig.helpLabel}
             </a>
-          </p>
+          </p>}
         </div>
 
         {/* More Providers section */}

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -843,6 +843,17 @@ export const ProviderSignInDialog = ({
               >
                 {saving ? 'Activating…' : isActiveProvider('knapsack') ? 'Update model' : 'Activate Knapsack'}
               </button>
+              <p style={{ margin: '12px 0 0', fontSize: 12, color: '#64748b', textAlign: 'center' }}>
+                Need credits?{' '}
+                <a
+                  href="https://studio.knapsack.ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: '#c54841', textDecoration: 'underline' }}
+                >
+                  Sign up at studio.knapsack.ai
+                </a>
+              </p>
             </div>
           )}
           {selectedProvider === 'openrouter' && (

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -59,7 +59,7 @@ type SettingsDialogProps = {
   fetchConnections: (email: string) => void
   deleteConnection: (id: number) => void
   profile: Profile | undefined
-  onProviderSignInClick?: (provider?: 'openai' | 'anthropic' | 'openrouter') => void
+  onProviderSignInClick?: (provider?: 'knapsack' | 'openai' | 'anthropic' | 'openrouter') => void
 }
 
 const PERMISSION_LIST_GOOGLE_CONNECTIONS = new Set([


### PR DESCRIPTION
## Summary
Adds support for Knapsack as a cloud inference provider alongside existing providers (OpenAI, Anthropic, OpenRouter, Gemini). Knapsack uses the user's existing Knapsack account for authentication (no separate API key required) and offers three model tiers (Standard/Haiku, Plus/Sonnet, Premium/Opus).

## Key Changes

**Frontend (TypeScript/React)**
- Added `'knapsack'` to the `Provider` type in `ProviderSignInDialog`
- Created dedicated Knapsack sign-in UI with model tier selection (Standard/Plus/Premium) instead of API key input
- Added `userEmail` prop to `ProviderSignInDialog` to display the signed-in user's email
- Implemented `handleActivateKnapsack()` callback that sends the user's email (not an API key) to the backend
- Added Knapsack icon (lock/keychain SVG) to the provider tab
- Conditionally hide API key input fields when Knapsack is selected
- Updated `ProviderSignInDialog` to default to `'knapsack'` instead of `'openai'`
- Updated `ApiKeyStatusResponse` type to include `has_knapsack`, `knapsack_email`, and `knapsack_model` fields

**Backend (Rust)**
- **`service.rs`** — Added Knapsack fields to `StoredTokens` struct (`knapsack_email`, `knapsack_model`)
- Updated `api_key_status()` to return Knapsack status and include it in `has_key` check
- Modified `set_api_key()` to handle `"knapsack"` provider: stores email instead of API key, skips API key format validation
- Added environment variable propagation for `KNAPSACK_USER_EMAIL` and `KNAPSACK_KNAPSACK_MODEL`
- **`complete.rs`** — Added `knapsack_completion()` function that:
  - Fetches a fresh JWT from the local gateway (`/api/knapsack/connections/refresh_token_api/{email}`)
  - Sends inference requests to `https://api.knapsack.ai/api/desktop/inference` with Bearer token auth
  - Parses SSE stream response and concatenates content chunks
  - Handles auth failures with user-friendly error messages
- Updated `resolve_provider()` to handle `"knapsack"` provider and read from environment variables
- Updated `multi_provider_completion()` to route Knapsack requests to `knapsack_completion()`

## Implementation Details

- **No API key storage**: Knapsack uses the user's email as the identifier; the actual JWT is fetched fresh from the local gateway before each inference request
- **Model tiers**: Three predefined models map to Anthropic Claude variants (Haiku, Sonnet, Opus) via Knapsack's API
- **SSE streaming**: Knapsack responses are server-sent events; the implementation concatenates `content` fields until `done: true`
- **Token refresh**: Each inference call fetches a fresh JWT to ensure the session doesn't expire mid-request
- **Graceful degradation**: Auth errors return specific messages ("Sign in to Knapsack first", "session expired") to guide users

https://claude.ai/code/session_01SfmFKmDpsSLSqszV8ArmE2