### PR TITLE
[codex] Improve meeting chat and transcript experience

### DIFF
--- a/src/src/components/organisms/CenterWorkspace/index.tsx
+++ b/src/src/components/organisms/CenterWorkspace/index.tsx
@@ -76,6 +76,7 @@ interface TemplatesState {
 interface TranscriptState {
   isOpen: boolean
   threadId?: number
+  participantNames?: string[]
 }
 
 export interface TaskItem {
@@ -233,7 +234,7 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
     checkPermissions()
   }, [])
 
-  const handleOpenTranscript = async (threadId: number | undefined) => {
+  const handleOpenTranscript = async (threadId: number | undefined, participantNames?: string[]) => {
     if (!threadId) return
 
     if (templatesState.isOpen) {
@@ -252,6 +253,7 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
     setTranscriptState(prev => ({
       isOpen: !prev.isOpen || prev.threadId !== threadId,
       threadId: threadId,
+      participantNames,
     }))
   }
 
@@ -356,6 +358,8 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
                       recordingHandlers={recordingHandlers}
                       handleOpenTasks={handleOpenTasks}
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
+                      userEmail={userEmail}
+                      userName={userName}
                       onEmailClick={(notesMarkdown, meeting) => {
                         const participants = meeting?.participants ?? []
                         const toEmails = participants
@@ -576,7 +580,11 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
             </div>
           )}
         {transcriptState.isOpen && transcriptState.threadId && (
-          <TranscriptView threadId={transcriptState.threadId} onClose={() => closeTranscript()} />
+          <TranscriptView
+            threadId={transcriptState.threadId}
+            participantNames={transcriptState.participantNames}
+            onClose={() => closeTranscript()}
+          />
         )}
         {templatesState.isOpen && templatesState.thread && (
           <TemplatesView

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -1507,9 +1507,14 @@ interface ClawdChatProps {
   openProviderPanel?: number
   /** Pre-fills the chat input field when set. */
   initialInput?: string
+  /** Extra context prepended to model/gateway requests without displaying it as the user's message. */
+  contextPrefix?: string
+  /** Render with a tighter header for embedded surfaces. */
+  compact?: boolean
+  title?: string
 }
 
-export default function ClawdChat({ showActivityPanel: externalActivityPanel, onToggleActivity, onCloseActivity, userEmail, userName, onBusyChange, openProviderPanel, initialInput }: ClawdChatProps = {}) {
+export default function ClawdChat({ showActivityPanel: externalActivityPanel, onToggleActivity, onCloseActivity, userEmail, userName, onBusyChange, openProviderPanel, initialInput, contextPrefix, compact = false, title = 'Knapsack Chat' }: ClawdChatProps = {}) {
   // Load chat history from localStorage on mount
   const [msgs, setMsgs] = useState<Msg[]>(() => {
     const stored = localStorage.getItem(CHAT_HISTORY_STORAGE)
@@ -4037,6 +4042,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           }
         }
 
+        if (contextPrefix?.trim()) {
+          actualText = `${contextPrefix.trim()}
+
+---
+User message:
+${actualText}`
+        }
+
         // Auto-include recent terminal output as context so the AI can see
         // what the user is working on without requiring copy-paste
         if (!isSmartPrompt) {
@@ -4459,12 +4472,12 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   }, [msgs])
 
   return (
-    <div className="ClawdChatRoot">
+    <div className={`ClawdChatRoot ${compact ? 'ClawdChatRoot--compact' : ''}`}>
       <div className="ClawdChatHeader">
         <div className="ClawdChatTitleRow">
           <img src="/assets/images/knap-logo-medium.png" alt="Knapsack" className="ClawdChatLogo" />
           <div className="ClawdChatTitleGroup">
-            <h1 className="ClawdChatTitle">Knapsack Chat</h1>
+            <h1 className="ClawdChatTitle">{title}</h1>
             {/* Attribution moved to Settings */}
             <div className="ClawdChatStatus">{statusLine}</div>
           </div>

--- a/src/src/components/organisms/ClawdChat/style.scss
+++ b/src/src/components/organisms/ClawdChat/style.scss
@@ -10,6 +10,45 @@
   box-sizing: border-box;
 }
 
+.ClawdChatRoot--compact {
+  padding: 0;
+
+  .ClawdChatHeader {
+    padding: 10px 12px;
+    gap: 6px;
+  }
+
+  .ClawdChatLogo {
+    display: none;
+  }
+
+  .ClawdChatTitle {
+    font-size: 15px;
+  }
+
+  .ClawdChatSubtitle,
+  .ClawdChatStatus {
+    font-size: 11px;
+  }
+
+  .ClawdChatActions {
+    gap: 4px;
+  }
+
+  .ClawdChatActions button {
+    font-size: 10px;
+    padding: 3px 6px;
+  }
+
+  .ClawdChatBody {
+    padding: 10px 12px;
+  }
+
+  .ClawdChatInput {
+    padding: 8px 10px;
+  }
+}
+
 // Flex row that holds the main chat area and any side panel
 .ClawdChatContent {
   display: flex;

--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -15,6 +15,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { FeedItem } from 'src/api/feed_items'
 import { isRecordingStatus, statusRecordByThreadID } from 'src/api/recording'
 import { IThread, ThreadType } from 'src/api/threads'
+import { getSavedTranscript } from 'src/api/transcripts'
 import { LLMParams } from 'src/App'
 import { Meeting } from 'src/hooks/dataSources/useCalendar'
 import { IFeed } from 'src/hooks/feed/useFeed'
@@ -33,6 +34,7 @@ import { Markdown } from 'tiptap-markdown'
 import MeetingNotesTabBar from 'src/components/molecules/MeetingNotesTabBar'
 import RecordControlPanel from 'src/components/molecules/RecordControlPanel'
 import MarkdownDisplay from 'src/components/molecules/MarkdownDisplay'
+import ClawdChat from 'src/components/organisms/ClawdChat'
 
 import { Event, listen } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/tauri'
@@ -90,17 +92,18 @@ interface MeetingNotesModeProps {
   synthesisState: boolean
   onSynthesisFinish: () => void
   handleOpenTemplates: (thread: IThread) => Promise<void>
-  handleOpenTranscript: (FeedItemId: number | undefined) => void
+  handleOpenTranscript: (FeedItemId: number | undefined, participantNames?: string[]) => void
   handleErrorContact: (message: string) => void
   closeTranscript: () => void
   closeTasks: () => void
   recordingHandlers: RecordingContextProps
   handleOpenTasks?: (threadId: number | undefined, tasks: TaskItem[]) => void
   handleOpenInsights?: (threadId: number | undefined) => void
-  onChatClick?: () => void
   onEmailClick?: (notesMarkdown: string, meeting: Meeting | undefined) => void
   onLibraryWorkspaceOpen?: (ws: Workspace) => void
   onAttendeeClick?: (email: string, name: string) => void
+  userEmail?: string
+  userName?: string
 }
 
 const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
@@ -125,16 +128,19 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   recordingHandlers,
   handleOpenTasks,
   handleOpenInsights,
-  onChatClick,
   onEmailClick,
   onLibraryWorkspaceOpen,
   onAttendeeClick,
+  userEmail,
+  userName,
 }) => {
   const [isInitialLoading, setIsInitialLoading] = useState(true)
   const [disableIsRecording, setDisableIsRecording] = useState(false)
   const [permissionError, setPermissionError] = useState<string | null>(null)
   const [notesMarkdown, setNotesMarkdown] = useState<string>('')
   const [personWorkspaces, setPersonWorkspaces] = useState<Record<string, Workspace>>({})
+  const [isMeetingChatOpen, setIsMeetingChatOpen] = useState(false)
+  const [meetingTranscriptContext, setMeetingTranscriptContext] = useState('')
 
   useEffect(() => {
     listWorkspaces().then(res => {
@@ -180,6 +186,47 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     }
     setIsEditingTitle(false)
   }
+
+  const openMeetingChat = () => {
+    setIsMeetingChatOpen(true)
+  }
+
+  useEffect(() => {
+    if (!isMeetingChatOpen || !thread.savedTranscript) return
+    let cancelled = false
+    getSavedTranscript(thread.id.toString()).then(data => {
+      if (cancelled || !data?.content) return
+      setMeetingTranscriptContext(extractTranscriptBodyForContext(data.content))
+    }).catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [isMeetingChatOpen, thread.id, thread.savedTranscript])
+
+  const meetingChatContext = useMemo(() => {
+    const participantList = meeting?.participants
+      ?.map(p => p.name ? `${p.name} (${p.email})` : p.email)
+      .filter(Boolean)
+      .join(', ') || 'Unknown'
+    const lines = [
+      'You are answering from the inline meeting chat. Use the full Knapsack gateway, tools, memory, and normal chat context, but prioritize the meeting context below over broader context when there is a conflict.',
+      '',
+      'Meeting details:',
+      `- Title: ${meeting?.title || thread.subtitle || 'Meeting'}`,
+      `- Participants: ${participantList}`,
+      meeting?.start ? `- Start: ${dayjs.unix(meeting.start).format('MMM D, YYYY h:mm A')}` : '',
+      meeting?.end ? `- End: ${dayjs.unix(meeting.end).format('MMM D, YYYY h:mm A')}` : '',
+      meeting?.description ? `- Description: ${meeting.description}` : '',
+      `- Recording status: ${recordingHandlers.isRecording(thread.id) ? 'currently recording' : 'not recording'}`,
+      '',
+      'Current notes:',
+      notesMarkdown || 'No notes yet.',
+      '',
+      'Transcript:',
+      meetingTranscriptContext || (thread.savedTranscript ? 'Transcript is being loaded or unavailable.' : 'No saved transcript yet. If the meeting is still live, rely on current notes and meeting details.'),
+    ]
+    return lines.filter(line => line !== '').join('\n')
+  }, [meeting, meetingTranscriptContext, notesMarkdown, recordingHandlers, thread.id, thread.savedTranscript, thread.subtitle])
 
   const [transcribingTextIndex, setTranscribingTextIndex] = useState(0)
   const transcribingTexts = [
@@ -1250,7 +1297,10 @@ Be direct, specific, and concise. No filler text.`
             templateLabel={templatePrompt.title}
             hasActionItems={hasActionItems()}
             onOpenTemplatesClick={handleOpenTemplates}
-            onViewTranscriptClick={handleOpenTranscript}
+            onViewTranscriptClick={() => handleOpenTranscript(
+              thread.id,
+              meeting?.participants?.map(p => p.name || p.email).filter(Boolean),
+            )}
             onTasksButtonClick={handleTasksButtonClick}
             onInsightsClick={handleOpenInsights ? () => handleOpenInsights(thread.id) : undefined}
             onCopyClick={() => {
@@ -1502,6 +1552,36 @@ Be direct, specific, and concise. No filler text.`
       </div>
       </div>
 
+      {isMeetingChatOpen && (
+        <div className="notetaker-note__chat-drawer">
+          <div className="notetaker-note__chat-drawer-header">
+            <div>
+              <div className="notetaker-note__chat-drawer-title">Meeting Chat</div>
+              <div className="notetaker-note__chat-drawer-subtitle">
+                Full gateway chat, grounded first in this meeting.
+              </div>
+            </div>
+            <button
+              className="notetaker-note__chat-drawer-close"
+              onClick={() => setIsMeetingChatOpen(false)}
+              title="Close meeting chat"
+            >
+              ×
+            </button>
+          </div>
+          <div className="notetaker-note__chat-drawer-body">
+            <ClawdChat
+              userName={userName}
+              userEmail={userEmail}
+              compact
+              title="Meeting Chat"
+              contextPrefix={meetingChatContext}
+              initialInput="What should I pay attention to in this meeting?"
+            />
+          </div>
+        </div>
+      )}
+
       {/* Notetaker bottom bar */}
       <div className="notetaker-note__bottom-bar">
         {recordingHandlers.isRecording(thread.id) ? (
@@ -1516,7 +1596,19 @@ Be direct, specific, and concise. No filler text.`
             <div className="notetaker-note__bottom-recording-status">
               Privately transcribing...
             </div>
-            <div className="flex-1" />
+            <div
+              className="notetaker-note__bottom-chat"
+              onClick={openMeetingChat}
+              style={{ cursor: 'pointer' }}
+            >
+              <input
+                type="text"
+                placeholder="Ask about the meeting"
+                className="notetaker-note__bottom-chat-input"
+                readOnly
+                style={{ cursor: 'pointer' }}
+              />
+            </div>
             <button
               className="notetaker-note__bottom-stop"
               onClick={() => handleStopRecording('Manually')}
@@ -1537,7 +1629,7 @@ Be direct, specific, and concise. No filler text.`
             </button>
             <div
               className="notetaker-note__bottom-chat"
-              onClick={() => onChatClick?.()}
+              onClick={openMeetingChat}
               style={{ cursor: 'pointer' }}
             >
               <input
@@ -1567,6 +1659,11 @@ Be direct, specific, and concise. No filler text.`
       </div>
     </div>
   )
+}
+
+const extractTranscriptBodyForContext = (raw: string) => {
+  const parts = raw.split(/\n{3,}/).map(part => part.trim()).filter(Boolean)
+  return parts.length > 1 ? parts.slice(1).join('\n\n') : raw.trim()
 }
 
 export default MeetingNotesMode

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -31,6 +31,7 @@ interface TemplatesState {
 interface TranscriptState {
   isOpen: boolean
   threadId?: number
+  participantNames?: string[]
 }
 
 interface TasksState {
@@ -53,10 +54,11 @@ interface MeetingsTabViewProps {
   connections?: Record<string, Connection>
   onConnectCalendar?: () => void
   onBack?: () => void
-  onChatClick?: () => void
   onEmailClick?: (notesMarkdown: string, meeting?: Meeting) => void
   onAttendeeClick?: (email: string, name: string) => void
   onLibraryWorkspaceOpen?: (ws: Workspace) => void
+  userEmail?: string
+  userName?: string
 }
 
 const MeetingsTabView = ({
@@ -68,10 +70,11 @@ const MeetingsTabView = ({
   connections,
   onConnectCalendar,
   onBack,
-  onChatClick,
   onEmailClick,
   onAttendeeClick,
   onLibraryWorkspaceOpen,
+  userEmail,
+  userName,
 }: MeetingsTabViewProps) => {
   const [micPermission, setMicPermission] = useState(localStorage.getItem('micPermissionGranted') === 'true')
   const [screenPermission, setScreenPermission] = useState(localStorage.getItem('screenPermissionGranted') === 'true')
@@ -146,7 +149,7 @@ const MeetingsTabView = ({
     }))
   }
 
-  const handleOpenTranscript = async (threadId: number | undefined) => {
+  const handleOpenTranscript = async (threadId: number | undefined, participantNames?: string[]) => {
     if (!threadId) return
     if (templatesState.isOpen) {
       setTemplatesState(prev => ({ ...prev, isOpen: false }))
@@ -160,6 +163,7 @@ const MeetingsTabView = ({
     setTranscriptState(prev => ({
       isOpen: !prev.isOpen || prev.threadId !== threadId,
       threadId: threadId,
+      participantNames,
     }))
   }
 
@@ -382,10 +386,11 @@ const MeetingsTabView = ({
                       recordingHandlers={recordingHandlers}
                       handleOpenTasks={handleOpenTasks}
                       handleOpenInsights={handleOpenInsights}
-                      onChatClick={onChatClick}
                       onEmailClick={onEmailClick}
                       onAttendeeClick={onAttendeeClick}
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
+                      userEmail={userEmail}
+                      userName={userName}
                     />
                   ) : null
                 })()}
@@ -395,7 +400,11 @@ const MeetingsTabView = ({
 
           {/* Right-side panels (Templates, Transcript, Tasks) */}
           {transcriptState.isOpen && transcriptState.threadId && (
-            <TranscriptView threadId={transcriptState.threadId} onClose={closeTranscript} />
+            <TranscriptView
+              threadId={transcriptState.threadId}
+              participantNames={transcriptState.participantNames}
+              onClose={closeTranscript}
+            />
           )}
           {templatesState.isOpen && templatesState.thread && (
             <TemplatesView

--- a/src/src/components/organisms/TranscriptView/index.tsx
+++ b/src/src/components/organisms/TranscriptView/index.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getSavedTranscript } from "src/api/transcripts";
 import { detectLanguage, translateToEnglish, type DetectedLanguage } from "src/utils/translate";
 
@@ -8,11 +8,13 @@ import styles from './styles.module.scss'
 interface TranscriptViewProps {
   threadId: number
   onClose: () => void
+  participantNames?: string[]
 }
 
 const TranscriptView: React.FC<TranscriptViewProps> = ({
   threadId,
   onClose,
+  participantNames = [],
 }) => {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -29,7 +31,7 @@ const TranscriptView: React.FC<TranscriptViewProps> = ({
           setError("Transcript not found")
           return
         }
-        const text = data.content.split("\n\n\n")[1];
+        const text = extractTranscriptBody(data.content);
         setContent(text);
         setDetectedLang(detectLanguage(text ?? ''));
         setIsTranslated(false);
@@ -61,9 +63,13 @@ const TranscriptView: React.FC<TranscriptViewProps> = ({
   };
 
   const displayedContent = isTranslated ? translatedContent : content;
+  const turns = useMemo(
+    () => formatTranscriptTurns(displayedContent ?? '', participantNames),
+    [displayedContent, participantNames],
+  );
 
   return (
-    <div className="text-ks-warm-grey-900 h-screen flex flex-col overflow-hidden mt-3 mr-0 w-[18em] ml-1">
+    <div className="text-ks-warm-grey-900 h-screen flex flex-col overflow-hidden mt-3 mr-0 w-[22em] ml-1">
       <div className="flex flex-row w-full mt-6 justify-between pl-1 pr-3">
         <div className="uppercase text-ks-warm-grey-800 font-Lora font-bold text-xs leading-4 tracking-[1.44px] ml-1">
           Transcript
@@ -108,12 +114,16 @@ const TranscriptView: React.FC<TranscriptViewProps> = ({
           <>
             <div className="flex-1 flex flex-col overflow-hidden mt-6 mb-24">
               <div className={
-                  cn("space-y-4 text-sm leading-relaxed flex-1 overflow-auto pl-1 pr-3",
+                  cn("space-y-3 text-sm leading-relaxed flex-1 overflow-auto pl-1 pr-3",
                      styles.scrollbarHide)}>
-                {displayedContent?.split('\n').map((paragraph, index) => (
-                  <p key={index} className="text-start leading-[1.6] mb-2">
-                    {paragraph}
-                  </p>
+                {turns.map((turn, index) => (
+                  <article key={index} className={styles.turn}>
+                    <div className={styles.turnHeader}>
+                      <span className={styles.speaker}>{turn.speaker}</span>
+                      {turn.inferred && <span className={styles.inferred}>inferred</span>}
+                    </div>
+                    <p className={styles.turnText}>{turn.text}</p>
+                  </article>
                 ))}
               </div>
             </div>
@@ -125,3 +135,97 @@ const TranscriptView: React.FC<TranscriptViewProps> = ({
 }
 
 export default TranscriptView;
+
+interface TranscriptTurn {
+  speaker: string
+  text: string
+  inferred: boolean
+}
+
+const extractTranscriptBody = (raw: string) => {
+  const parts = raw.split(/\n{3,}/).map(part => part.trim()).filter(Boolean)
+  return parts.length > 1 ? parts.slice(1).join('\n\n') : raw.trim()
+}
+
+const formatTranscriptTurns = (raw: string, participantNames: string[]): TranscriptTurn[] => {
+  const text = raw.replace(/\r/g, '').trim()
+  if (!text) return []
+
+  const knownSpeakers = participantNames
+    .map(name => name.trim())
+    .filter(Boolean)
+  const fallbackSpeakers = knownSpeakers.length > 0
+    ? knownSpeakers.slice(0, 4)
+    : ['Speaker 1', 'Speaker 2']
+
+  const explicitTurns = parseExplicitSpeakerTurns(text, knownSpeakers)
+  if (explicitTurns.length > 0) return explicitTurns
+
+  return inferSpeakerTurns(text, fallbackSpeakers)
+}
+
+const parseExplicitSpeakerTurns = (text: string, knownSpeakers: string[]): TranscriptTurn[] => {
+  const speakerPattern = /^([A-Z][\w'.-]+(?:\s+[A-Z][\w'.-]+){0,3}|Speaker\s+\d+|You|Me)\s*:\s*(.+)$/i
+  const turns: TranscriptTurn[] = []
+
+  text.split(/\n+/).forEach(line => {
+    const trimmed = line.trim()
+    if (!trimmed) return
+    const match = trimmed.match(speakerPattern)
+    if (!match) {
+      if (turns.length > 0) {
+        turns[turns.length - 1].text += ` ${trimmed}`
+      }
+      return
+    }
+    turns.push({
+      speaker: normalizeSpeakerName(match[1], knownSpeakers),
+      text: match[2].trim(),
+      inferred: false,
+    })
+  })
+
+  return turns
+}
+
+const inferSpeakerTurns = (text: string, speakerNames: string[]): TranscriptTurn[] => {
+  const sentences = text
+    .replace(/\s+/g, ' ')
+    .match(/[^.!?]+[.!?]+(?:["']|\))?|[^.!?]+$/g)
+    ?.map(sentence => sentence.trim())
+    .filter(Boolean) ?? []
+
+  if (sentences.length === 0) return []
+
+  const turns: TranscriptTurn[] = []
+  let speakerIndex = 0
+
+  sentences.forEach((sentence, index) => {
+    const startsResponse = /^(yes|yeah|yep|no|right|okay|ok|exactly|interesting|got it|sure|well)\b/i.test(sentence)
+    const previous = turns[turns.length - 1]
+    const previousLooksLikeQuestion = previous?.text.trim().endsWith('?')
+    const shouldStartTurn =
+      index === 0 ||
+      previousLooksLikeQuestion ||
+      startsResponse ||
+      previous.text.length > 260
+
+    if (shouldStartTurn) {
+      if (index > 0) speakerIndex = (speakerIndex + 1) % Math.max(speakerNames.length, 1)
+      turns.push({
+        speaker: speakerNames[speakerIndex] ?? `Speaker ${speakerIndex + 1}`,
+        text: sentence,
+        inferred: true,
+      })
+    } else {
+      previous.text += ` ${sentence}`
+    }
+  })
+
+  return turns
+}
+
+const normalizeSpeakerName = (speaker: string, knownSpeakers: string[]) => {
+  const known = knownSpeakers.find(name => name.toLowerCase() === speaker.toLowerCase())
+  return known ?? speaker
+}

--- a/src/src/components/organisms/TranscriptView/styles.module.scss
+++ b/src/src/components/organisms/TranscriptView/styles.module.scss
@@ -6,3 +6,44 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+.turn {
+  border: 1px solid #ecebea;
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px 12px;
+}
+
+.turnHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+
+.speaker {
+  color: #333333;
+  font-family: Inter, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.inferred {
+  color: #8a8787;
+  background: #f3f2f1;
+  border-radius: 4px;
+  font-family: Inter, sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  text-transform: uppercase;
+}
+
+.turnText {
+  color: #222222;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 0;
+  white-space: pre-wrap;
+}

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -655,10 +655,11 @@ function Home({
                   recordingHandlers={recordingHandlers}
                   connections={connections}
                   onConnectCalendar={() => onConnectAccountClick([ConnectionKeys.GOOGLE_CALENDAR])}
+                  userEmail={userEmail}
+                  userName={userName}
                   onBack={() => {
                     // Back from note view returns to sidebar
                   }}
-                  onChatClick={() => setMeetingSubView('chat')}
                   onAttendeeClick={(email, name) => {
                     setChatInitialInput(`Tell me about ${name || email}`)
                     setMeetingSubView('chat')

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -253,6 +253,7 @@ html, body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
 }
 
 .notetaker-note__scroll-area {
@@ -436,6 +437,63 @@ html, body {
 
 .notetaker-note__bottom-action svg {
   flex-shrink: 0;
+}
+
+.notetaker-note__chat-drawer {
+  position: absolute;
+  right: 16px;
+  bottom: 58px;
+  width: min(540px, calc(100% - 32px));
+  max-height: min(620px, calc(100% - 96px));
+  height: min(620px, calc(100% - 96px));
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #ffffff;
+  border: 1px solid #E3E2E2;
+  border-radius: 8px;
+  box-shadow: 0 -4px 18px rgba(0, 0, 0, 0.12);
+}
+
+.notetaker-note__chat-drawer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #E3E2E2;
+}
+
+.notetaker-note__chat-drawer-title {
+  color: #333333;
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.notetaker-note__chat-drawer-subtitle {
+  color: #6A6969;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 1.35;
+  margin-top: 2px;
+}
+
+.notetaker-note__chat-drawer-close {
+  border: none;
+  background: transparent;
+  color: #8A8787;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.notetaker-note__chat-drawer-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* Recording-specific bottom bar */


### PR DESCRIPTION
## Summary

- Adds an inline Meeting Chat drawer to the meeting notes experience.
- Reuses the normal ClawdChat gateway flow while prepending meeting-specific context, including participants, current notes, recording state, and saved transcript.
- Improves transcript presentation by grouping speaker turns and inferring likely speakers from attendee names.

## Why

The meeting screen should support asking questions during or after a meeting without leaving the notes/transcript context. Chat responses should still use the full normal gateway context, but prioritize the meeting details already on screen.

## Validation

- `npx tsc --noEmit`
- `git diff --check`