### PR TITLE
fix: stabilize gateway and browser startup

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
     "prebuild": "node scripts/sync-version.cjs && node scripts/prepare-node.cjs && node scripts/ensure-clawdbot-deps.cjs && node scripts/prune-clawdbot.cjs && node scripts/verify-clawdbot-bundle.cjs",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "qa:dev": "node scripts/qa-dev-run.cjs",
     "tauri": "node scripts/load-env-and-run.cjs tauri",
     "release": "bash scripts/release.sh"
   },

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * Stable dev launcher for desktop QA.
+ *
+ * `tauri dev` watches the whole src-tauri tree, including the large mutable
+ * clawdbot resource bundle. Gateway dependency staging can touch that tree and
+ * trigger rebuild loops. This launcher uses the same dev frontend port but runs
+ * the compiled debug binary directly, so the QA loop has a steady app process.
+ */
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const projectDir = path.resolve(__dirname, '..');
+const tauriDir = path.join(projectDir, 'src-tauri');
+const binary = path.join(tauriDir, 'target', 'debug', process.platform === 'win32' ? 'knapsack.exe' : 'knapsack');
+const viteBin = path.join(projectDir, 'node_modules', '.bin', process.platform === 'win32' ? 'vite.cmd' : 'vite');
+const launchAgentPlist = path.join(
+  process.env.HOME || '',
+  'Library',
+  'LaunchAgents',
+  'ai.knap.knapsack.clawdbot.plist',
+);
+
+function qaEnv(extra = {}) {
+  const env = { ...process.env, ...extra };
+  for (const key of Object.keys(env)) {
+    if (key === 'CODEX_SANDBOX_NETWORK_DISABLED' || key.startsWith('CODEX_')) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+function runChecked(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || projectDir,
+    stdio: 'inherit',
+    env: options.env || qaEnv(),
+  });
+  if (result.status !== 0) {
+    process.exit(result.status || 1);
+  }
+}
+
+function waitForUrl(url, timeoutMs = 30_000) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      const req = http.get(url, (res) => {
+        res.resume();
+        resolve();
+      });
+      req.on('error', () => {
+        if (Date.now() - started > timeoutMs) {
+          reject(new Error(`Timed out waiting for ${url}`));
+        } else {
+          setTimeout(attempt, 500);
+        }
+      });
+      req.setTimeout(1000, () => req.destroy());
+    };
+    attempt();
+  });
+}
+
+function waitForFile(file, timeoutMs = 30_000) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      if (fs.existsSync(file)) {
+        resolve();
+      } else if (Date.now() - started > timeoutMs) {
+        reject(new Error(`Timed out waiting for ${file}`));
+      } else {
+        setTimeout(attempt, 500);
+      }
+    };
+    attempt();
+  });
+}
+
+function waitForFreshLaunchAgentPlist(minMtimeMs, timeoutMs = 45_000) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      try {
+        if (fs.existsSync(launchAgentPlist) && fs.statSync(launchAgentPlist).mtimeMs >= minMtimeMs) {
+          const plist = readLaunchAgentPlist();
+          const entry = plist.ProgramArguments?.[1] || '';
+          if (entry.startsWith(path.join(projectDir, 'src-tauri', 'resources', 'clawdbot'))) {
+            resolve(plist);
+            return;
+          }
+        }
+      } catch {
+        // Keep polling while the app is writing the plist.
+      }
+
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error(`Timed out waiting for a fresh dev Clawdbot LaunchAgent plist`));
+      } else {
+        setTimeout(attempt, 500);
+      }
+    };
+    attempt();
+  });
+}
+
+function readLaunchAgentPlist() {
+  const result = spawnSync('plutil', ['-convert', 'json', '-o', '-', launchAgentPlist], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(`Could not read Clawdbot LaunchAgent plist${stderr ? `: ${stderr}` : ''}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function bootoutLaunchAgent() {
+  if (process.platform !== 'darwin') return;
+  const uid = process.getuid?.();
+  if (typeof uid !== 'number') return;
+  const domain = `gui/${uid}`;
+  const service = `${domain}/ai.knap.knapsack.clawdbot`;
+  spawnSync('launchctl', ['bootout', service], { stdio: 'ignore' });
+  spawnSync('launchctl', ['bootout', domain, launchAgentPlist], { stdio: 'ignore' });
+}
+
+function killStaleGateways() {
+  if (process.platform !== 'darwin') return;
+  spawnSync('pkill', ['-TERM', '-f', 'openclaw-gateway'], { stdio: 'ignore' });
+
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const holders = gatewayPortHolderPids();
+    if (holders.length === 0) return;
+    sleep(150);
+  }
+
+  const holders = gatewayPortHolderPids();
+  if (holders.length > 0) {
+    console.warn(`[qa-dev-run] Force-killing stale gateway port holder(s): ${holders.join(', ')}`);
+    spawnSync('kill', ['-KILL', ...holders], { stdio: 'ignore' });
+  }
+}
+
+function killStaleOpenClawChrome() {
+  if (process.platform !== 'darwin') return;
+  const profileNeedles = [
+    path.join('.openclaw', 'browser-profiles', 'openclaw'),
+    path.join('clawdbot', 'browser', 'openclaw', 'user-data'),
+  ];
+  for (const profileNeedle of profileNeedles) {
+    spawnSync('pkill', ['-TERM', '-f', profileNeedle], { stdio: 'ignore' });
+  }
+
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const holders = openClawChromePids(profileNeedles);
+    if (holders.length === 0) return;
+    sleep(150);
+  }
+
+  const holders = openClawChromePids(profileNeedles);
+  if (holders.length > 0) {
+    console.warn(`[qa-dev-run] Force-killing stale OpenClaw Chrome profile process(es): ${holders.join(', ')}`);
+    spawnSync('kill', ['-KILL', ...holders], { stdio: 'ignore' });
+  }
+}
+
+function gatewayPortHolderPids() {
+  const result = spawnSync('lsof', ['-tiTCP:18789', '-sTCP:LISTEN'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0 || !result.stdout) return [];
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((pid) => /^\d+$/.test(pid) && pid !== String(process.pid));
+}
+
+function openClawChromePids(profileNeedles) {
+  const pids = new Set();
+  for (const profileNeedle of profileNeedles) {
+    const result = spawnSync('pgrep', ['-f', profileNeedle], {
+      encoding: 'utf8',
+    });
+    if (result.status !== 0 || !result.stdout) continue;
+    for (const line of result.stdout.split(/\r?\n/)) {
+      const pid = line.trim();
+      if (/^\d+$/.test(pid) && pid !== String(process.pid)) pids.add(pid);
+    }
+  }
+  return [...pids];
+}
+
+function sleep(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // Busy wait is acceptable here: this is a short process-cleanup gate before
+    // launching the dev app, and it avoids adding another async dependency.
+  }
+}
+
+function startDirectGatewayFromPlist() {
+  if (process.platform !== 'darwin') return null;
+  const plist = readLaunchAgentPlist();
+  const args = plist.ProgramArguments;
+  if (!Array.isArray(args) || args.length < 2) {
+    throw new Error('Clawdbot LaunchAgent plist did not include ProgramArguments');
+  }
+
+  const entry = args[1] || '';
+  if (!entry.startsWith(path.join(projectDir, 'src-tauri', 'resources', 'clawdbot'))) {
+    console.warn(`[qa-dev-run] Skipping direct gateway: plist is not targeting this checkout (${entry})`);
+    return null;
+  }
+
+  console.log('[qa-dev-run] Starting direct dev gateway from LaunchAgent plist');
+  bootoutLaunchAgent();
+  killStaleGateways();
+  return spawn(args[0], args.slice(1), {
+    cwd: tauriDir,
+    stdio: 'inherit',
+    env: qaEnv({
+      ...(plist.EnvironmentVariables || {}),
+      OPENCLAW_QA_DIRECT_GATEWAY: '1',
+    }),
+  });
+}
+
+function latestMtimeMs(dir, shouldInclude) {
+  let latest = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'target') continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      latest = Math.max(latest, latestMtimeMs(fullPath, shouldInclude));
+      continue;
+    }
+    if (entry.isFile() && shouldInclude(fullPath)) {
+      latest = Math.max(latest, fs.statSync(fullPath).mtimeMs);
+    }
+  }
+  return latest;
+}
+
+function binaryNeedsRebuild() {
+  if (!fs.existsSync(binary)) return true;
+  const binaryMtime = fs.statSync(binary).mtimeMs;
+  const rustSourceMtime = Math.max(
+    latestMtimeMs(path.join(tauriDir, 'src'), (file) => file.endsWith('.rs')),
+    fs.statSync(path.join(tauriDir, 'Cargo.toml')).mtimeMs,
+    fs.statSync(path.join(tauriDir, 'build.rs')).mtimeMs,
+  );
+  return rustSourceMtime > binaryMtime;
+}
+
+async function main() {
+  runChecked(process.execPath, [path.join(projectDir, 'scripts', 'ensure-clawdbot-deps.cjs')]);
+
+  if (binaryNeedsRebuild()) {
+    const tauriConfig = JSON.stringify({
+      tauri: {
+        bundle: {
+          resources: [
+            'resources/signin_success.html',
+            'resources/signin_error.html',
+          ],
+        },
+      },
+    });
+    runChecked('cargo', ['build', '--no-default-features'], {
+      cwd: tauriDir,
+      env: qaEnv({ TAURI_CONFIG: tauriConfig }),
+    });
+  }
+
+  const vite = spawn(viteBin, ['--host', '127.0.0.1', '--port', '1420', '--strictPort'], {
+    cwd: projectDir,
+    stdio: 'inherit',
+    env: qaEnv(),
+  });
+  let gateway = null;
+  let shuttingDown = false;
+
+  const cleanup = () => {
+    shuttingDown = true;
+    if (!vite.killed) vite.kill('SIGTERM');
+    if (gateway && !gateway.killed) gateway.kill('SIGTERM');
+  };
+  process.on('SIGINT', () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.on('SIGTERM', () => {
+    cleanup();
+    process.exit(143);
+  });
+  process.on('exit', cleanup);
+
+  const startManagedGateway = () => {
+    gateway = startDirectGatewayFromPlist();
+    if (!gateway) return;
+    gateway.on('exit', (code, signal) => {
+      if (shuttingDown) return;
+      console.warn(
+        `[qa-dev-run] Direct gateway exited (${signal || code}); restarting in 3s`,
+      );
+      setTimeout(() => {
+        if (!shuttingDown) startManagedGateway();
+      }, 3000);
+    });
+  };
+
+  await waitForUrl('http://127.0.0.1:1420/');
+  bootoutLaunchAgent();
+  killStaleGateways();
+  killStaleOpenClawChrome();
+
+  const app = spawn(binary, [], {
+    cwd: tauriDir,
+    stdio: 'inherit',
+    env: qaEnv({ KNAPSACK_QA_DIRECT_GATEWAY: '1' }),
+  });
+  const appStartedAt = Date.now();
+  await waitForUrl('http://127.0.0.1:8897/api/clawd/service/status', 45_000);
+  await waitForFreshLaunchAgentPlist(appStartedAt, 60_000);
+  startManagedGateway();
+  app.on('exit', (code, signal) => {
+    cleanup();
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code || 0);
+    }
+  });
+}
+
+main().catch((err) => {
+  console.error(`[qa-dev-run] ${err.message}`);
+  process.exit(1);
+});

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
@@ -7911,8 +7911,8 @@ async function prestageGatewayBundledRuntimeDeps(params) {
 		scanResult = scanBundledPluginRuntimeDeps({
 			packageRoot,
 			config: params.cfg,
-			selectedPluginIds: [...params.pluginIds],
-			env: process.env
+			env: process.env,
+			selectedPluginIds: [...new Set([...params.pluginIds, "acpx"])]
 		});
 	} catch (error) {
 		params.log.warn(`[plugins] failed to scan bundled runtime deps before gateway startup; gateway startup will continue with per-plugin runtime-deps installs: ${String(error)}`);
@@ -8551,16 +8551,21 @@ async function startGatewaySidecars(params) {
 	});
 	const skipChannels = isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
 	await measureStartup(params.startupTrace, "sidecars.channels", async () => {
-		if (!skipChannels) try {
-			await prewarmConfiguredPrimaryModel({
-				cfg: params.cfg,
-				log: params.log
-			});
-			await params.startChannels();
-		} catch (err) {
-			params.logChannels.error(`channel startup failed: ${String(err)}`);
-		}
-		else params.logChannels.info("skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)");
+		if (!skipChannels) {
+			const startConfiguredChannels = async () => {
+				try {
+					await prewarmConfiguredPrimaryModel({
+						cfg: params.cfg,
+						log: params.log
+					});
+					await params.startChannels();
+				} catch (err) {
+					params.logChannels.error(`channel startup failed: ${String(err)}`);
+				}
+			};
+			if (isTruthyEnvValue(process.env.OPENCLAW_QA_DIRECT_GATEWAY)) setTimeout(startConfiguredChannels, 15e3);
+			else setImmediate(startConfiguredChannels);
+		} else params.logChannels.info("skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)");
 	});
 	if (internalHooksConfigured || await hasGatewayStartupInternalHookListeners()) setTimeout(() => {
 		import("./internal-hooks-Cu-9gpiV.js").then(({ createInternalHookEvent, triggerInternalHook }) => {

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -206,15 +206,10 @@ fn clawd_profile(chrome: Option<bool>) -> &'static str {
 }
 
 /// Determine the user-data-dir for the isolated "openclaw" browser profile.
-/// This keeps the fallback browser separate from the user's personal profile.
-fn openclaw_user_data_dir() -> PathBuf {
-  let home = std::env::var("HOME")
-    .or_else(|_| std::env::var("USERPROFILE"))
-    .unwrap_or_else(|_| {
-      if cfg!(target_os = "windows") { r"C:\Users\Default".to_string() }
-      else { "/tmp".to_string() }
-    });
-  PathBuf::from(&home).join(".openclaw").join("browser-profiles").join("openclaw")
+/// This keeps the fallback browser aligned with the gateway-managed profile
+/// instead of opening a second legacy profile under ~/.openclaw.
+fn openclaw_user_data_dir(app_handle: &tauri::AppHandle) -> PathBuf {
+  app_clawdbot_home(app_handle).join("browser").join("openclaw").join("user-data")
 }
 
 /// Cross-platform home directory string (prefers dirs::home_dir, then HOME/USERPROFILE).
@@ -270,12 +265,12 @@ fn knapsack_extension_dir() -> Option<PathBuf> {
 
 /// Build Chromium CLI args for the managed browser profile.
 /// Includes --user-data-dir and --load-extension if the Knapsack extension is found.
-fn build_chromium_args(url: &str) -> Vec<String> {
-  let user_data_dir = openclaw_user_data_dir();
+fn build_chromium_args(app_handle: &tauri::AppHandle, url: &str) -> Vec<String> {
+  let user_data_dir = openclaw_user_data_dir(app_handle);
   let _ = std::fs::create_dir_all(&user_data_dir);
   let udd_arg = format!("--user-data-dir={}", user_data_dir.to_string_lossy());
 
-  let mut args = vec![udd_arg];
+  let mut args = vec![udd_arg, "--remote-debugging-port=18800".to_string()];
 
   // Auto-sideload the Knapsack extension if it's installed locally
   if let Some(ext_dir) = knapsack_extension_dir() {
@@ -292,8 +287,8 @@ fn build_chromium_args(url: &str) -> Vec<String> {
 /// "openclaw" user data directory so it never hijacks the user's personal
 /// profile.  Falls back to the system default only if no Chrome-family browser
 /// can be found.
-fn open_url_in_chrome(url: &str) -> Result<(), String> {
-  let args = build_chromium_args(url);
+fn open_url_in_chrome(app_handle: &tauri::AppHandle, url: &str) -> Result<(), String> {
+  let args = build_chromium_args(app_handle, url);
 
   #[cfg(target_os = "macos")]
   {
@@ -363,7 +358,7 @@ fn open_url_in_chrome(url: &str) -> Result<(), String> {
 
 /// Best-effort fallback: open URL in Chrome first, then system default.
 fn fallback_open_url(app_handle: &tauri::AppHandle, url: &str) -> Result<(), String> {
-  match open_url_in_chrome(url) {
+  match open_url_in_chrome(app_handle, url) {
     Ok(_) => {
       eprintln!("[clawd/browser] Opened URL in Chrome (fallback): {}", url);
       Ok(())
@@ -1321,8 +1316,13 @@ pub async fn agent_chat(
       &text_with_attachments[..text_with_attachments.len().min(100)],
       gateway_attachments.len());
 
-    match gateway_client::agent_chat(&text_with_attachments, &gateway_attachments, None).await {
-      Ok(result) => {
+    match tokio::time::timeout(
+      std::time::Duration::from_secs(20),
+      gateway_client::agent_chat(&text_with_attachments, &gateway_attachments, None),
+    )
+    .await
+    {
+      Ok(Ok(result)) => {
         eprintln!("[clawd/agent-chat] Gateway returned OK. Keys: {:?}",
           result.as_object().map(|o| o.keys().collect::<Vec<_>>()));
         let status = result.get("status").and_then(|s| s.as_str()).unwrap_or("unknown");
@@ -1376,8 +1376,12 @@ pub async fn agent_chat(
           None
         }
       }
-      Err(e) => {
+      Ok(Err(e)) => {
         eprintln!("[clawd/agent-chat] Gateway agent request FAILED: {}, falling back to direct chat", e);
+        None
+      }
+      Err(_) => {
+        eprintln!("[clawd/agent-chat] Gateway agent request timed out after 20s, falling back to direct chat");
         None
       }
     }

--- a/src/src-tauri/src/clawd/gateway_supervisor.rs
+++ b/src/src-tauri/src/clawd/gateway_supervisor.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 /// Global mutex to prevent concurrent `ensure_gateway_running` calls.
@@ -104,6 +105,14 @@ fn check_app_bundle_signature() -> Option<String> {
 
 #[cfg(target_os = "macos")]
 pub fn kickstart_launch_agent(label: &str) -> Result<(), String> {
+  if std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() == Some("1") {
+    eprintln!(
+      "[gateway_supervisor] skipping launchctl kickstart for {} in QA direct gateway mode",
+      label
+    );
+    return Ok(());
+  }
+
   // Verify the app bundle seal before attempting to bootstrap the LaunchAgent.
   // launchd rejects binaries from a bundle with a broken signature with a
   // cryptic I/O error; surface a clear message instead.
@@ -115,10 +124,11 @@ pub fn kickstart_launch_agent(label: &str) -> Result<(), String> {
   let service = format!("gui/{}/{}", uid, label);
 
   // kickstart will start it if loaded; if not loaded, it errors.
-  let output = Command::new("launchctl")
-    .args(["kickstart", "-k", &service])
-    .output()
-    .map_err(|e| format!("Failed to run launchctl kickstart: {}", e))?;
+  let output = launchctl_output_with_timeout(
+    &["kickstart", "-k", &service],
+    Duration::from_secs(5),
+    "gateway supervisor kickstart",
+  )?;
 
   if output.status.success() {
     return Ok(());
@@ -154,17 +164,20 @@ pub fn kickstart_launch_agent(label: &str) -> Result<(), String> {
   eprintln!("[gateway_supervisor] trying bootout + bootstrap fallback");
 
   // bootout (ignore errors — service may not be loaded)
-  let _ = Command::new("launchctl")
-    .args(["bootout", &domain, &plist_str])
-    .output();
+  let _ = launchctl_output_with_timeout(
+    &["bootout", &domain, &plist_str],
+    Duration::from_secs(5),
+    "gateway supervisor bootout",
+  );
 
   // Small delay to let launchd clean up
   std::thread::sleep(std::time::Duration::from_millis(500));
 
-  let boot = Command::new("launchctl")
-    .args(["bootstrap", &domain, &plist_str])
-    .output()
-    .map_err(|e| format!("Failed to run launchctl bootstrap: {}", e))?;
+  let boot = launchctl_output_with_timeout(
+    &["bootstrap", &domain, &plist_str],
+    Duration::from_secs(5),
+    "gateway supervisor bootstrap",
+  )?;
 
   if !boot.status.success() {
     let boot_stderr = String::from_utf8_lossy(&boot.stderr);
@@ -175,9 +188,11 @@ pub fn kickstart_launch_agent(label: &str) -> Result<(), String> {
   }
 
   // kickstart after bootstrap to ensure the process actually starts
-  let kick2 = Command::new("launchctl")
-    .args(["kickstart", "-k", &service])
-    .output();
+  let kick2 = launchctl_output_with_timeout(
+    &["kickstart", "-k", &service],
+    Duration::from_secs(5),
+    "gateway supervisor post-bootstrap kickstart",
+  );
 
   match kick2 {
     Ok(o) if o.status.success() => {
@@ -196,6 +211,44 @@ pub fn kickstart_launch_agent(label: &str) -> Result<(), String> {
     Err(e) => {
       eprintln!("[gateway_supervisor] post-bootstrap kickstart error: {}", e);
       Ok(()) // Bootstrap succeeded, KeepAlive should handle it
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn launchctl_output_with_timeout(
+  args: &[&str],
+  timeout: Duration,
+  context: &str,
+) -> Result<std::process::Output, String> {
+  let mut child = Command::new("launchctl")
+    .args(args)
+    .spawn()
+    .map_err(|e| format!("Failed to run launchctl {}: {}", context, e))?;
+  let start = Instant::now();
+
+  loop {
+    match child.try_wait() {
+      Ok(Some(_)) => {
+        return child
+          .wait_with_output()
+          .map_err(|e| format!("Failed to collect launchctl {} output: {}", context, e));
+      }
+      Ok(None) if start.elapsed() < timeout => {
+        std::thread::sleep(Duration::from_millis(100));
+      }
+      Ok(None) => {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!(
+          "launchctl {} timed out after {}s",
+          context,
+          timeout.as_secs()
+        ));
+      }
+      Err(e) => {
+        return Err(format!("Failed to poll launchctl {}: {}", context, e));
+      }
     }
   }
 }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -242,6 +242,10 @@ fn is_pid_alive(pid: u32) -> bool {
 /// or when the browser transitions from healthy to down, so the nudge
 /// fires again after a gateway restart or a browser crash.
 static BROWSER_START_NUDGED: AtomicBool = AtomicBool::new(false);
+static GATEWAY_LAST_LAUNCH_MS: AtomicU64 = AtomicU64::new(0);
+static QA_DIRECT_GATEWAY_FIRST_SEEN_MS: AtomicU64 = AtomicU64::new(0);
+const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 600_000;
+const PLUGIN_RUNTIME_DEPS_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Browser-control status can temporarily hang while Chrome/CDP is starting.
 /// Health polling is frequent and can otherwise pile up concurrent probes,
@@ -270,7 +274,7 @@ static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
 
 const GATEWAY_HEALTH_SELF_HEAL_GRACE_MS: u64 = 180_000;
 const GATEWAY_POST_BIND_STARTUP_GRACE_MS: u64 = 300_000;
-const BROWSER_START_NUDGE_COOLDOWN_MS: u64 = 15_000;
+const BROWSER_START_NUDGE_COOLDOWN_MS: u64 = 45_000;
 
 fn now_epoch_ms() -> u64 {
   std::time::SystemTime::now()
@@ -351,6 +355,75 @@ pub fn gateway_log_dir() -> PathBuf {
 /// Path to the gateway stdout log file.
 pub fn gateway_stdout_log() -> PathBuf {
   gateway_log_dir().join("knapsack-clawdbot.out.log")
+}
+
+fn mark_gateway_launch_started() {
+  GATEWAY_LAST_LAUNCH_MS.store(now_epoch_ms(), Ordering::Relaxed);
+  GATEWAY_UNREACHABLE_SINCE_MS.store(0, Ordering::Relaxed);
+}
+
+fn gateway_launch_grace_active() -> Option<u64> {
+  let started = GATEWAY_LAST_LAUNCH_MS.load(Ordering::Relaxed);
+  if started == 0 {
+    return None;
+  }
+  let elapsed = now_epoch_ms().saturating_sub(started);
+  if elapsed < GATEWAY_PRE_BIND_STARTUP_GRACE_MS {
+    Some(elapsed)
+  } else {
+    None
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn qa_direct_gateway_process_active() -> bool {
+  if std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() != Some("1") {
+    return false;
+  }
+
+  std::process::Command::new("pgrep")
+    .args(["-f", "openclaw-gateway"])
+    .output()
+    .ok()
+    .filter(|output| output.status.success())
+    .map(|output| {
+      String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .any(process_is_alive)
+    })
+    .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn qa_direct_gateway_process_active() -> bool {
+  false
+}
+
+fn qa_direct_gateway_mode() -> bool {
+  std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() == Some("1")
+}
+
+fn qa_direct_gateway_grace_active() -> Option<u64> {
+  if !qa_direct_gateway_process_active() {
+    QA_DIRECT_GATEWAY_FIRST_SEEN_MS.store(0, Ordering::Relaxed);
+    return None;
+  }
+
+  let now = now_epoch_ms();
+  let started = QA_DIRECT_GATEWAY_FIRST_SEEN_MS.load(Ordering::Relaxed);
+  let started = if started == 0 {
+    QA_DIRECT_GATEWAY_FIRST_SEEN_MS.store(now, Ordering::Relaxed);
+    now
+  } else {
+    started
+  };
+  let elapsed = now.saturating_sub(started);
+  if elapsed < GATEWAY_PRE_BIND_STARTUP_GRACE_MS {
+    Some(elapsed)
+  } else {
+    None
+  }
 }
 
 /// Path to the gateway stderr log file.
@@ -821,6 +894,96 @@ fn count_incomplete_plugin_runtime_deps_dirs(
     }
   }
   incomplete
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+  if pid == 0 {
+    return false;
+  }
+  let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+  if rc == 0 {
+    return true;
+  }
+  std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_is_alive(_pid: u32) -> bool {
+  false
+}
+
+fn plugin_runtime_deps_install_in_progress(clawdbot_home: &std::path::Path) -> bool {
+  let base = clawdbot_home.join("plugin-runtime-deps");
+  let entries = match fs::read_dir(&base) {
+    Ok(d) => d,
+    Err(_) => return false,
+  };
+
+  for entry in entries.flatten() {
+    if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+      continue;
+    }
+
+    let lock_dir = entry.path().join(".openclaw-runtime-deps.lock");
+    if !lock_dir.is_dir() {
+      continue;
+    }
+
+    let owner_path = lock_dir.join("owner.json");
+    if let Ok(raw) = fs::read_to_string(&owner_path) {
+      if let Ok(owner) = serde_json::from_str::<serde_json::Value>(&raw) {
+        if let Some(pid) = owner.get("pid").and_then(|v| v.as_u64()) {
+          if pid <= u32::MAX as u64 && process_is_alive(pid as u32) {
+            return true;
+          }
+          continue;
+        }
+      }
+    }
+
+    // If the owner file has not been written yet, or it is transiently
+    // unreadable, treat a fresh lock as active. This avoids killing the gateway
+    // in the tiny window between mkdir(lock) and owner.json write.
+    if let Ok(meta) = fs::metadata(&lock_dir) {
+      if meta
+        .modified()
+        .ok()
+        .and_then(|mtime| mtime.elapsed().ok())
+        .map(|age| age < PLUGIN_RUNTIME_DEPS_LOCK_GRACE)
+        .unwrap_or(false)
+      {
+        return true;
+      }
+    }
+  }
+
+  false
+}
+
+fn default_clawdbot_home_from_env() -> Option<PathBuf> {
+  if let Some(raw) = std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("OPENCLAW_HOME")) {
+    let path = PathBuf::from(raw);
+    if !path.as_os_str().is_empty() {
+      return Some(path);
+    }
+  }
+
+  #[cfg(target_os = "macos")]
+  {
+    return dirs::home_dir().map(|home| {
+      home
+        .join("Library")
+        .join("Application Support")
+        .join("ai.knap.knapsack")
+        .join("clawdbot")
+    });
+  }
+
+  #[cfg(not(target_os = "macos"))]
+  {
+    None
+  }
 }
 
 /// Remove current-version plugin-runtime-deps dirs left half-created by an
@@ -1676,6 +1839,69 @@ fn launchctl_service_loaded(domain: &str, timeout: std::time::Duration) -> bool 
   }
 }
 
+#[cfg(target_os = "macos")]
+fn launchctl_status_with_timeout(
+  args: &[&str],
+  timeout: std::time::Duration,
+  context: &str,
+) -> Option<std::process::ExitStatus> {
+  let mut child = match std::process::Command::new("launchctl")
+    .args(args)
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+  {
+    Ok(child) => child,
+    Err(e) => {
+      eprintln!("[clawd/service] {}: launchctl spawn failed: {}", context, e);
+      return None;
+    }
+  };
+
+  let started = std::time::Instant::now();
+  loop {
+    match child.try_wait() {
+      Ok(Some(status)) => return Some(status),
+      Ok(None) if started.elapsed() < timeout => {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+      }
+      Ok(None) => {
+        let _ = child.kill();
+        let _ = child.wait();
+        eprintln!(
+          "[clawd/service] {}: launchctl timed out after {:?}",
+          context, timeout
+        );
+        return None;
+      }
+      Err(e) => {
+        eprintln!("[clawd/service] {}: launchctl wait failed: {}", context, e);
+        return None;
+      }
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn launchctl_kickstart_with_timeout(service: &str, context: &str) {
+  if qa_direct_gateway_mode() {
+    eprintln!(
+      "[clawd/service] {}: skipping launchctl kickstart in QA direct gateway mode",
+      context
+    );
+    mark_gateway_launch_started();
+    return;
+  }
+
+  let _ = launchctl_status_with_timeout(
+    &["kickstart", "-k", service],
+    std::time::Duration::from_secs(5),
+    context,
+  );
+  mark_gateway_launch_started();
+}
+
 async fn gateway_health_port_ok(timeout: std::time::Duration) -> bool {
   let client = match reqwest::Client::builder().timeout(timeout).build() {
     Ok(c) => c,
@@ -1706,7 +1932,15 @@ async fn browser_cdp_port_open(timeout: std::time::Duration) -> bool {
 }
 
 pub async fn gateway_reachable_or_ready(timeout: std::time::Duration) -> bool {
-  gateway_health_port_ok(timeout).await
+  if gateway_health_port_ok(timeout).await {
+    return true;
+  }
+
+  if qa_direct_gateway_mode() {
+    return gateway_tcp_port_open(timeout).await;
+  }
+
+  false
 }
 
 fn read_log_tail_lines_bounded(
@@ -2966,6 +3200,14 @@ async fn run_gateway_self_heal_cycle(
     return;
   }
 
+  if qa_direct_gateway_mode() {
+    eprintln!(
+      "[clawd/service] self-heal: skipping launchd recovery in QA direct gateway mode; qa-dev-run supervises the gateway process"
+    );
+    GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
+    return;
+  }
+
   let cfg: crate::clawd::sidecar::SharedClawdbotConfig = std::sync::Arc::new(
     tokio::sync::RwLock::new(crate::clawd::sidecar::ClawdbotConfig::default()),
   );
@@ -3042,7 +3284,7 @@ async fn run_gateway_self_heal_cycle(
   let bundle_version = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
   remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
 
-  if crash_class == "module_resolution_fail" {
+  if crash_class == "module_resolution_fail" || crash_class == "plugin_install_fail" {
     eprintln!("[clawd/service] self-heal: plugin runtime corruption detected — force-wiping all plugin-runtime-deps dirs");
     remove_stale_plugin_runtime_deps_versions(&clawdbot_home, "");
   } else {
@@ -3174,6 +3416,18 @@ async fn run_gateway_self_heal_cycle(
 /// bundled plugin runtime dependencies. Treat that as startup progress, not a
 /// crash, so health polling does not repeatedly SIGTERM the installer process.
 pub(crate) fn gateway_runtime_deps_startup_in_progress() -> bool {
+  if default_clawdbot_home_from_env()
+    .as_deref()
+    .map(plugin_runtime_deps_install_in_progress)
+    .unwrap_or(false)
+  {
+    return true;
+  }
+
+  if qa_direct_gateway_mode() {
+    return false;
+  }
+
   let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
     return false;
   };
@@ -3188,11 +3442,18 @@ fn gateway_post_bind_startup_in_progress() -> bool {
 }
 
 pub(crate) fn gateway_startup_in_progress() -> bool {
+  if qa_direct_gateway_grace_active().is_some() {
+    return true;
+  }
+
+  if gateway_runtime_deps_startup_in_progress() {
+    return true;
+  }
+
   let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
     return false;
   };
-  gateway_runtime_deps_startup_in_progress_from_log(&content)
-    || gateway_pre_bind_startup_in_progress_from_log(&content)
+  gateway_pre_bind_startup_in_progress_from_log(&content)
     || gateway_post_bind_startup_in_progress_from_log(&content)
 }
 
@@ -3407,6 +3668,44 @@ async fn browser_control_start_direct(
   }
 }
 
+#[cfg(target_os = "macos")]
+fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), String> {
+  let chrome = Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
+  if !chrome.exists() {
+    return Err("Google Chrome app binary was not found".to_string());
+  }
+
+  let user_data_dir = app_clawdbot_home(app_handle)
+    .join("browser")
+    .join("openclaw")
+    .join("user-data");
+  fs::create_dir_all(&user_data_dir).map_err(|e| {
+    format!(
+      "failed to create OpenClaw Chrome profile at {}: {}",
+      user_data_dir.display(),
+      e
+    )
+  })?;
+
+  std::process::Command::new(chrome)
+    .arg("--remote-debugging-port=18800")
+    .arg(format!("--user-data-dir={}", user_data_dir.to_string_lossy()))
+    .arg("--profile-directory=Default")
+    .arg("--no-first-run")
+    .arg("--no-default-browser-check")
+    .arg("--disable-background-networking")
+    .arg("--disable-features=Translate,OptimizationHints,MediaRouter")
+    .arg("--disable-sync")
+    .arg("--no-proxy-server")
+    .arg("about:blank")
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+    .map(|_| ())
+    .map_err(|e| format!("failed to launch OpenClaw Chrome profile: {}", e))
+}
+
 #[get("/api/clawd/service/health")]
 pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
   #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -3468,6 +3767,16 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     } else {
       gateway_post_bind_startup_in_progress()
     };
+    let runtime_deps_startup = if gateway_ok {
+      false
+    } else {
+      gateway_runtime_deps_startup_in_progress()
+    };
+    let launch_grace_elapsed_ms = if gateway_ok {
+      None
+    } else {
+      gateway_launch_grace_active().or_else(qa_direct_gateway_grace_active)
+    };
 
     if gateway_ok {
       // Gateway is up — record it so we can detect down→up transitions.
@@ -3489,7 +3798,9 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         // session.  They may still hold the CDP port (18800), preventing
         // the new gateway from launching its own browser.
         #[cfg(any(target_os = "macos", target_os = "windows"))]
-        kill_stale_clawdbot_chromes();
+        if !qa_direct_gateway_mode() {
+          kill_stale_clawdbot_chromes();
+        }
         // Invalidate the pooled WebSocket connection — the old one is dead.
         gateway_client::invalidate();
       }
@@ -3525,9 +3836,15 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     // If gateway is down, try to restart it via launchctl kickstart.
     // This runs in a background task to avoid blocking the health poll.
     // We guard with GATEWAY_RESTART_IN_PROGRESS to prevent concurrent restarts.
-    if !gateway_ok && gateway_runtime_deps_startup_in_progress() {
+    if !gateway_ok && runtime_deps_startup {
       eprintln!(
         "[clawd/service] gateway not reachable but plugin runtime deps are staging - skipping restart"
+      );
+    } else if !gateway_ok && launch_grace_elapsed_ms.is_some() {
+      let elapsed = launch_grace_elapsed_ms.unwrap_or(0);
+      eprintln!(
+        "[clawd/service] gateway not reachable for {}ms after launch - waiting before self-heal",
+        elapsed
       );
     } else if !gateway_ok
       && !was_healthy
@@ -3640,7 +3957,38 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       eprintln!("[clawd/service] browser not reachable — sending /start nudge");
       BROWSER_LAST_NUDGE_MS.store(now_epoch_ms(), Ordering::Relaxed);
       let token = tokens.gateway_token.clone();
+      let nudge_app_handle: tauri::AppHandle = app_handle.get_ref().clone();
       tokio::spawn(async move {
+        if qa_direct_gateway_mode() {
+          #[cfg(target_os = "macos")]
+          {
+            match start_openclaw_chrome_direct(&nudge_app_handle) {
+              Ok(()) => {
+                eprintln!(
+                  "[clawd/service] launched OpenClaw Chrome profile directly for QA startup"
+                );
+              }
+              Err(e) => {
+                eprintln!(
+                  "[clawd/service] direct OpenClaw Chrome launch failed in QA startup: {}",
+                  e
+                );
+                BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
+              }
+            }
+            return;
+          }
+
+          #[cfg(not(target_os = "macos"))]
+          {
+            eprintln!(
+              "[clawd/service] QA direct browser nudge is not implemented on this platform"
+            );
+            BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
+            return;
+          }
+        }
+
         // Kill any stale Chrome holding the CDP port (18800) before asking the
         // gateway to start a new one.  This handles the case where the app
         // started with the gateway already running but Chrome crashed and left
@@ -3700,6 +4048,11 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     } else if gateway_ok && browser_probe == BrowserControlProbe::Starting {
       "Clawdbot gateway OK; browser is still starting up — waiting for Chrome CDP to become ready"
         .to_string()
+    } else if runtime_deps_startup {
+      "Clawdbot gateway is staging plugin runtime dependencies — please wait for startup to finish"
+        .to_string()
+    } else if launch_grace_elapsed_ms.is_some() {
+      "Clawdbot gateway is starting — please wait for startup to finish".to_string()
     } else if gateway_ok {
       "Clawdbot gateway OK; browser control is not reachable".to_string()
     } else if browser_ok {
@@ -3716,7 +4069,26 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       {
         match launch_agent_plist_path() {
           Ok(plist) => {
-            if !plist.exists() {
+            if qa_direct_gateway_mode() {
+              if runtime_deps_startup {
+                message.push_str(
+                  "\n[diagnostic] QA direct gateway is installing plugin runtime dependencies.",
+                );
+                diagnostic_type = Some("runtime_deps_installing".to_string());
+              } else if let Some(elapsed) = launch_grace_elapsed_ms {
+                message.push_str(&format!(
+                  "\n[diagnostic] QA direct gateway launched {}ms ago and is still starting.",
+                  elapsed
+                ));
+                diagnostic_type = Some("gateway_starting".to_string());
+              } else {
+                message.push_str(
+                  "\n[diagnostic] QA direct gateway is running outside launchd but is not responding yet.",
+                );
+                diagnostic_type = Some("gateway_starting".to_string());
+              }
+              eprintln!("[clawd/service] gateway down: QA direct gateway starting");
+            } else if !plist.exists() {
               // Differentiate: auto-enable already started means first-install race,
               // otherwise the service truly hasn't been set up.
               if AUTO_ENABLE_STARTED.load(Ordering::Relaxed) {
@@ -3743,6 +4115,19 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
                 );
               } else {
                 eprintln!("[clawd/service] gateway down: service is loaded but not responding on port 18789");
+
+                if runtime_deps_startup {
+                  message.push_str(
+                    "\n[diagnostic] Gateway process is installing plugin runtime dependencies.",
+                  );
+                  diagnostic_type = Some("runtime_deps_installing".to_string());
+                } else if let Some(elapsed) = launch_grace_elapsed_ms {
+                  message.push_str(&format!(
+                    "\n[diagnostic] Gateway launched {}ms ago and is still starting.",
+                    elapsed
+                  ));
+                  diagnostic_type = Some("gateway_starting".to_string());
+                }
 
                 // Check if Gatekeeper quarantine is blocking the gateway binary.
                 // macOS can silently kill quarantined or improperly signed processes.
@@ -3788,7 +4173,11 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       let legacy_err_path = std::path::PathBuf::from("/tmp/knapsack-clawdbot.err.log");
       let log_content =
         read_log_tail_lines_bounded(&[err_path.clone(), legacy_err_path], 256 * 1024, 400);
-      if let Ok(content) = log_content {
+      if runtime_deps_startup || launch_grace_elapsed_ms.is_some() {
+        // During active startup the stderr file commonly contains stale lines
+        // from previous gateway runs. Showing/classifying those makes the UI
+        // report old crashes while the current gateway is still booting.
+      } else if let Ok(content) = log_content {
         // Detect version mismatch before noise-filtering so we can tag diagnostic_type,
         // even though the lines are stripped from the user-visible tail below.
         let has_version_mismatch = content.lines().any(|l| {
@@ -4781,6 +5170,41 @@ pub async fn set_api_key(
     {
       if let Ok(plist_path) = launch_agent_plist_path() {
         regenerate_macos_plist_with_current_env(&plist_path);
+        if qa_direct_gateway_mode() {
+          bootout_gateway_launch_agent(LAUNCH_AGENT_LABEL);
+          let qa_switch_model = switch_model.clone();
+          tokio::spawn(async move {
+            if !crate::clawd::gateway_client::is_gateway_port_open().await {
+              return;
+            }
+            let cfg_result = crate::clawd::gateway_client::config_get(None).await;
+            if let Ok(cfg_val) = cfg_result {
+              let base_hash = cfg_val.get("hash").and_then(|h| h.as_str()).unwrap_or("");
+              if !base_hash.is_empty() {
+                let patch = serde_json::json!({
+                  "agents": {"defaults": {"model": {"primary": qa_switch_model}}}
+                });
+                match crate::clawd::gateway_client::config_patch(&patch.to_string(), base_hash, None).await {
+                  Ok(_) => eprintln!(
+                    "[clawd/service] Pushed provider switch model to running gateway in QA direct mode"
+                  ),
+                  Err(e) => eprintln!(
+                    "[clawd/service] Failed to push QA direct provider switch model to gateway: {}",
+                    e
+                  ),
+                }
+              }
+            }
+          });
+          eprintln!(
+            "[clawd/service] Provider switch to '{}' prepared plist without launchd restart in QA direct mode",
+            provider
+          );
+          return HttpResponse::Ok().json(SetApiKeyResponse {
+            success: true,
+            message: format!("Switched to {}", provider_name),
+          });
+        }
         let uid = unsafe { libc::getuid() };
         let domain = format!("gui/{}", uid);
         let _ = std::process::Command::new("launchctl")
@@ -4791,9 +5215,7 @@ pub async fn set_api_key(
           .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
           .status();
         let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-        let _ = std::process::Command::new("launchctl")
-          .args(["kickstart", "-k", &service])
-          .status();
+        launchctl_kickstart_with_timeout(&service, "provider switch kickstart");
       }
     }
     return HttpResponse::Ok().json(SetApiKeyResponse {
@@ -5052,9 +5474,7 @@ pub async fn set_api_key(
         .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
         .status();
       let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-      let _ = std::process::Command::new("launchctl")
-        .args(["kickstart", "-k", &service])
-        .status();
+      launchctl_kickstart_with_timeout(&service, "api key restart kickstart");
     }
   }
 
@@ -7388,6 +7808,22 @@ pub async fn set_service_enabled(
     };
 
     if enabled {
+      if qa_direct_gateway_mode() {
+        {
+          let mut cfg_guard = cfg.write().await;
+          cfg_guard.base_url = Some("http://127.0.0.1:18791".to_string());
+        }
+        eprintln!(
+          "[clawd/service] QA direct gateway is managed by qa-dev-run; leaving service plist unchanged"
+        );
+        return HttpResponse::Ok().json(EnableServiceResponse {
+          success: true,
+          enabled,
+          message:
+            "QA direct gateway is managed by qa-dev-run; left service plist unchanged".to_string(),
+        });
+      }
+
       // Ensure dirs
       if let Some(parent) = plist_path.parent() {
         if let Err(e) = ensure_dir(parent) {
@@ -8767,9 +9203,7 @@ pub async fn set_service_enabled(
       }
 
       let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-      let _ = std::process::Command::new("launchctl")
-        .args(["kickstart", "-k", &service])
-        .status();
+      launchctl_kickstart_with_timeout(&service, "enable service kickstart");
 
       // Workaround for OpenClaw #23006: patch paired.json after the gateway
       // starts to ensure devices get operator.admin scope.  The gateway may
@@ -8859,9 +9293,7 @@ pub async fn cycle_service(_app_handle: &tauri::AppHandle) {
     .status();
 
   let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-  let _ = std::process::Command::new("launchctl")
-    .args(["kickstart", "-k", &service])
-    .status();
+  launchctl_kickstart_with_timeout(&service, "cycle service kickstart");
 
   eprintln!("[clawd/service] Service cycle complete — waiting for browser to start.");
 }
@@ -9449,9 +9881,7 @@ async fn do_gemini_connect(app_handle: &tauri::AppHandle, code: &str) -> Result<
         .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
         .status();
       let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-      let _ = std::process::Command::new("launchctl")
-        .args(["kickstart", "-k", &service])
-        .status();
+      launchctl_kickstart_with_timeout(&service, "gemini oauth kickstart");
     }
   }
 
@@ -9679,9 +10109,7 @@ fn save_and_restart_for_oauth(
         .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
         .status();
       let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-      let _ = std::process::Command::new("launchctl")
-        .args(["kickstart", "-k", &service])
-        .status();
+      launchctl_kickstart_with_timeout(&service, "provider oauth kickstart");
     }
   }
 
@@ -9772,6 +10200,62 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   let _lifecycle_guard = GATEWAY_LIFECYCLE_MUTEX.lock().await;
   let _progress_guard = GatewayRestartProgressGuard::set();
 
+  if qa_direct_gateway_mode() {
+    let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+    sanitize_config_file_allowlist(&config_path);
+    remove_stale_standalone_gateway();
+
+    let cfg: crate::clawd::sidecar::SharedClawdbotConfig = std::sync::Arc::new(
+      tokio::sync::RwLock::new(crate::clawd::sidecar::ClawdbotConfig::default()),
+    );
+    let setup = match prepare_gateway_config(app_handle, &cfg).await {
+      Ok(s) => s,
+      Err(e) => {
+        eprintln!(
+          "[clawd/service] auto_enable: prepare_gateway_config failed in QA direct mode: {}",
+          e
+        );
+        return;
+      }
+    };
+
+    if let Some(parent) = plist_path.parent() {
+      if let Err(e) = fs::create_dir_all(parent) {
+        eprintln!(
+          "[clawd/service] auto_enable: failed to create LaunchAgents dir in QA direct mode: {}",
+          e
+        );
+        return;
+      }
+    }
+
+    let plist_content = generate_plist(&setup.program_args, &setup.env);
+    if let Err(e) = fs::write(&plist_path, &plist_content) {
+      eprintln!(
+        "[clawd/service] auto_enable: failed to write QA direct plist: {}",
+        e
+      );
+      return;
+    }
+    harden_file_permissions(&plist_path);
+    *LAST_MACOS_PLIST_ARGS.lock().unwrap() = Some((setup.program_args.clone(), setup.env));
+
+    let uid = unsafe { libc::getuid() };
+    let domain = format!("gui/{}", uid);
+    let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
+    let _ = std::process::Command::new("launchctl")
+      .args(["bootout", &service])
+      .status();
+    let _ = std::process::Command::new("launchctl")
+      .args(["bootout", &domain, plist_path.to_string_lossy().as_ref()])
+      .status();
+    mark_gateway_launch_started();
+    eprintln!(
+      "[clawd/service] auto_enable: wrote plist and skipped launchd bootstrap in QA direct mode"
+    );
+    return;
+  }
+
   if plist_path.exists() {
     // Plist exists — check if the service is actually loaded.  If it is,
     // there's nothing to do.  If it isn't (e.g. bootstrap failed on a prior
@@ -9809,9 +10293,25 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
       let incomplete = count_incomplete_plugin_runtime_deps_dirs(&clawdbot_home, &bundle_ver);
       if stale == 0 && incomplete > 0 {
         eprintln!(
-          "[clawd/service] auto_enable: detected {} incomplete plugin-runtime-deps dir(s) for current bundle — leaving running gateway alone",
+          "[clawd/service] auto_enable: detected {} incomplete plugin-runtime-deps dir(s) for current bundle — cleaning and forcing gateway restart",
           incomplete
         );
+        let uid = unsafe { libc::getuid() };
+        let domain = format!("gui/{}", uid);
+        let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
+        let _ = std::process::Command::new("launchctl")
+          .args(["bootout", &service])
+          .status();
+        std::thread::sleep(std::time::Duration::from_millis(800));
+        kill_process_on_port(18789);
+        remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
+        remove_incomplete_plugin_runtime_deps_dirs(&clawdbot_home, &bundle_ver);
+        if let Ok(plist_path) = launch_agent_plist_path() {
+          let _ = std::process::Command::new("launchctl")
+            .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
+            .status();
+          launchctl_kickstart_with_timeout(&service, "auto-enable incomplete deps kickstart");
+        }
       } else if stale > 0 {
         eprintln!(
           "[clawd/service] auto_enable: detected {} stale and {} incomplete plugin-runtime-deps dir(s) (bundle ver={}) — cleaning and forcing gateway restart",
@@ -9837,9 +10337,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
           let _ = std::process::Command::new("launchctl")
             .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
             .status();
-          let _ = std::process::Command::new("launchctl")
-            .args(["kickstart", "-k", &service])
-            .status();
+          launchctl_kickstart_with_timeout(&service, "auto-enable stale deps kickstart");
         }
         sentry::with_scope(
           |scope| {
@@ -9874,9 +10372,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
           let _ = std::process::Command::new("launchctl")
             .args(["bootstrap", &domain, plist_path.to_string_lossy().as_ref()])
             .status();
-          let _ = std::process::Command::new("launchctl")
-            .args(["kickstart", "-k", &service])
-            .status();
+          launchctl_kickstart_with_timeout(&service, "auto-enable content refresh kickstart");
         }
         sentry::capture_message(
           "[gateway] auto_enable: bundle content changed — wiped stale plugin-runtime-deps + restarted",
@@ -10043,9 +10539,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   match boot {
     Ok(s) if s.success() => {
       let service = format!("{}/{}", domain, LAUNCH_AGENT_LABEL);
-      let _ = std::process::Command::new("launchctl")
-        .args(["kickstart", "-k", &service])
-        .status();
+      launchctl_kickstart_with_timeout(&service, "auto-enable initial kickstart");
       eprintln!("[clawd/service] auto_enable: LaunchAgent registered and started");
 
       // Workaround for OpenClaw #23006: patch paired.json after the gateway

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -130,11 +130,24 @@ pub async fn start_server<'a>(
         .output();
 
       if let Ok(output) = lsof_output {
-        let pid_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !pid_str.is_empty() {
-          eprintln!("Killing zombie process on port {} (PID: {})", port, pid_str);
+        let pid_output = String::from_utf8_lossy(&output.stdout);
+        let current_pid = std::process::id().to_string();
+        let pids: Vec<String> = pid_output
+          .lines()
+          .map(str::trim)
+          .filter(|pid| !pid.is_empty() && *pid != current_pid)
+          .map(ToString::to_string)
+          .collect();
+
+        if !pids.is_empty() {
+          eprintln!(
+            "Killing zombie process(es) on port {} (PIDs: {})",
+            port,
+            pids.join(", ")
+          );
           let _ = std::process::Command::new("kill")
-            .args(["-9", &pid_str])
+            .arg("-9")
+            .args(&pids)
             .status();
           std::thread::sleep(std::time::Duration::from_millis(500));
         }


### PR DESCRIPTION
## Summary
Stabilizes Knapsack/Clawdbot startup by hardening gateway launch, browser-control readiness, runtime dependency staging, and dev QA startup.

This is the clean main-based release PR containing only the startup fix cherry-picked from 5454f37ac.

## Fixes
- Avoids launchd/plist races during QA direct startup.
- Adds startup grace windows for gateway and plugin runtime dependency staging.
- Prevents browser-control health polling from repeatedly invoking /start.
- Launches the OpenClaw Chrome profile directly during QA startup when browser-control is not yet responsive.
- Adds timeouts around launchctl recovery paths.
- Cleans incomplete plugin runtime dependency directories before restart.
- Fixes multi-PID port cleanup for the local Actix server.

## Verification
- node --check src/scripts/qa-dev-run.cjs
- cargo check --no-default-features
- Earlier QA verification: npm run qa:dev confirmed /api/clawd/service/health returns gateway/browser healthy and Chrome DevTools responds on 127.0.0.1:18800 using the OpenClaw profile.