### PR TITLE
Detect and display OpenClaw version mismatch in gateway diagnostics

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2890,6 +2890,17 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       let log_content = std::fs::read_to_string(&err_path)
         .or_else(|_| std::fs::read_to_string(&legacy_err_path));
       if let Ok(content) = log_content {
+        // Detect version mismatch before noise-filtering so we can tag diagnostic_type,
+        // even though the lines are stripped from the user-visible tail below.
+        let has_version_mismatch = content.lines().any(|l| {
+          let l = l.to_ascii_lowercase();
+          l.contains("config was last written by a newer openclaw")
+            || l.contains("config was last written by an older openclaw")
+        });
+        if has_version_mismatch && diagnostic_type.is_none() {
+          diagnostic_type = Some("version_mismatch".to_string());
+        }
+
         // Strip known-noisy lines that appear during normal gateway operation
         // and would only confuse users when shown as a diagnostic.
         let is_noise = |line: &str| {
@@ -2899,6 +2910,8 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
             || l.contains("bonjour: gateway hostname conflict resolved")
             || l.contains("unhandled promise rejection: ciao")
             || (l.contains("security warning") && l.contains("allowinsecureauth"))
+            || l.contains("config was last written by a newer openclaw")
+            || l.contains("config was last written by an older openclaw")
         };
         let all_filtered: Vec<&str> = content.lines().filter(|l| !is_noise(l)).collect();
         let start = all_filtered.len().saturating_sub(25);

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -335,6 +335,7 @@ type ServiceHealth = {
   gateway_ok: boolean
   browser_ok: boolean
   message: string
+  diagnostic_type?: string
 }
 
 type Tab = {
@@ -4850,9 +4851,13 @@ ${actualText}`
         {hasCompletedOnboarding && health && !health.gateway_ok && gatewayDownPolls >= 3 && !channelStatus.gatewayStarting && (
           <div className="ClawdMsg ClawdMsg-assistant">
             <div className="ClawdBubble ClawdGatewayBanner">
-              <p className="ClawdGatewayBannerTitle">Gateway connectivity issue</p>
+              <p className="ClawdGatewayBannerTitle">
+                {health.diagnostic_type === 'version_mismatch' ? 'OpenClaw version mismatch' : 'Gateway connectivity issue'}
+              </p>
               <p className="ClawdGatewayBannerDesc">
-                The gateway isn't responding. This can happen after a crash, permission change, or system sleep. Try one of these:
+                {health.diagnostic_type === 'version_mismatch'
+                  ? 'The gateway config was written by a different OpenClaw version. Knapsack will attempt to recover automatically — if the gateway does not come back up, try restarting it below.'
+                  : 'The gateway isn\'t responding. This can happen after a crash, permission change, or system sleep. Try one of these:'}
               </p>
               <div className="ClawdPromptActions">
                 <button


### PR DESCRIPTION
## Summary
Adds detection and user-facing messaging for OpenClaw version mismatch errors in the gateway health diagnostics. When the gateway config was written by a different OpenClaw version, the UI now displays a specific error message instead of the generic "Gateway connectivity issue" banner.

## Changes
- **`clawd/service.rs`**: 
  - Detect version mismatch errors in gateway logs before noise-filtering
  - Set `diagnostic_type` to `"version_mismatch"` when detected
  - Add version mismatch lines to the noise filter so they don't appear in the user-visible log tail
  
- **`ClawdChat/index.tsx`**:
  - Add `diagnostic_type` field to `ServiceHealth` type
  - Conditionally render banner title and description based on diagnostic type
  - Show "OpenClaw version mismatch" title and recovery instructions when `diagnostic_type === 'version_mismatch'`
  - Fall back to generic "Gateway connectivity issue" messaging for other cases

## Implementation Details
Version mismatch detection looks for log lines containing:
- `"config was last written by a newer openclaw"`
- `"config was last written by an older openclaw"`

These lines are detected early (before noise-filtering) so the diagnostic type can be tagged, then filtered out from the user-visible log tail to avoid confusion.

https://claude.ai/code/session_01BDm7nLiuES4mVDiaAabX4G