### PR TITLE
fix: show newest log lines when /logs output is truncated

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -12859,17 +12859,6 @@
         "react": "^19.0.0"
       }
     },
-    "node_modules/react-spring/node_modules/@types/react": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
-      "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/react-spring/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -3795,7 +3795,13 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         const logs = await apiGet<{ success: boolean; text: string }>(
           `/api/clawd/service/logs?stream=${encodeURIComponent(stream)}&lines=250`,
         )
-        pushAssistant(formatMaybeJson(logs.text || '(no logs)'))
+        const text = logs.text || '(no logs)'
+        const maxChars = 20000
+        const display =
+          text.length > maxChars
+            ? `...(${text.length - maxChars} chars omitted from start)\n\n` + text.slice(-maxChars)
+            : text
+        pushAssistant(display)
         return
       }
 


### PR DESCRIPTION
## Summary

- `/logs` in ClawdChat previously passed output through `formatMaybeJson`, which truncates at the start — so exceeding 8 000 chars would drop the most recent log entries and show only old ones
- Now truncation takes the **tail** (`text.slice(-maxChars)`) so the newest lines are always visible, with an omission note prepended if content was cut
- Raised the char limit from 8 000 → 20 000 to cover a full 250-line response without cutting in most cases