### PR TITLE
[codex] Add OpenCode coding fallback

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -65,7 +65,12 @@ jobs:
 
       - name: Build Tauri app (universal)
         working-directory: src
-        run: npm exec -- tauri build --target universal-apple-darwin
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npm exec -- tauri build --target universal-apple-darwin --bundles app updater --ci
+          else
+            npm exec -- tauri build --target universal-apple-darwin --ci
+          fi
         env:
           VITE_KN_API_SERVER: https://api.knapsack.ai
           MICROSOFT_CLIENT_ID: unused
@@ -117,6 +122,7 @@ jobs:
           rm -rf "$EXTRACT_DIR"
 
       - name: Upload DMG artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v6
         with:
           name: knapsack-macos-dmg

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2621,7 +2621,8 @@ pub async fn chat(
       let process_id = uuid::Uuid::new_v4().to_string();
 
       // Select which coding CLI to use: check user preference first, then fall back to
-      // whichever API key is available. Anthropic → claude, OpenAI → codex, Google → gemini.
+      // whichever API key is available. Anthropic → claude, OpenAI → codex,
+      // Google → gemini, otherwise OpenCode.
       let coding_agent = {
         let pref = std::env::var("KNAPSACK_CODING_AGENT").unwrap_or_default();
         let pref = pref.trim().to_lowercase();
@@ -2632,7 +2633,7 @@ pub async fn chat(
           if has("ANTHROPIC_API_KEY") { "claude".to_string() }
           else if has("OPENAI_API_KEY") { "codex".to_string() }
           else if has("GEMINI_API_KEY") || has("GOOGLE_API_KEY") { "gemini".to_string() }
-          else { "claude".to_string() }
+          else { "opencode".to_string() }
         }
       };
 
@@ -2649,6 +2650,7 @@ pub async fn chat(
       // claude: --yes auto-accepts tool use so it can read/write files without prompting.
       // codex:  --approval-mode auto-edit allows file edits non-interactively.
       // gemini: -p (--prompt) triggers headless mode, returning stdout output without TTY UI.
+      // opencode: use npx so the fallback can work even when the binary is not already installed.
       //         Note: Antigravity (`agy`) is an IDE, not a headless CLI — use `gemini` instead.
       // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
       let claude_cmd = match coding_agent.as_str() {
@@ -2663,6 +2665,12 @@ pub async fn chat(
           { format!("gemini -p \"{}\"", prompt.replace('"', "\\\"")) }
           #[cfg(not(target_os = "windows"))]
           { format!("gemini -p '{}'", prompt.replace('\'', "'\\''")) }
+        }
+        "opencode" => {
+          #[cfg(target_os = "windows")]
+          { format!("npx -y opencode-ai run \"{}\"", prompt.replace('"', "\\\"")) }
+          #[cfg(not(target_os = "windows"))]
+          { format!("npx -y opencode-ai run '{}'", prompt.replace('\'', "'\\''")) }
         }
         _ => {
           #[cfg(target_os = "windows")]

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3656,7 +3656,7 @@ pub struct SetApiKeyRequest {
   /// For extra providers: the environment variable name to store the key under.
   /// e.g. "MINIMAX_API_KEY", "ZAI_API_KEY", "HF_TOKEN"
   pub env_var: Option<String>,
-  /// Preferred coding CLI agent: "claude", "codex", or "gemini".
+  /// Preferred coding CLI agent: "claude", "codex", "gemini", or "opencode".
   /// When provided alongside or without a key change, updates the stored preference.
   pub preferred_coding_agent: Option<String>,
 }
@@ -3665,6 +3665,15 @@ pub struct SetApiKeyRequest {
 pub struct SetApiKeyResponse {
   pub success: bool,
   pub message: String,
+}
+
+fn normalize_coding_agent(agent: &str) -> Option<String> {
+  let agent = agent.trim().to_lowercase();
+  if ["claude", "codex", "gemini", "opencode"].contains(&agent.as_str()) {
+    Some(agent)
+  } else {
+    None
+  }
 }
 
 #[post("/api/clawd/service/set-api-key")]
@@ -3684,6 +3693,26 @@ pub async fn set_api_key(
 
   let key = payload.key.trim().to_string();
   let provider = payload.provider.as_deref().unwrap_or("openai").to_lowercase();
+
+  if key.is_empty() && payload.model.is_none() && payload.env_var.is_none() {
+    if let Some(agent) = &payload.preferred_coding_agent {
+      tokens.preferred_coding_agent = normalize_coding_agent(agent);
+      match &tokens.preferred_coding_agent {
+        Some(agent) => std::env::set_var("KNAPSACK_CODING_AGENT", agent),
+        None => std::env::remove_var("KNAPSACK_CODING_AGENT"),
+      }
+      if let Err(e) = save_tokens(&app_handle, &tokens) {
+        return HttpResponse::InternalServerError().json(SetApiKeyResponse {
+          success: false,
+          message: e,
+        });
+      }
+      return HttpResponse::Ok().json(SetApiKeyResponse {
+        success: true,
+        message: "Coding agent preference saved".to_string(),
+      });
+    }
+  }
 
   // Validate key format before storing (skip for ollama and knapsack which don't use API keys)
   if !key.is_empty() && provider != "ollama" && provider != "knapsack" {
@@ -3934,10 +3963,9 @@ pub async fn set_api_key(
     }
   };
 
-  // Persist coding agent preference if provided ("claude", "codex", or "gemini")
+  // Persist coding agent preference if provided ("claude", "codex", "gemini", or "opencode")
   if let Some(agent) = &payload.preferred_coding_agent {
-    let agent = agent.trim().to_lowercase();
-    if ["claude", "codex", "gemini"].contains(&agent.as_str()) {
+    if let Some(agent) = normalize_coding_agent(agent) {
       tokens.preferred_coding_agent = Some(agent.clone());
       std::env::set_var("KNAPSACK_CODING_AGENT", &agent);
     }
@@ -8546,6 +8574,16 @@ mod provider_key_tests {
 
   fn clear_all() {
     for v in ALL_VARS { std::env::remove_var(v); }
+  }
+
+  #[test]
+  fn coding_agent_preference_accepts_opencode() {
+    assert_eq!(normalize_coding_agent(" opencode "), Some("opencode".to_string()));
+  }
+
+  #[test]
+  fn coding_agent_preference_rejects_unknown_values() {
+    assert_eq!(normalize_coding_agent("vim"), None);
   }
 
   #[test]

--- a/src/src/components/organisms/ActivityPanel/index.tsx
+++ b/src/src/components/organisms/ActivityPanel/index.tsx
@@ -1486,13 +1486,16 @@ const TerminalView: React.FC = () => {
         return
       }
 
-      // Coding agent CLIs (claude, codex) — run as streaming processes so output appears in real-time
+      // Coding agent CLIs — run as streaming processes so output appears in real-time
       const isCodingAgentCmd = cmd === 'claude' || cmd.startsWith('claude ')
         || cmd === 'codex' || cmd.startsWith('codex ')
         || cmd === 'gemini' || cmd.startsWith('gemini ')
+        || cmd === 'opencode' || cmd.startsWith('opencode ')
+        || cmd === 'npx -y opencode-ai' || cmd.startsWith('npx -y opencode-ai ')
       if (isCodingAgentCmd) {
         const agentLabel = cmd.startsWith('codex') ? 'Codex'
           : cmd.startsWith('gemini') ? 'Gemini CLI'
+          : cmd.startsWith('opencode') || cmd.startsWith('npx -y opencode-ai') ? 'OpenCode'
           : 'Claude Code'
         updateSession(sessionId, s => ({ ...s, isExecuting: true }))
         try {

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -2731,7 +2731,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           setClaudeCodeActive(true)
           setClaudeCodePrompt(event.payload.prompt)
           const a = event.payload.agent
-          setCodingAgentName(a === 'codex' ? 'Codex' : a === 'gemini' ? 'Gemini CLI' : 'Claude Code')
+          setCodingAgentName(a === 'codex' ? 'Codex' : a === 'gemini' ? 'Gemini CLI' : a === 'opencode' ? 'OpenCode' : 'Claude Code')
           // Auto-open Activity Panel if not already open
           if (!externalActivityPanelRef.current && onToggleActivityRef.current) {
             onToggleActivityRef.current()
@@ -6973,6 +6973,7 @@ ${actualText}`
                   <option value="claude">Claude Code (Anthropic)</option>
                   <option value="codex">Codex (OpenAI)</option>
                   <option value="gemini">Gemini CLI (Google)</option>
+                  <option value="opencode">OpenCode</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add OpenCode as the automatic coding-agent fallback when Anthropic, OpenAI, and Gemini/Google keys are unavailable
- keep Gemini CLI selected automatically when Gemini/Google keys exist
- allow OpenCode as a saved coding-agent preference and support preference-only settings updates
- label OpenCode activity and stream OpenCode commands in the activity panel

## Validation
- `git diff --check`
- `npx tsc --noEmit`
- `./node_modules/.bin/vite build`
- `cargo test provider_key_tests --manifest-path src/src-tauri/Cargo.toml`
- `npx -y opencode-ai --help`