### PR TITLE
Add crash reporting with enriched panic hook and log ring buffer

### DIFF
--- a/src/scripts/sign-and-notarize.sh
+++ b/src/scripts/sign-and-notarize.sh
@@ -328,6 +328,11 @@ if [ "$DO_NOTARIZE" = true ]; then
 
   echo "[notarize] Stapling notarization ticket to .app..."
   xcrun stapler staple "$APP_PATH"
+  echo "[notarize] Validating .app staple ticket..."
+  xcrun stapler validate "$APP_PATH" || {
+    echo "[notarize] ERROR: .app staple ticket invalid — users would see 'damaged'." >&2
+    exit 1
+  }
 
   # Recreate DMG with the stapled .app, then notarize & staple the DMG
   DMG_DIR="$(dirname "$BUNDLE_DIR")/dmg"
@@ -386,6 +391,16 @@ if [ "$DO_NOTARIZE" = true ]; then
       if [ "$DMG_STATUS" = "Accepted" ]; then
         echo "[notarize] Stapling DMG..."
         xcrun stapler staple "$DMG_PATH"
+        echo "[notarize] Validating DMG staple ticket..."
+        xcrun stapler validate "$DMG_PATH" || {
+          echo "[notarize] ERROR: DMG staple ticket invalid — users would see 'damaged'." >&2
+          exit 1
+        }
+        echo "[notarize] Verifying Gatekeeper approval of DMG..."
+        spctl --assess --type open --context context:primary-signature --verbose=2 "$DMG_PATH" || {
+          echo "[notarize] ERROR: DMG fails Gatekeeper check — users would see 'damaged' on download." >&2
+          exit 1
+        }
       else
         echo "[notarize] ERROR: DMG notarization failed with status: $DMG_STATUS" >&2
         echo "[notarize]        An unnotarized DMG will show 'damaged' on user machines." >&2

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -412,14 +412,46 @@ fn evict_competing_gateway_plists() -> Vec<String> {
   vec![]
 }
 
+/// On macOS, kill the standalone `openclaw-gateway` binary if it is holding
+/// `port` WITHOUT a LaunchAgent plist (e.g. started via `openclaw gateway
+/// start`).  Our own clawdbot runs as a `node` process so filtering on the
+/// binary name "openclaw-gateway" is safe to call even when our gateway is
+/// healthy.
+#[cfg(target_os = "macos")]
+fn kill_standalone_openclaw_gateway_on_port(port: u16) {
+  // `lsof -c <name>` matches on command name prefix; `-ti :<port>` returns
+  // just the PID if that command holds the port.
+  let output = std::process::Command::new("lsof")
+    .args(["-c", "openclaw-gateway", "-ti", &format!(":{}", port)])
+    .output();
+  if let Ok(out) = output {
+    let pid_str = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if !pid_str.is_empty() {
+      eprintln!(
+        "[clawd/service] standalone openclaw-gateway binary on port {} (pid={}) without plist — killing",
+        port, pid_str
+      );
+      kill_process_on_port(port);
+    }
+  }
+}
+
 /// Thin shim kept for existing call sites that don't need the return value.
 /// After evicting competing LaunchAgent plists, also kills any process still
 /// holding port 18789 — `launchctl bootout` removes launchd management but
 /// leaves the process alive, so without the kill it keeps blocking the port.
+/// Additionally kills a standalone `openclaw-gateway` binary on the port even
+/// when no plist was found (started via `openclaw gateway start` with no
+/// LaunchAgent registration).
 fn remove_stale_standalone_gateway() {
   let evicted = evict_competing_gateway_plists();
   if !evicted.is_empty() {
     kill_process_on_port(18789);
+  } else {
+    // No LaunchAgent plist was evicted, but a manually-started
+    // openclaw-gateway binary may still be holding port 18789.
+    #[cfg(target_os = "macos")]
+    kill_standalone_openclaw_gateway_on_port(18789);
   }
 }
 

