### PR TITLE
Prevent infinite gateway restart loop on persistent corruption

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -76,6 +76,46 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+      - name: Verify app bundle code signature
+        working-directory: src
+        run: |
+          APP=src-tauri/target/universal-apple-darwin/release/bundle/macos/Knapsack.app
+          RESULT=$(codesign --verify --deep --strict "$APP" 2>&1 || true)
+          # An unsigned build is fine (signing requires Apple certs).
+          # A *broken seal* ("sealed resource is missing or invalid") must fail the build.
+          if echo "$RESULT" | grep -q "a sealed resource is missing or invalid"; then
+            echo "ERROR: App bundle seal is broken — files were modified after signing:"
+            echo "$RESULT"
+            exit 1
+          fi
+          echo "Bundle integrity check: OK"
+
+      - name: Verify updater artifact integrity after extraction
+        working-directory: src
+        run: |
+          TARBALL=$(ls src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz 2>/dev/null | head -1)
+          if [ -z "$TARBALL" ]; then
+            echo "No updater tarball found — skipping extraction integrity check"
+            exit 0
+          fi
+          EXTRACT_DIR=$(mktemp -d)
+          tar -xzf "$TARBALL" -C "$EXTRACT_DIR"
+          EXTRACTED_APP=$(find "$EXTRACT_DIR" -maxdepth 1 -name "*.app" | head -1)
+          if [ -z "$EXTRACTED_APP" ]; then
+            echo "ERROR: No .app found after extracting updater tarball"
+            rm -rf "$EXTRACT_DIR"
+            exit 1
+          fi
+          RESULT=$(codesign --verify --deep --strict "$EXTRACTED_APP" 2>&1 || true)
+          if echo "$RESULT" | grep -q "a sealed resource is missing or invalid"; then
+            echo "ERROR: Updater tarball breaks the app bundle seal after extraction:"
+            echo "$RESULT"
+            rm -rf "$EXTRACT_DIR"
+            exit 1
+          fi
+          echo "Updater extraction integrity check: OK"
+          rm -rf "$EXTRACT_DIR"
+
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
         working-directory: src
         run: node scripts/install-bundled-plugin-deps.cjs
 
+      - name: Smoke-test gateway plugin registration
+        working-directory: src
+        run: bash scripts/smoke-test-gateway-plugins.sh
+
       - name: Run prebuild scripts
         working-directory: src
         env:
@@ -145,6 +149,32 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: bash scripts/sign-and-notarize.sh --notarize
+
+      - name: Verify signed app passes Gatekeeper as a user would see it
+        working-directory: src
+        run: |
+          APP=$(ls -d src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app | head -1)
+          DMG=$(ls src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg 2>/dev/null | head -1)
+
+          echo "=== codesign --verify (app) ==="
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+          echo "=== spctl open check (app) — mirrors Finder double-click ==="
+          spctl --assess --type open --context context:primary-signature --verbose=2 "$APP"
+
+          if [ -n "$DMG" ]; then
+            echo "=== Mounting DMG and verifying .app inside ==="
+            MOUNT_PT=$(mktemp -d)
+            hdiutil attach "$DMG" -mountpoint "$MOUNT_PT" -nobrowse -quiet
+            INNER_APP=$(find "$MOUNT_PT" -maxdepth 1 -name "*.app" | head -1)
+            codesign --verify --deep --strict --verbose=2 "$INNER_APP"
+            spctl --assess --type open --context context:primary-signature --verbose=2 "$INNER_APP"
+            hdiutil detach "$MOUNT_PT" -quiet
+            rm -rf "$MOUNT_PT"
+            echo "=== DMG mount check passed ==="
+          fi
+
+          echo "=== All Gatekeeper checks passed ==="
 
       - name: Recreate updater archive after signing
         working-directory: src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,23 @@ jobs:
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         run: bash scripts/recreate-updater-archive.sh
 
