### PR TITLE
Remove NSIS web installer stub and related infrastructure

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -260,56 +260,9 @@ jobs:
           path: ${{ runner.temp }}/tauri-build.log
           if-no-files-found: ignore
 
-      - name: Build web installer stub
-        shell: pwsh
-        run: |
-          # Windows-2022 runners ship NSIS; use it to compile the stub.
-          $makensis = "C:\Program Files (x86)\NSIS\makensis.exe"
-          if (-not (Test-Path $makensis)) {
-            Write-Error "NSIS not found at $makensis"; exit 1
-          }
-          & $makensis /V3 src\installer\stub.nsi
-          if ($LASTEXITCODE -ne 0) { Write-Error "makensis failed"; exit 1 }
-          Write-Host "Built: src\installer\Knapsack-web-setup.exe"
-
-      - name: Sign web installer stub
-        if: env.AZURE_KEY_VAULT_URI != ''
-        shell: pwsh
-        env:
-          AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
-          AZURE_KEY_VAULT_CERT_NAME: ${{ secrets.AZURE_KEY_VAULT_CERT_NAME }}
-          AZURE_KEY_VAULT_CLIENT_ID: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
-          AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-          AZURE_KEY_VAULT_TENANT_ID: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
-        run: |
-          AzureSignTool sign `
-            -kvu "$env:AZURE_KEY_VAULT_URI" `
-            -kvc "$env:AZURE_KEY_VAULT_CERT_NAME" `
-            -kvi "$env:AZURE_KEY_VAULT_CLIENT_ID" `
-            -kvs "$env:AZURE_KEY_VAULT_CLIENT_SECRET" `
-            -kvt "$env:AZURE_KEY_VAULT_TENANT_ID" `
-            -tr http://timestamp.globalsign.com/tsa/advanced `
-            -td sha256 `
-            src\installer\Knapsack-web-setup.exe
-          Write-Host "Signed: Knapsack-web-setup.exe"
-
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v6
         with:
           name: knapsack-windows-msi
           path: src/src-tauri/target/release/bundle/msi/*.msi
-          if-no-files-found: warn
-
-      - name: Upload NSIS artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: knapsack-windows-nsis
-          path: src/src-tauri/target/release/bundle/nsis/*.exe
-          if-no-files-found: warn
-
-      - name: Upload web installer stub artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: knapsack-windows-web-setup
-          path: src/installer/Knapsack-web-setup.exe
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Windows — MSI installer (WiX, 64-bit) + lightweight NSIS web-setup stub
+  # Windows — MSI installer (WiX, 64-bit)
   # ---------------------------------------------------------------------------
   build-windows:
     needs: bump-version
@@ -410,43 +410,6 @@ jobs:
           path: ${{ runner.temp }}/tauri-build.log
           if-no-files-found: ignore
 
-      - name: Build web installer stub
-        shell: pwsh
-        run: |
-          $makensis = "C:\Program Files (x86)\NSIS\makensis.exe"
-          if (-not (Test-Path $makensis)) {
-            Write-Error "NSIS not found at $makensis"; exit 1
-          }
-          & $makensis /V3 src\installer\stub.nsi
-          if ($LASTEXITCODE -ne 0) { Write-Error "makensis failed"; exit 1 }
-          Write-Host "Built: src\installer\Knapsack-web-setup.exe"
-
-      - name: Sign web installer stub
-        if: env.AZURE_KEY_VAULT_URI != ''
-        shell: pwsh
-        env:
-          AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
-          AZURE_KEY_VAULT_CERT_NAME: ${{ secrets.AZURE_KEY_VAULT_CERT_NAME }}
-          AZURE_KEY_VAULT_CLIENT_ID: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
-          AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-          AZURE_KEY_VAULT_TENANT_ID: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
-        run: |
-          $installerPath = "src\installer\Knapsack-web-setup.exe"
-          if (-not (Test-Path $installerPath)) {
-            Write-Error "Installer not found at $installerPath"
-            exit 1
-          }
-          AzureSignTool sign `
-            -kvu "$env:AZURE_KEY_VAULT_URI" `
-            -kvc "$env:AZURE_KEY_VAULT_CERT_NAME" `
-            -kvi "$env:AZURE_KEY_VAULT_CLIENT_ID" `
-            -kvs "$env:AZURE_KEY_VAULT_CLIENT_SECRET" `
-            -kvt "$env:AZURE_KEY_VAULT_TENANT_ID" `
-            -tr http://timestamp.globalsign.com/tsa/advanced `
-            -td sha256 `
-            "$installerPath"
-          Write-Host "Signed: Knapsack-web-setup.exe"
-
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v6
         with:
@@ -455,7 +418,6 @@ jobs:
             src/src-tauri/target/release/bundle/msi/*.msi
             src/src-tauri/target/release/bundle/msi/*.msi.zip
             src/src-tauri/target/release/bundle/msi/*.msi.zip.sig
-            src/installer/Knapsack-web-setup.exe
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -503,18 +465,6 @@ jobs:
             fi
           done
 
-          # Find the MSI installer (exclude the zip and sig variants).
-          # This URL is used by the stub installer to download and install the MSI.
-          WIN_MSI_NAME=""
-          for f in artifacts/windows-artifacts/**/*.msi artifacts/windows-artifacts/*.msi; do
-            name=$(basename "$f")
-            # Skip .msi.zip files
-            if [ -f "$f" ] && [[ "$name" != *.zip ]]; then
-              WIN_MSI_NAME="$name"
-              break
-            fi
-          done
-
           # Build latest.json
           cat > artifacts/latest.json <<EOF
           {
@@ -532,8 +482,7 @@ jobs:
               },
               "windows-x86_64": {
                 "url": "$RELEASE_URL/$WIN_ZIP_NAME",
-                "signature": "$WIN_SIG",
-                "setupUrl": "$RELEASE_URL/$WIN_MSI_NAME"
+                "signature": "$WIN_SIG"
               }
             }
           }
@@ -548,9 +497,7 @@ jobs:
           # macOS
           find artifacts/macos-artifacts -type f \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \) -exec cp {} release-files/ \;
           # Windows
-          find artifacts/windows-artifacts -type f \( -name "*.msi" -o -name "*.msi.zip" -o -name "*.msi.zip.sig" -o -name "Knapsack-web-setup.exe" \) -exec cp {} release-files/ \;
-          # Web installer stub (promote to top-level with a stable name)
-          find artifacts/windows-artifacts -name "Knapsack-web-setup.exe" -exec cp {} release-files/ \; 2>/dev/null || true
+          find artifacts/windows-artifacts -type f \( -name "*.msi" -o -name "*.msi.zip" -o -name "*.msi.zip.sig" \) -exec cp {} release-files/ \;
           # Updater metadata
           cp artifacts/latest.json release-files/
           echo "[release] Files to upload:"


### PR DESCRIPTION
## Summary
Removes the NSIS-based web installer stub (`Knapsack-web-setup.exe`) and all associated build, signing, and release infrastructure. The MSI installer is now the sole Windows distribution method.

## Changes
- **Removed build steps**: Deleted NSIS compilation (`makensis`) and Azure Key Vault signing for the web installer stub from both `release.yml` and `build-windows.yml`
- **Removed artifact uploads**: Eliminated artifact upload steps for the NSIS stub in `build-windows.yml`
- **Simplified release metadata**: Removed `setupUrl` field from `latest.json` Windows entry; now only includes direct MSI download URL and signature
- **Cleaned up release packaging**: Removed web installer stub from artifact collection and release file staging in `release.yml`
- **Updated workflow documentation**: Changed Windows build job description from "MSI installer (WiX, 64-bit) + lightweight NSIS web-setup stub" to "MSI installer (WiX, 64-bit)"

## Implementation Details
- The MSI installer (built via WiX) remains the primary Windows distribution method
- Removed ~100 lines of PowerShell build and signing logic across both workflows
- Simplified the updater metadata structure by removing the `setupUrl` field that pointed to the web installer
- No changes to MSI build, signing, or distribution logic

https://claude.ai/code/session_01UPvknvu4axBK39nb7Qiq4i