--- a/src/src-tauri/src/crash_reporter.rs
+++ b/src/src-tauri/src/crash_reporter.rs
@@ -1,0 +1,151 @@
+//! Crash reporting: in-memory log ring buffer + enriched panic hook.
+//!
+//! How it works:
+//!  1. A custom log4rs appender (`CrashLogAppender`) pushes every log record into
+//!     a fixed-size ring buffer *and* adds it as a Sentry breadcrumb.  This gives
+//!     Sentry a live trail of recent log activity for every event it captures.
+//!  2. `install_panic_hook()` wraps whatever hook is already set (after
+//!     `sentry::init()` that is sentry's own panic hook).  The wrapper runs first,
+//!     attaching the ring-buffer contents and a live memory snapshot to the Sentry
+//!     scope, then calls through to sentry's hook which captures the event, flushes
+//!     the transport, and finally calls the default Rust panic hook.
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+use chrono::Local;
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
+
+/// Number of log lines retained in the ring buffer.
+const RING_CAPACITY: usize = 200;
+
+static LOG_RING: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+
+fn ring() -> &'static Mutex<VecDeque<String>> {
+    LOG_RING.get_or_init(|| Mutex::new(VecDeque::with_capacity(RING_CAPACITY + 1)))
+}
+
+/// Push a formatted log line into the ring buffer.
+/// Called by `CrashLogAppender` for every log record.
+pub fn push_log_line(line: String) {
+    if let Ok(mut buf) = ring().lock() {
+        if buf.len() >= RING_CAPACITY {
+            buf.pop_front();
+        }
+        buf.push_back(line);
+    }
+}
+
+fn drain_ring() -> String {
+    ring()
+        .lock()
+        .map(|buf| buf.iter().cloned().collect::<Vec<_>>().join("\n"))
+        .unwrap_or_default()
+}
+
+fn collect_system_state() -> String {
+    let mut sys = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::new().with_memory()),
+    );
+    sys.refresh_processes(ProcessesToUpdate::All);
+    sys.refresh_memory();
+
+    let main_rss_mb = sysinfo::get_current_pid()
+        .ok()
+        .and_then(|pid| sys.process(pid))
+        .map(|p| p.memory() / 1_048_576)
+        .unwrap_or(0);
+
+    format!(
+        "rss_mb={} | system_total_mb={} | system_avail_mb={} | num_cpus={}",
+        main_rss_mb,
+        sys.total_memory() / 1_048_576,
+        sys.available_memory() / 1_048_576,
+        sys.cpus().len(),
+    )
+}
+
+/// Install the enriched panic hook.
+///
+/// Must be called **after** `sentry::init()` so that the hook we wrap is
+/// already sentry's (which captures the event and flushes the transport before
+/// calling the default Rust panic hook).
+pub fn install_panic_hook() {
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let logs = drain_ring();
+        let sys_state = collect_system_state();
+
+        let location = panic_info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "unknown".into());
+
+        // Attach context to the current scope so sentry's event picks it up.
+        sentry::configure_scope(|scope| {
+            scope.set_extra(
+                "system_state_at_crash",
+                sentry::protocol::Value::String(sys_state.clone()),
+            );
+            scope.set_extra(
+                "recent_logs",
+                sentry::protocol::Value::String(logs.clone()),
+            );
+        });
+
+        sentry::add_breadcrumb(sentry::Breadcrumb {
+            ty: "debug".to_string(),
+            level: sentry::Level::Fatal,
+            message: Some(format!(
+                "CRASH at {} — {} | log_lines={}",
+                location,
+                sys_state,
+                logs.lines().count(),
+            )),
+            ..Default::default()
+        });
+
+        // prev_hook is sentry's hook: it captures the panic event (with our
+        // enriched scope), flushes the transport, then calls the Rust default
+        // hook which prints the message and terminates the process.
+        prev_hook(panic_info);
+    }));
+}
+
+// ── log4rs appender ──────────────────────────────────────────────────────────
+
+/// A log4rs appender that feeds every record into both the crash ring buffer
+/// and Sentry breadcrumbs.  Add it to the log4rs config via `setup_logger`.
+#[derive(Debug)]
+pub struct CrashLogAppender;
+
+impl log4rs::append::Append for CrashLogAppender {
+    fn append(&self, record: &log::Record) -> anyhow::Result<()> {
+        let line = format!(
+            "{} [{:<5}] {} - {}",
+            Local::now().format("%Y-%m-%d %H:%M:%S"),
+            record.level(),
+            record.target(),
+            record.args(),
+        );
+        push_log_line(line.clone());
+
+        let sentry_level = match record.level() {
+            log::Level::Error => sentry::Level::Error,
+            log::Level::Warn => sentry::Level::Warning,
+            log::Level::Info => sentry::Level::Info,
+            log::Level::Debug | log::Level::Trace => sentry::Level::Debug,
+        };
+        sentry::add_breadcrumb(sentry::Breadcrumb {
+            ty: "log".to_string(),
+            message: Some(record.args().to_string()),
+            level: sentry_level,
+            category: Some(record.target().to_string()),
+            ..Default::default()
+        });
+
+        Ok(())
+    }
+
+    fn flush(&self) {}
+}

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -19,6 +19,7 @@ mod clawd;
 mod config;
 mod connections;
 mod constants;
