### PR TITLE
Redesign GBrain UI: calendar-driven skills with library integration

### DIFF
--- a/src/src-tauri/src/clawd/gbrain.rs
+++ b/src/src-tauri/src/clawd/gbrain.rs
@@ -73,7 +73,13 @@ pub fn kn_brain_list(brain_root: String, sub_path: String) -> Result<Vec<BrainEn
     };
 
     if !dir.exists() {
-        return Err(format!("Brain directory not found: {}", dir.display()));
+        // Auto-create the root brain directory on first use so the UI starts clean.
+        if sub_path.trim().is_empty() {
+            std::fs::create_dir_all(&dir)
+                .map_err(|e| format!("Cannot create brain directory {}: {}", dir.display(), e))?;
+        } else {
+            return Err(format!("Brain directory not found: {}", dir.display()));
+        }
     }
 
     let mut entries: Vec<BrainEntry> = std::fs::read_dir(&dir)

--- a/src/src/components/organisms/GBrainView/index.tsx
+++ b/src/src/components/organisms/GBrainView/index.tsx
@@ -5,70 +5,179 @@ import { KN_SERVER_HOST } from 'src/utils/constants'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+interface CalendarEvent {
+  id: number
+  title: string
+  start: number
+  end: number
+  attendees_json: string
+}
+
+interface Attendee {
+  name: string
+  email: string
+}
+
 interface BrainEntry {
   name: string
   relPath: string
   isDir: boolean
 }
 
-type PanelTab = 'brain' | 'skills'
+type PanelMode = 'skills' | 'brain'
 
 interface SkillDef {
-  name: string
   slug: string
   emoji: string
-  description: string
+  label: string
+  hint: string
   placeholder: string
 }
 
 // ── Skill catalog ─────────────────────────────────────────────────────────────
 
