### PR TITLE
feat: add Knapsack cloud inference as a first-class provider

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -362,6 +362,9 @@ type ApiKeyStatus = {
   has_gemini_key?: boolean
   has_groq_key?: boolean
   has_openrouter_key?: boolean
+  has_knapsack?: boolean
+  knapsack_email?: string
+  knapsack_model?: string
   openai_key_hint?: string
   anthropic_key_hint?: string
   gemini_key_hint?: string
@@ -389,7 +392,7 @@ type SkillInfo = {
   homepage?: string // URL for skill detail page (from gateway)
 }
 
-type Provider = 'openai' | 'anthropic' | 'gemini' | 'groq' | 'openrouter' | 'ollama'
+type Provider = 'knapsack' | 'openai' | 'anthropic' | 'gemini' | 'groq' | 'openrouter' | 'ollama'
 
 type ProviderOption = {
   id: Provider
@@ -399,7 +402,15 @@ type ProviderOption = {
   helpUrl: string
 }
 
+const KNAPSACK_MODELS = [
+  { id: 'anthropic/claude-haiku-4-5', name: 'Standard', description: 'Fast, efficient — great for everyday tasks' },
+  { id: 'anthropic/claude-sonnet-4-5', name: 'Plus', description: 'Balanced performance and capability' },
+  { id: 'anthropic/claude-opus-4-7', name: 'Premium', description: 'Most powerful — best for complex work' },
+]
+const KNAPSACK_MODEL_STORAGE = 'knapsack_knapsack_model'
+
 const PROVIDERS: ProviderOption[] = [
+  { id: 'knapsack', name: 'Knapsack', description: 'Powered by Knapsack — no API key needed', keyPrefix: '', helpUrl: 'https://studio.knapsack.ai' },
   { id: 'openai', name: 'OpenAI', description: 'GPT-5.5, GPT-5.4, o3', keyPrefix: 'sk-', helpUrl: 'https://platform.openai.com/api-keys' },
   { id: 'anthropic', name: 'Anthropic', description: 'Claude Opus 4.7, Sonnet 4.6, Haiku 4.5', keyPrefix: 'sk-ant-', helpUrl: 'https://console.anthropic.com/settings/keys' },
   { id: 'gemini', name: 'Google', description: 'Gemini 3.1 Pro, 3 Flash, 3.1 Flash Lite', keyPrefix: 'AI', helpUrl: 'https://aistudio.google.com/apikey' },
@@ -1595,6 +1606,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [selectedOllamaModel, setSelectedOllamaModel] = useState<string>(() => {
     return localStorage.getItem(OLLAMA_MODEL_STORAGE) || ''
   })
+  const [selectedKnapsackModel, setSelectedKnapsackModel] = useState<string>(() => {
+    return localStorage.getItem(KNAPSACK_MODEL_STORAGE) || 'anthropic/claude-haiku-4-5'
+  })
+  const [knapsackEmail, setKnapsackEmail] = useState<string>('')
   const [selectedProvider, setSelectedProvider] = useState<Provider>(() => {
     return (localStorage.getItem(ACTIVE_PROVIDER_STORAGE) as Provider) || 'openai'
   })
@@ -1927,12 +1942,20 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         })
         // Track which providers have saved keys
         setSavedProviderKeys({
+          knapsack: !!keyStatus.has_knapsack,
           openai: !!keyStatus.has_openai_key,
           anthropic: !!keyStatus.has_anthropic_key,
           gemini: !!keyStatus.has_gemini_key,
           groq: !!keyStatus.has_groq_key,
           openrouter: !!keyStatus.has_openrouter_key,
         })
+        if (keyStatus.knapsack_email) {
+          setKnapsackEmail(keyStatus.knapsack_email)
+        }
+        if (keyStatus.knapsack_model) {
+          setSelectedKnapsackModel(keyStatus.knapsack_model)
+          localStorage.setItem(KNAPSACK_MODEL_STORAGE, keyStatus.knapsack_model)
+        }
         // Restore Ollama model from backend if Ollama is the active provider
         if (keyStatus.ollama_enabled && keyStatus.ollama_model) {
           setSelectedOllamaModel(keyStatus.ollama_model)
@@ -6482,6 +6505,75 @@ ${actualText}`
               {/* ── Cloud providers ── */}
               {PROVIDERS.filter(p => p.id !== 'ollama').map(p => {
                 const isActive = selectedProvider === p.id
+
+                // ── Knapsack (no API key — uses Knapsack account) ──
+                if (p.id === 'knapsack') {
+                  return (
+                    <div key="knapsack" className={`ClawdAccordionItem ${isActive ? 'ClawdAccordionItem--open ClawdAccordionItem--connected' : ''}`}>
+                      <button className="ClawdAccordionHeader" onClick={() => setSelectedProvider('knapsack')}>
+                        <div className="ClawdAccordionTitle">{p.name}</div>
+                        <span className="ClawdAccordionDesc">{p.description}</span>
+                        {isActive && (
+                          <span className="ClawdAccordionCheck">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                          </span>
+                        )}
+                        <svg className="ClawdAccordionChevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                      </button>
+                      <div className="ClawdAccordionBody">
+                        {knapsackEmail && (
+                          <p style={{ margin: '0 0 10px', fontSize: 12, color: '#64748b' }}>
+                            Signed in as <strong>{knapsackEmail}</strong>
+                          </p>
+                        )}
+                        <label className="ClawdKeyPromptLabel">Model tier</label>
+                        <div className="ClawdModelSelector">
+                          {KNAPSACK_MODELS.map(model => (
+                            <button
+                              key={model.id}
+                              className={`ClawdModelOption${selectedKnapsackModel === model.id ? ' selected' : ''}`}
+                              onClick={() => {
+                                setSelectedKnapsackModel(model.id)
+                                localStorage.setItem(KNAPSACK_MODEL_STORAGE, model.id)
+                              }}
+                              disabled={savingKey}
+                            >
+                              <span className="ClawdModelName">{model.name}</span>
+                              <span className="ClawdModelDesc">{model.description}</span>
+                            </button>
+                          ))}
+                        </div>
+                        <div className="ClawdAccordionActions">
+                          <button
+                            className="ClawdChannelCardAction ClawdChannelCardAction--connect"
+                            onClick={async () => {
+                              if (!knapsackEmail) return
+                              setSavingKey(true)
+                              try {
+                                await apiPost('/api/clawd/service/set-api-key', { provider: 'knapsack', key: knapsackEmail, model: selectedKnapsackModel })
+                                setSelectedProvider('knapsack')
+                                localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
+                                setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
+                                pushAssistant(`Switched to Knapsack (${KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel}).`)
+                              } catch {}
+                              setSavingKey(false)
+                            }}
+                            disabled={savingKey || !knapsackEmail}
+                          >
+                            {savingKey ? 'Switching...' : isActive ? 'Select' : 'Use Knapsack'}
+                          </button>
+                        </div>
+                        <p style={{ margin: '8px 0 0', fontSize: 11, color: '#94a3b8' }}>
+                          Need credits?{' '}
+                          <a href="https://studio.knapsack.ai" target="_blank" rel="noopener noreferrer" style={{ color: '#c54841' }}>
+                            studio.knapsack.ai
+                          </a>
+                        </p>
+                      </div>
+                    </div>
+                  )
+                }
+
                 const models = p.id === 'openai' ? OPENAI_MODELS
                   : p.id === 'anthropic' ? ANTHROPIC_MODELS
                   : p.id === 'gemini' ? GEMINI_MODELS

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -258,6 +258,8 @@ export const SettingsDialog = ({
     has_anthropic_key?: boolean
     has_openrouter_key?: boolean
     has_gemini_cli_key?: boolean
+    has_knapsack?: boolean
+    knapsack_email?: string
     ollama_enabled?: boolean
     ollama_model?: string
     ollama_base_url?: string
@@ -303,6 +305,8 @@ export const SettingsDialog = ({
           has_anthropic_key: data.has_anthropic_key,
           has_openrouter_key: data.has_openrouter_key,
           has_gemini_cli_key: data.has_gemini_cli_key,
+          has_knapsack: data.has_knapsack,
+          knapsack_email: data.knapsack_email,
           ollama_enabled: data.ollama_enabled,
           ollama_model: data.ollama_model,
           ollama_base_url: data.ollama_base_url,
@@ -549,6 +553,37 @@ export const SettingsDialog = ({
           <Typography weight={TypographyWeight.medium}>AI Provider</Typography>
 
           <div className={styles.providerAccordion}>
+            {/* Knapsack cloud inference */}
+            <ProviderAccordion
+              title="Knapsack"
+              isActive={providerStatus?.active_provider === 'knapsack'}
+              isConnected={!!providerStatus?.has_knapsack}
+              expanded={expandedProvider === 'knapsack'}
+              onToggle={() => toggleProvider('knapsack')}
+            >
+              <div className={styles.providerActions}>
+                <span className={styles.providerStatus}>
+                  {providerStatus?.has_knapsack
+                    ? `Connected as ${providerStatus.knapsack_email}`
+                    : 'No Knapsack account connected'}
+                </span>
+                <button
+                  className={styles.providerActionLink}
+                  onClick={() => { handleClose(); onProviderSignInClick?.('knapsack') }}
+                >
+                  {providerStatus?.has_knapsack ? 'Change model' : 'Connect'}
+                </button>
+              </div>
+              {!providerStatus?.has_knapsack && (
+                <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+                  Need an account?{' '}
+                  <a href="https://studio.knapsack.ai" target="_blank" rel="noopener noreferrer" style={{ color: '#c54841' }}>
+                    Sign up at studio.knapsack.ai
+                  </a>
+                </p>
+              )}
+            </ProviderAccordion>
+
             {/* OpenAI */}
             <ProviderAccordion
               title="OpenAI"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds Knapsack cloud inference (Bedrock-backed) as the first provider option across all three provider selection UIs: `ProviderSignInDialog`, `ClawdChat` welcome panel, and `SettingsDialog`
- No API key required — uses the user's existing Knapsack account JWT fetched from the local gateway
- Three model tiers: **Standard** (Haiku), **Plus** (Sonnet), **Premium** (Opus)
- On 402 (no credits), user is directed to `https://studio.knapsack.ai`

## Changes

**Rust (`src-tauri`)**
- `service.rs`: `StoredTokens` and `ApiKeyStatusResponse` gain `knapsack_email` / `knapsack_model` fields; `set_api_key` handles `provider = "knapsack"` (skips key validation, stores email)
- `complete.rs`: `resolve_provider()` resolves Knapsack from env vars; new `knapsack_completion()` fetches a fresh JWT from the local gateway then streams SSE from `https://api.knapsack.ai/api/desktop/inference`

**Frontend**
- `ProviderSignInDialog`: Knapsack added as first tab with model tier selection and activate button
- `ClawdChat/index.tsx`: Knapsack accordion in the welcome/provider panel with tier buttons and "Use Knapsack" CTA
- `SettingsDialog/index.tsx`: Knapsack accordion at top of AI Provider list showing connection status and Connect/Change model button
- `Home.tsx`: passes `userEmail` down to `ProviderSignInDialog`

## Test plan

- [ ] Open the welcome panel (no provider set) — Knapsack should appear first
- [ ] Select a model tier and click "Use Knapsack" — active provider switches to Knapsack
- [ ] Open Settings → AI Provider — Knapsack shows at top with correct connected state
- [ ] Trigger inference with Knapsack active — response streams correctly
- [ ] Remove credits from account — confirm redirect message to studio.knapsack.ai

https://claude.ai/code/session_01SfmFKmDpsSLSqszV8ArmE2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfmFKmDpsSLSqszV8ArmE2)_