+mod crash_reporter;
 mod db;
 mod error;
 mod file_upload;
@@ -1389,6 +1390,10 @@ async fn main() {
     scope.set_tag("platform", "desktop");
     scope.set_tag("app", "knapsack_desktop");
   });
+
+  // Wrap sentry's panic hook so we can attach recent logs + a memory snapshot
+  // to the scope before the event is captured and flushed.
+  crash_reporter::install_panic_hook();
 
   // log4rs::init_file("log4rs.yaml", Default::default()).unwrap();
   // setup_tracing();

--- a/src/src-tauri/src/utils/log.rs
+++ b/src/src-tauri/src/utils/log.rs
@@ -8,6 +8,7 @@ use log4rs::{
 use log::LevelFilter;
 use sentry;
 
+use crate::crash_reporter::CrashLogAppender;
 use crate::error::Error;
 use serde_json::Value;
 use std::fs;
@@ -137,11 +138,13 @@ pub fn setup_logger(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Erro
       .filter(Box::new(ThresholdFilter::new(LevelFilter::Error)))
       .build("error_logs", Box::new(error_logs)),
     )
+    .appender(Appender::builder().build("crash_ring", Box::new(CrashLogAppender)))
     .build(
       Root::builder()
       .appender("stdout")
       .appender("all_logs")
       .appender("error_logs")
+      .appender("crash_ring")
       .build(LevelFilter::Info),
     )?;
 


### PR DESCRIPTION
## Summary

Adds a crash reporting system that captures recent logs and system state when the application panics, enriching Sentry events with diagnostic context. This helps diagnose production crashes by providing a live trail of recent activity and memory snapshots at the time of failure.

## Key Changes

- **New `crash_reporter` module** (`src/src-tauri/src/crash_reporter.rs`):
  - `CrashLogAppender`: A log4rs appender that feeds every log record into both a fixed-size ring buffer (200 lines) and Sentry breadcrumbs
  - `install_panic_hook()`: Wraps Sentry's panic hook to attach recent logs and system state (RSS, total/available memory, CPU count) to the scope before the event is captured
  - Ring buffer management with `push_log_line()` and `drain_ring()` utilities
  - System state collection via `sysinfo` crate

- **Integration in `main.rs`**:
  - Import and call `crash_reporter::install_panic_hook()` after `sentry::init()` to wrap Sentry's hook

- **Integration in `utils/log.rs`**:
  - Add `CrashLogAppender` to the log4rs configuration as a root appender so all logs feed into the crash ring buffer

- **Gateway service improvements** (`clawd/service.rs`):
  - New `kill_standalone_openclaw_gateway_on_port()` function to detect and kill standalone `openclaw-gateway` binaries (started via CLI) that are holding a port without a LaunchAgent plist
  - Enhanced `remove_stale_standalone_gateway()` to also kill manually-started gateway processes even when no plist was evicted

- **Notarization validation** (`scripts/sign-and-notarize.sh`):
  - Add staple ticket validation after stapling both the .app and DMG
  - Add Gatekeeper approval check for the DMG to catch issues before distribution
  - Fail the build if validation fails, preventing distribution of "damaged" binaries to users

## Implementation Details

- The panic hook runs *before* Sentry's hook, so it enriches the scope with `system_state_at_crash` and `recent_logs` extras, plus a fatal-level breadcrumb summarizing the crash location and log count
- Sentry's hook then captures the event (with our enriched scope), flushes the transport, and calls the default Rust panic hook
- The ring buffer uses a `VecDeque` with capacity 201 to efficiently evict the oldest line when full
- Log lines are formatted with timestamp, level, target, and message for context
- System state collection is deferred to panic time to capture the live state at failure

https://claude.ai/code/session_01SdbP7PFqTiCcHkAwMNCuGw