### PR TITLE
fix: time out gateway readiness polls

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -656,8 +656,24 @@ function apiUrl(path: string): string {
   return API_BASE + path
 }
 
-async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(apiUrl(path))
+type ApiFetchOptions = {
+  timeoutMs?: number
+}
+
+async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, timeoutMs?: number): Promise<Response> {
+  if (!timeoutMs || timeoutMs <= 0) return fetch(input, init)
+
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(input, { ...init, signal: controller.signal })
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}
+
+async function apiGet<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const res = await fetchWithTimeout(apiUrl(path), {}, options.timeoutMs)
   if (!res.ok) {
     const t = await res.text().catch(() => '')
     throw new Error(t || `HTTP ${res.status}`)
@@ -3108,14 +3124,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         let catchBackoffMs = 1000
         const pollGateway = async () => {
           try {
-            const h = await apiGet<ServiceHealth>('/api/clawd/service/health')
+            const h = await apiGet<ServiceHealth>('/api/clawd/service/health', { timeoutMs: 2500 })
             const hJson = JSON.stringify(h)
             if (hJson !== lastHealthJson) {
               lastHealthJson = hJson
               setHealth(h)
             }
             // Also refresh service status periodically
-            const s2 = await apiGet<ServiceStatus>('/api/clawd/service/status')
+            const s2 = await apiGet<ServiceStatus>('/api/clawd/service/status', { timeoutMs: 2500 })
             const s2Json = JSON.stringify(s2)
             if (s2Json !== lastStatusJson) {
               lastStatusJson = s2Json

--- a/src/src/hooks/channels/useChannelStatus.ts
+++ b/src/src/hooks/channels/useChannelStatus.ts
@@ -56,11 +56,24 @@ export interface ChannelStates {
 
 /** Interval for polling unconfigured channels (30s instead of active interval). */
 const UNCONFIGURED_POLL_INTERVAL = 30_000
+const GATEWAY_HEALTH_POLL_TIMEOUT_MS = 2500
 
 /** Returns true if a channel status indicates it has been configured/enabled by the user. */
 function isChannelConfigured(status: ChannelStatus | null): boolean {
   if (!status) return false
   return !!(status.linked || status.configured || status.enabled)
+}
+
+async function fetchGatewayHealthWithTimeout(): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), GATEWAY_HEALTH_POLL_TIMEOUT_MS)
+  try {
+    return await fetch('http://127.0.0.1:8897/api/clawd/service/health', {
+      signal: controller.signal,
+    })
+  } finally {
+    window.clearTimeout(timeout)
+  }
 }
 
 /**
@@ -150,7 +163,7 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
       // expensive per-channel status polls which each timeout after 10-20s.
       let gwOk = false
       try {
-        const hRes = await fetch('http://127.0.0.1:8897/api/clawd/service/health')
+        const hRes = await fetchGatewayHealthWithTimeout()
         if (hRes.ok) {
           const hData = await hRes.json()
           gwOk = !!hData.gateway_ok
@@ -188,7 +201,7 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
         // diagnostic details so on-call can investigate early.
         if (gwDownCountRef.current === 3 && !sentryCrashAlertedRef.current) {
           sentryCrashAlertedRef.current = true
-          fetch('http://127.0.0.1:8897/api/clawd/service/health')
+          fetchGatewayHealthWithTimeout()
             .then(r => r.json())
             .then((data: { message?: string; diagnostic_type?: string }) => {
               const diagType = data.diagnostic_type ?? 'unknown'


### PR DESCRIPTION
## Summary
- add bounded fetch timeouts to the chat gateway/service status poll
- add bounded fetch timeouts to channel gateway health checks and Sentry diagnostic follow-up
- prevent a hung local health endpoint from leaving stale green Gateway/Browser status in the UI

## QA context
During the v2.0.5 Mac QA loop, the app briefly showed `Gateway: OK | Browser: OK` while direct probes to the local gateway accepted TCP connections but hung without returning health. The OpenClaw Chrome profile eventually launched on `127.0.0.1:18800`, but the Gemini chat request did not return in a timely manner and the app later regressed to reconnecting/waiting states.

This PR does not claim to fix the deeper gateway startup/event-loop blocking; it makes the desktop UI and QA loop fail fast and accurately instead of preserving stale healthy state when readiness probes hang.

## Test plan
- [x] `npx tsc --noEmit`
