### PR TITLE
Fix Mac startup stalls and code-signing invalidation

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
+++ b/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
@@ -1389,6 +1389,7 @@ function ensureBundledPluginRuntimeDeps(params) {
 //#region src/plugins/bundled-runtime-root.ts
 const bundledRuntimeDepsRetainSpecsByInstallRoot = /* @__PURE__ */ new Map();
 const BUNDLED_RUNTIME_MIRROR_LOCK_DIR = ".openclaw-runtime-mirror.lock";
+const BUNDLED_RUNTIME_MIRROR_SOURCE_MARKER = ".openclaw-runtime-mirror-source.json";
 function isBuiltBundledPluginRuntimeRoot(pluginRoot) {
 	const extensionsDir = path.dirname(pluginRoot);
 	const buildDir = path.dirname(extensionsDir);
@@ -1442,6 +1443,10 @@ function mirrorBundledPluginRuntimeRoot(params) {
 			pluginRoot: params.pluginRoot
 		});
 		const mirrorRoot = path.join(mirrorParent, params.pluginId);
+		if (isReusableBundledRuntimeMirror({
+			pluginRoot: params.pluginRoot,
+			mirrorRoot
+		})) return mirrorRoot;
 		fs.mkdirSync(params.installRoot, { recursive: true });
 		try {
 			fs.chmodSync(params.installRoot, 493);
@@ -1456,6 +1461,7 @@ function mirrorBundledPluginRuntimeRoot(params) {
 		const stagedRoot = path.join(tempDir, "plugin");
 		try {
 			copyBundledPluginRuntimeRoot(params.pluginRoot, stagedRoot);
+			writeBundledRuntimeMirrorSourceMarker(stagedRoot, params.pluginRoot);
 			fs.rmSync(mirrorRoot, {
 				recursive: true,
 				force: true
@@ -1469,6 +1475,23 @@ function mirrorBundledPluginRuntimeRoot(params) {
 		}
 		return mirrorRoot;
 	});
+}
+function isReusableBundledRuntimeMirror(params) {
+	if (!fs.existsSync(params.mirrorRoot)) return false;
+	const marker = readJsonObject(path.join(params.mirrorRoot, BUNDLED_RUNTIME_MIRROR_SOURCE_MARKER));
+	if (!marker || typeof marker.sourceRealpath !== "string") return false;
+	try {
+		return marker.sourceRealpath === fs.realpathSync(params.pluginRoot);
+	} catch {
+		return false;
+	}
+}
+function writeBundledRuntimeMirrorSourceMarker(mirrorRoot, pluginRoot) {
+	try {
+		writeRuntimeJsonFile(path.join(mirrorRoot, BUNDLED_RUNTIME_MIRROR_SOURCE_MARKER), {
+			sourceRealpath: fs.realpathSync(pluginRoot)
+		});
+	} catch {}
 }
 function prepareBundledPluginRuntimeDistMirror(params) {
 	const sourceExtensionsRoot = path.dirname(params.pluginRoot);
@@ -1525,11 +1548,7 @@ function copyBundledPluginRuntimeRoot(sourceRoot, targetRoot) {
 			continue;
 		}
 		if (!entry.isFile()) continue;
-		fs.copyFileSync(sourcePath, targetPath);
-		try {
-			const sourceMode = fs.statSync(sourcePath).mode;
-			fs.chmodSync(targetPath, sourceMode | 384);
-		} catch {}
+		materializeBundledRuntimeMirrorDistFile(sourcePath, targetPath);
 	}
 }
 function writeRuntimeJsonFile(targetPath, value) {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -914,6 +914,10 @@ fn process_is_alive(_pid: u32) -> bool {
 }
 
 fn plugin_runtime_deps_install_in_progress(clawdbot_home: &std::path::Path) -> bool {
+  const LOCK_DIR_NAMES: &[&str] = &[
+    ".openclaw-runtime-deps.lock",
+    ".openclaw-runtime-mirror.lock",
+  ];
   let base = clawdbot_home.join("plugin-runtime-deps");
   let entries = match fs::read_dir(&base) {
     Ok(d) => d,
@@ -925,40 +929,57 @@ fn plugin_runtime_deps_install_in_progress(clawdbot_home: &std::path::Path) -> b
       continue;
     }
 
-    let lock_dir = entry.path().join(".openclaw-runtime-deps.lock");
-    if !lock_dir.is_dir() {
-      continue;
+    let package_dir = entry.path();
+    if LOCK_DIR_NAMES
+      .iter()
+      .any(|name| plugin_runtime_deps_lock_active(&package_dir.join(name)))
+    {
+      return true;
     }
 
-    let owner_path = lock_dir.join("owner.json");
-    if let Ok(raw) = fs::read_to_string(&owner_path) {
-      if let Ok(owner) = serde_json::from_str::<serde_json::Value>(&raw) {
-        if let Some(pid) = owner.get("pid").and_then(|v| v.as_u64()) {
-          if pid <= u32::MAX as u64 && process_is_alive(pid as u32) {
-            return true;
-          }
-          continue;
+    let dist_extensions = package_dir.join("dist").join("extensions");
+    if let Ok(plugins) = fs::read_dir(&dist_extensions) {
+      for plugin in plugins.flatten() {
+        if plugin.file_type().map(|t| t.is_dir()).unwrap_or(false)
+          && LOCK_DIR_NAMES
+            .iter()
+            .any(|name| plugin_runtime_deps_lock_active(&plugin.path().join(name)))
+        {
+          return true;
         }
-      }
-    }
-
-    // If the owner file has not been written yet, or it is transiently
-    // unreadable, treat a fresh lock as active. This avoids killing the gateway
-    // in the tiny window between mkdir(lock) and owner.json write.
-    if let Ok(meta) = fs::metadata(&lock_dir) {
-      if meta
-        .modified()
-        .ok()
-        .and_then(|mtime| mtime.elapsed().ok())
-        .map(|age| age < PLUGIN_RUNTIME_DEPS_LOCK_GRACE)
-        .unwrap_or(false)
-      {
-        return true;
       }
     }
   }
 
   false
+}
+
+fn plugin_runtime_deps_lock_active(lock_dir: &std::path::Path) -> bool {
+  if !lock_dir.is_dir() {
+    return false;
+  }
+
+  let owner_path = lock_dir.join("owner.json");
+  if let Ok(raw) = fs::read_to_string(&owner_path) {
+    if let Ok(owner) = serde_json::from_str::<serde_json::Value>(&raw) {
+      if let Some(pid) = owner.get("pid").and_then(|v| v.as_u64()) {
+        if pid <= u32::MAX as u64 {
+          return process_is_alive(pid as u32);
+        }
+        return false;
+      }
+    }
+  }
+
+  // If the owner file has not been written yet, or it is transiently
+  // unreadable, treat a fresh lock as active. This avoids killing the gateway
+  // in the tiny window between mkdir(lock) and owner.json write.
+  fs::metadata(lock_dir)
+    .ok()
+    .and_then(|meta| meta.modified().ok())
+    .and_then(|mtime| mtime.elapsed().ok())
+    .map(|age| age < PLUGIN_RUNTIME_DEPS_LOCK_GRACE)
+    .unwrap_or(false)
 }
 
 fn default_clawdbot_home_from_env() -> Option<PathBuf> {
@@ -7323,11 +7344,6 @@ async fn prepare_gateway_config(
     .join("plugin-runtime-deps")
     .to_string_lossy()
     .to_string();
-  let jiti_cache_dir = PathBuf::from(&clawdbot_home_str)
-    .join("jiti-cache")
-    .to_string_lossy()
-    .to_string();
-
   let mut env = vec![
     ("PATH".to_string(), clawdbot_path),
     ("HOME".to_string(), user_home.clone()),
@@ -7339,7 +7355,10 @@ async fn prepare_gateway_config(
     ),
     ("OPENCLAW_GATEWAY_PORT".to_string(), "18789".to_string()),
     ("OPENCLAW_PLUGIN_STAGE_DIR".to_string(), plugin_stage_dir),
-    ("JITI_FS_CACHE".to_string(), jiti_cache_dir),
+    // Jiti's env parser treats JITI_FS_CACHE as a boolean, not a cache path.
+    // Leaving it enabled writes node_modules/.cache/jiti under the signed app
+    // resources bundle and invalidates macOS code signing after first launch.
+    ("JITI_FS_CACHE".to_string(), "false".to_string()),
     (
       "OPENCLAW_BUNDLED_PLUGINS_DIR".to_string(),
       bundled_plugins_dir_str,
@@ -8887,11 +8906,6 @@ pub async fn set_service_enabled(
       // bundled_plugins_dir was resolved earlier (before config patching)
       let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
       let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
-      let jiti_cache_dir = PathBuf::from(&clawdbot_home_str)
-        .join("jiti-cache")
-        .to_string_lossy()
-        .to_string();
-
       eprintln!("[clawd/service] Running OpenClaw doctor --fix to ensure plugin dependencies...");
       let doctor_status = std::process::Command::new(&node_path)
         .arg(&clawdbot_entry)
@@ -8899,7 +8913,7 @@ pub async fn set_service_enabled(
         .arg("--fix")
         .env("OPENCLAW_STATE_DIR", &clawdbot_home_str)
         .env("OPENCLAW_BUNDLED_PLUGINS_DIR", &bundled_plugins_dir_str)
-        .env("JITI_FS_CACHE", &jiti_cache_dir)
+        .env("JITI_FS_CACHE", "false")
         .status();
 
       match doctor_status {
@@ -8956,11 +8970,6 @@ pub async fn set_service_enabled(
         .join("plugin-runtime-deps")
         .to_string_lossy()
         .to_string();
-      let jiti_cache_dir = PathBuf::from(&clawdbot_home_str)
-        .join("jiti-cache")
-        .to_string_lossy()
-        .to_string();
-
       let mut env = vec![
         ("PATH".to_string(), clawdbot_path),
         ("HOME".to_string(), user_home),
@@ -8975,7 +8984,10 @@ pub async fn set_service_enabled(
         // Ensure control server family ports remain default.
         ("OPENCLAW_GATEWAY_PORT".to_string(), "18789".to_string()),
         ("OPENCLAW_PLUGIN_STAGE_DIR".to_string(), plugin_stage_dir),
-        ("JITI_FS_CACHE".to_string(), jiti_cache_dir),
+        // Jiti's env parser treats JITI_FS_CACHE as a boolean, not a cache path.
+        // Leaving it enabled writes node_modules/.cache/jiti under the signed app
+        // resources bundle and invalidates macOS code signing after first launch.
+        ("JITI_FS_CACHE".to_string(), "false".to_string()),
         // Point to bundled plugins/extensions directory so OpenClaw can find memory-core etc.
         // Point to bundled plugins/extensions directory so OpenClaw can find memory-core etc.
         (
@@ -10867,6 +10879,37 @@ mod crash_classifier_tests {
     );
     assert!(!incomplete.exists());
     assert!(complete.exists());
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn runtime_deps_locks_are_startup_progress() {
+    let root = std::env::temp_dir().join(format!(
+      "knapsack-runtime-deps-lock-test-{}-{}",
+      std::process::id(),
+      std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+    let package_dir = root
+      .join("plugin-runtime-deps")
+      .join("openclaw-2026.4.26-test");
+
+    fs::create_dir_all(package_dir.join(".openclaw-runtime-mirror.lock")).unwrap();
+    assert!(plugin_runtime_deps_install_in_progress(&root));
+
+    fs::remove_dir_all(package_dir.join(".openclaw-runtime-mirror.lock")).unwrap();
+    fs::create_dir_all(
+      package_dir
+        .join("dist")
+        .join("extensions")
+        .join("slack")
+        .join(".openclaw-runtime-deps.lock"),
+    )
+    .unwrap();
+    assert!(plugin_runtime_deps_install_in_progress(&root));
 
     let _ = fs::remove_dir_all(root);
   }


### PR DESCRIPTION
## Summary
- reuse packaged plugin runtime mirrors when they already match the bundled plugin source
- use hardlink-first materialization while copying bundled plugin runtime mirror files
- treat package-level and plugin-level runtime dependency mirror/install locks as startup progress so health/self-heal does not misdiagnose active startup work
- disable Jiti filesystem cache for gateway and doctor processes so runtime transpilation does not write node_modules/.cache/jiti into the signed macOS app bundle

## Why
Mac QA on v2.0.3 showed the gateway could spend several minutes blocked in runtime mirror copy work while the UI reported gateway/browser startup problems. A process sample showed Node stuck in filesystem copy/link/stat work inside bundled runtime mirror staging.

The installed app also failed local signature verification. codesign reported sealed-resource additions under /Applications/Knapsack.app/Contents/Resources/resources/clawdbot/dist/extensions/*/node_modules/.cache/jiti/*. Jiti 2.6.1 parses JITI_FS_CACHE as a boolean, so setting it to a path still leaves filesystem caching enabled and allows writes inside the signed bundle. This PR sets JITI_FS_CACHE=false for the gateway/doctor environment.

## Tests
- node --check src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
- node sanity check: createJiti with JITI_FS_CACHE=false reports fsCache=false
- cargo test --manifest-path src/src-tauri/Cargo.toml runtime_deps -- --nocapture