+      - name: Verify updater archive preserves signature after repack
+        working-directory: src
+        run: |
+          TARBALL=$(ls src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz | head -1)
+          EXTRACT_DIR=$(mktemp -d)
+          tar -xzf "$TARBALL" -C "$EXTRACT_DIR"
+          EXTRACTED_APP=$(find "$EXTRACT_DIR" -maxdepth 1 -name "*.app" | head -1)
+
+          echo "=== codesign --verify (extracted updater app) ==="
+          codesign --verify --deep --strict --verbose=2 "$EXTRACTED_APP"
+
+          echo "=== spctl open check (extracted updater app) ==="
+          spctl --assess --type open --context context:primary-signature --verbose=2 "$EXTRACTED_APP"
+
+          rm -rf "$EXTRACT_DIR"
+          echo "=== Updater archive signature check passed ==="
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/src/scripts/sign-and-notarize.sh
+++ b/src/scripts/sign-and-notarize.sh
@@ -411,7 +411,11 @@ if [ "$DO_NOTARIZE" = true ]; then
   fi
 
   echo "[notarize] Verifying Gatekeeper approval..."
-  spctl --assess --type execute --verbose=2 "$APP_PATH"
+  # --type open --context context:primary-signature is exactly what Finder uses
+  # when a user double-clicks the app.  --type execute (command-line executables)
+  # produces a different assessment and can pass even when the Finder open check
+  # fails, which means CI passes but users see "damaged or incomplete".
+  spctl --assess --type open --context context:primary-signature --verbose=2 "$APP_PATH"
 
   echo "[notarize] Done! App is signed, notarized, and stapled."
 else