-const GBRAIN_SKILLS: SkillDef[] = [
+const SKILLS: SkillDef[] = [
   {
-    name: 'Meeting Prep',
     slug: 'meeting-prep',
     emoji: '🤝',
-    description: 'Prep context, angles, and hooks for an upcoming meeting with someone.',
-    placeholder: 'Person name or topic (e.g. "Demis Hassabis")',
+    label: 'Meeting Prep',
+    hint: 'Who are you meeting?',
+    placeholder: 'e.g. Sam Altman',
   },
   {
-    name: 'Book Mirror',
-    slug: 'book-mirror',
-    emoji: '📚',
-    description: 'Mirror a book\'s ideas to your life context — two-column synthesis.',
-    placeholder: 'Book title (e.g. "When Things Fall Apart")',
-  },
-  {
-    name: 'Enrich',
     slug: 'enrich',
     emoji: '🧠',
-    description: 'Research and enrich a person\'s brain page from multiple sources.',
-    placeholder: 'Person name (e.g. "Sam Altman")',
+    label: 'Enrich Person',
+    hint: 'Research and update someone\'s brain page',
+    placeholder: 'e.g. Demis Hassabis',
   },
   {
-    name: 'Media Ingest',
-    slug: 'media-ingest',
-    emoji: '🎬',
-    description: 'Ingest a video, audio, PDF, or URL into the brain.',
-    placeholder: 'URL or file path',
+    slug: 'book-mirror',
+    emoji: '📚',
+    label: 'Book Mirror',
+    hint: 'Map a book\'s ideas to your life context',
+    placeholder: 'e.g. Zero to One',
   },
   {
-    name: 'Skillify',
-    slug: 'skillify',
-    emoji: '⚡',
-    description: 'Turn a workflow you just ran into a reusable registered skill.',
-    placeholder: 'Describe the workflow to extract (e.g. "the book mirror I just did")',
-  },
-  {
-    name: 'Perplexity Research',
     slug: 'perplexity-research',
     emoji: '🔍',
-    description: 'Web research that checks what the brain already knows first.',
-    placeholder: 'Research question (e.g. "What is Sam Altman\'s view on AGI timelines?")',
+    label: 'Research',
+    hint: 'Brain-augmented web research',
+    placeholder: 'e.g. What is Sam\'s view on AGI timelines?',
+  },
+  {
+    slug: 'media-ingest',
+    emoji: '🎬',
+    label: 'Ingest Media',
+    hint: 'Add a video, podcast, or URL to your brain',
+    placeholder: 'URL or file path',
   },
 ]
 
-// ── Brain tree node ───────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatTime(unix: number): string {
+  return new Date(unix * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+}
+
+function isToday(unix: number): boolean {
+  const d = new Date(unix * 1000)
+  const now = new Date()
+  return d.toDateString() === now.toDateString()
+}
+
+function isTomorrow(unix: number): boolean {
+  const d = new Date(unix * 1000)
+  const tomorrow = new Date()
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  return d.toDateString() === tomorrow.toDateString()
+}
+
+function dayLabel(unix: number): string {
+  if (isToday(unix)) return 'Today'
+  if (isTomorrow(unix)) return 'Tomorrow'
+  return new Date(unix * 1000).toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+function parseAttendees(json: string): Attendee[] {
+  try { return JSON.parse(json) } catch { return [] }
+}
+
+function shortName(name: string): string {
+  const parts = name.trim().split(' ')
+  return parts[0]
+}
+
+// ── Meeting card ──────────────────────────────────────────────────────────────
+
+const MeetingCard: React.FC<{
+  event: CalendarEvent
+  onPrep: (event: CalendarEvent) => void
+  running: boolean
+}> = ({ event, onPrep, running }) => {
+  const attendees = parseAttendees(event.attendees_json)
+  const names = attendees.map(a => shortName(a.name)).filter(Boolean).slice(0, 4)
+
+  return (
+    <div className="flex-shrink-0 w-48 border border-gray-200 rounded-xl p-3 bg-white flex flex-col gap-2">
+      <div className="text-xs text-gray-400 font-medium">
+        {dayLabel(event.start)} · {formatTime(event.start)}
+      </div>
+      <div className="text-sm font-medium text-gray-800 leading-tight line-clamp-2 flex-1">
+        {event.title}
+      </div>
+      {names.length > 0 && (
+        <div className="text-xs text-gray-400 truncate">
+          {names.join(', ')}
+        </div>
+      )}
+      <button
+        className="w-full py-1.5 rounded-lg bg-gray-900 text-white text-xs font-medium hover:bg-gray-700 disabled:opacity-40 transition-colors"
+        disabled={running}
+        onClick={() => onPrep(event)}
+      >
+        {running ? '…' : 'Prep'}
+      </button>
+    </div>
+  )
+}
+
+// ── Skill row ─────────────────────────────────────────────────────────────────
+
+const SkillRow: React.FC<{
+  skill: SkillDef
+  onRun: (slug: string, context: string) => void
+  running: boolean
+}> = ({ skill, onRun, running }) => {
+  const [input, setInput] = useState('')
+
+  return (
+    <div className="flex items-center gap-3 py-2.5 border-b border-gray-100 last:border-0">
+      <span className="text-lg w-7 flex-shrink-0 text-center">{skill.emoji}</span>
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-semibold text-gray-700">{skill.label}</div>
+        <input
+          className="mt-1 w-full text-sm bg-transparent outline-none text-gray-600 placeholder-gray-300"
+          placeholder={skill.placeholder}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && input.trim()) onRun(skill.slug, input.trim())
+          }}
+        />
+      </div>
+      <button
+        className="flex-shrink-0 px-3 py-1.5 rounded-lg bg-gray-100 text-gray-700 text-xs font-medium hover:bg-gray-200 disabled:opacity-40 transition-colors"
+        disabled={running || !input.trim()}
+        onClick={() => onRun(skill.slug, input.trim())}
+      >
+        Run
+      </button>
+    </div>
+  )
+}
+
+// ── Brain tree ────────────────────────────────────────────────────────────────
 
 const BrainTreeNode: React.FC<{
   entry: BrainEntry
@@ -79,114 +188,32 @@ const BrainTreeNode: React.FC<{
 }> = ({ entry, brainRoot, depth, onSelectFile, selectedPath }) => {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<BrainEntry[]>([])
-  const [loading, setLoading] = useState(false)
 
   const toggle = useCallback(async () => {
-    if (!entry.isDir) {
-      onSelectFile(entry.relPath)
-      return
-    }
+    if (!entry.isDir) { onSelectFile(entry.relPath); return }
     if (!expanded && children.length === 0) {
-      setLoading(true)
-      try {
-        const result = await invoke<BrainEntry[]>('kn_brain_list', {
-          brainRoot,
-          subPath: entry.relPath,
-        })
-        setChildren(result)
-      } catch (e) {
-        console.error('kn_brain_list error:', e)
-      } finally {
-        setLoading(false)
-      }
+      const result = await invoke<BrainEntry[]>('kn_brain_list', { brainRoot, subPath: entry.relPath }).catch(() => [])
+      setChildren(result)
     }
-    setExpanded(prev => !prev)
+    setExpanded(e => !e)
   }, [entry, brainRoot, expanded, children, onSelectFile])
 
   const isSelected = !entry.isDir && selectedPath === entry.relPath
-  const paddingLeft = 12 + depth * 16
 
   return (
     <div>
       <div
         onClick={toggle}
-        style={{ paddingLeft }}
+        style={{ paddingLeft: 12 + depth * 16 }}
         className={`flex items-center gap-1.5 py-1 px-2 text-sm cursor-pointer rounded transition-colors
-          ${isSelected ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100'}`}
+          ${isSelected ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-600 hover:bg-gray-100'}`}
       >
-        <span className="flex-shrink-0 text-xs opacity-50 w-4">
-          {entry.isDir ? (expanded ? '▾' : '▸') : ''}
-        </span>
-        <span className="truncate">
-          {entry.isDir ? '📁 ' : '📄 '}
-          {entry.name.replace(/\.md$/, '')}
-        </span>
-        {loading && <span className="ml-auto text-xs text-gray-400">…</span>}
+        <span className="w-4 text-xs opacity-40">{entry.isDir ? (expanded ? '▾' : '▸') : ''}</span>
+        <span className="truncate">{entry.isDir ? '📁 ' : '📄 '}{entry.name.replace(/\.md$/, '')}</span>
       </div>
-      {entry.isDir && expanded && (
-        <div>
-          {children.map(child => (
-            <BrainTreeNode
-              key={child.relPath}
-              entry={child}
-              brainRoot={brainRoot}
-              depth={depth + 1}
-              onSelectFile={onSelectFile}
-              selectedPath={selectedPath}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── Skill card ────────────────────────────────────────────────────────────────
-
-const SkillCard: React.FC<{
-  skill: SkillDef
-  onRun: (slug: string, context: string) => void
-  running: boolean
-}> = ({ skill, onRun, running }) => {
-  const [input, setInput] = useState('')
-  const [expanded, setExpanded] = useState(false)
-
-  return (
-    <div className="border border-gray-200 rounded-lg p-4 bg-white hover:border-gray-300 transition-colors">
-      <div
-        className="flex items-start justify-between cursor-pointer"
-        onClick={() => setExpanded(e => !e)}
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-xl">{skill.emoji}</span>
-          <div>
-            <div className="font-medium text-sm text-gray-900">{skill.name}</div>
-            <div className="text-xs text-gray-500 mt-0.5 line-clamp-1">{skill.description}</div>
-          </div>
-        </div>
-        <span className="text-xs text-gray-400 ml-2 mt-0.5">{expanded ? '▾' : '▸'}</span>
-      </div>
-
-      {expanded && (
-        <div className="mt-3 flex gap-2">
-          <input
-            className="flex-1 text-sm border border-gray-200 rounded-md px-3 py-1.5 outline-none focus:border-blue-400"
-            placeholder={skill.placeholder}
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && input.trim()) onRun(skill.slug, input.trim())
-            }}
-          />
-          <button
-            className="px-3 py-1.5 rounded-md bg-gray-900 text-white text-sm hover:bg-gray-700 disabled:opacity-40 transition-colors"
-            disabled={running || !input.trim()}
-            onClick={() => onRun(skill.slug, input.trim())}
-          >
-            {running ? '…' : 'Run'}
-          </button>
-        </div>
-      )}
+      {entry.isDir && expanded && children.map(c => (
+        <BrainTreeNode key={c.relPath} entry={c} brainRoot={brainRoot} depth={depth + 1} onSelectFile={onSelectFile} selectedPath={selectedPath} />
+      ))}
     </div>
   )
 }
@@ -194,22 +221,27 @@ const SkillCard: React.FC<{
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 const GBrainView: React.FC = () => {
+  const [mode, setMode] = useState<PanelMode>('skills')
+
+  // meetings
+  const [meetings, setMeetings] = useState<CalendarEvent[]>([])
+
+  // skill runner
+  const [running, setRunning] = useState(false)
+  const [runningLabel, setRunningLabel] = useState('')
+  const [output, setOutput] = useState<string | null>(null)
+  const [customText, setCustomText] = useState('')
+  const customRef = useRef<HTMLInputElement>(null)
+
+  // brain
   const [brainRoot, setBrainRoot] = useState('')
   const [editingRoot, setEditingRoot] = useState(false)
   const [rootInput, setRootInput] = useState('')
   const [rootEntries, setRootEntries] = useState<BrainEntry[]>([])
-  const [rootError, setRootError] = useState<string | null>(null)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [pageContent, setPageContent] = useState<string | null>(null)
-  const [pageLoading, setPageLoading] = useState(false)
-  const [panelTab, setPanelTab] = useState<PanelTab>('skills')
 
-  const [skillRunning, setSkillRunning] = useState(false)
-  const [skillOutput, setSkillOutput] = useState<string | null>(null)
-  const [customSkillText, setCustomSkillText] = useState('')
-  const customInputRef = useRef<HTMLInputElement>(null)
-
-  // Load default brain root on mount
+  // Load default brain root
   useEffect(() => {
     invoke<string>('kn_brain_default_root').then(root => {
       setBrainRoot(root)
@@ -217,49 +249,39 @@ const GBrainView: React.FC = () => {
     }).catch(() => {})
   }, [])
 
-  // Load root-level entries when brainRoot changes
-  const loadRoot = useCallback(async (root: string) => {
-    setRootError(null)
-    setRootEntries([])
-    try {
-      const entries = await invoke<BrainEntry[]>('kn_brain_list', {
-        brainRoot: root,
-        subPath: '',
-      })
-      setRootEntries(entries)
-    } catch (e: any) {
-      setRootError(typeof e === 'string' ? e : e?.message ?? 'Failed to load brain')
-    }
-  }, [])
-
+  // Load brain root entries
   useEffect(() => {
-    if (brainRoot) loadRoot(brainRoot)
-  }, [brainRoot, loadRoot])
-
-  // Load selected brain page
-  const handleSelectFile = useCallback(async (relPath: string) => {
-    setSelectedPath(relPath)
-    setPageContent(null)
-    setPageLoading(true)
-    setPanelTab('brain')
-    try {
-      const content = await invoke<string>('kn_brain_read_page', {
-        brainRoot,
-        relPath,
-      })
-      setPageContent(content)
-    } catch (e: any) {
-      setPageContent(`> Error reading page: ${typeof e === 'string' ? e : e?.message}`)
-    } finally {
-      setPageLoading(false)
-    }
+    if (!brainRoot) return
+    invoke<BrainEntry[]>('kn_brain_list', { brainRoot, subPath: '' })
+      .then(setRootEntries)
+      .catch(() => setRootEntries([]))
   }, [brainRoot])
 
-  // Run a GBrain skill via OpenClaw agent-run endpoint
-  const runSkill = useCallback(async (slug: string, context: string) => {
-    setSkillRunning(true)
-    setSkillOutput(null)
-    setPanelTab('skills')
+  // Fetch upcoming meetings (next 3 days)
+  useEffect(() => {
+    const now = Math.floor(Date.now() / 1000)
+    const end = now + 60 * 60 * 24 * 3
+    fetch(`${KN_SERVER_HOST}/api/knapsack/calendar/get_events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ start_timestamp: now, end_timestamp: end }),
+    })
+      .then(r => r.json())
+      .then((data: CalendarEvent[]) => {
+        const upcoming = (Array.isArray(data) ? data : [])
+          .filter(e => e.start > now)
+          .sort((a, b) => a.start - b.start)
+          .slice(0, 8)
+        setMeetings(upcoming)
+      })
+      .catch(() => {})
+  }, [])
+
+  // Run a skill
+  const runSkill = useCallback(async (slug: string, context: string, label?: string) => {
+    setRunning(true)
+    setRunningLabel(label ?? context)
+    setOutput(null)
     try {
       const res = await fetch(`${KN_SERVER_HOST}/api/clawd/agent-run`, {
         method: 'POST',
@@ -267,204 +289,215 @@ const GBrainView: React.FC = () => {
         body: JSON.stringify({ text: `/${slug} ${context}`, channel: 'automation' }),
       })
       const data = await res.json()
-      if (!data.ok || !data.reply) {
-        setSkillOutput(`❌ Skill failed: ${data.message ?? 'no reply'}`)
-      } else {
-        setSkillOutput(data.reply)
-      }
+      setOutput(data.ok && data.reply ? data.reply : `❌ ${data.message ?? 'No reply from OpenClaw. Is the gateway running?'}`)
     } catch (e: any) {
-      setSkillOutput(`❌ Request error: ${typeof e === 'string' ? e : e?.message}`)
+      setOutput(`❌ ${e?.message ?? 'Network error'}`)
     } finally {
-      setSkillRunning(false)
+      setRunning(false)
     }
   }, [])
 
-  const handleCustomSkill = useCallback(() => {
-    const text = customSkillText.trim()
+  const prepMeeting = useCallback((event: CalendarEvent) => {
+    const attendees = parseAttendees(event.attendees_json).map(a => a.name).join(', ')
+    const context = `${event.title}${attendees ? ` — Attendees: ${attendees}` : ''}`
+    runSkill('meeting-prep', context, event.title)
+  }, [runSkill])
+
+  const handleCustom = useCallback(() => {
+    const text = customText.trim()
     if (!text) return
-    setSkillRunning(true)
-    setSkillOutput(null)
-    setPanelTab('skills')
+    setRunning(true)
+    setRunningLabel(text)
+    setOutput(null)
     fetch(`${KN_SERVER_HOST}/api/clawd/agent-run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, channel: 'automation' }),
     })
       .then(r => r.json())
-      .then(data => {
-        setSkillOutput(data.ok ? data.reply : `❌ ${data.message ?? 'no reply'}`)
-      })
-      .catch((e: any) => setSkillOutput(`❌ ${e?.message ?? e}`))
-      .finally(() => setSkillRunning(false))
-  }, [customSkillText])
+      .then(data => setOutput(data.ok && data.reply ? data.reply : `❌ ${data.message ?? 'No reply'}`))
+      .catch((e: any) => setOutput(`❌ ${e?.message ?? 'Network error'}`))
+      .finally(() => setRunning(false))
+  }, [customText])
+
+  const handleSelectBrainPage = useCallback(async (relPath: string) => {
+    setSelectedPath(relPath)
+    setPageContent(null)
+    const content = await invoke<string>('kn_brain_read_page', { brainRoot, relPath }).catch((e: any) => `> Error: ${e}`)
+    setPageContent(content)
+  }, [brainRoot])
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
+    <div className="flex flex-col h-full bg-white">
       {/* ── Header ── */}
-      <div className="flex items-center gap-3 px-4 py-2.5 bg-white border-b border-gray-200 flex-shrink-0">
-        <span className="text-sm font-semibold text-gray-700">🧠 GBrain</span>
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          {editingRoot ? (
-            <input
-              autoFocus
-              className="flex-1 text-xs border border-blue-300 rounded px-2 py-1 outline-none bg-white"
-              value={rootInput}
-              onChange={e => setRootInput(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') {
-                  setBrainRoot(rootInput.trim())
-                  setEditingRoot(false)
-                } else if (e.key === 'Escape') {
-                  setRootInput(brainRoot)
-                  setEditingRoot(false)
-                }
-              }}
-              onBlur={() => {
-                setBrainRoot(rootInput.trim())
-                setEditingRoot(false)
-              }}
-            />
-          ) : (
-            <button
-              className="text-xs text-gray-400 truncate max-w-xs hover:text-gray-600 transition-colors text-left"
-              title="Click to change brain path"
-              onClick={() => setEditingRoot(true)}
-            >
-              {brainRoot || '(set brain path)'}
-            </button>
-          )}
-        </div>
-        <div className="flex gap-1 flex-shrink-0">
+      <div className="flex items-center gap-3 px-5 py-3 border-b border-gray-100 flex-shrink-0">
+        <span className="text-sm font-semibold text-gray-800">🧠 GBrain</span>
+        <div className="flex gap-1 ml-auto">
           <button
-            className={`px-3 py-1 rounded text-xs font-medium transition-colors
-              ${panelTab === 'brain' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
-            onClick={() => setPanelTab('brain')}
-          >
-            Brain
-          </button>
-          <button
-            className={`px-3 py-1 rounded text-xs font-medium transition-colors
-              ${panelTab === 'skills' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
-            onClick={() => setPanelTab('skills')}
+            className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${mode === 'skills' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-100'}`}
+            onClick={() => setMode('skills')}
           >
             Skills
+          </button>
+          <button
+            className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${mode === 'brain' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-100'}`}
+            onClick={() => setMode('brain')}
+          >
+            Brain
           </button>
         </div>
       </div>
 
-      {/* ── Body ── */}
-      <div className="flex flex-1 min-h-0">
-        {/* Left: file tree */}
-        <div className="w-56 flex-shrink-0 border-r border-gray-200 bg-white overflow-y-auto">
-          {rootError ? (
-            <div className="p-4 flex flex-col gap-3">
-              <div className="text-xs font-semibold text-red-500">Brain not found</div>
-              <div className="text-xs text-gray-500 leading-relaxed">{rootError}</div>
-              <button
-                className="w-full px-3 py-2 rounded-md bg-gray-900 text-white text-xs font-medium hover:bg-gray-700 transition-colors"
-                onClick={() => setEditingRoot(true)}
-              >
-                Change path
-              </button>
-            </div>
-          ) : rootEntries.length === 0 ? (
-            <div className="p-4 flex flex-col gap-3">
-              <div className="text-xs text-gray-400 leading-relaxed">
-                Brain is empty. Use the <strong>Skills</strong> tab to start building it, or add markdown files to:
+      {/* ── Skills mode ── */}
+      {mode === 'skills' && (
+        <div className="flex-1 overflow-y-auto">
+          {/* Meetings strip */}
+          {meetings.length > 0 && (
+            <div className="px-5 pt-5 pb-2">
+              <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+                Upcoming meetings
               </div>
-              <pre className="bg-gray-100 rounded p-2 text-xs select-all break-all">{brainRoot || '…'}</pre>
-            </div>
-          ) : (
-            <div className="py-1">
-              {rootEntries.map(entry => (
-                <BrainTreeNode
-                  key={entry.relPath}
-                  entry={entry}
-                  brainRoot={brainRoot}
-                  depth={0}
-                  onSelectFile={handleSelectFile}
-                  selectedPath={selectedPath}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Right: content area */}
-        <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
-          {panelTab === 'brain' ? (
-            <div className="flex-1 overflow-y-auto p-6">
-              {pageLoading && (
-                <div className="text-sm text-gray-400">Loading…</div>
-              )}
-              {!pageLoading && pageContent !== null && (
-                <div className="prose prose-sm max-w-none">
-                  <Markdown>{pageContent}</Markdown>
-                </div>
-              )}
-              {!pageLoading && pageContent === null && (
-                <div className="text-sm text-gray-400 mt-8 text-center">
-                  Select a brain page to read it
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
-              {/* Custom command bar */}
-              <div className="flex gap-2">
-                <input
-                  ref={customInputRef}
-                  className="flex-1 text-sm border border-gray-200 rounded-md px-3 py-2 outline-none focus:border-blue-400 bg-white"
-                  placeholder="/skill-name context… (e.g. /meeting-prep Sam Altman)"
-                  value={customSkillText}
-                  onChange={e => setCustomSkillText(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter' && customSkillText.trim()) handleCustomSkill()
-                  }}
-                />
-                <button
-                  className="px-4 py-2 rounded-md bg-gray-900 text-white text-sm hover:bg-gray-700 disabled:opacity-40 transition-colors"
-                  disabled={skillRunning || !customSkillText.trim()}
-                  onClick={handleCustomSkill}
-                >
-                  {skillRunning ? '…' : 'Run'}
-                </button>
-              </div>
-
-              {/* Skill output */}
-              {skillOutput !== null && (
-                <div className="bg-white border border-gray-200 rounded-lg p-4 text-sm">
-                  <div className="text-xs text-gray-400 mb-2 font-medium">Output</div>
-                  <div className="prose prose-sm max-w-none">
-                    <Markdown>{skillOutput}</Markdown>
-                  </div>
-                </div>
-              )}
-
-              {skillRunning && skillOutput === null && (
-                <div className="bg-white border border-gray-200 rounded-lg p-4 text-sm text-gray-400">
-                  Running skill…
-                </div>
-              )}
-
-              {/* Skill cards */}
-              <div className="grid grid-cols-1 gap-3">
-                <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
-                  Quick Launch
-                </div>
-                {GBRAIN_SKILLS.map(skill => (
-                  <SkillCard
-                    key={skill.slug}
-                    skill={skill}
-                    onRun={runSkill}
-                    running={skillRunning}
+              <div className="flex gap-3 overflow-x-auto pb-2">
+                {meetings.map(ev => (
+                  <MeetingCard
+                    key={ev.id}
+                    event={ev}
+                    onPrep={prepMeeting}
+                    running={running}
                   />
                 ))}
               </div>
             </div>
           )}
+
+          {/* Skills list */}
+          <div className="px-5 pt-4">
+            <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1">
+              Skills
+            </div>
+            <div className="bg-white border border-gray-200 rounded-xl divide-y divide-gray-100 mb-4">
+              {SKILLS.map(skill => (
+                <SkillRow key={skill.slug} skill={skill} onRun={runSkill} running={running} />
+              ))}
+            </div>
+          </div>
+
+          {/* Custom command */}
+          <div className="px-5 pb-4">
+            <div className="flex gap-2">
+              <input
+                ref={customRef}
+                className="flex-1 text-sm border border-gray-200 rounded-xl px-4 py-2.5 outline-none focus:border-gray-400 bg-white placeholder-gray-300"
+                placeholder="/skill-name context…"
+                value={customText}
+                onChange={e => setCustomText(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') handleCustom() }}
+              />
+              <button
+                className="px-4 py-2.5 rounded-xl bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 disabled:opacity-40 transition-colors"
+                disabled={running || !customText.trim()}
+                onClick={handleCustom}
+              >
+                Run
+              </button>
+            </div>
+          </div>
+
+          {/* Output */}
+          {(running || output !== null) && (
+            <div className="mx-5 mb-5 border border-gray-200 rounded-xl overflow-hidden">
+              <div className="px-4 py-2.5 bg-gray-50 border-b border-gray-100 flex items-center gap-2">
+                <span className="text-xs font-medium text-gray-500 truncate flex-1">
+                  {running ? `Running: ${runningLabel}…` : runningLabel}
+                </span>
+                {!running && (
+                  <button
+                    className="text-xs text-gray-400 hover:text-gray-600"
+                    onClick={() => setOutput(null)}
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+              <div className="px-5 py-4">
+                {running ? (
+                  <div className="flex items-center gap-2 text-sm text-gray-400">
+                    <span className="animate-pulse">●</span> Working…
+                  </div>
+                ) : (
+                  <div className="prose prose-sm max-w-none">
+                    <Markdown>{output ?? ''}</Markdown>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
         </div>
-      </div>
+      )}
+
+      {/* ── Brain mode ── */}
+      {mode === 'brain' && (
+        <div className="flex flex-1 min-h-0">
+          {/* Tree */}
+          <div className="w-56 flex-shrink-0 border-r border-gray-100 overflow-y-auto bg-white">
+            {/* Path editor */}
+            <div className="px-3 py-2 border-b border-gray-100">
+              {editingRoot ? (
+                <input
+                  autoFocus
+                  className="w-full text-xs border border-blue-300 rounded px-2 py-1 outline-none"
+                  value={rootInput}
+                  onChange={e => setRootInput(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') { setBrainRoot(rootInput.trim()); setEditingRoot(false) }
+                    if (e.key === 'Escape') { setRootInput(brainRoot); setEditingRoot(false) }
+                  }}
+                  onBlur={() => { setBrainRoot(rootInput.trim()); setEditingRoot(false) }}
+                />
+              ) : (
+                <button
+                  className="w-full text-left text-xs text-gray-400 hover:text-gray-600 truncate"
+                  title="Click to change path"
+                  onClick={() => setEditingRoot(true)}
+                >
+                  {brainRoot || '(set path)'}
+                </button>
+              )}
+            </div>
+            {rootEntries.length === 0 ? (
+              <div className="p-4 text-xs text-gray-400 leading-relaxed">
+                Brain is empty. Run skills to auto-populate it, or add <code>.md</code> files to <span className="font-mono">{brainRoot}</span>.
+              </div>
+            ) : (
+              <div className="py-1">
+                {rootEntries.map(entry => (
+                  <BrainTreeNode
+                    key={entry.relPath}
+                    entry={entry}
+                    brainRoot={brainRoot}
+                    depth={0}
+                    onSelectFile={handleSelectBrainPage}
+                    selectedPath={selectedPath}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Page viewer */}
+          <div className="flex-1 overflow-y-auto p-6">
+            {pageContent !== null ? (
+              <div className="prose prose-sm max-w-none">
+                <Markdown>{pageContent}</Markdown>
+              </div>
+            ) : (
+              <div className="text-sm text-gray-300 mt-12 text-center">
+                Select a brain page
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/src/components/organisms/GBrainView/index.tsx
+++ b/src/src/components/organisms/GBrainView/index.tsx
@@ -202,7 +202,7 @@ const GBrainView: React.FC = () => {
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [pageContent, setPageContent] = useState<string | null>(null)
   const [pageLoading, setPageLoading] = useState(false)
-  const [panelTab, setPanelTab] = useState<PanelTab>('brain')
+  const [panelTab, setPanelTab] = useState<PanelTab>('skills')
 
   const [skillRunning, setSkillRunning] = useState(false)
   const [skillOutput, setSkillOutput] = useState<string | null>(null)
@@ -357,16 +357,22 @@ const GBrainView: React.FC = () => {
         {/* Left: file tree */}
         <div className="w-56 flex-shrink-0 border-r border-gray-200 bg-white overflow-y-auto">
           {rootError ? (
-            <div className="p-3 text-xs text-red-500">
-              <div className="font-medium">Brain not found</div>
-              <div className="mt-1 text-gray-400">{rootError}</div>
-              <div className="mt-2 text-gray-400">
-                Clone GBrain: <code className="bg-gray-100 px-1 rounded">git clone github.com/garrytan/gbrain ~/gbrain</code>
-              </div>
+            <div className="p-4 flex flex-col gap-3">
+              <div className="text-xs font-semibold text-red-500">Brain not found</div>
+              <div className="text-xs text-gray-500 leading-relaxed">{rootError}</div>
+              <button
+                className="w-full px-3 py-2 rounded-md bg-gray-900 text-white text-xs font-medium hover:bg-gray-700 transition-colors"
+                onClick={() => setEditingRoot(true)}
+              >
+                Change path
+              </button>
             </div>
           ) : rootEntries.length === 0 ? (
-            <div className="p-3 text-xs text-gray-400">
-              {brainRoot ? 'Loading…' : 'Set a brain path above'}
+            <div className="p-4 flex flex-col gap-3">
+              <div className="text-xs text-gray-400 leading-relaxed">
+                Brain is empty. Use the <strong>Skills</strong> tab to start building it, or add markdown files to:
+              </div>
+              <pre className="bg-gray-100 rounded p-2 text-xs select-all break-all">{brainRoot || '…'}</pre>
             </div>
           ) : (
             <div className="py-1">

--- a/src/src/components/organisms/GBrainView/index.tsx
+++ b/src/src/components/organisms/GBrainView/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { invoke } from '@tauri-apps/api/tauri'
 import Markdown from 'marked-react'
 import { KN_SERVER_HOST } from 'src/utils/constants'
+import { listWorkspaces, Workspace } from 'src/api/workspaces'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -26,156 +27,186 @@ interface BrainEntry {
 
 type PanelMode = 'skills' | 'brain'
 
-interface SkillDef {
-  slug: string
-  emoji: string
-  label: string
-  hint: string
-  placeholder: string
-}
-
-// ── Skill catalog ─────────────────────────────────────────────────────────────
-
-const SKILLS: SkillDef[] = [
-  {
-    slug: 'meeting-prep',
-    emoji: '🤝',
-    label: 'Meeting Prep',
-    hint: 'Who are you meeting?',
-    placeholder: 'e.g. Sam Altman',
-  },
-  {
-    slug: 'enrich',
-    emoji: '🧠',
-    label: 'Enrich Person',
-    hint: 'Research and update someone\'s brain page',
-    placeholder: 'e.g. Demis Hassabis',
-  },
-  {
-    slug: 'book-mirror',
-    emoji: '📚',
-    label: 'Book Mirror',
-    hint: 'Map a book\'s ideas to your life context',
-    placeholder: 'e.g. Zero to One',
-  },
-  {
-    slug: 'perplexity-research',
-    emoji: '🔍',
-    label: 'Research',
-    hint: 'Brain-augmented web research',
-    placeholder: 'e.g. What is Sam\'s view on AGI timelines?',
-  },
-  {
-    slug: 'media-ingest',
-    emoji: '🎬',
-    label: 'Ingest Media',
-    hint: 'Add a video, podcast, or URL to your brain',
-    placeholder: 'URL or file path',
-  },
-]
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function formatTime(unix: number): string {
   return new Date(unix * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
 }
 
-function isToday(unix: number): boolean {
+function dayLabel(unix: number): string {
   const d = new Date(unix * 1000)
   const now = new Date()
-  return d.toDateString() === now.toDateString()
-}
-
-function isTomorrow(unix: number): boolean {
-  const d = new Date(unix * 1000)
-  const tomorrow = new Date()
-  tomorrow.setDate(tomorrow.getDate() + 1)
-  return d.toDateString() === tomorrow.toDateString()
-}
-
-function dayLabel(unix: number): string {
-  if (isToday(unix)) return 'Today'
-  if (isTomorrow(unix)) return 'Tomorrow'
-  return new Date(unix * 1000).toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
+  const tomorrow = new Date(); tomorrow.setDate(now.getDate() + 1)
+  if (d.toDateString() === now.toDateString()) return 'Today'
+  if (d.toDateString() === tomorrow.toDateString()) return 'Tomorrow'
+  return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
 }
 
 function parseAttendees(json: string): Attendee[] {
   try { return JSON.parse(json) } catch { return [] }
 }
 
-function shortName(name: string): string {
-  const parts = name.trim().split(' ')
-  return parts[0]
+// ── Shared: skill runner hook ─────────────────────────────────────────────────
+
+function useSkillRunner() {
+  const [running, setRunning] = useState(false)
+  const [runningLabel, setRunningLabel] = useState('')
+  const [output, setOutput] = useState<string | null>(null)
+
+  const run = useCallback(async (text: string, label: string) => {
+    setRunning(true)
+    setRunningLabel(label)
+    setOutput(null)
+    try {
+      const res = await fetch(`${KN_SERVER_HOST}/api/clawd/agent-run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, channel: 'automation' }),
+      })
+      const data = await res.json()
+      setOutput(data.ok && data.reply
+        ? data.reply
+        : `❌ ${data.message ?? 'No reply. Is the OpenClaw gateway running?'}`)
+    } catch (e: any) {
+      setOutput(`❌ ${e?.message ?? 'Network error'}`)
+    } finally {
+      setRunning(false)
+    }
+  }, [])
+
+  const dismiss = useCallback(() => setOutput(null), [])
+
+  return { running, runningLabel, output, run, dismiss }
 }
 
-// ── Meeting card ──────────────────────────────────────────────────────────────
+// ── Output panel ──────────────────────────────────────────────────────────────
 
-const MeetingCard: React.FC<{
+const OutputPanel: React.FC<{
+  running: boolean
+  label: string
+  output: string | null
+  onDismiss: () => void
+}> = ({ running, label, output, onDismiss }) => {
+  if (!running && output === null) return null
+  return (
+    <div className="mx-4 mb-4 border border-gray-200 rounded-xl overflow-hidden">
+      <div className="px-4 py-2.5 bg-gray-50 border-b border-gray-100 flex items-center gap-2">
+        <span className="text-xs font-medium text-gray-500 truncate flex-1">
+          {running ? `${label}…` : label}
+        </span>
+        {!running && (
+          <button className="text-xs text-gray-400 hover:text-gray-600 flex-shrink-0" onClick={onDismiss}>✕</button>
+        )}
+      </div>
+      <div className="px-5 py-4">
+        {running ? (
+          <div className="flex items-center gap-2 text-sm text-gray-400">
+            <span className="animate-pulse">●</span> Working…
+          </div>
+        ) : (
+          <div className="prose prose-sm max-w-none">
+            <Markdown>{output ?? ''}</Markdown>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Section header ────────────────────────────────────────────────────────────
+
+const SectionHeader: React.FC<{ label: string }> = ({ label }) => (
+  <div className="px-4 pt-5 pb-2">
+    <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">{label}</span>
+  </div>
+)
+
+// ── Meeting row ───────────────────────────────────────────────────────────────
+
+const MeetingRow: React.FC<{
   event: CalendarEvent
   onPrep: (event: CalendarEvent) => void
   running: boolean
 }> = ({ event, onPrep, running }) => {
   const attendees = parseAttendees(event.attendees_json)
-  const names = attendees.map(a => shortName(a.name)).filter(Boolean).slice(0, 4)
+  const names = attendees.map(a => a.name).filter(Boolean)
 
   return (
-    <div className="flex-shrink-0 w-48 border border-gray-200 rounded-xl p-3 bg-white flex flex-col gap-2">
-      <div className="text-xs text-gray-400 font-medium">
-        {dayLabel(event.start)} · {formatTime(event.start)}
+    <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors group">
+      <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 text-base">
+        📅
       </div>
-      <div className="text-sm font-medium text-gray-800 leading-tight line-clamp-2 flex-1">
-        {event.title}
-      </div>
-      {names.length > 0 && (
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-gray-800 truncate">{event.title}</div>
         <div className="text-xs text-gray-400 truncate">
-          {names.join(', ')}
+          {dayLabel(event.start)} · {formatTime(event.start)}
+          {names.length > 0 && ` · ${names.slice(0, 2).join(', ')}${names.length > 2 ? ` +${names.length - 2}` : ''}`}
         </div>
-      )}
+      </div>
       <button
-        className="w-full py-1.5 rounded-lg bg-gray-900 text-white text-xs font-medium hover:bg-gray-700 disabled:opacity-40 transition-colors"
+        className="flex-shrink-0 px-3 py-1 rounded-lg text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-900 hover:text-white disabled:opacity-40 transition-colors opacity-0 group-hover:opacity-100"
         disabled={running}
         onClick={() => onPrep(event)}
       >
-        {running ? '…' : 'Prep'}
+        Prep
       </button>
     </div>
   )
 }
 
-// ── Skill row ─────────────────────────────────────────────────────────────────
+// ── Person row ────────────────────────────────────────────────────────────────
 
-const SkillRow: React.FC<{
-  skill: SkillDef
-  onRun: (slug: string, context: string) => void
+const PersonRow: React.FC<{
+  workspace: Workspace
+  onEnrich: (ws: Workspace) => void
   running: boolean
-}> = ({ skill, onRun, running }) => {
-  const [input, setInput] = useState('')
-
-  return (
-    <div className="flex items-center gap-3 py-2.5 border-b border-gray-100 last:border-0">
-      <span className="text-lg w-7 flex-shrink-0 text-center">{skill.emoji}</span>
-      <div className="flex-1 min-w-0">
-        <div className="text-xs font-semibold text-gray-700">{skill.label}</div>
-        <input
-          className="mt-1 w-full text-sm bg-transparent outline-none text-gray-600 placeholder-gray-300"
-          placeholder={skill.placeholder}
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={e => {
-            if (e.key === 'Enter' && input.trim()) onRun(skill.slug, input.trim())
-          }}
-        />
-      </div>
-      <button
-        className="flex-shrink-0 px-3 py-1.5 rounded-lg bg-gray-100 text-gray-700 text-xs font-medium hover:bg-gray-200 disabled:opacity-40 transition-colors"
-        disabled={running || !input.trim()}
-        onClick={() => onRun(skill.slug, input.trim())}
-      >
-        Run
-      </button>
+}> = ({ workspace, onEnrich, running }) => (
+  <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors group">
+    <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center flex-shrink-0 text-base">
+      {workspace.icon || '👤'}
     </div>
-  )
-}
+    <div className="flex-1 min-w-0">
+      <div className="text-sm font-medium text-gray-800 truncate">{workspace.name}</div>
+      {workspace.description && (
+        <div className="text-xs text-gray-400 truncate">{workspace.description}</div>
+      )}
+    </div>
+    <button
+      className="flex-shrink-0 px-3 py-1 rounded-lg text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-900 hover:text-white disabled:opacity-40 transition-colors opacity-0 group-hover:opacity-100"
+      disabled={running}
+      onClick={() => onEnrich(workspace)}
+    >
+      Enrich
+    </button>
+  </div>
+)
+
+// ── Project row ───────────────────────────────────────────────────────────────
+
+const ProjectRow: React.FC<{
+  workspace: Workspace
+  onResearch: (ws: Workspace) => void
+  running: boolean
+}> = ({ workspace, onResearch, running }) => (
+  <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors group">
+    <div className="w-8 h-8 rounded-lg bg-green-50 flex items-center justify-center flex-shrink-0 text-base">
+      {workspace.icon || '📁'}
+    </div>
+    <div className="flex-1 min-w-0">
+      <div className="text-sm font-medium text-gray-800 truncate">{workspace.name}</div>
+      {workspace.description && (
+        <div className="text-xs text-gray-400 truncate">{workspace.description}</div>
+      )}
+    </div>
+    <button
+      className="flex-shrink-0 px-3 py-1 rounded-lg text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-900 hover:text-white disabled:opacity-40 transition-colors opacity-0 group-hover:opacity-100"
+      disabled={running}
+      onClick={() => onResearch(workspace)}
+    >
+      Research
+    </button>
+  </div>
+)
 
 // ── Brain tree ────────────────────────────────────────────────────────────────
 
@@ -222,18 +253,19 @@ const BrainTreeNode: React.FC<{
 
 const GBrainView: React.FC = () => {
   const [mode, setMode] = useState<PanelMode>('skills')
+  const { running, runningLabel, output, run, dismiss } = useSkillRunner()
 
-  // meetings
+  // Meetings
   const [meetings, setMeetings] = useState<CalendarEvent[]>([])
 
-  // skill runner
-  const [running, setRunning] = useState(false)
-  const [runningLabel, setRunningLabel] = useState('')
-  const [output, setOutput] = useState<string | null>(null)
-  const [customText, setCustomText] = useState('')
-  const customRef = useRef<HTMLInputElement>(null)
+  // Library
+  const [people, setPeople] = useState<Workspace[]>([])
+  const [projects, setProjects] = useState<Workspace[]>([])
 
-  // brain
+  // Custom command
+  const [customText, setCustomText] = useState('')
+
+  // Brain
   const [brainRoot, setBrainRoot] = useState('')
   const [editingRoot, setEditingRoot] = useState(false)
   const [rootInput, setRootInput] = useState('')
@@ -241,84 +273,67 @@ const GBrainView: React.FC = () => {
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [pageContent, setPageContent] = useState<string | null>(null)
 
-  // Load default brain root
+  // Load brain root
   useEffect(() => {
     invoke<string>('kn_brain_default_root').then(root => {
-      setBrainRoot(root)
-      setRootInput(root)
+      setBrainRoot(root); setRootInput(root)
     }).catch(() => {})
   }, [])
 
-  // Load brain root entries
   useEffect(() => {
     if (!brainRoot) return
     invoke<BrainEntry[]>('kn_brain_list', { brainRoot, subPath: '' })
-      .then(setRootEntries)
-      .catch(() => setRootEntries([]))
+      .then(setRootEntries).catch(() => setRootEntries([]))
   }, [brainRoot])
 
-  // Fetch upcoming meetings (next 3 days)
+  // Fetch upcoming meetings
   useEffect(() => {
     const now = Math.floor(Date.now() / 1000)
-    const end = now + 60 * 60 * 24 * 3
     fetch(`${KN_SERVER_HOST}/api/knapsack/calendar/get_events`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ start_timestamp: now, end_timestamp: end }),
+      body: JSON.stringify({ start_timestamp: now, end_timestamp: now + 60 * 60 * 24 * 3 }),
     })
       .then(r => r.json())
       .then((data: CalendarEvent[]) => {
-        const upcoming = (Array.isArray(data) ? data : [])
-          .filter(e => e.start > now)
-          .sort((a, b) => a.start - b.start)
-          .slice(0, 8)
-        setMeetings(upcoming)
+        setMeetings(
+          (Array.isArray(data) ? data : [])
+            .filter(e => e.start > now)
+            .sort((a, b) => a.start - b.start)
+            .slice(0, 10)
+        )
       })
       .catch(() => {})
   }, [])
 
-  // Run a skill
-  const runSkill = useCallback(async (slug: string, context: string, label?: string) => {
-    setRunning(true)
-    setRunningLabel(label ?? context)
-    setOutput(null)
-    try {
-      const res = await fetch(`${KN_SERVER_HOST}/api/clawd/agent-run`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: `/${slug} ${context}`, channel: 'automation' }),
-      })
-      const data = await res.json()
-      setOutput(data.ok && data.reply ? data.reply : `❌ ${data.message ?? 'No reply from OpenClaw. Is the gateway running?'}`)
-    } catch (e: any) {
-      setOutput(`❌ ${e?.message ?? 'Network error'}`)
-    } finally {
-      setRunning(false)
-    }
+  // Fetch library workspaces
+  useEffect(() => {
+    listWorkspaces().then(res => {
+      if (!res.success) return
+      setPeople(res.data.filter(w => w.autoCurated && w.entityType === 'person'))
+      setProjects(res.data.filter(w => w.autoCurated && w.entityType === 'project'))
+    }).catch(() => {})
   }, [])
 
+  // Actions
   const prepMeeting = useCallback((event: CalendarEvent) => {
     const attendees = parseAttendees(event.attendees_json).map(a => a.name).join(', ')
-    const context = `${event.title}${attendees ? ` — Attendees: ${attendees}` : ''}`
-    runSkill('meeting-prep', context, event.title)
-  }, [runSkill])
+    run(`/meeting-prep ${event.title}${attendees ? ` — Attendees: ${attendees}` : ''}`, `Prepping: ${event.title}`)
+  }, [run])
+
+  const enrichPerson = useCallback((ws: Workspace) => {
+    run(`/enrich ${ws.name}`, `Enriching: ${ws.name}`)
+  }, [run])
+
+  const researchProject = useCallback((ws: Workspace) => {
+    run(`/perplexity-research ${ws.name} project — ${ws.description ?? ''}`, `Researching: ${ws.name}`)
+  }, [run])
 
   const handleCustom = useCallback(() => {
     const text = customText.trim()
     if (!text) return
-    setRunning(true)
-    setRunningLabel(text)
-    setOutput(null)
-    fetch(`${KN_SERVER_HOST}/api/clawd/agent-run`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, channel: 'automation' }),
-    })
-      .then(r => r.json())
-      .then(data => setOutput(data.ok && data.reply ? data.reply : `❌ ${data.message ?? 'No reply'}`))
-      .catch((e: any) => setOutput(`❌ ${e?.message ?? 'Network error'}`))
-      .finally(() => setRunning(false))
-  }, [customText])
+    run(text, text)
+  }, [customText, run])
 
   const handleSelectBrainPage = useCallback(async (relPath: string) => {
     setSelectedPath(relPath)
@@ -327,10 +342,12 @@ const GBrainView: React.FC = () => {
     setPageContent(content)
   }, [brainRoot])
 
+  const noData = meetings.length === 0 && people.length === 0 && projects.length === 0
+
   return (
     <div className="flex flex-col h-full bg-white">
-      {/* ── Header ── */}
-      <div className="flex items-center gap-3 px-5 py-3 border-b border-gray-100 flex-shrink-0">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 flex-shrink-0">
         <span className="text-sm font-semibold text-gray-800">🧠 GBrain</span>
         <div className="flex gap-1 ml-auto">
           <button
@@ -348,99 +365,81 @@ const GBrainView: React.FC = () => {
         </div>
       </div>
 
-      {/* ── Skills mode ── */}
+      {/* Skills mode */}
       {mode === 'skills' && (
         <div className="flex-1 overflow-y-auto">
-          {/* Meetings strip */}
-          {meetings.length > 0 && (
-            <div className="px-5 pt-5 pb-2">
-              <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
-                Upcoming meetings
-              </div>
-              <div className="flex gap-3 overflow-x-auto pb-2">
-                {meetings.map(ev => (
-                  <MeetingCard
-                    key={ev.id}
-                    event={ev}
-                    onPrep={prepMeeting}
-                    running={running}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
 
-          {/* Skills list */}
-          <div className="px-5 pt-4">
-            <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1">
-              Skills
-            </div>
-            <div className="bg-white border border-gray-200 rounded-xl divide-y divide-gray-100 mb-4">
-              {SKILLS.map(skill => (
-                <SkillRow key={skill.slug} skill={skill} onRun={runSkill} running={running} />
-              ))}
-            </div>
-          </div>
-
-          {/* Custom command */}
-          <div className="px-5 pb-4">
-            <div className="flex gap-2">
-              <input
-                ref={customRef}
-                className="flex-1 text-sm border border-gray-200 rounded-xl px-4 py-2.5 outline-none focus:border-gray-400 bg-white placeholder-gray-300"
-                placeholder="/skill-name context…"
-                value={customText}
-                onChange={e => setCustomText(e.target.value)}
-                onKeyDown={e => { if (e.key === 'Enter') handleCustom() }}
-              />
-              <button
-                className="px-4 py-2.5 rounded-xl bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 disabled:opacity-40 transition-colors"
-                disabled={running || !customText.trim()}
-                onClick={handleCustom}
-              >
-                Run
-              </button>
-            </div>
+          {/* Custom command bar */}
+          <div className="px-4 pt-4 pb-2 flex gap-2">
+            <input
+              className="flex-1 text-sm border border-gray-200 rounded-xl px-4 py-2.5 outline-none focus:border-gray-400 placeholder-gray-300"
+              placeholder="/skill-name context… or just describe what you want"
+              value={customText}
+              onChange={e => setCustomText(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') handleCustom() }}
+            />
+            <button
+              className="px-4 py-2.5 rounded-xl bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 disabled:opacity-40 transition-colors"
+              disabled={running || !customText.trim()}
+              onClick={handleCustom}
+            >
+              Run
+            </button>
           </div>
 
           {/* Output */}
-          {(running || output !== null) && (
-            <div className="mx-5 mb-5 border border-gray-200 rounded-xl overflow-hidden">
-              <div className="px-4 py-2.5 bg-gray-50 border-b border-gray-100 flex items-center gap-2">
-                <span className="text-xs font-medium text-gray-500 truncate flex-1">
-                  {running ? `Running: ${runningLabel}…` : runningLabel}
-                </span>
-                {!running && (
-                  <button
-                    className="text-xs text-gray-400 hover:text-gray-600"
-                    onClick={() => setOutput(null)}
-                  >
-                    ✕
-                  </button>
-                )}
-              </div>
-              <div className="px-5 py-4">
-                {running ? (
-                  <div className="flex items-center gap-2 text-sm text-gray-400">
-                    <span className="animate-pulse">●</span> Working…
-                  </div>
-                ) : (
-                  <div className="prose prose-sm max-w-none">
-                    <Markdown>{output ?? ''}</Markdown>
-                  </div>
-                )}
-              </div>
+          <OutputPanel running={running} label={runningLabel} output={output} onDismiss={dismiss} />
+
+          {noData && (
+            <div className="px-4 py-8 text-sm text-gray-400 text-center">
+              Syncing your calendar and library…
             </div>
           )}
+
+          {/* Meetings */}
+          {meetings.length > 0 && (
+            <>
+              <SectionHeader label="Meetings" />
+              <div className="divide-y divide-gray-50">
+                {meetings.map(ev => (
+                  <MeetingRow key={ev.id} event={ev} onPrep={prepMeeting} running={running} />
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* People */}
+          {people.length > 0 && (
+            <>
+              <SectionHeader label="People" />
+              <div className="divide-y divide-gray-50">
+                {people.map(ws => (
+                  <PersonRow key={ws.uuid} workspace={ws} onEnrich={enrichPerson} running={running} />
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* Projects */}
+          {projects.length > 0 && (
+            <>
+              <SectionHeader label="Projects" />
+              <div className="divide-y divide-gray-50">
+                {projects.map(ws => (
+                  <ProjectRow key={ws.uuid} workspace={ws} onResearch={researchProject} running={running} />
+                ))}
+              </div>
+            </>
+          )}
+
+          <div className="h-4" />
         </div>
       )}
 
-      {/* ── Brain mode ── */}
+      {/* Brain mode */}
       {mode === 'brain' && (
         <div className="flex flex-1 min-h-0">
-          {/* Tree */}
           <div className="w-56 flex-shrink-0 border-r border-gray-100 overflow-y-auto bg-white">
-            {/* Path editor */}
             <div className="px-3 py-2 border-b border-gray-100">
               {editingRoot ? (
                 <input
@@ -466,7 +465,7 @@ const GBrainView: React.FC = () => {
             </div>
             {rootEntries.length === 0 ? (
               <div className="p-4 text-xs text-gray-400 leading-relaxed">
-                Brain is empty. Run skills to auto-populate it, or add <code>.md</code> files to <span className="font-mono">{brainRoot}</span>.
+                Brain is empty. Run skills to auto-populate it.
               </div>
             ) : (
               <div className="py-1">
@@ -483,17 +482,13 @@ const GBrainView: React.FC = () => {
               </div>
             )}
           </div>
-
-          {/* Page viewer */}
           <div className="flex-1 overflow-y-auto p-6">
             {pageContent !== null ? (
               <div className="prose prose-sm max-w-none">
                 <Markdown>{pageContent}</Markdown>
               </div>
             ) : (
-              <div className="text-sm text-gray-300 mt-12 text-center">
-                Select a brain page
-              </div>
+              <div className="text-sm text-gray-300 mt-12 text-center">Select a brain page</div>
             )}
           </div>
         </div>

--- a/src/src/components/organisms/GBrainView/index.tsx
+++ b/src/src/components/organisms/GBrainView/index.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/tauri'
 import Markdown from 'marked-react'
 import { KN_SERVER_HOST } from 'src/utils/constants'
 import { listWorkspaces, Workspace } from 'src/api/workspaces'
+import { getFeedItems, FeedItem } from 'src/api/feed_items'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -25,7 +26,7 @@ interface BrainEntry {
   isDir: boolean
 }
 
-type PanelMode = 'skills' | 'brain'
+type Tab = 'feed' | 'skills' | 'brain'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -42,11 +43,34 @@ function dayLabel(unix: number): string {
   return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
 }
 
+function relativeTime(date: Date): string {
+  const diff = Date.now() - date.getTime()
+  const m = Math.floor(diff / 60000)
+  const h = Math.floor(m / 60)
+  const d = Math.floor(h / 24)
+  if (m < 2) return 'just now'
+  if (m < 60) return `${m}m ago`
+  if (h < 24) return `${h}h ago`
+  if (d < 7) return `${d}d ago`
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
 function parseAttendees(json: string): Attendee[] {
   try { return JSON.parse(json) } catch { return [] }
 }
 
-// ── Shared: skill runner hook ─────────────────────────────────────────────────
+function skillEmoji(name: string): string {
+  const n = name.toLowerCase()
+  if (n.includes('meeting') || n.includes('prep')) return '📅'
+  if (n.includes('enrich') || n.includes('person')) return '🧠'
+  if (n.includes('book')) return '📚'
+  if (n.includes('research') || n.includes('perplexity')) return '🔍'
+  if (n.includes('media') || n.includes('ingest')) return '🎬'
+  if (n.includes('cron') || n.includes('task')) return '⏰'
+  return '⚡'
+}
+
+// ── Skill runner hook ─────────────────────────────────────────────────────────
 
 function useSkillRunner() {
   const [running, setRunning] = useState(false)
@@ -74,9 +98,7 @@ function useSkillRunner() {
     }
   }, [])
 
-  const dismiss = useCallback(() => setOutput(null), [])
-
-  return { running, runningLabel, output, run, dismiss }
+  return { running, runningLabel, output, setOutput, run }
 }
 
 // ── Output panel ──────────────────────────────────────────────────────────────
@@ -113,10 +135,58 @@ const OutputPanel: React.FC<{
   )
 }
 
+// ── Feed item card ────────────────────────────────────────────────────────────
+
+const FeedCard: React.FC<{ item: FeedItem }> = ({ item }) => {
+  const [expanded, setExpanded] = useState(false)
+
+  const automationName = item.automation?.name ?? 'Skill run'
+  const emoji = skillEmoji(automationName)
+  const when = item.run?.executionDate
+    ? relativeTime(item.run.executionDate)
+    : relativeTime(item.timestamp)
+
+  // Find the first bot reply in any thread
+  const botReply = item.threads
+    ?.flatMap(t => t.messages ?? [])
+    .find(m => m.user_type === 'bot')?.text
+
+  const snippet = botReply?.slice(0, 120).replace(/\n/g, ' ').trimEnd()
+
+  return (
+    <div
+      className="px-4 py-3 hover:bg-gray-50 transition-colors cursor-pointer border-b border-gray-50 last:border-0"
+      onClick={() => setExpanded(e => !e)}
+    >
+      <div className="flex items-start gap-3">
+        <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0 text-base mt-0.5">
+          {emoji}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 mb-0.5">
+            <span className="text-sm font-medium text-gray-800 truncate">{item.title}</span>
+            <span className="text-xs text-gray-400 flex-shrink-0">{when}</span>
+          </div>
+          <div className="text-xs text-gray-400 truncate">{automationName}</div>
+          {!expanded && snippet && (
+            <div className="text-xs text-gray-500 mt-1 line-clamp-2 leading-relaxed">{snippet}…</div>
+          )}
+          {expanded && botReply && (
+            <div className="mt-3 prose prose-sm max-w-none" onClick={e => e.stopPropagation()}>
+              <Markdown>{botReply}</Markdown>
+            </div>
+          )}
+        </div>
+        <span className="text-gray-300 text-xs flex-shrink-0 mt-1">{expanded ? '▾' : '▸'}</span>
+      </div>
+    </div>
+  )
+}
+
 // ── Section header ────────────────────────────────────────────────────────────
 
 const SectionHeader: React.FC<{ label: string }> = ({ label }) => (
-  <div className="px-4 pt-5 pb-2">
+  <div className="px-4 pt-5 pb-1">
     <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">{label}</span>
   </div>
 )
@@ -133,9 +203,7 @@ const MeetingRow: React.FC<{
 
   return (
     <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors group">
-      <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 text-base">
-        📅
-      </div>
+      <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 text-base">📅</div>
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-gray-800 truncate">{event.title}</div>
         <div className="text-xs text-gray-400 truncate">
@@ -252,13 +320,15 @@ const BrainTreeNode: React.FC<{
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 const GBrainView: React.FC = () => {
-  const [mode, setMode] = useState<PanelMode>('skills')
-  const { running, runningLabel, output, run, dismiss } = useSkillRunner()
+  const [tab, setTab] = useState<Tab>('feed')
+  const { running, runningLabel, output, setOutput, run } = useSkillRunner()
 
-  // Meetings
+  // Feed
+  const [feedItems, setFeedItems] = useState<FeedItem[]>([])
+  const [feedLoading, setFeedLoading] = useState(true)
+
+  // Meetings & library
   const [meetings, setMeetings] = useState<CalendarEvent[]>([])
-
-  // Library
   const [people, setPeople] = useState<Workspace[]>([])
   const [projects, setProjects] = useState<Workspace[]>([])
 
@@ -272,6 +342,23 @@ const GBrainView: React.FC = () => {
   const [rootEntries, setRootEntries] = useState<BrainEntry[]>([])
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [pageContent, setPageContent] = useState<string | null>(null)
+
+  // Load feed
+  const loadFeed = useCallback(() => {
+    setFeedLoading(true)
+    getFeedItems()
+      .then(items => {
+        const withRuns = (items as FeedItem[])
+          .filter(i => i.run || i.threads?.some(t => t.messages?.some(m => m.user_type === 'bot')))
+          .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+          .slice(0, 50)
+        setFeedItems(withRuns)
+      })
+      .catch(() => {})
+      .finally(() => setFeedLoading(false))
+  }, [])
+
+  useEffect(() => { loadFeed() }, [loadFeed])
 
   // Load brain root
   useEffect(() => {
@@ -319,20 +406,24 @@ const GBrainView: React.FC = () => {
   const prepMeeting = useCallback((event: CalendarEvent) => {
     const attendees = parseAttendees(event.attendees_json).map(a => a.name).join(', ')
     run(`/meeting-prep ${event.title}${attendees ? ` — Attendees: ${attendees}` : ''}`, `Prepping: ${event.title}`)
+    setTab('skills')
   }, [run])
 
   const enrichPerson = useCallback((ws: Workspace) => {
     run(`/enrich ${ws.name}`, `Enriching: ${ws.name}`)
+    setTab('skills')
   }, [run])
 
   const researchProject = useCallback((ws: Workspace) => {
-    run(`/perplexity-research ${ws.name} project — ${ws.description ?? ''}`, `Researching: ${ws.name}`)
+    run(`/perplexity-research ${ws.name}${ws.description ? ` — ${ws.description}` : ''}`, `Researching: ${ws.name}`)
+    setTab('skills')
   }, [run])
 
   const handleCustom = useCallback(() => {
     const text = customText.trim()
     if (!text) return
     run(text, text)
+    setCustomText('')
   }, [customText, run])
 
   const handleSelectBrainPage = useCallback(async (relPath: string) => {
@@ -342,34 +433,75 @@ const GBrainView: React.FC = () => {
     setPageContent(content)
   }, [brainRoot])
 
-  const noData = meetings.length === 0 && people.length === 0 && projects.length === 0
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'feed', label: 'Feed' },
+    { id: 'skills', label: 'Skills' },
+    { id: 'brain', label: 'Brain' },
+  ]
 
   return (
     <div className="flex flex-col h-full bg-white">
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 flex-shrink-0">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100 flex-shrink-0">
         <span className="text-sm font-semibold text-gray-800">🧠 GBrain</span>
         <div className="flex gap-1 ml-auto">
-          <button
-            className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${mode === 'skills' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-100'}`}
-            onClick={() => setMode('skills')}
-          >
-            Skills
-          </button>
-          <button
-            className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${mode === 'brain' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-100'}`}
-            onClick={() => setMode('brain')}
-          >
-            Brain
-          </button>
+          {tabs.map(t => (
+            <button
+              key={t.id}
+              className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${tab === t.id ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-100'}`}
+              onClick={() => setTab(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
         </div>
       </div>
 
-      {/* Skills mode */}
-      {mode === 'skills' && (
+      {/* ── Feed tab ── */}
+      {tab === 'feed' && (
         <div className="flex-1 overflow-y-auto">
+          <div className="flex items-center justify-between px-4 pt-4 pb-2">
+            <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">What your brain did</span>
+            <button
+              className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+              onClick={loadFeed}
+            >
+              Refresh
+            </button>
+          </div>
 
-          {/* Custom command bar */}
+          {feedLoading ? (
+            <div className="flex items-center gap-2 px-4 py-6 text-sm text-gray-400">
+              <span className="animate-pulse">●</span> Loading…
+            </div>
+          ) : feedItems.length === 0 ? (
+            <div className="px-4 py-8 text-center">
+              <div className="text-2xl mb-2">🌱</div>
+              <div className="text-sm font-medium text-gray-500 mb-1">No activity yet</div>
+              <div className="text-xs text-gray-400 leading-relaxed">
+                Run your first skill to start building your brain.
+              </div>
+              <button
+                className="mt-4 px-4 py-2 rounded-lg bg-gray-900 text-white text-xs font-medium hover:bg-gray-700 transition-colors"
+                onClick={() => setTab('skills')}
+              >
+                Open Skills →
+              </button>
+            </div>
+          ) : (
+            <div>
+              {feedItems.map(item => (
+                <FeedCard key={item.id ?? item.timestamp.getTime()} item={item} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Skills tab ── */}
+      {tab === 'skills' && (
+        <div className="flex-1 overflow-y-auto">
+          {/* Command bar */}
           <div className="px-4 pt-4 pb-2 flex gap-2">
             <input
               className="flex-1 text-sm border border-gray-200 rounded-xl px-4 py-2.5 outline-none focus:border-gray-400 placeholder-gray-300"
@@ -388,13 +520,7 @@ const GBrainView: React.FC = () => {
           </div>
 
           {/* Output */}
-          <OutputPanel running={running} label={runningLabel} output={output} onDismiss={dismiss} />
-
-          {noData && (
-            <div className="px-4 py-8 text-sm text-gray-400 text-center">
-              Syncing your calendar and library…
-            </div>
-          )}
+          <OutputPanel running={running} label={runningLabel} output={output} onDismiss={() => setOutput(null)} />
 
           {/* Meetings */}
           {meetings.length > 0 && (
@@ -436,8 +562,8 @@ const GBrainView: React.FC = () => {
         </div>
       )}
 
-      {/* Brain mode */}
-      {mode === 'brain' && (
+      {/* ── Brain tab ── */}
+      {tab === 'brain' && (
         <div className="flex flex-1 min-h-0">
           <div className="w-56 flex-shrink-0 border-r border-gray-100 overflow-y-auto bg-white">
             <div className="px-3 py-2 border-b border-gray-100">


### PR DESCRIPTION
## Summary

Redesigned the GBrain view from a static skill catalog to a dynamic, calendar-driven interface that surfaces upcoming meetings, people, and projects alongside a custom command runner. The new layout prioritizes actionable items (prep meetings, enrich people, research projects) over a fixed skill menu.

## Key Changes

- **Removed static skill catalog**: Replaced the hardcoded `GBRAIN_SKILLS` array and `SkillCard` component with a dynamic, data-driven approach
- **Added calendar integration**: Fetches upcoming meetings from `/api/knapsack/calendar/get_events` and displays them with attendee info and one-click prep actions
- **Integrated workspace library**: Fetches people and projects from `listWorkspaces()` API, filtered by `autoCurated` and `entityType`, with quick-action buttons (Enrich, Research)
- **Unified skill runner**: Extracted skill execution logic into a reusable `useSkillRunner()` hook that handles API calls, loading states, and output display
- **Refactored UI components**:
  - New `OutputPanel` component for consistent result display
  - New `MeetingRow`, `PersonRow`, `ProjectRow` components for list items
  - New `SectionHeader` component for section labels
  - Simplified `BrainTreeNode` with inline formatting
- **Custom command bar**: Prominent input field for arbitrary skill invocation (e.g., `/skill-name context`)
- **Improved layout**: Two-mode toggle (Skills / Brain) with cleaner spacing and hover states
- **Helper functions**: Added `formatTime()`, `dayLabel()`, and `parseAttendees()` for calendar event formatting

## Implementation Details

- Calendar events are fetched on mount for the next 3 days, filtered to future events, sorted by start time, and limited to 10 items
- Workspace filtering separates people (for enrichment) from projects (for research)
- The skill runner hook centralizes error handling and loading state, reducing duplication
- Brain tree node loading is simplified with `.catch(() => [])` pattern instead of explicit error state
- Removed unused `useRef` import and `loading` state from tree node component
- Rust backend auto-creates the brain directory on first use if it doesn't exist (prevents "not found" errors on fresh installs)

https://claude.ai/code/session_01UDCGPC76HLQE7wK4wSCtzN