### PR TITLE
Fix background daemon crash on update by running doctor --fix

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2192,6 +2192,27 @@ You can create, list, and cancel scheduled tasks (cron jobs).
       let bundled_plugins_dir = resource_path(&app_handle, "resources/clawdbot/extensions");
       let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
 
+      eprintln!("[clawd/service] Running OpenClaw doctor --fix to ensure plugin dependencies...");
+      let doctor_status = std::process::Command::new(&node_path)
+          .arg(&clawdbot_entry)
+          .arg("doctor")
+          .arg("--fix")
+          .env("OPENCLAW_STATE_DIR", &clawdbot_home_str)
+          .env("OPENCLAW_BUNDLED_PLUGINS_DIR", &bundled_plugins_dir_str)
+          .status();
+
+      match doctor_status {
+          Ok(status) if status.success() => {
+              eprintln!("[clawd/service] doctor --fix completed successfully.");
+          }
+          Ok(status) => {
+              eprintln!("[clawd/service] WARNING: doctor --fix exited with status {}", status);
+          }
+          Err(e) => {
+              eprintln!("[clawd/service] ERROR: failed to run doctor --fix: {}", e);
+          }
+      }
+
       // Build a PATH that includes the directory where we found node (so npm
       // is also discoverable), plus common macOS paths.  LaunchAgents get a
       // minimal PATH by default which typically excludes /opt/homebrew/bin.


### PR DESCRIPTION
This runs 'openclaw doctor --fix' during the LaunchAgent plist generation (which happens after updates when the app restarts) to ensure that the newly dropped Node bundle has all its required plugin dependencies installed before the background daemon tries to load them.