### PR TITLE
Keep Jiti runtime cache outside macOS app bundle

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/registry-0w2lmC7e.js
+++ b/src/src-tauri/resources/clawdbot/dist/registry-0w2lmC7e.js
@@ -138,7 +138,7 @@ function loadBundledCapabilityRuntimeRegistry(params) {
 	const registry = createEmptyPluginRegistry();
 	const jitiLoaders = /* @__PURE__ */ new Map();
 	const getJiti = (modulePath) => {
-		const tryNative = shouldPreferNativeJiti(modulePath) && !(env?.VITEST && params.pluginSdkResolution === "dist");
+		const tryNative = false;
 		const aliasMap = shouldApplyVitestCapabilityAliasOverrides({
 			pluginSdkResolution: params.pluginSdkResolution,
 			env

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -7323,6 +7323,10 @@ async fn prepare_gateway_config(
     .join("plugin-runtime-deps")
     .to_string_lossy()
     .to_string();
+  let jiti_cache_dir = PathBuf::from(&clawdbot_home_str)
+    .join("jiti-cache")
+    .to_string_lossy()
+    .to_string();
 
   let mut env = vec![
     ("PATH".to_string(), clawdbot_path),
@@ -7335,6 +7339,7 @@ async fn prepare_gateway_config(
     ),
     ("OPENCLAW_GATEWAY_PORT".to_string(), "18789".to_string()),
     ("OPENCLAW_PLUGIN_STAGE_DIR".to_string(), plugin_stage_dir),
+    ("JITI_FS_CACHE".to_string(), jiti_cache_dir),
     (
       "OPENCLAW_BUNDLED_PLUGINS_DIR".to_string(),
       bundled_plugins_dir_str,
@@ -8882,6 +8887,10 @@ pub async fn set_service_enabled(
       // bundled_plugins_dir was resolved earlier (before config patching)
       let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
       let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
+      let jiti_cache_dir = PathBuf::from(&clawdbot_home_str)
+        .join("jiti-cache")
+        .to_string_lossy()
+        .to_string();
 
       eprintln!("[clawd/service] Running OpenClaw doctor --fix to ensure plugin dependencies...");
       let doctor_status = std::process::Command::new(&node_path)
@@ -8890,6 +8899,7 @@ pub async fn set_service_enabled(
         .arg("--fix")
         .env("OPENCLAW_STATE_DIR", &clawdbot_home_str)
         .env("OPENCLAW_BUNDLED_PLUGINS_DIR", &bundled_plugins_dir_str)
+        .env("JITI_FS_CACHE", &jiti_cache_dir)
         .status();
 
       match doctor_status {
@@ -8946,6 +8956,10 @@ pub async fn set_service_enabled(
         .join("plugin-runtime-deps")
         .to_string_lossy()
         .to_string();
+      let jiti_cache_dir = PathBuf::from(&clawdbot_home_str)
+        .join("jiti-cache")
+        .to_string_lossy()
+        .to_string();
 
       let mut env = vec![
         ("PATH".to_string(), clawdbot_path),
@@ -8961,6 +8975,7 @@ pub async fn set_service_enabled(
         // Ensure control server family ports remain default.
         ("OPENCLAW_GATEWAY_PORT".to_string(), "18789".to_string()),
         ("OPENCLAW_PLUGIN_STAGE_DIR".to_string(), plugin_stage_dir),
+        ("JITI_FS_CACHE".to_string(), jiti_cache_dir),
         // Point to bundled plugins/extensions directory so OpenClaw can find memory-core etc.
         // Point to bundled plugins/extensions directory so OpenClaw can find memory-core etc.
         (


### PR DESCRIPTION
## Summary
- set JITI_FS_CACHE to the Knapsack Application Support clawdbot cache dir for gateway startup
- apply the same cache location to the doctor --fix path
- prevents Jiti from creating dist/extensions/*/node_modules/.cache/jiti files inside the signed Knapsack.app bundle

## QA finding
After installing v2.0.1 from knapsack.ai and replacing /Applications/Knapsack.app, the QA loop blocked at gateway/browser readiness. The LaunchAgent was loaded and the gateway process listened on 18789, but /health timed out and browser control on 18791 was down. Local code signature verification showed the app seal was invalidated by Jiti cache files created under Contents/Resources/resources/clawdbot/dist/extensions/*/node_modules/.cache/jiti.

## Test
- cargo check --manifest-path src/src-tauri/Cargo.toml
