### PR TITLE
[codex] Prevent clawdbot self-link build loops

### DIFF
--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -130,9 +130,24 @@ for (const dir of clawdbotDirs) {
   }
 }
 
-// Step 3: ensure the openclaw self-link exists in each clawdbot dir so that
-// bundled extensions can resolve `openclaw/plugin-sdk/*` imports at runtime.
-for (const dir of clawdbotDirs) {
+// Step 3: ensure the openclaw self-link exists only in copied runtime dirs.
+// Do not create it in the source resources/clawdbot tree: node_modules/openclaw
+// points back to the clawdbot root, and Tauri's resources/clawdbot/**/* glob
+// follows that cycle during dev/build, producing enormous recursive
+// cargo:rerun-if-changed paths. service.rs recreates the link at runtime after
+// resources have been copied, so the source bundle should remain acyclic.
+const sourceSelfLinkPath = path.join(SOURCE_CLAWDBOT_DIR, 'node_modules', 'openclaw');
+try {
+  const stat = fs.lstatSync(sourceSelfLinkPath);
+  if (stat.isSymbolicLink()) {
+    fs.unlinkSync(sourceSelfLinkPath);
+    console.log('[ensure-clawdbot-deps] Removed source openclaw self-link to prevent Tauri glob recursion');
+  }
+} catch {
+  // absent is fine
+}
+
+for (const dir of clawdbotDirs.filter(dir => dir !== SOURCE_CLAWDBOT_DIR)) {
   if (!fs.existsSync(dir)) continue;
   const selfLinkPath = path.join(dir, 'node_modules', 'openclaw');
   if (!fs.existsSync(selfLinkPath)) {

--- a/src/src-tauri/build.rs
+++ b/src/src-tauri/build.rs
@@ -28,6 +28,7 @@ fn remove_broken_symlinks_recursive(dir: &Path) {
 
 fn main() {
     let node_modules = Path::new("resources/clawdbot/node_modules");
+    let openclaw_self_link = node_modules.join("openclaw");
 
     // Remove .pnpm virtual store — not needed at runtime with hoisted
     // node_modules, and it contains thousands of internal symlinks that
@@ -41,6 +42,15 @@ fn main() {
     // tauri_build to fail.
     if node_modules.exists() {
         remove_broken_symlinks_recursive(node_modules);
+    }
+
+    // Keep the source resource tree acyclic for Tauri's resources/clawdbot/**/*
+    // glob. The runtime recreates node_modules/openclaw -> .. after resources
+    // are copied, so it should not exist while Cargo/Tauri are scanning.
+    if let Ok(meta) = openclaw_self_link.symlink_metadata() {
+        if meta.file_type().is_symlink() {
+            let _ = fs::remove_file(&openclaw_self_link);
+        }
     }
 
     // Fail the build early if the bundled Node.js binary is missing.


### PR DESCRIPTION
## Summary

- Stops the dependency bootstrap script from creating the source-tree `resources/clawdbot/node_modules/openclaw -> ..` self-link.
- Keeps the runtime/debug copied-resource self-link behavior where the gateway expects it.
- Adds a defensive cleanup in `src-tauri/build.rs` before Tauri scans bundled resources.

## Root Cause

The source-tree self-link let Tauri's resource scanner walk `resources/clawdbot/node_modules/openclaw/node_modules/openclaw/...`, producing huge repeated `cargo:rerun-if-changed` output and missing-path messages such as `.bin/esvalidate does not exist` in dev builds.

## Validation

- `node scripts/ensure-clawdbot-deps.cjs` leaves the source self-link absent.
- `cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-apple-darwin` passed in the prepared checkout with bundled Node present.
- A clean isolated worktree check confirmed the recursive `openclaw/node_modules/openclaw` paths no longer appear, but could not complete there because the untracked bundled Node binary was not present in that worktree.
- `git diff --check`