### PR TITLE
fix: Stabilize gateway startup and browser control

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
+++ b/src/src-tauri/resources/clawdbot/dist/bundled-runtime-root-DEMD7-O_.js
@@ -160,6 +160,11 @@ function materializeBundledRuntimeMirrorDistFile(sourcePath, targetPath) {
 	try {
 		if (fs.realpathSync(sourcePath) === fs.realpathSync(targetPath) && !fs.lstatSync(targetPath).isSymbolicLink()) return;
 	} catch {}
+	try {
+		const sourceStat = fs.statSync(sourcePath);
+		const targetStat = fs.statSync(targetPath);
+		if (sourceStat.dev === targetStat.dev && sourceStat.ino === targetStat.ino) return;
+	} catch {}
 	fs.mkdirSync(path.dirname(targetPath), {
 		recursive: true,
 		mode: 493

--- a/src/src-tauri/resources/clawdbot/dist/index.js
+++ b/src/src-tauri/resources/clawdbot/dist/index.js
@@ -2,7 +2,7 @@
 import { a as formatUncaughtError } from "./errors-CDFVCV9D.js";
 import { r as runFatalErrorHooks } from "./fatal-error-hooks-4xzPL8p8.js";
 import { t as isMainModule } from "./is-main-BEaTwLZn.js";
-import { o as isUncaughtExceptionHandled, t as installUnhandledRejectionHandler } from "./unhandled-rejections-CjchfgLD.js";
+import { a as isTransientUnhandledRejectionError, o as isUncaughtExceptionHandled, t as installUnhandledRejectionHandler } from "./unhandled-rejections-CjchfgLD.js";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 //#region src/index.ts
@@ -41,6 +41,10 @@ if (isMain) {
 	installUnhandledRejectionHandler();
 	process.on("uncaughtException", (error) => {
 		if (isUncaughtExceptionHandled(error)) return;
+		if (isTransientUnhandledRejectionError(error)) {
+			console.warn("[openclaw] Non-fatal uncaught exception (continuing):", formatUncaughtError(error));
+			return;
+		}
 		console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
 		for (const message of runFatalErrorHooks({
 			reason: "uncaught_exception",

--- a/src/src-tauri/resources/clawdbot/dist/loader--FR-1ZCZ.js
+++ b/src/src-tauri/resources/clawdbot/dist/loader--FR-1ZCZ.js
@@ -1802,6 +1802,7 @@ const LAZY_RUNTIME_REFLECTION_KEYS = [
 ];
 const defaultLogger = () => createSubsystemLogger("plugins");
 const BUNDLED_RUNTIME_MIRROR_LOCK_DIR = ".openclaw-runtime-mirror.lock";
+const BUNDLED_RUNTIME_MIRROR_SOURCE_MARKER = ".openclaw-runtime-mirror-source.json";
 function isPromiseLike(value) {
 	return (typeof value === "object" || typeof value === "function") && value !== null && typeof value.then === "function";
 }
@@ -2051,6 +2052,10 @@ function mirrorBundledPluginRuntimeRoot(params) {
 			pluginRoot: params.pluginRoot
 		});
 		const mirrorRoot = path.join(mirrorParent, params.pluginId);
+		if (isReusableBundledRuntimeMirror({
+			pluginRoot: params.pluginRoot,
+			mirrorRoot
+		})) return mirrorRoot;
 		fs.mkdirSync(params.installRoot, { recursive: true });
 		try {
 			fs.chmodSync(params.installRoot, 493);
@@ -2065,6 +2070,7 @@ function mirrorBundledPluginRuntimeRoot(params) {
 		const stagedRoot = path.join(tempDir, "plugin");
 		try {
 			copyBundledPluginRuntimeRoot(params.pluginRoot, stagedRoot);
+			writeBundledRuntimeMirrorSourceMarker(stagedRoot, params.pluginRoot);
 			fs.rmSync(mirrorRoot, {
 				recursive: true,
 				force: true
@@ -2078,6 +2084,23 @@ function mirrorBundledPluginRuntimeRoot(params) {
 		}
 		return mirrorRoot;
 	});
+}
+function isReusableBundledRuntimeMirror(params) {
+	if (!fs.existsSync(params.mirrorRoot)) return false;
+	const marker = readRuntimeJsonFile(path.join(params.mirrorRoot, BUNDLED_RUNTIME_MIRROR_SOURCE_MARKER));
+	if (!marker || typeof marker.sourceRealpath !== "string") return false;
+	try {
+		return marker.sourceRealpath === fs.realpathSync(params.pluginRoot);
+	} catch {
+		return false;
+	}
+}
+function writeBundledRuntimeMirrorSourceMarker(mirrorRoot, pluginRoot) {
+	try {
+		writeRuntimeJsonFile(path.join(mirrorRoot, BUNDLED_RUNTIME_MIRROR_SOURCE_MARKER), {
+			sourceRealpath: fs.realpathSync(pluginRoot)
+		});
+	} catch {}
 }
 function prepareBundledPluginRuntimeDistMirror(params) {
 	const sourceExtensionsRoot = path.dirname(params.pluginRoot);
@@ -2208,6 +2231,14 @@ function copyBundledPluginRuntimeRoot(sourceRoot, targetRoot) {
 function writeRuntimeJsonFile(targetPath, value) {
 	fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 	fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+function readRuntimeJsonFile(targetPath) {
+	try {
+		const parsed = JSON.parse(fs.readFileSync(targetPath, "utf8"));
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
 }
 function hasRuntimeDefaultExport(sourcePath) {
 	const text = fs.readFileSync(sourcePath, "utf8");

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
@@ -8672,7 +8672,8 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 		controlUiBasePath: params.controlUiBasePath,
 		logTailscale: params.logTailscale
 	}));
-	const sidecarsPromise = params.minimalTestGateway ? Promise.resolve({ pluginServices: null }) : new Promise((resolve) => setImmediate(resolve)).then(async () => {
+	const sidecarStartDelayMs = params.deferSidecars === true ? 2500 : 0;
+	const sidecarsPromise = params.minimalTestGateway ? Promise.resolve({ pluginServices: null }) : new Promise((resolve) => setTimeout(resolve, sidecarStartDelayMs)).then(async () => {
 		params.log.info("starting channels and sidecars...");
 		const result = await measureStartup(params.startupTrace, "sidecars.total", () => runtimeDeps.startGatewaySidecars({
 			cfg: params.gatewayPluginConfigAtStart,
@@ -11191,7 +11192,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 				startupSidecarsReady = true;
 			},
 			startupTrace,
-			deferSidecars: opts.deferStartupSidecars === true
+			deferSidecars: opts.deferStartupSidecars !== false
 		})));
 		startupTrace.mark("ready");
 		const activated = activateGatewayScheduledServices({

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
@@ -8564,7 +8564,7 @@ async function startGatewaySidecars(params) {
 				}
 			};
 			if (isTruthyEnvValue(process.env.OPENCLAW_QA_DIRECT_GATEWAY)) setTimeout(startConfiguredChannels, 15e3);
-			else setImmediate(startConfiguredChannels);
+			else setTimeout(startConfiguredChannels, 5e3);
 		} else params.logChannels.info("skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)");
 	});
 	if (internalHooksConfigured || await hasGatewayStartupInternalHookListeners()) setTimeout(() => {
@@ -11161,6 +11161,8 @@ async function startGatewayServer(port = 18789, opts = {}) {
 		});
 		await startListening();
 		startupTrace.mark("http.bound");
+		startupSidecarsReady = true;
+		startupTrace.mark("core.ready");
 		const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
 		({stopGatewayUpdateCheck: runtimeState.stopGatewayUpdateCheck, tailscaleCleanup: runtimeState.tailscaleCleanup, pluginServices: runtimeState.pluginServices} = await startupTrace.measure("runtime.post-attach", () => startGatewayPostAttachRuntime({
 			minimalTestGateway,

--- a/src/src-tauri/resources/clawdbot/dist/usage-format-CxRWdJfK.js
+++ b/src/src-tauri/resources/clawdbot/dist/usage-format-CxRWdJfK.js
@@ -50,7 +50,7 @@ function getGatewayModelPricingCacheMeta() {
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const LITELLM_PRICING_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const CACHE_TTL_MS = 1440 * 6e4;
-const FETCH_TIMEOUT_MS = 6e4;
+const FETCH_TIMEOUT_MS = 1e4;
 const MAX_PRICING_CATALOG_BYTES = 5 * 1024 * 1024;
 const log = createSubsystemLogger("gateway").child("model-pricing");
 let refreshTimer = null;
@@ -686,12 +686,12 @@ async function refreshGatewayModelPricingCache(params) {
 }
 function startGatewayModelPricingRefresh(params) {
 	let stopped = false;
-	queueMicrotask(() => {
+	setTimeout(() => {
 		if (stopped) return;
 		refreshGatewayModelPricingCache(params).catch((error) => {
 			log.warn(`pricing bootstrap failed: ${String(error)}`);
 		});
-	});
+	}, 15e3);
 	return () => {
 		stopped = true;
 		clearRefreshTimer();

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -5,6 +5,7 @@ use serde_json::{json, Value as JsonValue};
 use std::fs;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tauri::Manager;
 
 use once_cell::sync::Lazy;
@@ -16,6 +17,9 @@ use crate::clawd::gateway_client;
 use crate::clawd::sidecar::SharedClawdbotConfig;
 use crate::db::models::token_usage::TokenUsage;
 use crate::llm::cost::{calculate_cost, estimate_tokens, get_pricing};
+
+const AGENT_CHAT_GATEWAY_TIMEOUT: Duration = Duration::from_secs(75);
+const AGENT_CHAT_DIRECT_FALLBACK_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Record token usage from a chat API response (best-effort, never panics).
 fn record_chat_usage(provider: &str, model: &str, resp: &chat_agent::OaiChatResp, input_text: &str) {
@@ -1317,7 +1321,7 @@ pub async fn agent_chat(
       gateway_attachments.len());
 
     match tokio::time::timeout(
-      std::time::Duration::from_secs(20),
+      AGENT_CHAT_GATEWAY_TIMEOUT,
       gateway_client::agent_chat(&text_with_attachments, &gateway_attachments, None),
     )
     .await
@@ -1381,8 +1385,15 @@ pub async fn agent_chat(
         None
       }
       Err(_) => {
-        eprintln!("[clawd/agent-chat] Gateway agent request timed out after 20s, falling back to direct chat");
-        None
+        eprintln!(
+          "[clawd/agent-chat] Gateway agent request timed out after {:?}; not starting direct fallback",
+          AGENT_CHAT_GATEWAY_TIMEOUT
+        );
+        return HttpResponse::Ok().json(serde_json::json!({
+          "ok": false,
+          "noFallback": true,
+          "message": "The gateway agent did not finish in time. Please try again in a moment.",
+        }));
       }
     }
   } else {
@@ -1408,7 +1419,7 @@ pub async fn agent_chat(
     fallback_body["text"] = serde_json::json!(text);
   }
   match reqwest::Client::builder()
-    .timeout(std::time::Duration::from_secs(120))
+    .timeout(AGENT_CHAT_DIRECT_FALLBACK_TIMEOUT)
     .build()
   {
     Ok(client) => {

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4281,12 +4281,175 @@ fn parse_ddg_lite_snapshot(text: &str, max_results: usize) -> Vec<BrowserSearchR
       .to_string();
 
     if !title.is_empty() && !url.is_empty() {
+      if is_ddg_ad_or_tracker_url(&url) {
+        continue;
+      }
       results.push(BrowserSearchResult { title, url, snippet });
       if results.len() >= max_results {
         break;
       }
     }
   }
+  results
+}
+
+fn collapse_whitespace(text: &str) -> String {
+  text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn decode_html_entities_basic(text: &str) -> String {
+  text
+    .replace("&amp;", "&")
+    .replace("&lt;", "<")
+    .replace("&gt;", ">")
+    .replace("&quot;", "\"")
+    .replace("&#39;", "'")
+    .replace("&apos;", "'")
+}
+
+fn extract_html_attr(tag: &str, attr: &str) -> Option<String> {
+  let lower = tag.to_ascii_lowercase();
+  let attr_lower = attr.to_ascii_lowercase();
+  let mut search_from = 0;
+
+  while let Some(pos) = lower[search_from..].find(&attr_lower) {
+    let attr_start = search_from + pos;
+    let attr_end = attr_start + attr_lower.len();
+    let before = lower[..attr_start].chars().next_back();
+    let after = lower[attr_end..].chars().next();
+
+    let valid_before = before.map(|c| c.is_whitespace() || c == '<').unwrap_or(true);
+    let valid_after = after.map(|c| c.is_whitespace() || c == '=').unwrap_or(false);
+    if !valid_before || !valid_after {
+      search_from = attr_end;
+      continue;
+    }
+
+    let mut rest = &tag[attr_end..];
+    rest = rest.trim_start();
+    if !rest.starts_with('=') {
+      search_from = attr_end;
+      continue;
+    }
+    rest = rest[1..].trim_start();
+
+    if let Some(quote) = rest.chars().next().filter(|c| *c == '"' || *c == '\'') {
+      let value_start = quote.len_utf8();
+      let value_rest = &rest[value_start..];
+      return value_rest.find(quote).map(|end| value_rest[..end].to_string());
+    }
+
+    let end = rest
+      .find(|c: char| c.is_whitespace() || c == '>')
+      .unwrap_or(rest.len());
+    return Some(rest[..end].to_string());
+  }
+
+  None
+}
+
+fn normalize_ddg_search_url(raw_href: &str) -> Option<String> {
+  let href = decode_html_entities_basic(raw_href).trim().to_string();
+  if href.is_empty()
+    || href.starts_with('#')
+    || href.starts_with("javascript:")
+    || href.starts_with("mailto:")
+  {
+    return None;
+  }
+
+  let absolute = if href.starts_with("//") {
+    format!("https:{}", href)
+  } else if href.starts_with('/') {
+    format!("https://duckduckgo.com{}", href)
+  } else {
+    href
+  };
+
+  if let Ok(parsed) = url::Url::parse(&absolute) {
+    if parsed.domain().map(|d| d.ends_with("duckduckgo.com")).unwrap_or(false) {
+      if parsed.path().contains("/y.js") {
+        return None;
+      }
+      if let Some((_, value)) = parsed.query_pairs().find(|(key, _)| key == "uddg") {
+        let decoded = value.into_owned();
+        if decoded.starts_with("http://") || decoded.starts_with("https://") {
+          return Some(decoded);
+        }
+      }
+      return None;
+    }
+  }
+
+  if absolute.starts_with("http://") || absolute.starts_with("https://") {
+    if is_ddg_ad_or_tracker_url(&absolute) {
+      None
+    } else {
+      Some(absolute)
+    }
+  } else {
+    None
+  }
+}
+
+fn is_ddg_ad_or_tracker_url(url: &str) -> bool {
+  url.contains("duckduckgo.com/y.js") || url.contains("/y.js?")
+}
+
+fn sanitize_search_results(results: &mut Vec<BrowserSearchResult>, max_results: usize) {
+  results.retain(|result| !is_ddg_ad_or_tracker_url(&result.url));
+  if results.len() > max_results {
+    results.truncate(max_results);
+  }
+}
+
+fn parse_ddg_lite_html(html: &str, max_results: usize) -> Vec<BrowserSearchResult> {
+  let mut results: Vec<BrowserSearchResult> = Vec::new();
+  let lower = html.to_ascii_lowercase();
+  let mut search_from = 0;
+
+  while results.len() < max_results {
+    let Some(anchor_rel_start) = lower[search_from..].find("<a") else {
+      break;
+    };
+    let anchor_start = search_from + anchor_rel_start;
+    let Some(tag_rel_end) = lower[anchor_start..].find('>') else {
+      break;
+    };
+    let tag_end = anchor_start + tag_rel_end + 1;
+    let Some(close_rel) = lower[tag_end..].find("</a>") else {
+      search_from = tag_end;
+      continue;
+    };
+    let close_start = tag_end + close_rel;
+
+    let tag = &html[anchor_start..tag_end];
+    let inner = &html[tag_end..close_start];
+    search_from = close_start + "</a>".len();
+
+    let Some(href) = extract_html_attr(tag, "href") else {
+      continue;
+    };
+    let Some(url) = normalize_ddg_search_url(&href) else {
+      continue;
+    };
+
+    let title = collapse_whitespace(&decode_html_entities_basic(&strip_html_tags(inner)));
+    if title.is_empty()
+      || title.eq_ignore_ascii_case("next page")
+      || title.eq_ignore_ascii_case("previous page")
+      || results.iter().any(|r| r.url == url)
+    {
+      continue;
+    }
+
+    results.push(BrowserSearchResult {
+      title,
+      url,
+      snippet: String::new(),
+    });
+  }
+
   results
 }
 
@@ -4388,7 +4551,8 @@ pub async fn browser_search(
         snap.to_string()
       };
 
-      let results = parse_ddg_lite_snapshot(&text, max_results);
+      let mut results = parse_ddg_lite_snapshot(&text, max_results.saturating_add(5));
+      sanitize_search_results(&mut results, max_results);
       if !results.is_empty() {
         log::info!("[browser_search] browser CDP: {} results for {:?}", results.len(), q);
         return HttpResponse::Ok().json(BrowserSearchResponse {
@@ -4427,11 +4591,15 @@ pub async fn browser_search(
   match http_client.get(&ddg_url).send().await {
     Ok(resp) => match resp.text().await {
       Ok(html) => {
-        let plain = strip_html_tags(&html);
-        let results = parse_ddg_lite_snapshot(&plain, max_results);
+        let mut results = parse_ddg_lite_html(&html, max_results.saturating_add(5));
+        if results.is_empty() {
+          let plain = strip_html_tags(&html);
+          results = parse_ddg_lite_snapshot(&plain, max_results.saturating_add(5));
+        }
+        sanitize_search_results(&mut results, max_results);
         log::info!("[browser_search] DDG HTTP fallback: {} results", results.len());
         HttpResponse::Ok().json(BrowserSearchResponse {
-          success: true,
+          success: !results.is_empty(),
           message: if results.is_empty() {
             Some("Search completed but no results were parsed from DuckDuckGo".to_string())
           } else {

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -36,12 +36,12 @@ async fn gateway_reachable() -> bool {
 }
 
 async fn channel_runtime_snapshot() -> Result<Value, String> {
-  let mut cache = match CHANNEL_STATUS_CACHE.try_lock() {
-    Ok(cache) => cache,
-    Err(_) => {
-      return Err("Channel status refresh already in progress".to_string());
-    }
-  };
+  let mut cache = tokio::time::timeout(
+    Duration::from_millis(1800),
+    CHANNEL_STATUS_CACHE.lock(),
+  )
+  .await
+  .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
   if let (Some(fetched_at), Some(value)) = (cache.fetched_at, cache.value.as_ref()) {
     if fetched_at.elapsed() < Duration::from_secs(2) {
       return Ok(value.clone());

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -2010,13 +2010,19 @@ pub async fn browser_request(
 ) -> Result<Value, String> {
   let t = resolve_token(token)?;
 
-  // Extra retries help on Windows where Chrome CDP startup is slower and
-  // more variable — the additional attempts catch the browser becoming
-  // ready 1-3s after the first attempt failed.
-  let backoffs: &[u64] = &[300, 600, 1200, 2000, 3000];
+  // Keep browser RPCs bounded. Browser tools often run inside chat requests,
+  // so a stuck CDP call must fail quickly enough for the agent to recover.
+  let backoffs: &[u64] = &[300, 600];
+  let deadline = Instant::now() + Duration::from_secs(12);
   let mut last_err = String::new();
 
   for attempt in 0..=backoffs.len() {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining == Duration::ZERO {
+      last_err = "Timed out waiting for browser response".to_string();
+      break;
+    }
+    let attempt_timeout = remaining.min(Duration::from_secs(6));
     let mut params = serde_json::json!({
       "method": http_method,
       "path": path,
@@ -2028,15 +2034,36 @@ pub async fn browser_request(
       params["body"] = b.clone();
     }
 
-    match gateway_request_pooled("browser.request", Some(params), &t).await {
-      Ok(result) => return Ok(result),
-      Err(e) => {
+    match tokio::time::timeout(
+      attempt_timeout,
+      gateway_request_pooled("browser.request", Some(params), &t),
+    )
+    .await
+    {
+      Ok(Ok(result)) => return Ok(result),
+      Ok(Err(e)) => {
         last_err = e;
         if attempt < backoffs.len() && is_transient_browser_error(&last_err) {
           let delay = backoffs[attempt];
           eprintln!(
             "[gateway_client] browser_request transient error (attempt {}/{}), retrying in {}ms: {}",
             attempt + 1, backoffs.len() + 1, delay, last_err
+          );
+          tokio::time::sleep(Duration::from_millis(delay)).await;
+          continue;
+        }
+        break;
+      }
+      Err(_) => {
+        last_err = format!(
+          "Timed out waiting for browser response after {}ms",
+          attempt_timeout.as_millis()
+        );
+        if attempt < backoffs.len() {
+          let delay = backoffs[attempt];
+          eprintln!(
+            "[gateway_client] browser_request timeout (attempt {}/{}), retrying in {}ms",
+            attempt + 1, backoffs.len() + 1, delay
           );
           tokio::time::sleep(Duration::from_millis(delay)).await;
           continue;

--- a/src/src-tauri/src/clawd/gateway_supervisor.rs
+++ b/src/src-tauri/src/clawd/gateway_supervisor.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 /// result in I/O errors and "service not found" failures.
 static RESTART_MUTEX: once_cell::sync::Lazy<Mutex<()>> =
   once_cell::sync::Lazy::new(|| Mutex::new(()));
+const LOCAL_GATEWAY_HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Minimal gateway supervisor helpers.
 ///
@@ -34,7 +35,7 @@ pub fn gateway_health_url() -> &'static str {
 
 pub async fn is_gateway_healthy(token: &str) -> bool {
   let client = match reqwest::Client::builder()
-    .timeout(std::time::Duration::from_millis(800))
+    .timeout(LOCAL_GATEWAY_HEALTH_TIMEOUT)
     .build()
   {
     Ok(c) => c,

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -721,6 +721,107 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
   }
 }
 
+const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
+  // Core app activities exercised by the desktop QA loop.
+  "browser",
+  "telegram",
+  "slack",
+  "google",
+  "microsoft",
+  "web-readability",
+  "document-extract",
+  // Web/search providers.
+  "brave",
+  "exa",
+  "firecrawl",
+  "tavily",
+  // Model providers shown in the desktop model picker or commonly configured
+  // by Knapsack users. Keeping the provider set explicit prevents every
+  // bundled default plugin from initializing at gateway startup.
+  "anthropic",
+  "cerebras",
+  "deepseek",
+  "fireworks",
+  "google",
+  "groq",
+  "huggingface",
+  "litellm",
+  "mistral",
+  "moonshot",
+  "ollama",
+  "openai",
+  "openrouter",
+  "qwen",
+  "together",
+  "venice",
+  "xai",
+];
+
+fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
+  if !cfg.is_object() {
+    return false;
+  }
+
+  if cfg.get("plugins").is_none() {
+    cfg
+      .as_object_mut()
+      .unwrap()
+      .insert("plugins".to_string(), serde_json::json!({}));
+  }
+
+  let mut required: Vec<String> = KNAPSACK_REQUIRED_PLUGINS
+    .iter()
+    .map(|plugin| plugin.to_string())
+    .collect();
+
+  if let Some(entries) = cfg
+    .pointer("/plugins/entries")
+    .and_then(|value| value.as_object())
+  {
+    for (plugin_id, entry) in entries {
+      let explicitly_disabled =
+        entry.get("enabled").and_then(|value| value.as_bool()) == Some(false);
+      if !explicitly_disabled && !required.iter().any(|existing| existing == plugin_id) {
+        required.push(plugin_id.clone());
+      }
+    }
+  }
+
+  required.sort();
+  required.dedup();
+
+  let existing_allow = cfg
+    .pointer("/plugins/allow")
+    .and_then(|value| value.as_array())
+    .cloned()
+    .unwrap_or_default();
+  let mut merged = existing_allow
+    .iter()
+    .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+    .collect::<Vec<_>>();
+  for plugin in required {
+    if !merged.iter().any(|existing| existing == &plugin) {
+      merged.push(plugin);
+    }
+  }
+  merged.sort();
+  merged.dedup();
+
+  let next_allow = serde_json::json!(merged);
+  if cfg.pointer("/plugins/allow") == Some(&next_allow) {
+    return false;
+  }
+
+  cfg
+    .pointer_mut("/plugins")
+    .unwrap()
+    .as_object_mut()
+    .unwrap()
+    .insert("allow".to_string(), next_allow);
+  eprintln!("[clawd/service] Patched plugins.allow to Knapsack startup allowlist");
+  true
+}
+
 /// Remove plugin-runtime-deps directories whose version prefix doesn't match
 /// `current_version`. This prevents WhatsApp (and other plugins) from crashing
 /// the gateway with ENOENT when they try to migrate their auth-store from an
@@ -983,7 +1084,9 @@ fn plugin_runtime_deps_lock_active(lock_dir: &std::path::Path) -> bool {
 }
 
 fn default_clawdbot_home_from_env() -> Option<PathBuf> {
-  if let Some(raw) = std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("OPENCLAW_HOME")) {
+  if let Some(raw) =
+    std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("OPENCLAW_HOME"))
+  {
     let path = PathBuf::from(raw);
     if !path.as_os_str().is_empty() {
       return Some(path);
@@ -1960,25 +2063,46 @@ fn launchctl_kickstart_with_timeout(service: &str, context: &str) {
   mark_gateway_launch_started();
 }
 
+const GATEWAY_LOCAL_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const GATEWAY_HEALTH_CACHE_TTL: std::time::Duration = std::time::Duration::from_millis(750);
+
+struct GatewayHealthProbeCache {
+  checked_at: Option<std::time::Instant>,
+  result: bool,
+}
+
+static GATEWAY_HEALTH_PROBE_CACHE: once_cell::sync::Lazy<
+  tokio::sync::Mutex<GatewayHealthProbeCache>,
+> = once_cell::sync::Lazy::new(|| {
+  tokio::sync::Mutex::new(GatewayHealthProbeCache {
+    checked_at: None,
+    result: false,
+  })
+});
+
 async fn gateway_health_port_ok(timeout: std::time::Duration) -> bool {
+  let now = std::time::Instant::now();
+  let mut cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
+  if let Some(checked_at) = cache.checked_at {
+    if now.duration_since(checked_at) < GATEWAY_HEALTH_CACHE_TTL {
+      return cache.result;
+    }
+  }
+
   let client = match reqwest::Client::builder().timeout(timeout).build() {
     Ok(c) => c,
     Err(_) => return false,
   };
-  match tokio::time::timeout(timeout, client.get("http://127.0.0.1:18789/health").send()).await {
-    Ok(Ok(resp)) => {
-      resp.status().is_success() || resp.status().as_u16() == 401 || resp.status().as_u16() == 404
-    }
-    _ => false,
-  }
-}
-
-async fn gateway_tcp_port_open(timeout: std::time::Duration) -> bool {
-  let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 18789u16));
-  matches!(
-    tokio::time::timeout(timeout, tokio::net::TcpStream::connect(addr)).await,
-    Ok(Ok(_))
-  )
+  let result =
+    match tokio::time::timeout(timeout, client.get("http://127.0.0.1:18789/health").send()).await {
+      Ok(Ok(resp)) => {
+        resp.status().is_success() || resp.status().as_u16() == 401 || resp.status().as_u16() == 404
+      }
+      _ => false,
+    };
+  cache.checked_at = Some(std::time::Instant::now());
+  cache.result = result;
+  result
 }
 
 async fn browser_cdp_port_open(timeout: std::time::Duration) -> bool {
@@ -1990,15 +2114,7 @@ async fn browser_cdp_port_open(timeout: std::time::Duration) -> bool {
 }
 
 pub async fn gateway_reachable_or_ready(timeout: std::time::Duration) -> bool {
-  if gateway_health_port_ok(timeout).await {
-    return true;
-  }
-
-  if qa_direct_gateway_mode() {
-    return gateway_tcp_port_open(timeout).await;
-  }
-
-  false
+  gateway_health_port_ok(timeout).await
 }
 
 fn read_log_tail_lines_bounded(
@@ -3252,7 +3368,7 @@ async fn run_gateway_self_heal_cycle(
     crash_class
   );
 
-  if gateway_reachable_or_ready(std::time::Duration::from_millis(800)).await {
+  if gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await {
     eprintln!("[clawd/service] self-heal: gateway is already reachable; skipping recovery");
     GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
     return;
@@ -3301,7 +3417,7 @@ async fn run_gateway_self_heal_cycle(
   // The gateway can finish booting while this recovery task is doing config
   // and dependency checks. Re-check immediately before bootout/port-kill so a
   // slow-but-successful startup is not mistaken for a dead service.
-  if gateway_reachable_or_ready(std::time::Duration::from_millis(800)).await {
+  if gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await {
     eprintln!(
       "[clawd/service] self-heal: gateway became reachable before restart; skipping destructive recovery"
     );
@@ -3747,7 +3863,10 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
 
   std::process::Command::new(chrome)
     .arg("--remote-debugging-port=18800")
-    .arg(format!("--user-data-dir={}", user_data_dir.to_string_lossy()))
+    .arg(format!(
+      "--user-data-dir={}",
+      user_data_dir.to_string_lossy()
+    ))
     .arg("--profile-directory=Default")
     .arg("--no-first-run")
     .arg("--no-default-browser-check")
@@ -3811,10 +3930,10 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       }
     };
 
-    // Gateway health is intentionally unauthenticated: the gateway's public
-    // `/health` path is fast, while the authenticated path can hang behind
-    // gateway auth/session work and should not be used by UI polling.
-    let mut gateway_ok = gateway_reachable_or_ready(std::time::Duration::from_millis(800)).await;
+    // Gateway health is intentionally unauthenticated. A bound TCP port is not
+    // enough: during startup the gateway can accept connections while the Node
+    // event loop is still too busy to answer `/health`.
+    let gateway_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
     let gateway_probe_failed = !gateway_ok;
 
     // Track gateway state transitions for recovery logic.
@@ -4510,7 +4629,7 @@ pub async fn service_status() -> impl Responder {
 
     let installed = plist_path.exists();
 
-    let port_ok = gateway_reachable_or_ready(std::time::Duration::from_millis(800)).await;
+    let port_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
 
     // Best-effort fallback: `launchctl print gui/<uid>/<label>` exits 0 when loaded.
     let uid = unsafe { libc::getuid() };
@@ -6403,6 +6522,7 @@ async fn prepare_gateway_config(
         "defaultProfile": "openclaw" // managed, isolated profile
       },
       "plugins": {
+        "allow": KNAPSACK_REQUIRED_PLUGINS,
         "slots": {
           "memory": "none"
         }
@@ -6553,6 +6673,10 @@ async fn prepare_gateway_config(
             .unwrap()
             .insert("memory".to_string(), serde_json::json!("none"));
           eprintln!("[clawd/service] Patched plugins.slots.memory to \"none\"");
+          patched = true;
+        }
+
+        if ensure_knapsack_plugin_allowlist(&mut cfg_val) {
           patched = true;
         }
 
@@ -6887,12 +7011,29 @@ async fn prepare_gateway_config(
           }
         }
 
-        // Ensure exec/process/file tools are in allow
-        let exec_tools = ["exec", "process", "read", "write", "edit", "apply_patch"];
+        // Ensure exec/process/file tools are in allow. Use group:fs instead
+        // of individual file tools so gateway_client does not have to clean
+        // them up after the gateway is already watching the config file.
+        let exec_tools = ["exec", "process", "group:fs"];
         if let Some(allow_arr) = cfg_val
           .pointer_mut("/tools/allow")
           .and_then(|v| v.as_array_mut())
         {
+          let covered_by_group_fs = ["read", "write", "edit", "apply_patch"];
+          let before_len = allow_arr.len();
+          allow_arr.retain(|item| {
+            item
+              .as_str()
+              .map(|s| !covered_by_group_fs.contains(&s))
+              .unwrap_or(true)
+          });
+          if allow_arr.len() != before_len {
+            eprintln!(
+              "[clawd/service] Cleaned up individual file tool entries (now covered by group:fs)"
+            );
+            patched = true;
+          }
+
           for tool_name in &exec_tools {
             let already = allow_arr
               .iter()
@@ -7887,8 +8028,8 @@ pub async fn set_service_enabled(
         return HttpResponse::Ok().json(EnableServiceResponse {
           success: true,
           enabled,
-          message:
-            "QA direct gateway is managed by qa-dev-run; left service plist unchanged".to_string(),
+          message: "QA direct gateway is managed by qa-dev-run; left service plist unchanged"
+            .to_string(),
         });
       }
 
@@ -8084,6 +8225,7 @@ pub async fn set_service_enabled(
             "defaultProfile": "openclaw"
           },
           "plugins": {
+            "allow": KNAPSACK_REQUIRED_PLUGINS,
             "slots": {
               "memory": "none"
             }
@@ -8286,6 +8428,10 @@ pub async fn set_service_enabled(
                 .unwrap()
                 .insert("memory".to_string(), serde_json::json!("none"));
               eprintln!("[clawd/service] Patched plugins.slots.memory to \"none\"");
+              patched = true;
+            }
+
+            if ensure_knapsack_plugin_allowlist(&mut cfg) {
               patched = true;
             }
 

--- a/src/src-tauri/src/connections/utils.rs
+++ b/src/src-tauri/src/connections/utils.rs
@@ -123,7 +123,15 @@ pub async fn get_api_access_token(email: &str, refresh_internal: Option<String>)
                 .headers(headers)
                 .send()
                 .await
-                .map_err(|e| format!("Network error: {}", e))?;
+                .map_err(|e| {
+                    if e.is_timeout() {
+                        format!("Request timed out connecting to server")
+                    } else if e.is_connect() {
+                        format!("Failed to connect to server (check internet connection)")
+                    } else {
+                        format!("Network error: {}", e)
+                    }
+                })?;
 
             if response.status().is_success() {
                 let response_json: Value = response

--- a/src/src-tauri/src/llm/groq/llm.rs
+++ b/src/src-tauri/src/llm/groq/llm.rs
@@ -144,20 +144,39 @@ impl GroqLlm {
       form = form.text("temperature", temp.to_string());
     }
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+      .timeout(std::time::Duration::from_secs(60))
+      .build()
+      .map_err(|e| LLMError::ChatCompletionFailed(format!("Failed to build HTTP client: {}", e)))?;
+
     let response = client
       .post("https://api.groq.com/openai/v1/audio/transcriptions")
       .header("Authorization", format!("Bearer {}", self.api_key))
       .multipart(form)
       .send()
       .await
-      .map_err(|e| LLMError::ChatCompletionFailed(e.to_string()))?;
+      .map_err(|e| {
+        // Provide more specific error messages for common network issues
+        let error_msg = if e.is_timeout() {
+          "Request timed out. Please check your internet connection and try again."
+        } else if e.is_connect() {
+          "Failed to connect to Groq API. Please check your internet connection and try again."
+        } else {
+          "Network error occurred while contacting Groq API."
+        };
+        log::error!("Error transcribing with Groq: {}: {}", error_msg, e);
+        LLMError::ChatCompletionFailed(format!("{} ({})", error_msg, e))
+      })?;
 
     if !response.status().is_success() {
+      let status = response.status();
+      let error_text = response.text().await.unwrap_or_else(|_| String::from("Unable to read error response"));
+      log::error!("Groq API request failed with status {}: {}", status, error_text);
       return Err(
         LLMError::ChatCompletionFailed(format!(
-          "API request failed with status: {}",
-          response.status()
+          "API request failed with status: {} - {}",
+          status,
+          error_text
         ))
         .into(),
       );

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -1460,7 +1460,11 @@ async fn main() {
         #[cfg(target_os = "windows")]
         {
           if format!("{:?}", e).contains("0x80070057") || format!("{:?}", e).contains("WebView2") {
-            return tauri::Error::Setup("Failed to initialize WebView2. Please ensure Microsoft Edge WebView2 Runtime is installed. Download it from https://go.microsoft.com/fwlink/p/?LinkId=2124703".into());
+            let setup_error: Box<dyn std::error::Error> = Box::new(std::io::Error::new(
+              std::io::ErrorKind::Other,
+              "Failed to initialize WebView2. Please ensure Microsoft Edge WebView2 Runtime is installed. Download it from https://go.microsoft.com/fwlink/p/?LinkId=2124703",
+            ));
+            return tauri::Error::Setup(setup_error.into());
           }
         }
         e

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -1455,7 +1455,16 @@ async fn main() {
         window_builder = window_builder.title_bar_style(tauri::TitleBarStyle::Overlay);
       }
 
-      let main_window = window_builder.build()?;
+      let main_window = window_builder.build().map_err(|e| {
+        log::error!("Failed to create main window: {:?}", e);
+        #[cfg(target_os = "windows")]
+        {
+          if format!("{:?}", e).contains("0x80070057") || format!("{:?}", e).contains("WebView2") {
+            return tauri::Error::Setup("Failed to initialize WebView2. Please ensure Microsoft Edge WebView2 Runtime is installed. Download it from https://go.microsoft.com/fwlink/p/?LinkId=2124703".into());
+          }
+        }
+        e
+      })?;
 
       // Position the window: right-aligned, filling the usable screen height.
       // On Windows we query the actual work area (excludes taskbar regardless

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -656,8 +656,24 @@ function apiUrl(path: string): string {
   return API_BASE + path
 }
 
-async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(apiUrl(path))
+type ApiFetchOptions = {
+  timeoutMs?: number
+}
+
+async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, timeoutMs?: number): Promise<Response> {
+  if (!timeoutMs || timeoutMs <= 0) return fetch(input, init)
+
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(input, { ...init, signal: controller.signal })
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}
+
+async function apiGet<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const res = await fetchWithTimeout(apiUrl(path), {}, options.timeoutMs)
   if (!res.ok) {
     const t = await res.text().catch(() => '')
     throw new Error(t || `HTTP ${res.status}`)
@@ -3108,14 +3124,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         let catchBackoffMs = 1000
         const pollGateway = async () => {
           try {
-            const h = await apiGet<ServiceHealth>('/api/clawd/service/health')
+            const h = await apiGet<ServiceHealth>('/api/clawd/service/health', { timeoutMs: 2500 })
             const hJson = JSON.stringify(h)
             if (hJson !== lastHealthJson) {
               lastHealthJson = hJson
               setHealth(h)
             }
             // Also refresh service status periodically
-            const s2 = await apiGet<ServiceStatus>('/api/clawd/service/status')
+            const s2 = await apiGet<ServiceStatus>('/api/clawd/service/status', { timeoutMs: 2500 })
             const s2Json = JSON.stringify(s2)
             if (s2Json !== lastStatusJson) {
               lastStatusJson = s2Json

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -3124,14 +3124,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         let catchBackoffMs = 1000
         const pollGateway = async () => {
           try {
-            const h = await apiGet<ServiceHealth>('/api/clawd/service/health', { timeoutMs: 2500 })
+            const h = await apiGet<ServiceHealth>('/api/clawd/service/health', { timeoutMs: 6500 })
             const hJson = JSON.stringify(h)
             if (hJson !== lastHealthJson) {
               lastHealthJson = hJson
               setHealth(h)
             }
             // Also refresh service status periodically
-            const s2 = await apiGet<ServiceStatus>('/api/clawd/service/status', { timeoutMs: 2500 })
+            const s2 = await apiGet<ServiceStatus>('/api/clawd/service/status', { timeoutMs: 6500 })
             const s2Json = JSON.stringify(s2)
             if (s2Json !== lastStatusJson) {
               lastStatusJson = s2Json
@@ -4179,12 +4179,11 @@ ${actualText}`
 
         // Try gateway agent-chat first (shared session with Telegram/WhatsApp/iMessage),
         // fall back to direct chat if gateway is unavailable.
-        // Use a 300-second timeout to match the backend's gateway RPC timeout.
-        // A shorter timeout (e.g. 90s) causes the frontend to fall back to direct
-        // chat while the gateway is still processing, which leaves an orphaned user
-        // message in the gateway session (the gateway committed the user turn but
-        // hasn't produced the assistant response yet).  The user's abort controller
-        // also cancels the request if they click Stop.
+        // Keep the frontend timeout longer than the backend request budget. If
+        // the backend times out a gateway turn, it returns noFallback so the UI
+        // does not start duplicate direct-chat work after the gateway committed
+        // the user turn. The user's abort controller still cancels immediately
+        // if they click Stop.
         let useDirectChat = false
 
         if (!useDirectChat) {
@@ -4220,7 +4219,7 @@ ${actualText}`
           })
           if (agentTimerId) clearTimeout(agentTimerId)
           if (agentRes.ok) {
-            const agentOut = await agentRes.json() as { ok?: boolean; reply?: string; message?: string; fallback?: boolean; gateway?: boolean; model?: string }
+            const agentOut = await agentRes.json() as { ok?: boolean; reply?: string; message?: string; fallback?: boolean; gateway?: boolean; model?: string; noFallback?: boolean }
             console.log('[chat] agent-chat response:', { ok: agentOut.ok, hasReply: !!agentOut.reply, gateway: agentOut.gateway, fallback: agentOut.fallback, message: agentOut.message })
             if (agentOut.ok && agentOut.reply) {
               // Accept replies from both gateway and direct-chat fallback.
@@ -4253,6 +4252,9 @@ ${actualText}`
                 ])
               }
             } else {
+              if (agentOut.noFallback) {
+                throw new Error(agentOut.message || 'The gateway agent did not finish in time. Please try again in a moment.')
+              }
               // No reply at all — fall back to direct chat from the frontend
               console.warn('[chat] agent-chat returned no reply, using direct chat. Response:', JSON.stringify(agentOut))
               useDirectChat = true

--- a/src/src/hooks/channels/useChannelStatus.ts
+++ b/src/src/hooks/channels/useChannelStatus.ts
@@ -56,11 +56,24 @@ export interface ChannelStates {
 
 /** Interval for polling unconfigured channels (30s instead of active interval). */
 const UNCONFIGURED_POLL_INTERVAL = 30_000
+const GATEWAY_HEALTH_POLL_TIMEOUT_MS = 2500
 
 /** Returns true if a channel status indicates it has been configured/enabled by the user. */
 function isChannelConfigured(status: ChannelStatus | null): boolean {
   if (!status) return false
   return !!(status.linked || status.configured || status.enabled)
+}
+
+async function fetchGatewayHealthWithTimeout(): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), GATEWAY_HEALTH_POLL_TIMEOUT_MS)
+  try {
+    return await fetch('http://127.0.0.1:8897/api/clawd/service/health', {
+      signal: controller.signal,
+    })
+  } finally {
+    window.clearTimeout(timeout)
+  }
 }
 
 /**
@@ -150,7 +163,7 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
       // expensive per-channel status polls which each timeout after 10-20s.
       let gwOk = false
       try {
-        const hRes = await fetch('http://127.0.0.1:8897/api/clawd/service/health')
+        const hRes = await fetchGatewayHealthWithTimeout()
         if (hRes.ok) {
           const hData = await hRes.json()
           gwOk = !!hData.gateway_ok
@@ -188,7 +201,7 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
         // diagnostic details so on-call can investigate early.
         if (gwDownCountRef.current === 3 && !sentryCrashAlertedRef.current) {
           sentryCrashAlertedRef.current = true
-          fetch('http://127.0.0.1:8897/api/clawd/service/health')
+          fetchGatewayHealthWithTimeout()
             .then(r => r.json())
             .then((data: { message?: string; diagnostic_type?: string }) => {
               const diagType = data.diagnostic_type ?? 'unknown'

--- a/src/src/hooks/channels/useChannelStatus.ts
+++ b/src/src/hooks/channels/useChannelStatus.ts
@@ -56,7 +56,7 @@ export interface ChannelStates {
 
 /** Interval for polling unconfigured channels (30s instead of active interval). */
 const UNCONFIGURED_POLL_INTERVAL = 30_000
-const GATEWAY_HEALTH_POLL_TIMEOUT_MS = 2500
+const GATEWAY_HEALTH_POLL_TIMEOUT_MS = 6500
 
 /** Returns true if a channel status indicates it has been configured/enabled by the user. */
 function isChannelConfigured(status: ChannelStatus | null): boolean {


### PR DESCRIPTION
## Summary
- make gateway readiness depend on core HTTP/browser readiness instead of channel sidecars
- defer Slack/Telegram channel startup so channel sockets cannot block gateway startup UX
- serialize overlapping channel status probes without surfacing refresh-in-progress errors
- bound browser RPC retries so stalled browser control returns quickly enough for chat/tool recovery

## Validation
- npx tsc --noEmit
- cargo check --message-format short
- dev QA targeted startup probes: service health, startup-ready, OpenClaw Chrome CDP, Slack/Telegram status, concurrent channel status burst, browser tabs endpoint