### PR TITLE
fix(service): recover from npm cache corruption and stale staged plugin dist files

### DIFF
--- a/.github/workflows/gateway-regression.yml
+++ b/.github/workflows/gateway-regression.yml
@@ -1,0 +1,93 @@
+name: Gateway Regression Guards
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gateway-regression.yml"
+      - "src/scripts/**"
+      - "src/package.json"
+      - "src/package-lock.json"
+      - "src/src-tauri/Cargo.toml"
+      - "src/src-tauri/Cargo.lock"
+      - "src/src-tauri/src/clawd/**"
+      - "src/src-tauri/resources/clawdbot/**"
+  push:
+    branches: [main, "release/*"]
+    paths:
+      - ".github/workflows/gateway-regression.yml"
+      - "src/scripts/**"
+      - "src/package.json"
+      - "src/package-lock.json"
+      - "src/src-tauri/Cargo.toml"
+      - "src/src-tauri/Cargo.lock"
+      - "src/src-tauri/src/clawd/**"
+      - "src/src-tauri/resources/clawdbot/**"
+  workflow_dispatch:
+
+concurrency:
+  group: gateway-regression-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clawdbot-bundle-integrity:
+    name: Clawdbot bundle integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: src/src-tauri/resources/clawdbot/package-lock.json
+
+      - name: Install clawdbot dependencies
+        working-directory: src/src-tauri/resources/clawdbot
+        run: npm ci --ignore-scripts
+
+      - name: Install bundled plugin runtime deps
+        working-directory: src
+        run: node scripts/install-bundled-plugin-deps.cjs
+
+      - name: Prepare bundled Node.js
+        working-directory: src
+        run: node scripts/prepare-node.cjs
+
+      - name: Prune clawdbot bundle
+        working-directory: src
+        run: node scripts/prune-clawdbot.cjs
+
+      - name: Verify clawdbot bundle integrity
+        working-directory: src
+        run: node scripts/verify-clawdbot-bundle.cjs
+
+  rust-gateway-regressions:
+    name: Rust gateway regressions
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src/src-tauri
+
+      - name: Create Tauri dist directory
+        working-directory: src
+        run: mkdir -p dist
+
+      - name: Run gateway clawd tests
+        working-directory: src
+        env:
+          VITE_KN_API_SERVER: https://api.knapsack.ai
+          VITE_GOOGLE_CLIENT_ID: "963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com"
+        run: cargo test --manifest-path src-tauri/Cargo.toml clawd -- --nocapture

--- a/.github/workflows/gateway-regression.yml
+++ b/.github/workflows/gateway-regression.yml
@@ -85,9 +85,9 @@ jobs:
         working-directory: src
         run: mkdir -p dist
 
-      - name: Run gateway clawd tests
+      - name: Run gateway service tests
         working-directory: src
         env:
           VITE_KN_API_SERVER: https://api.knapsack.ai
           VITE_GOOGLE_CLIENT_ID: "963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com"
