### PR TITLE
Handle interrupted gateway runtime deps staging

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
+++ b/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
@@ -4,6 +4,7 @@ import { _ as resolveStateDir } from "./paths-B2cMK-wd.js";
 import { t as createNpmProjectInstallEnv } from "./npm-install-env-C2UCLEG0.js";
 import { t as sanitizeTerminalText } from "./safe-text-BsGBhnDf.js";
 import { o as normalizePluginsConfig } from "./config-state-Bw_lAn0M.js";
+import { i as formatErrorMessage } from "./errors-CDFVCV9D.js";
 import { Module, createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -2134,9 +2134,10 @@ mod tests {
   // invariant is added to ensure_browser_config_at(), add it here too.
 
   fn fully_correct_config() -> serde_json::Value {
+    let gateway_token = get_gateway_token().unwrap_or_else(|| "test-token".to_string());
     json!({
       "gateway": {
-        "auth": { "token": "test-token", "mode": "token" },
+        "auth": { "token": gateway_token, "mode": "token" },
         "controlUi": {
           "allowInsecureAuth": true,
           "allowedOrigins": ["tauri://localhost", "http://localhost:1420"]
@@ -2146,6 +2147,9 @@ mod tests {
         "enabled": true,
         "headless": false,
         "defaultProfile": "openclaw"
+      },
+      "agents": {
+        "defaults": { "model": "groq/llama-3.3-70b-versatile" }
       },
       "tools": {
         "deny": ["canvas", "nodes", "cron", "gateway"],
@@ -2283,14 +2287,10 @@ mod tests {
 
   #[test]
   fn telegram_timeout_not_patched_when_already_correct() {
-    let cfg_json = json!({
-      "channels": {
-        "telegram": { "botToken": "123:abc", "timeoutSeconds": 60 }
-      },
-      "gateway": { "auth": { "token": "t", "mode": "token" } },
-      "browser": { "enabled": true, "headless": false, "defaultProfile": "openclaw" },
-      "tools": { "deny": ["canvas","nodes","cron","gateway"], "allow": ["browser","group:web","exec","process","group:fs"] }
-    });
+    let mut cfg_json = fully_correct_config();
+    cfg_json.as_object_mut().unwrap().insert("channels".into(), json!({
+      "telegram": { "botToken": "123:abc", "timeoutSeconds": 60 }
+    }));
     let f = write_config(&serde_json::to_string(&cfg_json).unwrap());
     let changed = ensure_browser_config_at(f.path());
     assert!(!changed, "should not re-patch a config that already has correct timeoutSeconds");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -643,6 +643,89 @@ fn count_stale_plugin_runtime_deps_versions(
   stale
 }
 
+fn is_incomplete_plugin_runtime_deps_dir(path: &std::path::Path) -> bool {
+  !path.join("package.json").is_file()
+    || !path.join("node_modules").is_dir()
+    || !path.join("dist").join("extensions").is_dir()
+}
+
+fn count_incomplete_plugin_runtime_deps_dirs(
+  clawdbot_home: &std::path::Path,
+  current_version: &str,
+) -> usize {
+  let base = clawdbot_home.join("plugin-runtime-deps");
+  let entries = match fs::read_dir(&base) {
+    Ok(d) => d,
+    Err(_) => return 0,
+  };
+  let expected_prefix = format!("openclaw-{}-", current_version);
+  let mut incomplete = 0usize;
+  for entry in entries.flatten() {
+    if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+      continue;
+    }
+    let dir_name = entry.file_name().to_string_lossy().to_string();
+    if !dir_name.starts_with("openclaw-") {
+      continue;
+    }
+    if !current_version.is_empty() && !dir_name.starts_with(&expected_prefix) {
+      continue;
+    }
+    if is_incomplete_plugin_runtime_deps_dir(&entry.path()) {
+      incomplete += 1;
+    }
+  }
+  incomplete
+}
+
+/// Remove current-version plugin-runtime-deps dirs left half-created by an
+/// interrupted npm install. A SIGTERM during staging can leave only
+/// `.openclaw-npm-cache`; the version prefix is correct, so stale-version
+/// cleanup preserves it, but every restart keeps staging from a broken base.
+fn remove_incomplete_plugin_runtime_deps_dirs(
+  clawdbot_home: &std::path::Path,
+  current_version: &str,
+) -> usize {
+  let base = clawdbot_home.join("plugin-runtime-deps");
+  let entries = match fs::read_dir(&base) {
+    Ok(d) => d,
+    Err(_) => return 0,
+  };
+  let expected_prefix = format!("openclaw-{}-", current_version);
+  let mut removed = 0usize;
+  for entry in entries.flatten() {
+    if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+      continue;
+    }
+    let dir_name = entry.file_name().to_string_lossy().to_string();
+    if !dir_name.starts_with("openclaw-") {
+      continue;
+    }
+    if !current_version.is_empty() && !dir_name.starts_with(&expected_prefix) {
+      continue;
+    }
+    let path = entry.path();
+    if !is_incomplete_plugin_runtime_deps_dir(&path) {
+      continue;
+    }
+    match fs::remove_dir_all(&path) {
+      Ok(_) => {
+        removed += 1;
+        eprintln!(
+          "[clawd/service] Removed incomplete plugin runtime deps dir: {}",
+          path.display()
+        );
+      }
+      Err(e) => eprintln!(
+        "[clawd/service] WARNING: Failed to remove incomplete plugin runtime deps dir {}: {}",
+        path.display(),
+        e
+      ),
+    }
+  }
+  removed
+}
+
 /// Wipe corrupt `.openclaw-npm-cache` directories inside plugin-runtime-deps
 /// subdirs. These caches are disposable; npm will rebuild them on the next
 /// install attempt.
@@ -2359,6 +2442,14 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
           remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, "");
         } else {
           remove_stale_plugin_runtime_deps_versions(&restart_clawdbot_home, &restart_bundle_ver);
+          let removed_incomplete =
+            remove_incomplete_plugin_runtime_deps_dirs(&restart_clawdbot_home, &restart_bundle_ver);
+          if removed_incomplete > 0 {
+            eprintln!(
+              "[clawd/service] auto-restart: removed {} incomplete plugin-runtime-deps dir(s)",
+              removed_incomplete
+            );
+          }
         }
         if is_npm_cache_crash {
           eprintln!("[clawd/service] auto-restart: npm cache ENOENT detected — wiping corrupt caches");
@@ -5296,6 +5387,7 @@ pub async fn set_service_enabled(
       {
         let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
         remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(&app_handle), &ver);
+        remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(&app_handle), &ver);
       }
 
       // Run "openclaw doctor --fix" in a background thread — same reason as
@@ -7424,10 +7516,11 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
       let bundle_ver = read_clawdbot_bundle_version(&bundle_dir);
       let clawdbot_home = app_clawdbot_home(app_handle);
       let stale = count_stale_plugin_runtime_deps_versions(&clawdbot_home, &bundle_ver);
-      if stale > 0 {
+      let incomplete = count_incomplete_plugin_runtime_deps_dirs(&clawdbot_home, &bundle_ver);
+      if stale > 0 || incomplete > 0 {
         eprintln!(
-          "[clawd/service] auto_enable: detected {} stale plugin-runtime-deps dir(s) (bundle ver={}) — cleaning and forcing gateway restart",
-          stale, bundle_ver
+          "[clawd/service] auto_enable: detected {} stale and {} incomplete plugin-runtime-deps dir(s) (bundle ver={}) — cleaning and forcing gateway restart",
+          stale, incomplete, bundle_ver
         );
         // Bootout first so the gateway isn't holding files we're about to delete.
         let uid = unsafe { libc::getuid() };
@@ -7441,6 +7534,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
         kill_process_on_port(18789);
         remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
         remove_stale_plugin_runtime_deps_versions(&clawdbot_home, &bundle_ver);
+        remove_incomplete_plugin_runtime_deps_dirs(&clawdbot_home, &bundle_ver);
         // Re-bootstrap so the gateway is registered + started fresh.  The
         // gateway will re-stage plugin runtime deps under the correct
         // `openclaw-{bundle_ver}-{hash}` dir on first startup.
@@ -7597,6 +7691,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   {
     let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(app_handle));
     remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(app_handle), &ver);
+    remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(app_handle), &ver);
   }
 
   let boot = std::process::Command::new("launchctl")
@@ -7691,6 +7786,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   {
     let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(app_handle));
     remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(app_handle), &ver);
+    remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(app_handle), &ver);
   }
 
   let stdout_log = windows_log_path("stdout");
@@ -7762,6 +7858,32 @@ mod crash_classifier_tests {
   fn slack_runtime_deps_missing_module_is_plugin_install_fail() {
     let log_tail = "Error: Cannot find module '@slack/logger'\nRequire stack:\n- /Users/test/Library/Application Support/ai.knap.knapsack/clawdbot/plugin-runtime-deps/openclaw-1.2.3-abcd/node_modules/@slack/web-api/dist/logger.js";
     assert_eq!(classify_gateway_crash(log_tail), "plugin_install_fail");
+  }
+
+  #[test]
+  fn removes_current_version_incomplete_plugin_runtime_deps_dir() {
+    let root = std::env::temp_dir().join(format!(
+      "knapsack-incomplete-runtime-deps-{}-{}",
+      std::process::id(),
+      std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+    let base = root.join("plugin-runtime-deps");
+    let incomplete = base.join("openclaw-2026.4.26-abc123");
+    let complete = base.join("openclaw-2026.4.26-def456");
+    fs::create_dir_all(incomplete.join(".openclaw-npm-cache")).unwrap();
+    fs::create_dir_all(complete.join("node_modules")).unwrap();
+    fs::create_dir_all(complete.join("dist").join("extensions")).unwrap();
+    fs::write(complete.join("package.json"), "{}").unwrap();
+
+    assert_eq!(count_incomplete_plugin_runtime_deps_dirs(&root, "2026.4.26"), 1);
+    assert_eq!(remove_incomplete_plugin_runtime_deps_dirs(&root, "2026.4.26"), 1);
+    assert!(!incomplete.exists());
+    assert!(complete.exists());
+
+    let _ = fs::remove_dir_all(root);
   }
 
   #[test]


### PR DESCRIPTION
## Summary
- remove incomplete current-version plugin-runtime-deps dirs left behind by interrupted gateway staging
- run the cleanup on startup/enable and auto-restart paths before reinstalling runtime deps
- update Rust config fixtures so gateway regression tests match current invariants

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "test result|FAILED|^error"