### PR TITLE
Fix gateway runtime-deps install retries on npm cache ENOENT

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
+++ b/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
@@ -719,6 +719,18 @@ function createBundledRuntimeDepsInstallEnv(env, options = {}) {
 		npm_config_legacy_peer_deps: "true"
 	};
 }
+
+function shouldRetryBundledRuntimeDepsInstallWithoutCache(error) {
+	const message = formatErrorMessage(error).toLowerCase();
+	return message.includes("npm error code enoent") && message.includes(".openclaw-npm-cache") && message.includes("_cacache");
+}
+function clearBundledRuntimeDepsInstallCacheDir(cacheDir) {
+	try {
+		fs.rmSync(cacheDir, { recursive: true, force: true });
+	} catch {
+	}
+}
+
 function createBundledRuntimeDepsInstallArgs(missingSpecs) {
 	missingSpecs.forEach((spec) => {
 		parseInstallableRuntimeDepSpec(spec);
@@ -1087,19 +1099,29 @@ function installBundledRuntimeDeps(params) {
 		});
 		if (diskWarning) params.warn?.(diskWarning);
 		ensureNpmInstallExecutionManifest(installExecutionRoot);
-		const installEnv = createBundledRuntimeDepsInstallEnv(params.env, { cacheDir: path.join(installExecutionRoot, ".openclaw-npm-cache") });
+		const cacheDir = path.join(installExecutionRoot, ".openclaw-npm-cache");
+		const installEnv = createBundledRuntimeDepsInstallEnv(params.env, { cacheDir });
 		const npmRunner = resolveBundledRuntimeDepsNpmRunner({
 			env: installEnv,
 			npmArgs: createBundledRuntimeDepsInstallArgs(params.missingSpecs)
 		});
-		const result = spawnSync(npmRunner.command, npmRunner.args, {
+		const runInstall = () => spawnSync(npmRunner.command, npmRunner.args, {
 			cwd: installExecutionRoot,
 			encoding: "utf8",
 			env: npmRunner.env ?? installEnv,
 			stdio: "pipe",
 			windowsHide: true
 		});
-		if (result.status !== 0 || result.error) throw new Error(formatBundledRuntimeDepsInstallError(result));
+		let result = runInstall();
+		if (result.status !== 0 || result.error) {
+			const installError = new Error(formatBundledRuntimeDepsInstallError(result));
+			if (shouldRetryBundledRuntimeDepsInstallWithoutCache(installError)) {
+				params.warn?.("bundled runtime deps npm cache corruption detected; clearing install cache and retrying once");
+				clearBundledRuntimeDepsInstallCacheDir(cacheDir);
+				result = runInstall();
+			}
+			if (result.status !== 0 || result.error) throw new Error(formatBundledRuntimeDepsInstallError(result));
+		}
 		assertBundledRuntimeDepsInstalled(installExecutionRoot, params.missingSpecs);
 		if (isolatedExecutionRoot) {
 			const stagedNodeModulesDir = path.join(installExecutionRoot, "node_modules");
@@ -1132,19 +1154,33 @@ async function installBundledRuntimeDepsAsync(params) {
 		});
 		if (diskWarning) params.warn?.(diskWarning);
 		ensureNpmInstallExecutionManifest(installExecutionRoot);
-		const installEnv = createBundledRuntimeDepsInstallEnv(params.env, { cacheDir: path.join(installExecutionRoot, ".openclaw-npm-cache") });
+		const cacheDir = path.join(installExecutionRoot, ".openclaw-npm-cache");
+		const installEnv = createBundledRuntimeDepsInstallEnv(params.env, { cacheDir });
 		const npmRunner = resolveBundledRuntimeDepsNpmRunner({
 			env: installEnv,
 			npmArgs: createBundledRuntimeDepsInstallArgs(params.missingSpecs)
 		});
 		params.onProgress?.(`Starting npm install for bundled plugin runtime deps: ${params.missingSpecs.join(", ")}`);
-		await spawnBundledRuntimeDepsInstall({
-			command: npmRunner.command,
-			args: npmRunner.args,
-			cwd: installExecutionRoot,
-			env: npmRunner.env ?? installEnv,
-			onProgress: params.onProgress
-		});
+		try {
+			await spawnBundledRuntimeDepsInstall({
+				command: npmRunner.command,
+				args: npmRunner.args,
+				cwd: installExecutionRoot,
+				env: npmRunner.env ?? installEnv,
+				onProgress: params.onProgress
+			});
+		} catch (error) {
+			if (!shouldRetryBundledRuntimeDepsInstallWithoutCache(error)) throw error;
+			params.warn?.("bundled runtime deps npm cache corruption detected; clearing install cache and retrying once");
+			clearBundledRuntimeDepsInstallCacheDir(cacheDir);
+			await spawnBundledRuntimeDepsInstall({
+				command: npmRunner.command,
+				args: npmRunner.args,
+				cwd: installExecutionRoot,
+				env: npmRunner.env ?? installEnv,
+				onProgress: params.onProgress
+			});
+		}
 		assertBundledRuntimeDepsInstalled(installExecutionRoot, params.missingSpecs);
 		if (isolatedExecutionRoot) {
 			const stagedNodeModulesDir = path.join(installExecutionRoot, "node_modules");


### PR DESCRIPTION
### Motivation
- Gateway plugin staging could fail when `npm` returns `ENOENT` while reading the local install cache (`.openclaw-npm-cache/_cacache/...`), leaving bundled runtime deps (for example ACPX) unstaged and causing gateway reconnect loops.
- Add a targeted recovery so transient/corrupt local npm cache errors do not permanently block gateway startup or health repairs.

### Description
- Added `shouldRetryBundledRuntimeDepsInstallWithoutCache` to detect the specific `npm ENOENT` cache-corruption signature and `clearBundledRuntimeDepsInstallCacheDir` to remove the local install cache directory.
- Wire the recovery into the synchronous installer path so the sync install will clear the cache and retry once on the detected error before failing.
- Apply the same retry behavior to the asynchronous installer used by startup/doctor flows so both paths share consistent resilience.
- Changes are in `src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js` and include a warning log when a retry is attempted.

### Testing
- Ran `node --check src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js` and it completed successfully.
- Run a secondary JS runtime sanity check using `node -e "new Function(fs.readFileSync(...))"` which failed due to the file being an ESM module with `import` statements (this failure is expected for that check and is not a regression).
- Confirmed the modified installer code paths include the retry + cache-clear logic by inspecting the patched file and executing a syntax-level validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03bed16628832192a11b4dea70781b)