### PR TITLE
Fix macOS Tauri CLI install in workflows

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -63,12 +63,9 @@ jobs:
         working-directory: src
         run: node scripts/verify-clawdbot-bundle.cjs
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli@1.6.3 --locked
-
       - name: Build Tauri app (universal)
         working-directory: src
-        run: cargo tauri build --target universal-apple-darwin
+        run: npm exec -- tauri build --target universal-apple-darwin
         env:
           VITE_KN_API_SERVER: https://api.knapsack.ai
           MICROSOFT_CLIENT_ID: unused

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,9 @@ jobs:
         working-directory: src
         run: node scripts/verify-clawdbot-bundle.cjs
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli@1.6.3 --locked
-
       - name: Build Tauri app (universal)
         working-directory: src
-        run: cargo tauri build --target universal-apple-darwin
+        run: npm exec -- tauri build --target universal-apple-darwin
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}


### PR DESCRIPTION
## Summary
- Remove the macOS workflow step that runs `cargo install tauri-cli@1.6.3 --locked`.
- Build macOS via the repo's local npm-managed Tauri CLI: `npm exec -- tauri build --target universal-apple-darwin`.
- Apply the same fix to both Release and standalone Build macOS workflows.

## Context
The previous Release macOS attempt failed at `Install Tauri CLI` with:

`error: unexpected argument 'install' found`
`Usage: rustup-init[EXE] [OPTIONS]`

That means the command was being handled by `rustup-init` instead of Cargo. Since `@tauri-apps/cli@1.6.3` is already installed by `npm install` from `src/package.json`, using `npm exec -- tauri` avoids the broken cargo/rustup proxy while keeping the same Tauri CLI version.

## Verification
- `npm exec -- tauri --version` -> `tauri-cli 1.6.3`