### PR TITLE
Add model fallback support for rate-limit resilience

### DIFF
--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -129,7 +129,9 @@ const distDir = path.join(CLAWDBOT_DIR, 'dist');
 const relativeImportRegexes = [
   /(?:^|[;\n]\s*)import\s+(?:[^"';]+?\s+from\s+)?["'](\.{1,2}\/[^"']+)["']/g,
   /(?:^|[;\n]\s*)export\s+[^"';]+?\s+from\s+["'](\.{1,2}\/[^"']+)["']/g,
-  /(?:^|[=({[,;:\n]\s*)import\s*\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g,
+  // Matches dynamic import() — both `await import(...)` (space before "import")
+  // and call-expression forms like `foo(import(...))`, assignments, etc.
+  /(?:^|[=({[,;:\n\s]\s*)import\s*\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g,
 ];
 
 for (const jsFile of walkFiles(distDir)) {

--- a/src/src-tauri/resources/clawdbot/dist/extensions/slack/package.json
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/slack/package.json
@@ -8,7 +8,9 @@
     "@slack/bolt": "^4.7.1",
     "@slack/web-api": "^7.15.1",
     "https-proxy-agent": "^9.0.0",
-    "typebox": "1.1.33"
+    "typebox": "1.1.33",
+    "combined-stream": "^1.0.8",
+    "lodash.includes": "^4.3.0"
   },
   "openclaw": {
     "extensions": [

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -690,9 +690,10 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
         cfg.pointer_mut("/agents").unwrap().as_object_mut().unwrap()
           .insert("defaults".into(), serde_json::json!({}));
       }
-      // Write as plain string (gateway accepts both forms; string is simpler).
+      // Write as object with fallbacks so the gateway can retry when the primary
+      // model is rate-limited (429) or overloaded (503).
       cfg.pointer_mut("/agents/defaults").unwrap().as_object_mut().unwrap()
-        .insert("model".into(), serde_json::json!(current_model));
+        .insert("model".into(), build_model_config());
       eprintln!("[gateway_client] Patched agents.defaults.model: {:?} → '{}'", disk_model, current_model);
       patched = true;
     }
@@ -769,6 +770,12 @@ pub fn resolve_default_model() -> String {
         .unwrap_or_else(|_| "gemini-2.0-flash".to_string());
       return format!("google/{}", model);
     }
+    // Google OAuth CLI auth (no API key env var — credentials stored in auth-profiles.json).
+    "google-gemini-cli" => {
+      let model = std::env::var("KNAPSACK_GEMINI_MODEL")
+        .unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+      return format!("google-gemini-cli/{}", model);
+    }
     _ => {}
   }
 
@@ -777,7 +784,9 @@ pub fn resolve_default_model() -> String {
   let disable_paid = std::env::var("KNAPSACK_DISABLE_PAID_FALLBACK")
     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
     .unwrap_or(true);
-  let active_is_free = matches!(active.as_str(), "groq" | "gemini" | "ollama" | "openrouter");
+  // google-gemini-cli is OAuth-based (free tier) — treat it as a free provider
+  // so paid fallbacks are not silently selected when the CLI model is unavailable.
+  let active_is_free = matches!(active.as_str(), "groq" | "gemini" | "ollama" | "openrouter" | "google-gemini-cli");
 
   if !disable_paid || !active_is_free {
     if has_key("ANTHROPIC_API_KEY") {
@@ -823,6 +832,53 @@ pub fn resolve_default_model() -> String {
   // Final fallback: use Groq free model instead of expensive Anthropic Opus
   log::warn!("[resolve_default_model] No provider keys found, defaulting to groq/llama-3.3-70b-versatile");
   "groq/llama-3.3-70b-versatile".to_string()
+}
+
+/// Return fallback model refs to try when the primary model is rate-limited or overloaded.
+///
+/// Fallbacks are sourced from providers whose API keys are available and differ from the
+/// primary's provider.  Groq is preferred as a fallback because it is free and fast.
+/// Called by `build_model_config()` — prefer that over calling this directly.
+pub fn collect_fallback_models(primary: &str) -> Vec<String> {
+  let has_key = |var: &str| std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false);
+  let primary_provider = primary.split('/').next().unwrap_or("").to_lowercase();
+  let mut fallbacks = Vec::new();
+
+  // Groq first: free, fast, and a good rate-limit escape hatch.
+  if primary_provider != "groq" && has_key("GROQ_API_KEY") {
+    let model = std::env::var("KNAPSACK_GROQ_MODEL")
+      .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
+    fallbacks.push(format!("groq/{}", model));
+  }
+
+  // Google/Gemini as fallback when the primary is not already a Google provider.
+  let is_google_primary = matches!(
+    primary_provider.as_str(),
+    "google" | "gemini" | "google-gemini-cli"
+  );
+  if !is_google_primary && has_key("GEMINI_API_KEY") {
+    let model = std::env::var("KNAPSACK_GEMINI_MODEL")
+      .unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+    fallbacks.push(format!("google/{}", model));
+  }
+
+  fallbacks
+}
+
+/// Build the `agents.defaults.model` config object for the gateway.
+///
+/// Returns `{"primary": "...", "fallbacks": [...]}` when fallback providers are
+/// available, or `{"primary": "..."}` when none are.  The gateway uses `fallbacks`
+/// to retry with an alternative model when the primary is rate-limited (429) or
+/// overloaded (503), preventing `FailoverError` propagation to the user.
+pub fn build_model_config() -> serde_json::Value {
+  let primary = resolve_default_model();
+  let fallbacks = collect_fallback_models(&primary);
+  if fallbacks.is_empty() {
+    serde_json::json!({"primary": primary})
+  } else {
+    serde_json::json!({"primary": primary, "fallbacks": fallbacks})
+  }
 }
 
 /// connection.  config.patch triggers a SIGUSR1 restart on the gateway, so
@@ -1025,7 +1081,7 @@ async fn apply_runtime_browser_config(token: &str) {
   let model_changed = existing_model.as_deref() != Some(&model);
   patch_obj.as_object_mut().unwrap().insert(
     "agents".to_string(),
-    serde_json::json!({"defaults": {"model": model}}),
+    serde_json::json!({"defaults": {"model": build_model_config()}}),
   );
   if model_changed {
     eprintln!("[gateway_client] agents.defaults.model updated: {:?} → '{}' in runtime patch", existing_model, model);

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3684,6 +3684,7 @@ pub async fn set_api_key(
     let config_path = app_clawdbot_home(&app_handle).join("openclaw.json");
     if let Ok(cfg_str) = fs::read_to_string(&config_path) {
       if let Ok(mut cfg_val) = serde_json::from_str::<serde_json::Value>(&cfg_str) {
+        let model_cfg = crate::clawd::gateway_client::build_model_config();
         let model = crate::clawd::gateway_client::resolve_default_model();
         let agents = cfg_val
           .as_object_mut()
@@ -3697,7 +3698,7 @@ pub async fn set_api_key(
           .entry("defaults")
           .or_insert_with(|| serde_json::json!({}));
         defaults.as_object_mut().map(|d| {
-          d.insert("model".to_string(), serde_json::json!({"primary": model}));
+          d.insert("model".to_string(), model_cfg);
         });
         if let Ok(json) = serde_json::to_string_pretty(&cfg_val) {
           let _ = fs::write(&config_path, json);
@@ -3908,6 +3909,7 @@ pub async fn set_api_key(
   if let Ok(cfg_str) = fs::read_to_string(&config_path) {
     if let Ok(mut cfg_val) = serde_json::from_str::<serde_json::Value>(&cfg_str) {
       let model = crate::clawd::gateway_client::resolve_default_model();
+      let model_cfg = crate::clawd::gateway_client::build_model_config();
       let agents = cfg_val
         .as_object_mut()
         .unwrap()
@@ -3920,7 +3922,7 @@ pub async fn set_api_key(
         .entry("defaults")
         .or_insert_with(|| serde_json::json!({}));
       defaults.as_object_mut().map(|d| {
-        d.insert("model".to_string(), serde_json::json!({"primary": model}));
+        d.insert("model".to_string(), model_cfg);
       });
       if let Ok(json) = serde_json::to_string_pretty(&cfg_val) {
         let _ = fs::write(&config_path, json);
@@ -4198,6 +4200,7 @@ pub async fn ollama_configure(
   if let Ok(cfg_str) = fs::read_to_string(&config_path) {
     if let Ok(mut cfg_val) = serde_json::from_str::<serde_json::Value>(&cfg_str) {
       let model = crate::clawd::gateway_client::resolve_default_model();
+      let model_cfg = crate::clawd::gateway_client::build_model_config();
       let agents = cfg_val
         .as_object_mut()
         .unwrap()
@@ -4210,7 +4213,7 @@ pub async fn ollama_configure(
         .entry("defaults")
         .or_insert_with(|| serde_json::json!({}));
       defaults.as_object_mut().map(|d| {
-        d.insert("model".to_string(), serde_json::json!({"primary": model}));
+        d.insert("model".to_string(), model_cfg);
       });
       if let Ok(json) = serde_json::to_string_pretty(&cfg_val) {
         let _ = fs::write(&config_path, json);
@@ -4221,6 +4224,7 @@ pub async fn ollama_configure(
   }
 
   // Push model change to the running gateway immediately
+  let ollama_model_cfg = crate::clawd::gateway_client::build_model_config();
   let ollama_model = crate::clawd::gateway_client::resolve_default_model();
   tokio::spawn(async move {
     if !crate::clawd::gateway_client::is_gateway_port_open().await {
@@ -4233,7 +4237,7 @@ pub async fn ollama_configure(
         .unwrap_or("");
       if !base_hash.is_empty() {
         let patch = serde_json::json!({
-          "agents": {"defaults": {"model": {"primary": ollama_model}}}
+          "agents": {"defaults": {"model": ollama_model_cfg}}
         });
         match crate::clawd::gateway_client::config_patch(
           &patch.to_string(), base_hash, None
@@ -4736,7 +4740,7 @@ async fn prepare_gateway_config(
     let agents_defaults = if any_provider_key_available() {
       serde_json::json!({
         "defaults": {
-          "model": {"primary": crate::clawd::gateway_client::resolve_default_model()}
+          "model": crate::clawd::gateway_client::build_model_config()
         }
       })
     } else {
@@ -4977,7 +4981,7 @@ async fn prepare_gateway_config(
             }
             cfg_val.pointer_mut("/agents/defaults").unwrap().as_object_mut().unwrap().insert(
               "model".to_string(),
-              serde_json::json!({"primary": new_model.clone()}),
+              crate::clawd::gateway_client::build_model_config(),
             );
             eprintln!(
               "[clawd/service] Patched agents.defaults.model.primary: {:?} → '{}' (provider key mismatch)",
@@ -7491,6 +7495,33 @@ async fn do_gemini_connect(app_handle: &tauri::AppHandle, code: &str) -> Result<
     .map_err(|e| format!("Failed to save tokens: {}", e))?;
 
   std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "google-gemini-cli");
+
+  // Sync openclaw.json model to the Gemini CLI provider so the gateway starts
+  // with the correct model (and fallbacks) instead of a stale one from before.
+  {
+    let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+    if let Ok(cfg_str) = fs::read_to_string(&config_path) {
+      if let Ok(mut cfg_val) = serde_json::from_str::<serde_json::Value>(&cfg_str) {
+        let model_cfg = crate::clawd::gateway_client::build_model_config();
+        let model_str = crate::clawd::gateway_client::resolve_default_model();
+        if cfg_val.get("agents").is_none() {
+          cfg_val.as_object_mut().unwrap().insert("agents".to_string(), serde_json::json!({}));
+        }
+        if cfg_val.pointer("/agents/defaults").is_none() {
+          cfg_val.pointer_mut("/agents").unwrap().as_object_mut().unwrap()
+            .insert("defaults".to_string(), serde_json::json!({}));
+        }
+        cfg_val.pointer_mut("/agents/defaults").unwrap().as_object_mut().unwrap()
+          .insert("model".to_string(), model_cfg);
+        if let Ok(json) = serde_json::to_string_pretty(&cfg_val) {
+          let _ = fs::write(&config_path, json);
+          harden_file_permissions(&config_path);
+          eprintln!("[clawd/service] Gemini CLI OAuth: updated agents.defaults.model to '{}'", model_str);
+        }
+      }
+    }
+  }
+
   crate::clawd::gateway_client::invalidate();
 
   #[cfg(target_os = "windows")]

--- a/src/src-tauri/src/library_curator/retag.rs
+++ b/src/src-tauri/src/library_curator/retag.rs
@@ -25,6 +25,10 @@ const MAX_PER_PASS_FIRST_RUN: i64 = 5;
 const FIRST_RUN_THRESHOLD: i64 = 10;
 /// Pause between LLM calls to avoid rate-limit bursts.
 const INTER_CALL_DELAY_MS: u64 = 500;
+/// Substrings that indicate a rate-limit or overload error from the LLM layer.
+/// `multi_provider_completion` surfaces these as `LLMError::TooManyRequests`,
+/// which formats to `TooManyRequests("...")` via `{:?}`.
+const RATE_LIMIT_MARKERS: &[&str] = &["TooManyRequests", "rate limit", "429", "overload", "503"];
 const MAX_BODY_CHARS: usize = 4_000;
 
 #[derive(Debug, Deserialize)]
@@ -77,9 +81,19 @@ pub async fn retag_stale() -> Result<(), Error> {
                 let tags_json = serde_json::to_string(&tags).unwrap_or_else(|_| "[]".to_string());
                 let _ = WorkspaceDocument::update_auto_tags(id, Some(tags_json), Some(summary));
             }
+            Err(ref e) if RATE_LIMIT_MARKERS.iter().any(|m| e.contains(m)) => {
+                // Rate-limited or overloaded after all internal retries. Abort the
+                // remainder of this pass — continuing would just pile on more 429s.
+                // The 30-minute inter-pass interval is the effective backoff window.
+                log::warn!(
+                    "[library_curator/retag] rate limit detected ({}), aborting pass early",
+                    e
+                );
+                return Ok(());
+            }
             Err(e) => {
                 log::warn!("[library_curator/retag] tag failed for doc {}: {}", id, e);
-                // On failure, leave auto_tags NULL so we retry next pass.
+                // Non-rate-limit failure — leave auto_tags NULL so we retry next pass.
             }
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(INTER_CALL_DELAY_MS)).await;


### PR DESCRIPTION
## Summary

Implement automatic fallback model selection when the primary model is rate-limited (429) or overloaded (503). The gateway now receives a model config object with primary and fallback models, allowing it to retry with an alternative provider instead of propagating `FailoverError` to the user.

## Key Changes

- **New model config format**: `agents.defaults.model` now accepts `{"primary": "...", "fallbacks": [...]}` instead of a plain string. The gateway uses fallbacks to retry on 429/503 errors.

- **Fallback collection logic** (`collect_fallback_models()`): Groq is preferred as a fallback (free, fast), followed by Google/Gemini if the primary is not already a Google provider. Only providers with available API keys are included.

- **Centralized config builder** (`build_model_config()`): Replaces inline `{"primary": model}` construction across three `set_api_key()` handlers and `prepare_gateway_config()`. Ensures consistent fallback inclusion everywhere the model config is written.

- **Google Gemini CLI OAuth support**: Added `"google-gemini-cli"` provider variant that reads `KNAPSACK_GEMINI_MODEL` and is treated as a free provider (no paid fallback silently selected). Syncs model config to `openclaw.json` after OAuth completion.

- **Rate-limit abort in retag**: `library_curator/retag.rs` now detects rate-limit markers (`TooManyRequests`, `429`, `503`, etc.) and aborts the current pass early instead of continuing to pile on requests. The 30-minute inter-pass interval serves as the backoff window.

- **Regex fix in bundle verification**: Updated dynamic import regex to match `await import(...)` (space before "import") in addition to call-expression forms.

- **Dependency additions**: Added `combined-stream` and `lodash.includes` to Slack extension `package.json` (transitive dependencies).

## Implementation Details

- All three `set_api_key()` handlers and `ollama_configure()` now call `build_model_config()` instead of manually constructing the model object.
- The model config is built fresh each time (not cached) so fallbacks reflect the current set of available API keys.
- Fallback selection respects provider exclusion: if the primary is `google/...`, Gemini is not added as a fallback.
- Rate-limit detection in retag uses substring matching on the error message to catch both structured errors (`TooManyRequests`) and gateway-level HTTP status codes (`429`, `503`).

https://claude.ai/code/session_01WuxVJj13xi4tsGgCKrUCjM