### PR TITLE
Fix OpenClaw doctor import and add gateway regression CI

### DIFF
--- a/.github/workflows/gateway-regression.yml
+++ b/.github/workflows/gateway-regression.yml
@@ -87,4 +87,7 @@ jobs:
 
       - name: Run gateway crash-classifier tests
         working-directory: src
+        env:
+          VITE_KN_API_SERVER: https://api.knapsack.ai
+          VITE_GOOGLE_CLIENT_ID: "963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com"
         run: cargo test --manifest-path src-tauri/Cargo.toml crash_classifier_tests -- --nocapture

--- a/.github/workflows/gateway-regression.yml
+++ b/.github/workflows/gateway-regression.yml
@@ -67,7 +67,7 @@ jobs:
 
   rust-gateway-regressions:
     name: Rust gateway regressions
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/gateway-regression.yml
+++ b/.github/workflows/gateway-regression.yml
@@ -1,0 +1,90 @@
+name: Gateway Regression Guards
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gateway-regression.yml"
+      - "src/scripts/**"
+      - "src/package.json"
+      - "src/package-lock.json"
+      - "src/src-tauri/Cargo.toml"
+      - "src/src-tauri/Cargo.lock"
+      - "src/src-tauri/src/clawd/**"
+      - "src/src-tauri/resources/clawdbot/**"
+  push:
+    branches: [main, "release/*"]
+    paths:
+      - ".github/workflows/gateway-regression.yml"
+      - "src/scripts/**"
+      - "src/package.json"
+      - "src/package-lock.json"
+      - "src/src-tauri/Cargo.toml"
+      - "src/src-tauri/Cargo.lock"
+      - "src/src-tauri/src/clawd/**"
+      - "src/src-tauri/resources/clawdbot/**"
+  workflow_dispatch:
+
+concurrency:
+  group: gateway-regression-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clawdbot-bundle-integrity:
+    name: Clawdbot bundle integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: src/src-tauri/resources/clawdbot/package-lock.json
+
+      - name: Install clawdbot dependencies
+        working-directory: src/src-tauri/resources/clawdbot
+        run: npm ci --ignore-scripts
+
+      - name: Install bundled plugin runtime deps
+        working-directory: src
+        run: node scripts/install-bundled-plugin-deps.cjs
+
+      - name: Prepare bundled Node.js
+        working-directory: src
+        run: node scripts/prepare-node.cjs
+
+      - name: Prune clawdbot bundle
+        working-directory: src
+        run: node scripts/prune-clawdbot.cjs
+
+      - name: Verify clawdbot bundle integrity
+        working-directory: src
+        run: node scripts/verify-clawdbot-bundle.cjs
+
+  rust-gateway-regressions:
+    name: Rust gateway regressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src/src-tauri
+
+      - name: Create Tauri dist directory
+        working-directory: src
+        run: mkdir -p dist
+
+      - name: Run gateway crash-classifier tests
+        working-directory: src
+        run: cargo test --manifest-path src-tauri/Cargo.toml crash_classifier_tests -- --nocapture

--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -97,6 +97,63 @@ if (fs.existsSync(entryPath)) {
   }
 }
 