--- a/src/src-tauri/src/clawd/gateway_supervisor.rs
+++ b/src/src-tauri/src/clawd/gateway_supervisor.rs
@@ -56,25 +56,35 @@ pub async fn is_gateway_healthy(token: &str) -> bool {
 #[cfg(target_os = "macos")]
 fn check_app_bundle_signature() -> Option<String> {
   // Walk up from the executable: .../Knapsack.app/Contents/MacOS/Knapsack
-  //                                                 ^3         ^2  ^1   ^0
+  // parent() x3 gives us Knapsack.app; convert to PathBuf immediately so
+  // nothing borrows from `exe` past this point.
   let exe = std::env::current_exe().ok()?;
-  let app_path = exe.ancestors().nth(3)?;
-  if !app_path.to_string_lossy().ends_with(".app") {
+  let app_bundle: std::path::PathBuf = exe
+    .parent()                         // Contents/MacOS
+    .and_then(|p| p.parent())         // Contents
+    .and_then(|p| p.parent())         // Knapsack.app
+    .map(|p| p.to_path_buf())?;
+
+  if app_bundle.extension().map_or(true, |e| e != "app") {
     return None; // dev / test environment — skip check
   }
+
   let output = Command::new("codesign")
     .args(["--verify", "--deep", "--strict"])
-    .arg(app_path)
+    .arg(&app_bundle)
     .output()
     .ok()?;
+
   if output.status.success() {
     return None;
   }
+
   let stderr = String::from_utf8_lossy(&output.stderr);
   // "code object is not signed at all" is normal for unsigned dev builds.
   if stderr.contains("code object is not signed at all") {
     return None;
   }
+
   Some(format!(
     "App bundle code signature is broken ({}). \
      Reinstalling Knapsack from a fresh notarized DMG should fix this.",

--- a/src/src-tauri/src/clawd/gateway_supervisor.rs
+++ b/src/src-tauri/src/clawd/gateway_supervisor.rs
@@ -50,8 +50,47 @@ pub async fn is_gateway_healthy(token: &str) -> bool {
   }
 }
 
+/// Check the macOS code signature of the running app bundle.
+/// Returns `Some(message)` if the signature is broken, `None` if it's OK or
+/// the app is unsigned (unsigned dev builds are expected and not an error).
+#[cfg(target_os = "macos")]
+fn check_app_bundle_signature() -> Option<String> {
+  // Walk up from the executable: .../Knapsack.app/Contents/MacOS/Knapsack
+  //                                                 ^3         ^2  ^1   ^0
+  let exe = std::env::current_exe().ok()?;
+  let app_path = exe.ancestors().nth(3)?;
+  if !app_path.to_string_lossy().ends_with(".app") {
+    return None; // dev / test environment — skip check
+  }
+  let output = Command::new("codesign")
+    .args(["--verify", "--deep", "--strict"])
+    .arg(app_path)
+    .output()
+    .ok()?;
+  if output.status.success() {
+    return None;
+  }
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  // "code object is not signed at all" is normal for unsigned dev builds.
+  if stderr.contains("code object is not signed at all") {
+    return None;
+  }
+  Some(format!(
+    "App bundle code signature is broken ({}). \
+     Reinstalling Knapsack from a fresh notarized DMG should fix this.",
+    stderr.trim()
+  ))
+}
+
 #[cfg(target_os = "macos")]
 pub fn kickstart_launch_agent(label: &str) -> Result<(), String> {
+  // Verify the app bundle seal before attempting to bootstrap the LaunchAgent.
+  // launchd rejects binaries from a bundle with a broken signature with a
+  // cryptic I/O error; surface a clear message instead.
+  if let Some(sig_err) = check_app_bundle_signature() {
+    return Err(sig_err);
+  }
+
   let uid = unsafe { libc::getuid() };
   let service = format!("gui/{}/{}", uid, label);
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -243,6 +243,21 @@ static GATEWAY_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 /// outage can trigger a new alert.
 static GATEWAY_DOWN_SENTRY_ALERTED: AtomicBool = AtomicBool::new(false);
 
+/// Counts consecutive self-heal cycles that ended with the gateway still
+/// unhealthy.  Reset to 0 on any successful recovery.  When this hits
+/// HEAL_FAILURE_CAP we stop restarting for HEAL_SUPPRESS_SECS seconds so the
+/// app doesn't burn CPU in an infinite wipe-reinstall-restart loop.
+static CONSECUTIVE_HEAL_FAILURES: std::sync::atomic::AtomicU32 =
+  std::sync::atomic::AtomicU32::new(0);
+
+/// Unix timestamp (seconds) before which new self-heal cycles are suppressed.
+/// Written by the cap logic; read by the health-poll loop.
+static HEAL_SUPPRESSED_UNTIL_SECS: std::sync::atomic::AtomicU64 =
+  std::sync::atomic::AtomicU64::new(0);
+
+const HEAL_FAILURE_CAP: u32 = 3;
+const HEAL_SUPPRESS_SECS: u64 = 300; // 5 minutes
+
 const LAUNCH_AGENT_LABEL: &str = "ai.knap.knapsack.clawdbot";
 
 /// Resolve the directory for gateway service logs.
@@ -2574,16 +2589,40 @@ async fn run_gateway_self_heal_cycle(
   let ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 10_000).await;
   if ready {
     eprintln!("[clawd/service] self-heal: gateway healthy after recovery cycle");
+    CONSECUTIVE_HEAL_FAILURES.store(0, Ordering::Relaxed);
+    HEAL_SUPPRESSED_UNTIL_SECS.store(0, Ordering::Relaxed);
     gateway_client::invalidate();
     GATEWAY_WAS_HEALTHY.store(true, Ordering::Relaxed);
     BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
     patch_paired_json_scopes(&app_handle);
   } else {
+    let failures = CONSECUTIVE_HEAL_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
     eprintln!(
-      "[clawd/service] self-heal: gateway still unhealthy after recovery cycle (class={}, doctor_ok={})",
-      crash_class,
-      doctor_ok
+      "[clawd/service] self-heal: gateway still unhealthy after recovery cycle (class={}, doctor_ok={}, consecutive_failures={})",
+      crash_class, doctor_ok, failures
     );
+    if failures >= HEAL_FAILURE_CAP {
+      let suppress_until = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .saturating_add(HEAL_SUPPRESS_SECS);
+      HEAL_SUPPRESSED_UNTIL_SECS.store(suppress_until, Ordering::Relaxed);
+      eprintln!(
+        "[clawd/service] self-heal: {} consecutive failed recovery cycles (class={}) — suppressing restarts for {}s",
+        failures, crash_class, HEAL_SUPPRESS_SECS
+      );
+      sentry::with_scope(
+        |scope| {
+          scope.set_tag("gateway_crash_type", &crash_class);
+          scope.set_tag("consecutive_failures", &failures.to_string());
+        },
+        || sentry::capture_message(
+          &format!("[gateway] self-heal suppressed after {} consecutive failures (class={})", failures, crash_class),
+          sentry::Level::Error,
+        ),
+      );
+    }
   }
 
   sentry::with_scope(
@@ -2732,23 +2771,37 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         "[clawd/service] gateway not reachable but plugin runtime deps are staging - skipping restart"
       );
     } else if !gateway_ok && !GATEWAY_RESTART_IN_PROGRESS.swap(true, Ordering::Relaxed) {
-      let token = tokens.gateway_token.clone();
-      #[cfg(target_os = "windows")]
-      let restart_err_path = windows_log_path("stderr");
-      #[cfg(not(target_os = "windows"))]
-      let restart_err_path = gateway_stderr_log();
-      let restart_log_lower = fs::read_to_string(&restart_err_path)
-        .or_else(|_| fs::read_to_string("/tmp/knapsack-clawdbot.err.log"))
+      // Check if restarts are suppressed after too many consecutive failures.
+      let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .to_lowercase();
-      let heal_app_handle: tauri::AppHandle = app_handle.get_ref().clone();
-      eprintln!(
-        "[clawd/service] gateway not reachable — starting background self-heal (class={})",
-        classify_gateway_crash(&restart_log_lower)
-      );
-      tokio::spawn(async move {
-        run_gateway_self_heal_cycle(heal_app_handle, token, restart_log_lower).await;
-      });
+        .as_secs();
+      let suppressed_until = HEAL_SUPPRESSED_UNTIL_SECS.load(Ordering::Relaxed);
+      if suppressed_until > now_secs {
+        eprintln!(
+          "[clawd/service] self-heal suppressed for {}s more (too many consecutive failures) — skipping restart",
+          suppressed_until - now_secs
+        );
+        GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
+      } else {
+        let token = tokens.gateway_token.clone();
+        #[cfg(target_os = "windows")]
+        let restart_err_path = windows_log_path("stderr");
+        #[cfg(not(target_os = "windows"))]
+        let restart_err_path = gateway_stderr_log();
+        let restart_log_lower = fs::read_to_string(&restart_err_path)
+          .or_else(|_| fs::read_to_string("/tmp/knapsack-clawdbot.err.log"))
+          .unwrap_or_default()
+          .to_lowercase();
+        let heal_app_handle: tauri::AppHandle = app_handle.get_ref().clone();
+        eprintln!(
+          "[clawd/service] gateway not reachable — starting background self-heal (class={})",
+          classify_gateway_crash(&restart_log_lower)
+        );
+        tokio::spawn(async move {
+          run_gateway_self_heal_cycle(heal_app_handle, token, restart_log_lower).await;
+        });
+      }
     }
 
     // Browser control is accessed through the gateway's `browser.request` RPC
@@ -8334,6 +8387,14 @@ mod crash_classifier_tests {
     assert!(complete.exists());
 
     let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn heal_suppression_constants_are_sane() {
+    // HEAL_FAILURE_CAP and HEAL_SUPPRESS_SECS must be positive and the
+    // suppression window long enough to matter (≥1 minute).
+    assert!(HEAL_FAILURE_CAP >= 2, "cap should allow at least one retry");
+    assert!(HEAL_SUPPRESS_SECS >= 60, "suppression window should be at least 60s");
   }
 
   #[test]

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2258,6 +2258,19 @@ fn is_openclaw_npm_cache_enoent(lower: &str) -> bool {
 }
 
 fn is_plugin_runtime_deps_corruption(lower: &str) -> bool {
+  // `npm warn tar TAR_ENTRY_ERROR ENOENT` lines are non-fatal npm extraction
+  // warnings that appear during a healthy install of packages with deep nesting
+  // (e.g. @buape/carbon → discord-api-types). If those warnings are the only
+  // ENOENT signal in the log — i.e. no actual module-resolution failures — we
+  // must not classify as corruption. Doing so triggers an infinite loop:
+  // self-heal wipes the deps dir → gateway restarts → npm warns again → repeat.
+  let only_tar_enoent = lower.contains("tar_entry_error")
+    && !lower.contains("cannot find module")
+    && !lower.contains("err_module_not_found");
+  if only_tar_enoent {
+    return false;
+  }
+
   let mentions_staged_plugin = lower.contains("plugin-runtime-deps")
     && (lower.contains("dist/extensions/slack")
       || lower.contains("dist/extensions/telegram")
@@ -8274,6 +8287,27 @@ mod crash_classifier_tests {
   fn missing_node_binary_is_node_unavailable() {
     let log_tail = "launchctl: node: No such file or directory";
     assert_eq!(classify_gateway_crash(log_tail), "node_unavailable");
+  }
+
+  #[test]
+  fn tar_entry_error_enoent_is_not_corruption() {
+    // npm `warn tar TAR_ENTRY_ERROR ENOENT` lines are non-fatal extraction
+    // warnings (e.g. from @buape/carbon → discord-api-types deep nesting).
+    // They must NOT trigger the self-heal wipe or we get an infinite restart loop.
+    let log_tail = "npm warn tar TAR_ENTRY_ERROR ENOENT: no such file or directory, lstat '/Users/test/Library/Application Support/ai.knap.knapsack/clawdbot/plugin-runtime-deps/openclaw-2026.4.26-5b9d7b421f2e/node_modules/@buape/carbon/node_modules/discord-api-types/rest'";
+    assert!(
+      !is_plugin_runtime_deps_corruption(&log_tail.to_lowercase()),
+      "TAR_ENTRY_ERROR warnings should not be classified as corruption"
+    );
+    assert_ne!(classify_gateway_crash(log_tail), "plugin_install_fail");
+  }
+
+  #[test]
+  fn tar_entry_error_with_module_fail_is_still_corruption() {
+    // If the log also contains a real module-resolution failure alongside
+    // TAR_ENTRY_ERROR warnings, it should still be classified as corruption.
+    let log_tail = "npm warn tar TAR_ENTRY_ERROR ENOENT: no such file or directory, lstat '/Users/test/Library/Application Support/ai.knap.knapsack/clawdbot/plugin-runtime-deps/openclaw-2026.4.26-5b9d7b421f2e/node_modules/@buape/carbon/node_modules/discord-api-types/rest'\nError: Cannot find module '@slack/logger'\nRequire stack:\n- /Users/test/Library/Application Support/ai.knap.knapsack/clawdbot/plugin-runtime-deps/openclaw-2026.4.26-5b9d7b421f2e/node_modules/@slack/web-api/dist/logger.js";
+    assert_eq!(classify_gateway_crash(log_tail), "plugin_install_fail");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Add circuit-breaker logic to prevent the gateway self-heal mechanism from entering an infinite restart loop when the gateway remains unhealthy after multiple recovery attempts. This addresses a specific failure mode where npm extraction warnings (TAR_ENTRY_ERROR) were incorrectly triggering dependency corruption detection, causing repeated wipe-reinstall-restart cycles that burned CPU.

## Key Changes

- **Self-heal failure tracking**: Introduce `CONSECUTIVE_HEAL_FAILURES` counter and `HEAL_SUPPRESSED_UNTIL_SECS` timestamp to track failed recovery cycles and suppress restarts after hitting a threshold (3 consecutive failures → 5-minute suppression window).

- **Improved corruption detection**: Fix `is_plugin_runtime_deps_corruption()` to distinguish between non-fatal npm TAR_ENTRY_ERROR warnings (from deep package nesting like @buape/carbon → discord-api-types) and actual module-resolution failures. TAR_ENTRY_ERROR alone no longer triggers self-heal.

- **Health check suppression logic**: In `service_health()`, check if restarts are currently suppressed before spawning a new self-heal cycle. Log suppression status and reset the flag when recovery succeeds.

- **Code signature verification**: Add `check_app_bundle_signature()` on macOS to detect broken app bundle seals before attempting LaunchAgent bootstrap, surfacing a clear error message instead of launchd's cryptic I/O error.

- **Build-time integrity checks**: Add macOS CI steps to verify app bundle code signature and updater tarball extraction integrity, catching seal breakage early in the build pipeline.

- **Gatekeeper validation**: Update release workflow and sign-and-notarize script to use `spctl --type open --context context:primary-signature` (what Finder uses) instead of `--type execute`, ensuring CI validation matches user experience.

- **Smoke test**: Add gateway plugin registration smoke test to release workflow to catch plugin loading failures before release.

- **Unit tests**: Add tests for TAR_ENTRY_ERROR handling and heal suppression constant validation.

## Implementation Details

The circuit-breaker uses atomic operations (`AtomicU32`, `AtomicU64`) with `Ordering::Relaxed` for lock-free updates across the health-poll loop and self-heal background task. When `CONSECUTIVE_HEAL_FAILURES` reaches `HEAL_FAILURE_CAP` (3), the code calculates a Unix timestamp threshold and stores it in `HEAL_SUPPRESSED_UNTIL_SECS`. The health check loop compares current time against this threshold before spawning new cycles. On successful recovery, both counters reset to 0.

The TAR_ENTRY_ERROR fix checks for the presence of actual module-resolution errors (`cannot find module`, `err_module_not_found`) before classifying as corruption. This prevents the infinite loop: wipe → restart → npm warns again → repeat.

https://claude.ai/code/session_018GMHkUQB7AdAjuXWrQVpZy