### PR TITLE
fix: harden release readiness and browser search

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,11 +165,28 @@ jobs:
           if [ -n "$DMG" ]; then
             echo "=== Mounting DMG and verifying .app inside ==="
             MOUNT_PT=$(mktemp -d)
-            hdiutil attach "$DMG" -mountpoint "$MOUNT_PT" -nobrowse -quiet
+            STAGE=""
+            trap 'hdiutil detach "$MOUNT_PT" -quiet 2>/dev/null || true; [ -n "${STAGE:-}" ] && rm -rf "$STAGE"; rm -rf "$MOUNT_PT"' EXIT
+            hdiutil attach "$DMG" -mountpoint "$MOUNT_PT" -nobrowse -readonly -quiet
             INNER_APP=$(find "$MOUNT_PT" -maxdepth 1 -name "*.app" | head -1)
+            if [ -z "$INNER_APP" ]; then
+              echo "ERROR: No .app found inside DMG"
+              exit 1
+            fi
+            if [ -e "$INNER_APP/Contents/CodeResources" ]; then
+              echo "ERROR: DMG app contains stray Contents/CodeResources"
+              exit 1
+            fi
             codesign --verify --deep --strict --verbose=2 "$INNER_APP"
             spctl --assess --type open --context context:primary-signature --verbose=2 "$INNER_APP"
+            STAGE=$(mktemp -d)
+            ditto "$INNER_APP" "$STAGE/Knapsack.app"
+            codesign --verify --deep --strict --verbose=2 "$STAGE/Knapsack.app"
+            spctl --assess --type open --context context:primary-signature --verbose=2 "$STAGE/Knapsack.app"
+            rm -rf "$STAGE"
+            STAGE=""
             hdiutil detach "$MOUNT_PT" -quiet