-        run: cargo test --manifest-path src-tauri/Cargo.toml clawd -- --nocapture
+        run: cargo test --manifest-path src-tauri/Cargo.toml clawd::service -- --nocapture

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -7784,6 +7784,7 @@ mod crash_classifier_tests {
 #[cfg(test)]
 mod bundle_key_tests {
   use super::*;
+  use std::fs;
 
   #[test]
   fn compute_key_sorted_and_stable() {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -7782,6 +7782,81 @@ mod crash_classifier_tests {
 }
 
 #[cfg(test)]
+mod bundle_key_tests {
+  use super::*;
+
+  #[test]
+  fn compute_key_sorted_and_stable() {
+    let tmp = std::env::temp_dir().join(format!("bundle-key-test-{}", std::process::id()));
+    let ext_dir = tmp.join("extensions");
+    let slack_dir = ext_dir.join("slack");
+    let tg_dir = ext_dir.join("telegram");
+    fs::create_dir_all(&slack_dir).unwrap();
+    fs::create_dir_all(&tg_dir).unwrap();
+    fs::write(slack_dir.join("channel-abc.js"), "").unwrap();
+    fs::write(slack_dir.join("index.js"), "").unwrap();
+    fs::write(tg_dir.join("index.js"), "").unwrap();
+
+    let key1 = compute_bundle_extensions_key(&tmp);
+    let key2 = compute_bundle_extensions_key(&tmp);
+    assert_eq!(key1, key2, "key must be deterministic");
+    assert!(key1.contains("slack/channel-abc.js"));
+    assert!(key1.contains("slack/index.js"));
+    assert!(key1.contains("telegram/index.js"));
+
+    fs::remove_dir_all(&tmp).ok();
+  }
+
+  #[test]
+  fn key_changes_when_file_added() {
+    let tmp = std::env::temp_dir().join(format!("bundle-key-test-add-{}", std::process::id()));
+    let ext_dir = tmp.join("extensions").join("slack");
+    fs::create_dir_all(&ext_dir).unwrap();
+    fs::write(ext_dir.join("index.js"), "").unwrap();
+    let key_before = compute_bundle_extensions_key(&tmp);
+
+    fs::write(ext_dir.join("allow-list-new.js"), "").unwrap();
+    let key_after = compute_bundle_extensions_key(&tmp);
+    assert_ne!(key_before, key_after, "adding a file must change the key");
+
+    fs::remove_dir_all(&tmp).ok();
+  }
+
+  #[test]
+  fn check_and_refresh_wipes_dirs_on_change() {
+    let tmp = std::env::temp_dir().join(format!("bundle-key-test-wipe-{}", std::process::id()));
+    let dist_dir = tmp.join("dist");
+    let ext_dir = dist_dir.join("extensions").join("slack");
+    let home_dir = tmp.join("home");
+    let deps_dir = home_dir.join("plugin-runtime-deps");
+    let staged = deps_dir.join("openclaw-1.0.0-abc");
+    fs::create_dir_all(&ext_dir).unwrap();
+    fs::create_dir_all(&staged).unwrap();
+    fs::write(ext_dir.join("index.js"), "").unwrap();
+
+    // First call: no sentinel → wipes and writes
+    let changed = check_and_refresh_bundle_content_key(&home_dir, &dist_dir);
+    assert!(changed, "first call with no sentinel should report changed");
+    assert!(!staged.exists(), "staged dir should be wiped");
+    assert!(deps_dir.join(".bundle-content-key").exists(), "sentinel should be written");
+
+    // Recreate staged dir; second call with same key should be a no-op
+    fs::create_dir_all(&staged).unwrap();
+    let changed2 = check_and_refresh_bundle_content_key(&home_dir, &dist_dir);
+    assert!(!changed2, "same key should not trigger wipe");
+    assert!(staged.exists(), "staged dir should still exist");
+
+    // Add a dist file; key changes → wipe fires again
+    fs::write(ext_dir.join("new-chunk.js"), "").unwrap();
+    let changed3 = check_and_refresh_bundle_content_key(&home_dir, &dist_dir);
+    assert!(changed3, "new dist file should trigger wipe");
+    assert!(!staged.exists(), "staged dir should be wiped again");
+
+    fs::remove_dir_all(&tmp).ok();
+  }
+}
+
+#[cfg(test)]
 mod provider_key_tests {
   use super::*;
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -554,6 +554,88 @@ fn remove_stale_plugin_runtime_deps_versions(clawdbot_home: &std::path::Path, cu
   }
 }
 
+/// Wipe `.openclaw-npm-cache` directories inside plugin-runtime-deps subdirs.
+/// Called when an npm cache ENOENT crash is detected — the corrupted cache
+/// causes every subsequent npm install attempt to fail with the same ENOENT.
+fn remove_stale_openclaw_npm_caches(clawdbot_home: &std::path::Path) {
+  let base = clawdbot_home.join("plugin-runtime-deps");
+  let entries = match fs::read_dir(&base) {
+    Ok(d) => d,
+    Err(_) => return,
+  };
+  for entry in entries.flatten() {
+    if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+      continue;
+    }
+    let cache_dir = entry.path().join(".openclaw-npm-cache");
+    if cache_dir.is_dir() {
+      match fs::remove_dir_all(&cache_dir) {
+        Ok(_) => eprintln!(
+          "[clawd/service] Removed corrupt npm cache: {}",
+          cache_dir.display()
+        ),
+        Err(e) => eprintln!(
+          "[clawd/service] WARNING: Failed to remove npm cache {}: {}",
+          cache_dir.display(),
+          e
+        ),
+      }
+    }
+  }
+}
+
+/// Compute a stable key from the sorted list of .js filenames inside
+/// `dist/extensions/*/`. Bundler assigns content-based names, so any dist
+/// change produces a new filename and therefore a new key.
+fn compute_bundle_extensions_key(clawdbot_dist_dir: &std::path::Path) -> String {
+  let ext_dir = clawdbot_dist_dir.join("extensions");
+  let mut names: Vec<String> = Vec::new();
+  if let Ok(plugins) = fs::read_dir(&ext_dir) {
+    for plugin in plugins.flatten() {
+      if !plugin.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        continue;
+      }
+      let plugin_name = plugin.file_name().to_string_lossy().to_string();
+      if let Ok(files) = fs::read_dir(plugin.path()) {
+        for file in files.flatten() {
+          let fname = file.file_name().to_string_lossy().to_string();
+          if fname.ends_with(".js") {
+            names.push(format!("{}/{}", plugin_name, fname));
+          }
+        }
+      }
+    }
+  }
+  names.sort();
+  names.join("\n")
+}
+
+/// Compare the stored bundle-content key against the current dist layout.
+/// Returns true and wipes all staged dirs if the key changed (meaning the
+/// app bundle was updated but the staged dirs weren't re-created).
+fn check_and_refresh_bundle_content_key(
+  clawdbot_home: &std::path::Path,
+  clawdbot_dist_dir: &std::path::Path,
+) -> bool {
+  let sentinel = clawdbot_home.join("plugin-runtime-deps").join(".bundle-content-key");
+  let current_key = compute_bundle_extensions_key(clawdbot_dist_dir);
+  if current_key.is_empty() {
+    return false;
+  }
+  let stored = fs::read_to_string(&sentinel).unwrap_or_default();
+  if stored == current_key {
+    return false;
+  }
+  eprintln!(
+    "[clawd/service] bundle dist content changed — wiping all plugin-runtime-deps for re-stage"
+  );
+  remove_stale_plugin_runtime_deps_versions(clawdbot_home, "");
+  let base = clawdbot_home.join("plugin-runtime-deps");
+  let _ = fs::create_dir_all(&base);
+  let _ = fs::write(&sentinel, &current_key);
+  true
+}
+
 /// Count plugin-runtime-deps directories whose version prefix doesn't match
 /// `current_version` — i.e. stale dirs from a prior gateway version that
 /// `remove_stale_plugin_runtime_deps_versions` would remove.
@@ -1978,7 +2060,8 @@ fn classify_gateway_crash(log_tail: &str) -> &'static str {
     "gatekeeper_blocked"
   } else if lower.contains("missing-meta-before-write") || lower.contains("config write anomaly") {
     "config_anomaly"
-  } else if lower.contains("enotempty") || lower.contains("stage bundled runtime deps") || (lower.contains("plugin") && (lower.contains("npm install failed") || lower.contains("failed to install"))) {
+  } else if (lower.contains("enoent") && (lower.contains("openclaw-npm-cache") || lower.contains("_cacache")))
+    || lower.contains("enotempty") || lower.contains("stage bundled runtime deps") || (lower.contains("plugin") && (lower.contains("npm install failed") || lower.contains("failed to install"))) {
     "plugin_install_fail"
   } else if lower.contains("cannot find module") && (lower.contains("plugin-sdk") || lower.contains("channel-config") || lower.contains("root-alias")) {
     // Stale plugin-runtime-deps with wrong internal structure — version prefix
@@ -2208,14 +2291,24 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         // fail their npm install on every subsequent gateway start.
         remove_stale_plugin_runtime_deps_locks(&restart_clawdbot_home);
 
+        let log_lower = std::fs::read_to_string(gateway_stderr_log())
+          .unwrap_or_default()
+          .to_lowercase();
+
+        // Wipe corrupt npm caches on ENOENT cache failures so the next npm
+        // install doesn't hit the same broken _cacache entries.
+        let is_npm_cache_crash = log_lower.contains("enoent")
+          && (log_lower.contains("openclaw-npm-cache") || log_lower.contains("_cacache"));
+        if is_npm_cache_crash {
+          eprintln!("[clawd/service] auto-restart: npm cache ENOENT detected — wiping corrupt caches");
+          remove_stale_openclaw_npm_caches(&restart_clawdbot_home);
+        }
+
         // Check if the crash is a module-resolution failure (e.g. "Cannot find
         // module .../plugin-sdk/root-alias.cjs/channel-config-schema-legacy").
         // This happens when a plugin-runtime-deps dir has the correct version
         // prefix but incompatible internal structure — the normal version-prefix
         // cleanup skips it.  Force a full wipe so the gateway re-stages clean deps.
-        let log_lower = std::fs::read_to_string(gateway_stderr_log())
-          .unwrap_or_default()
-          .to_lowercase();
         let is_module_resolution_crash = log_lower.contains("cannot find module")
           && (log_lower.contains("plugin-sdk") || log_lower.contains("channel-config") || log_lower.contains("root-alias"));
         if is_module_resolution_crash {
@@ -7341,6 +7434,35 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
             "[gateway] auto_enable: cleaned stale plugin-runtime-deps + restarted",
             sentry::Level::Warning,
           ),
+        );
+      }
+
+      // Detect when the app bundle dist content changed but the staged
+      // plugin-runtime-deps dir was NOT invalidated (because the JS staging
+      // key is based on package path, not content).  Wipe and restart so the
+      // gateway re-stages fresh dist files on next start.
+      let bundle_dist_dir = bundle_dir.join("dist");
+      if check_and_refresh_bundle_content_key(&clawdbot_home, &bundle_dist_dir) {
+        let uid = unsafe { libc::getuid() };
+        let domain = format!("gui/{}", uid);
+        let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
+        let _ = std::process::Command::new("launchctl")
+          .args(["bootout", &service])
+          .status();
+        std::thread::sleep(std::time::Duration::from_millis(800));
+        kill_process_on_port(18789);
+        remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
+        if let Ok(plist_path) = launch_agent_plist_path() {
+          let _ = std::process::Command::new("launchctl")
+            .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
+            .status();
+          let _ = std::process::Command::new("launchctl")
+            .args(["kickstart", "-k", &service])
+            .status();
+        }
+        sentry::capture_message(
+          "[gateway] auto_enable: bundle content changed — wiped stale plugin-runtime-deps + restarted",
+          sentry::Level::Warning,
         );
       }
 