+// Verify all relative JS imports inside dist resolve. Some bundled chunks use
+// dynamic imports that entry.js does not reference directly; missing those files
+// only appears at runtime (for example, `openclaw doctor --fix`).
+function walkFiles(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, out);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+function stripQueryOrHash(specifier) {
+  return specifier.split(/[?#]/, 1)[0];
+}
+
+function resolveRelativeJsImport(importerPath, specifier) {
+  const clean = stripQueryOrHash(specifier);
+  const resolved = path.resolve(path.dirname(importerPath), clean);
+  if (path.extname(resolved)) return resolved;
+  return `${resolved}.js`;
+}
+
+const distDir = path.join(CLAWDBOT_DIR, 'dist');
+const relativeImportRegexes = [
+  /(?:^|[;\n]\s*)import\s+(?:[^"';]+?\s+from\s+)?["'](\.{1,2}\/[^"']+)["']/g,
+  /(?:^|[;\n]\s*)export\s+[^"';]+?\s+from\s+["'](\.{1,2}\/[^"']+)["']/g,
+  /(?:^|[=({[,;:\n]\s*)import\s*\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g,
+];
+
+for (const jsFile of walkFiles(distDir)) {
+  // Remove comments first so JSDoc type references like
+  // `@type {import("./foo")}` are not treated as runtime imports.
+  const content = fs
+    .readFileSync(jsFile, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  for (const regex of relativeImportRegexes) {
+    let match;
+    while ((match = regex.exec(content)) !== null) {
+      const targetPath = resolveRelativeJsImport(jsFile, match[1]);
+      if (!fs.existsSync(targetPath)) {
+        const importer = path.relative(CLAWDBOT_DIR, jsFile);
+        const target = path.relative(CLAWDBOT_DIR, targetPath);
+        console.error(
+          `[verify-clawdbot] MISSING RELATIVE IMPORT: ${target} (imported by ${importer})`
+        );
+        errors++;
+      }
+    }
+  }
+}
+
 // Verify bundled extensions have required plugin metadata
 const extensionsDir = path.join(CLAWDBOT_DIR, 'dist', 'extensions');
 if (fs.existsSync(extensionsDir)) {

--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -105,6 +105,7 @@ function walkFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
       walkFiles(fullPath, out);
     } else if (entry.isFile() && entry.name.endsWith('.js')) {
       out.push(fullPath);

--- a/src/src-tauri/resources/clawdbot/dist/config/config.js
+++ b/src/src-tauri/resources/clawdbot/dist/config/config.js
@@ -1,0 +1,20 @@
+export { t as CONFIG_PATH, n as DEFAULT_GATEWAY_PORT, u as resolveGatewayPort } from "../paths-B2cMK-wd.js";
+export {
+  a as loadConfig,
+  b as writeConfigFile,
+  d as readConfigFileSnapshotForWrite,
+  h as readSourceConfigSnapshotForWrite,
+  i as getRuntimeConfig,
+  l as readBestEffortConfig,
+  m as readSourceConfigSnapshot,
+  p as readSourceConfigBestEffort,
+  r as createConfigIO,
+  u as readConfigFileSnapshot,
+  v as registerConfigWriteListener,
+  w as validateConfigObject,
+} from "../io-CFdEhZuM.js";
+export {
+  n as mutateConfigFile,
+  r as replaceConfigFile,
+  t as ConfigMutationConflictError,
+} from "../config--k_1dtUP.js";


### PR DESCRIPTION
## Summary
- add the missing bundled `dist/config/config.js` compatibility module expected by OpenClaw CLI chunks such as `doctor-health-duZiQDZc.js`
- re-export the config path, config IO, config mutation, and runtime config helpers from the hashed bundled chunks already present in the app bundle
- extend `verify-clawdbot-bundle.cjs` to scan all bundled JS chunks for unresolved relative static and dynamic imports, not only imports reachable from `entry.js`
- add a focused `Gateway Regression Guards` GitHub Actions workflow for gateway/bundle-related PRs

## Root Cause
The release bundle includes chunks that dynamically import `./config/config.js`, but pruning/build output only shipped hashed config chunks such as `config--k_1dtUP.js`, `io-CFdEhZuM.js`, and `paths-B2cMK-wd.js`. Running `openclaw doctor --fix` therefore succeeds through part of the flow and then crashes with `ERR_MODULE_NOT_FOUND` when the doctor health step imports `dist/config/config.js`.

## Regression Coverage
The new CI workflow runs on PRs and pushes that touch gateway, clawdbot bundle, or related script/package files. It adds two faster guards ahead of the full app build:
- `Clawdbot bundle integrity`: installs clawdbot deps, stages bundled plugin runtime deps, prepares bundled Node, prunes the bundle, then runs the enhanced bundle verifier.
- `Rust gateway regressions`: creates the Tauri dist directory and runs the gateway crash-classifier/config-sanitizer regression tests.

This should catch the missing dynamic import class from this PR and the plugin/runtime-deps classification failures from PR #398 before another release bundle ships.

## Impact
This should let the bundled `openclaw doctor --fix` path complete instead of crashing after applying config migrations. The verifier plus focused CI coverage should catch similar missing import targets and gateway recovery regressions earlier in PR review.

## Testing
- `node --check scripts/verify-clawdbot-bundle.cjs` ✅
- `node --check src/src-tauri/resources/clawdbot/dist/config/config.js` ✅
- `node scripts/verify-clawdbot-bundle.cjs 2>&1 | rg "MISSING RELATIVE IMPORT|FAILED|MISSING CRITICAL|MISSING: resources/node|package.json type|build version"` ⚠️ no `MISSING RELATIVE IMPORT`; full verifier still fails in the clean temp worktree because bundled `node_modules` and `resources/node/node` are absent there
- `mkdir -p dist && cargo test --manifest-path src-tauri/Cargo.toml crash_classifier_tests -- --nocapture` ✅
- `git diff --check` ✅

## Notes
This is separate from PR #398. That PR handles corrupt runtime-deps/cache recovery; this PR fixes a bundled CLI import path that `doctor --fix` hits directly and adds CI to make the related regression class harder to miss.