### PR TITLE
[codex] Fix mic-triggered recording prompts

### DIFF
--- a/src/src-tauri/src/audio/audio.rs
+++ b/src/src-tauri/src/audio/audio.rs
@@ -1237,7 +1237,7 @@ async fn stream_audio(
         should_stop_flag = false;
       } else if let Some(end_time) = meeting_end_time {
         if Utc::now() > end_time {
-          handle_stop_events(&app_handle).await;
+          handle_stop_events(&app_handle, &recording_state).await;
           should_stop_flag = false;
           stop_event_called = true;
         } else if (Utc::now() - should_stop_time) >= ChronoDuration::seconds(3) {
@@ -1277,7 +1277,10 @@ async fn stream_audio(
   Ok(())
 }
 
-async fn handle_stop_events(app_handle: &tauri::AppHandle) -> Result<(), Error> {
+async fn handle_stop_events(
+  app_handle: &tauri::AppHandle,
+  recording_state: &RecordingState,
+) -> Result<(), Error> {
   let window = match app_handle.get_window(WINDOW_LABEL) {
     Some(w) => w,
     None => {
@@ -1291,10 +1294,15 @@ async fn handle_stop_events(app_handle: &tauri::AppHandle) -> Result<(), Error> 
     let _ = indicator_window.hide();
   }
 
-  let _ = window.emit("open_feed_item", {});
-  sleep(Duration::from_millis(100)).await;
+  let active_thread_id = {
+    let thread_id_guard = recording_state.thread_id.lock().unwrap();
+    *thread_id_guard
+  };
 
-  let _ = window.emit("stop_recording", {});
+  let _ = window.emit("open_feed_item", json!({ "threadId": active_thread_id }));
+  sleep(Duration::from_millis(750)).await;
+
+  let _ = window.emit("stop_recording", json!({ "threadId": active_thread_id }));
   sleep(Duration::from_millis(500)).await;
 
   focus_window(window);
@@ -1302,8 +1310,11 @@ async fn handle_stop_events(app_handle: &tauri::AppHandle) -> Result<(), Error> 
 }
 
 #[tauri::command]
-pub async fn emit_stop_events(app_handle: tauri::AppHandle) -> Result<(), String> {
-  match handle_stop_events(&app_handle).await {
+pub async fn emit_stop_events(
+  app_handle: tauri::AppHandle,
+  recording_state: tauri::State<'_, RecordingState>,
+) -> Result<(), String> {
+  match handle_stop_events(&app_handle, &recording_state).await {
     Ok(_) => Ok(()),
     Err(e) => {
       let err_msg = format!("Error in stop Recording from tauri command: {:?}", e);

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -9,7 +9,7 @@ extern crate derive_more;
 extern crate dirs;
 extern crate qdrant_client;
 extern crate serde;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 extern crate tokio;
 
 mod api;
@@ -388,6 +388,80 @@ async fn kn_get_search_indexing_status(
 struct ButtonConfig {
   button_text: String,
   button_handler: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FrontmostAppInfo {
+  name: String,
+  bundle_id: Option<String>,
+  window_title: Option<String>,
+}
+
+#[tauri::command]
+fn get_frontmost_app_info() -> Result<FrontmostAppInfo, String> {
+  #[cfg(target_os = "macos")]
+  {
+    use std::process::Command;
+
+    let script = r#"
+      tell application "System Events"
+        set frontApp to first application process whose frontmost is true
+        set appName to name of frontApp
+        set bundleId to ""
+        set windowTitle to ""
+        try
+          set bundleId to bundle identifier of frontApp
+        end try
+        try
+          set windowTitle to name of front window of frontApp
+        end try
+        return appName & linefeed & bundleId & linefeed & windowTitle
+      end tell
+    "#;
+
+    let output = Command::new("osascript")
+      .arg("-e")
+      .arg(script)
+      .output()
+      .map_err(|e| format!("Failed to inspect frontmost app: {}", e))?;
+
+    if !output.status.success() {
+      return Err(format!(
+        "Failed to inspect frontmost app: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+      ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let name = lines.next().unwrap_or_default().trim().to_string();
+    let bundle_id = lines
+      .next()
+      .map(str::trim)
+      .filter(|s| !s.is_empty())
+      .map(ToString::to_string);
+    let window_title = lines
+      .next()
+      .map(str::trim)
+      .filter(|s| !s.is_empty())
+      .map(ToString::to_string);
+
+    return Ok(FrontmostAppInfo {
+      name,
+      bundle_id,
+      window_title,
+    });
+  }
+
+  #[cfg(not(target_os = "macos"))]
+  {
+    Ok(FrontmostAppInfo {
+      name: String::new(),
+      bundle_id: None,
+      window_title: None,
+    })
+  }
 }
 
 #[tauri::command]
@@ -1609,6 +1683,7 @@ async fn main() {
       kn_get_search_indexing_status,
       start_oauth,
       show_notification_window,
+      get_frontmost_app_info,
       close_notification_window,
       start_meeting_recording,
       activate_main_window,

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -69,6 +69,53 @@ export interface IGoogleDriveItem {
   id: string
 }
 
+type FrontmostAppInfo = {
+  name?: string
+  bundleId?: string | null
+  windowTitle?: string | null
+}
+
+const EXCLUDED_MIC_PROMPT_APPS = [
+  'wispr',
+  'superwhisper',
+  'super whisper',
+  'voice control',
+  'dictation',
+  'chatgpt',
+  'claude',
+]
+
+const MEETING_MIC_PROMPT_APPS = [
+  'zoom',
+  'microsoft teams',
+  'teams',
+  'google meet',
+  'meet.google.com',
+  'slack',
+  'webex',
+  'facetime',
+  'around',
+  'whereby',
+  'gotomeeting',
+]
+
+function shouldShowMicPromptForApp(appInfo: FrontmostAppInfo | null): boolean {
+  if (!appInfo) return true
+
+  const haystack = [
+    appInfo.name,
+    appInfo.bundleId,
+    appInfo.windowTitle,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  if (!haystack) return true
+  if (EXCLUDED_MIC_PROMPT_APPS.some(app => haystack.includes(app))) return false
+  return MEETING_MIC_PROMPT_APPS.some(app => haystack.includes(app))
+}
+
 export interface IGoogleDriveData {
   docs: IGoogleDriveItem[]
   action: string
@@ -239,6 +286,7 @@ function App() {
   const {
     isRecording,
     setIsRecording,
+    activeRecordingThreadId,
     isLoadingNotes,
     startRecording,
     stopRecording,
@@ -1020,6 +1068,7 @@ function App() {
   const recordingHandlers: RecordingContextProps = {
     isRecording,
     setIsRecording,
+    activeRecordingThreadId,
     isLoadingNotes,
     startRecording,
     stopRecording,
@@ -1071,6 +1120,12 @@ function App() {
     const unlistenPromise = listen('mic-activated', async () => {
       if (isAnyRecordingRef.current || suppressMicNotificationRef.current) return
       try {
+        const appInfo = await invoke<FrontmostAppInfo>('get_frontmost_app_info').catch(error => {
+          console.warn('Unable to inspect frontmost app for mic prompt filtering:', error)
+          return null
+        })
+        if (!shouldShowMicPromptForApp(appInfo)) return
+
         await openNotificationWindow(
           undefined,
           [

--- a/src/src/components/organisms/MeetingNotesMode/RecordingContext.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/RecordingContext.tsx
@@ -12,6 +12,7 @@ import { openBesideApp } from 'src/utils/openBesideApp'
 export interface RecordingContextProps {
   isRecording: (threadId: number) => boolean
   setIsRecording: (threadId: number, isRecording: boolean) => void
+  activeRecordingThreadId: number | null
   isLoadingNotes: (threadId: number) => boolean
   startRecording: (
     setFeedIsRecording: (isRecording: boolean | undefined) => void,
@@ -66,6 +67,7 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
   const [loadingStates, setLoadingStates] = useState<Map<number, boolean>>(new Map())
   const [hasSynthesizedState, setHasSynthesizedState] = useState<Map<number, boolean>>(new Map())
   const [isAnyRecording, setIsAnyRecording] = useState(false)
+  const [activeRecordingThreadId, setActiveRecordingThreadId] = useState<number | null>(null)
   const [isPaused, setIsPaused] = useState(false)
   const isStartingRef = useRef(false)
 
@@ -94,6 +96,10 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
       const newMap = new Map(prev).set(threadId, isRecording)
       setIsAnyRecording(Array.from(newMap.values()).some(Boolean))
       return newMap
+    })
+    setActiveRecordingThreadId(prev => {
+      if (isRecording) return threadId
+      return prev === threadId ? null : prev
     })
   }, [])
 
@@ -221,6 +227,7 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
         await synthesizeContent(threadId, notesMarkdown, meeting)
         setHasSynthesized(threadId, true)
         setIsRecording(threadId, false)
+        setActiveRecordingThreadId(prev => prev === threadId ? null : prev)
         await saveNotes(threadId, notesMarkdown)
         // Emit event for post-meeting follow-up notifications
         emit('notes_synthesized', {
@@ -313,6 +320,7 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
   const contextValue = useMemo(() => ({
     isRecording,
     setIsRecording,
+    activeRecordingThreadId,
     isLoadingNotes,
     startRecording,
     stopRecording,
@@ -321,7 +329,7 @@ export const RecordingProvider: React.FC<RecordingProviderProps> = ({ children }
     isPaused,
     generateNotes,
     hasSynthesized,
-  }), [isRecording, setIsRecording, isLoadingNotes, startRecording, stopRecording, isAnyRecording, pauseRecording, isPaused, generateNotes, hasSynthesized])
+  }), [isRecording, setIsRecording, activeRecordingThreadId, isLoadingNotes, startRecording, stopRecording, isAnyRecording, pauseRecording, isPaused, generateNotes, hasSynthesized])
 
   return (
     <RecordingContext.Provider value={contextValue}>

--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -399,16 +399,21 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
         }
       },
     )
-    const unlistenAutoStartRecordingPromise = listen('stop_recording', async () => {
-      const statusDisable = await isRecordingStatus()
-      if (statusDisable && statusDisable.isRecording) {
-        setDisableIsRecording(statusDisable.threadId !== thread.id)
-      }
-      // Do NOT update isRecording state here — stopRecording() manages it.
-      // Setting it to false before calling handleStopRecording would cause
-      // wasRecording to be false inside stopRecording, preventing note generation.
-      handleStopRecording('Automatic')
-    })
+    const unlistenAutoStartRecordingPromise = listen(
+      'stop_recording',
+      async (event: Event<{ threadId?: number | null }>) => {
+        if (event.payload?.threadId && event.payload.threadId !== thread.id) return
+
+        const statusDisable = await isRecordingStatus()
+        if (statusDisable && statusDisable.isRecording) {
+          setDisableIsRecording(statusDisable.threadId !== thread.id)
+        }
+        // Do NOT update isRecording state here — stopRecording() manages it.
+        // Setting it to false before calling handleStopRecording would cause
+        // wasRecording to be false inside stopRecording, preventing note generation.
+        handleStopRecording('Automatic')
+      },
+    )
     // Listen for heartbeat insights during recording — always show inline, notify if proactive mode on
     const unlistenHeartbeatPromise = listen(
       'meeting_heartbeat',


### PR DESCRIPTION
## Summary

Fixes two issues from user feedback around meeting recording prompts:

- Suppresses mic-activated recording prompts for foreground dictation/voice assistant contexts such as Wispr, ChatGPT, Claude, and system dictation.
- Limits unscheduled mic prompts to meeting-like apps or window titles such as Zoom, Teams, Meet, Slack, Webex, FaceTime, and similar call tools.
- Makes notification-driven stop actions carry the active recording thread id so the correct meeting view handles the stop after Knapsack is brought forward.

## Root Cause

The macOS mic monitor emitted `mic-activated` whenever any input device was running anywhere. The frontend then showed a generic meeting prompt without checking whether the foreground app was actually a call surface. Separately, the notification stop path only emitted UI events and did not identify the active recording thread, so it could miss when Knapsack was minimized or not already showing the recording view.

## Validation

- `npm exec tsc -- --noEmit` from `src`
- `cargo check` from `src/src-tauri`