### PR DESCRIPTION
## Summary

Two related plugin-runtime-deps reliability fixes in `service.rs` (no JS changes):

**Bug 1 — npm cache ENOENT crash loop**
- Adds `remove_stale_openclaw_npm_caches`: wipes `.openclaw-npm-cache` dirs inside `plugin-runtime-deps/*/` when corrupt `_cacache` entries cause every subsequent `npm install` to fail with ENOENT
- Extends crash classifier to surface `enoent` + `openclaw-npm-cache`/`_cacache` as `plugin_install_fail` (was falling through to `"unknown"`, hiding it from the UI diagnostic)
- Auto-restart handler now reads `log_lower` once (moved up) and calls the npm cache wipe before retrying npm install

**Bug 2 — stale staged dist files (root cause of prod logs 2026-05-12)**
- Telegram failed: `channel-plugin-api.js` missing from staged dir
- Slack failed: `allow-list-GR9Gx-es.js` missing, `Cannot find package 'openclaw'`
- Root cause: the JS staging code reuses an existing `openclaw-{version}-{hash}` dir unconditionally — the `{hash}` is a PATH hash, not a content hash, so a bundle update that doesn't change the install path silently serves stale dist files. The gateway doesn't crash-loop (plugins fail to register but HTTP `/health` still passes), so auto-restart never fires.
- Fix: `compute_bundle_extensions_key` collects the sorted list of `.js` filenames from `resources/clawdbot/dist/extensions/*/` (bundler assigns content-based names, so any dist change = new filename = new key). `check_and_refresh_bundle_content_key` compares to `plugin-runtime-deps/.bundle-content-key` on every startup; if different, wipes all staged dirs and restarts the gateway so fresh dist files are staged.

## Test plan

- [ ] Rust tests pass: `cd src && cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "test result|FAILED|^error"`
- [ ] Bug 1: corrupt an npm cache dir (`rm -rf plugin-runtime-deps/openclaw-*/openclaw-*/node_modules && mkdir -p plugin-runtime-deps/openclaw-*/.openclaw-npm-cache/_cacache && echo bad > plugin-runtime-deps/openclaw-*/.openclaw-npm-cache/_cacache/fake`), trigger "Core Repair" restart, verify log shows `"Removed corrupt npm cache"` and gateway recovers
- [ ] Bug 2: add a dummy `.js` file to `resources/clawdbot/dist/extensions/telegram/`, relaunch the app, verify log shows `"bundle dist content changed — wiping all plugin-runtime-deps for re-stage"` and gateway restarts cleanly with all plugins registered

https://claude.ai/code/session_01X47LtAjNkXL4ss5zgEkVxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01X47LtAjNkXL4ss5zgEkVxQ)_