+            trap - EXIT
             rm -rf "$MOUNT_PT"
             echo "=== DMG mount check passed ==="
           fi

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -86,10 +86,14 @@ function waitForFreshLaunchAgentPlist(minMtimeMs, timeoutMs = 45_000) {
   return new Promise((resolve, reject) => {
     const attempt = () => {
       try {
-        if (fs.existsSync(launchAgentPlist) && fs.statSync(launchAgentPlist).mtimeMs >= minMtimeMs) {
+        if (fs.existsSync(launchAgentPlist)) {
+          const mtimeMs = fs.statSync(launchAgentPlist).mtimeMs;
           const plist = readLaunchAgentPlist();
           const entry = plist.ProgramArguments?.[1] || '';
           if (entry.startsWith(path.join(projectDir, 'src-tauri', 'resources', 'clawdbot'))) {
+            if (mtimeMs < minMtimeMs) {
+              console.warn('[qa-dev-run] Reusing existing dev Clawdbot LaunchAgent plist');
+            }
             resolve(plist);
             return;
           }

--- a/src/scripts/sign-and-notarize.sh
+++ b/src/scripts/sign-and-notarize.sh
@@ -157,6 +157,15 @@ done < <(find "$RESOURCES" \( -path "*/node-llama-cpp*" -o -path "*/@node-llama-
 echo "[sign] Clearing extended attributes..."
 xattr -cr "$APP_PATH"
 
+# Tauri/codesign should only keep the resource seal in
+# Contents/_CodeSignature/CodeResources. A stray legacy Contents/CodeResources
+# file can be copied into DMGs and confuse downstream verification after users
+# drag the app into /Applications.
+if [ -e "$CONTENTS/CodeResources" ]; then
+  echo "[sign] Removing stray legacy CodeResources file: $CONTENTS/CodeResources"
+  rm -f "$CONTENTS/CodeResources"
+fi
+
 # ---------------------------------------------------------------------------
 # 3. Sign all native .node addon files
 # ---------------------------------------------------------------------------
@@ -247,6 +256,10 @@ codesign --force --options runtime --timestamp \
 # ---------------------------------------------------------------------------
 echo "[sign] Verifying signature..."
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+if [ -e "$CONTENTS/CodeResources" ]; then
+  echo "ERROR: Unexpected $CONTENTS/CodeResources after signing; only Contents/_CodeSignature/CodeResources is allowed." >&2
+  exit 1
+fi
 echo "[sign] Signature verification passed."
 
 # ---------------------------------------------------------------------------

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -203,7 +203,10 @@ fn bearer_token_for_control(app_handle: &tauri::AppHandle) -> Option<String> {
 
 fn clawd_profile(chrome: Option<bool>) -> &'static str {
   if chrome.unwrap_or(false) {
-    "chrome"
+    // The gateway exposes the controlled Chrome profile as "openclaw".
+    // Older callers still pass chrome=true, so keep that flag wired to the
+    // OpenClaw profile instead of the removed legacy "chrome" profile.
+    "openclaw"
   } else {
     "openclaw"
   }
@@ -4453,6 +4456,57 @@ fn parse_ddg_lite_html(html: &str, max_results: usize) -> Vec<BrowserSearchResul
   results
 }
 
+fn extract_xml_tag(block: &str, tag: &str) -> Option<String> {
+  let open = format!("<{}>", tag);
+  let close = format!("</{}>", tag);
+  let start = block.find(&open)? + open.len();
+  let end = block[start..].find(&close)? + start;
+  Some(decode_html_entities_basic(block[start..end].trim()))
+}
+
+fn parse_google_news_rss(xml: &str, max_results: usize) -> Vec<BrowserSearchResult> {
+  let mut results = Vec::new();
+  let mut search_from = 0;
+
+  while results.len() < max_results {
+    let Some(item_rel_start) = xml[search_from..].find("<item>") else {
+      break;
+    };
+    let item_start = search_from + item_rel_start + "<item>".len();
+    let Some(item_rel_end) = xml[item_start..].find("</item>") else {
+      break;
+    };
+    let item_end = item_start + item_rel_end;
+    let item = &xml[item_start..item_end];
+    search_from = item_end + "</item>".len();
+
+    let Some(title) = extract_xml_tag(item, "title") else {
+      continue;
+    };
+    let Some(url) = extract_xml_tag(item, "link") else {
+      continue;
+    };
+    let source = extract_xml_tag(item, "source").unwrap_or_default();
+    let pub_date = extract_xml_tag(item, "pubDate").unwrap_or_default();
+    let snippet = match (source.is_empty(), pub_date.is_empty()) {
+      (false, false) => format!("{} - {}", source, pub_date),
+      (false, true) => source,
+      (true, false) => pub_date,
+      (true, true) => String::new(),
+    };
+
+    if !title.is_empty() && !url.is_empty() {
+      results.push(BrowserSearchResult {
+        title,
+        url,
+        snippet,
+      });
+    }
+  }
+
+  results
+}
+
 /// Browser-based web search via CDP (DuckDuckGo Lite).
 ///
 /// `GET /api/clawd/browser/search?q=<query>[&count=5][&chrome=true]`
@@ -4597,17 +4651,62 @@ pub async fn browser_search(
           results = parse_ddg_lite_snapshot(&plain, max_results.saturating_add(5));
         }
         sanitize_search_results(&mut results, max_results);
-        log::info!("[browser_search] DDG HTTP fallback: {} results", results.len());
-        HttpResponse::Ok().json(BrowserSearchResponse {
-          success: !results.is_empty(),
-          message: if results.is_empty() {
-            Some("Search completed but no results were parsed from DuckDuckGo".to_string())
-          } else {
-            None
+        if !results.is_empty() {
+          log::info!("[browser_search] DDG HTTP fallback: {} results", results.len());
+          return HttpResponse::Ok().json(BrowserSearchResponse {
+            success: true,
+            message: None,
+            results,
+            provider: "ddg-fallback".to_string(),
+          });
+        }
+
+        let news_url = format!(
+          "https://news.google.com/rss/search?q={}&hl=en-US&gl=US&ceid=US:en",
+          encoded_q
+        );
+        log::warn!(
+          "[browser_search] DDG returned no parseable results; trying Google News RSS fallback"
+        );
+        match http_client.get(&news_url).send().await {
+          Ok(news_resp) => match news_resp.text().await {
+            Ok(xml) => {
+              let results = parse_google_news_rss(&xml, max_results);
+              log::info!(
+                "[browser_search] Google News RSS fallback: {} results",
+                results.len()
+              );
+              HttpResponse::Ok().json(BrowserSearchResponse {
+                success: !results.is_empty(),
+                message: if results.is_empty() {
+                  Some(
+                    "Search completed but no results were parsed from DuckDuckGo or Google News RSS"
+                      .to_string(),
+                  )
+                } else {
+                  None
+                },
+                results,
+                provider: "google-news-rss".to_string(),
+              })
+            }
+            Err(e) => HttpResponse::Ok().json(BrowserSearchResponse {
+              success: false,
+              message: Some(format!("Failed to read Google News RSS response: {}", e)),
+              results: vec![],
+              provider: "google-news-rss".to_string(),
+            }),
           },
-          results,
-          provider: "ddg-fallback".to_string(),
-        })
+          Err(e) => HttpResponse::Ok().json(BrowserSearchResponse {
+            success: false,
+            message: Some(format!(
+              "Search completed but DuckDuckGo returned no parseable results and Google News RSS failed: {}",
+              e
+            )),
+            results: vec![],
+            provider: "none".to_string(),
+          }),
+        }
       }
       Err(e) => HttpResponse::Ok().json(BrowserSearchResponse {
         success: false,

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -755,16 +755,19 @@ function clearOnboardingAgents() {
 const GATEWAY_DIAGNOSE_PROMPT = `The Knapsack gateway appears to be having connectivity issues. Please help me diagnose and fix this. Run these checks in order:
 
 1. Check the gateway service status by running: curl -s http://127.0.0.1:8897/api/clawd/service/health | python3 -m json.tool
-2. Check if the gateway process is running: ps aux | grep -i "entry.js\\|clawdbot" | grep -v grep
-3. Check for stale Chrome/Chromium processes: ps aux | grep -i "chrome.*clawdbot\\|chromium.*clawdbot" | grep -v grep
-4. Check the error logs (last 30 lines): tail -30 ~/Library/Logs/ks_error.log 2>/dev/null || echo "No error log found"
-5. Check if port 18789 is in use: lsof -i :18789 2>/dev/null || echo "Port 18789 not in use"
+2. Check startup readiness by running: curl -s http://127.0.0.1:8897/api/clawd/service/startup-ready | python3 -m json.tool
+3. Check if ports are listening without printing process environments: lsof -nP -iTCP:18789 -iTCP:18791 -sTCP:LISTEN 2>/dev/null
+4. Check the current Knapsack gateway logs, filtering stale/noisy lines:
+   tail -80 ~/Library/Logs/Knapsack/knapsack-clawdbot.err.log 2>/dev/null | grep -Ev "security warning|model-pricing|socket-mode:SlackWebSocket|slack.*socket disconnected|bonjour|CIAO|staging bundled runtime deps" || true
+5. Check browser tabs through Knapsack: curl -s http://127.0.0.1:8897/api/clawd/browser/tabs | python3 -m json.tool
 
 Based on the results, tell me:
 - Whether the gateway process is running
 - Whether the browser (Chrome CDP) is connected
 - Any specific errors you see in the logs (like permission denied, port conflicts, session expired)
 - The recommended fix based on actual evidence found (e.g. restart the gateway, re-link WhatsApp, kill stale processes)
+- Treat live /service/health and /startup-ready as authoritative over old chat messages or stale log lines.
+- Never run ps/pgrep with full command lines or environment output, because provider keys can appear there.
 IMPORTANT: Only suggest Full Disk Access if you see an explicit permission-denied error in the logs. Do not suggest it based on absence of a log file alone.`
 
 const GATEWAY_RESTART_PROMPT = `Please restart the Knapsack gateway service. Run this command:
@@ -773,10 +776,12 @@ Then check if it recovered:
 curl -s http://127.0.0.1:8897/api/clawd/service/health | python3 -m json.tool
 Tell me whether the gateway and browser are now healthy.`
 
-const GATEWAY_VIEW_LOGS_PROMPT = `Show me the recent Knapsack error logs to help diagnose connectivity issues. Run:
-tail -50 ~/Library/Logs/ks_error.log 2>/dev/null || echo "No error log found at ~/Library/Logs/ks_error.log"
-Summarize any recurring errors you find, especially related to: gateway connectivity, browser/CDP failures, channel errors (WhatsApp, iMessage), or port conflicts.
-IMPORTANT: If the log is empty or not found, do NOT speculate about Full Disk Access or other permissions — the absence of logs does not imply a permission issue. Instead, report that no errors were found and suggest waiting a bit longer for the browser to finish starting.`
+const GATEWAY_VIEW_LOGS_PROMPT = `Show me the recent Knapsack gateway error logs to help diagnose connectivity issues. Run:
+tail -80 ~/Library/Logs/Knapsack/knapsack-clawdbot.err.log 2>/dev/null | grep -Ev "security warning|model-pricing|socket-mode:SlackWebSocket|slack.*socket disconnected|bonjour|CIAO|staging bundled runtime deps" || echo "No relevant gateway error log lines found"
+Then compare against live health:
+curl -s http://127.0.0.1:8897/api/clawd/service/health | python3 -m json.tool
+Summarize only recurring current errors, especially related to: gateway connectivity, browser/CDP failures, channel errors (WhatsApp, iMessage), or port conflicts.
+IMPORTANT: Treat live health as authoritative over stale log lines. If the log is empty or not found, do NOT speculate about Full Disk Access or other permissions — the absence of logs does not imply a permission issue.`
 
 function buildWebsiteInstructions(userName: string, userEmail: string): string {
   const namePart = userName ? `My name is ${userName}.` : ''
@@ -3461,6 +3466,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       health?.gateway_ok &&
       !autoTriggeredBriefingRef.current &&
       !busy &&
+      !advancedMode &&
+      !developerMode &&
+      autonomyMode === 'assist' &&
       msgs.length > 0 &&
       msgs.every(m => m.id.startsWith('welcome-'))
     ) {
@@ -3478,7 +3486,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       }, 800)
       return () => clearTimeout(timer)
     }
-  }, [hasCompletedOnboarding, health?.gateway_ok, busy, msgs])
+  }, [hasCompletedOnboarding, health?.gateway_ok, busy, advancedMode, developerMode, autonomyMode, msgs])
 
   const enableAssistant = async (enabled: boolean) => {
     setBusy(true)


### PR DESCRIPTION
## Summary
- map legacy browser requests onto the OpenClaw Chrome profile and add a Google News RSS fallback when DuckDuckGo automation is challenged or empty
- tighten gateway Diagnose/View Logs prompts around live health and recent logs while avoiding full process-env dumps
- make dev QA reuse the checkout-specific LaunchAgent plist when available
- remove/reject stray Contents/CodeResources and strengthen DMG Gatekeeper validation in release CI

## Validation
- npm exec -- tsc --noEmit
- cargo check