### PR TITLE
fix: make iMessage pairing usable

### DIFF
--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -1018,13 +1018,13 @@ pub async fn imessage_enable(
     Ok(config_snapshot) => {
       let base_hash = extract_base_hash(&config_snapshot);
 
-      // iMessage channel config:
-      // - dmPolicy "allowlist" = only owner (linked self number) can interact; others silently ignored
-      // - service "auto" = detect iMessage vs SMS automatically
+      // iMessage does not expose a reliable "self" handle we can pre-allow.
+      // Start in pairing mode so the first sender can be approved, then the
+      // auto-approve watcher switches the channel back to allowlist.
       // Also ensures agents.defaults.model is set so auto-reply actually works.
       let patch = if body.enabled {
         build_enable_patch(
-          r#"{"channels": {"imessage": {"dmPolicy": "allowlist", "service": "auto"}}}"#,
+          r#"{"channels": {"imessage": {"dmPolicy": "pairing", "service": "auto"}}}"#,
           &config_snapshot,
         )
       } else {
@@ -1032,16 +1032,21 @@ pub async fn imessage_enable(
       };
 
       match gateway_client::config_patch(&patch, &base_hash, None).await {
-        Ok(_) => HttpResponse::Ok().json(GenericResponse {
-          success: true,
-          message: Some(if body.enabled {
-            "iMessage enabled".to_string()
-          } else {
-            "iMessage disabled".to_string()
-          }),
-          configured: None,
-          linked: None,
-        }),
+        Ok(_) => {
+          if body.enabled {
+            pairing_auto_approve::spawn_auto_approve("imessage");
+          }
+          HttpResponse::Ok().json(GenericResponse {
+            success: true,
+            message: Some(if body.enabled {
+              "iMessage enabled".to_string()
+            } else {
+              "iMessage disabled".to_string()
+            }),
+            configured: None,
+            linked: None,
+          })
+        }
         Err(e) => HttpResponse::Ok().json(GenericResponse {
           success: false,
           message: Some(format!("Failed to update config: {}", e)),
@@ -1062,25 +1067,48 @@ pub async fn imessage_enable(
 /// Setup iMessage channel
 #[post("/api/clawd/channels/imessage/setup")]
 pub async fn imessage_setup(_cfg: web::Data<SharedClawdbotConfig>) -> impl Responder {
-  // Check iMessage status from gateway
-  match gateway_client::get_channel_status(None).await {
+  match channel_runtime_snapshot().await {
     Ok(status) => {
-      let (_enabled, _linked, configured) = parse_channel_from_summary(&status, "iMessage");
+      let channel = runtime_channel(&status, "imessage");
+      let configured = channel
+        .and_then(|s| s.get("configured"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| configured_channel("imessage").is_some());
+      let last_error = channel
+        .and_then(|s| s.get("lastError"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
 
       if configured {
+        pairing_auto_approve::spawn_auto_approve("imessage");
         HttpResponse::Ok().json(GenericResponse {
           success: true,
           message: Some("iMessage is configured".to_string()),
           configured: Some(true),
           linked: None,
         })
+      } else if last_error.to_lowercase().contains("full disk")
+        || last_error.to_lowercase().contains("permission")
+        || last_error.to_lowercase().contains("messages database")
+      {
+        HttpResponse::Ok().json(GenericResponse {
+          success: false,
+          message: Some("iMessage requires Full Disk Access permission. Go to System Settings > Privacy & Security > Full Disk Access and add Knapsack.".to_string()),
+          configured: Some(false),
+          linked: None,
+        })
       } else {
         HttpResponse::Ok().json(GenericResponse {
-                    success: false,
-                    message: Some("iMessage requires Full Disk Access permission. Go to System Preferences > Privacy & Security > Full Disk Access and add Knapsack.".to_string()),
-                    configured: Some(false),
-                    linked: None,
-                })
+          success: false,
+          message: Some(if last_error.is_empty() {
+            "iMessage is enabled but the gateway does not report it as configured yet. Try again after the gateway finishes starting.".to_string()
+          } else {
+            format!("iMessage is not configured yet: {}", last_error)
+          }),
+          configured: Some(false),
+          linked: None,
+        })
       }
     }
     Err(e) => HttpResponse::Ok().json(GenericResponse {
@@ -1884,7 +1912,7 @@ pub async fn generic_channel_configure(
           log::info!("[channels] {} configured successfully", channel);
           // For channels using pairing mode, auto-approve the first
           // request so the device owner is seamlessly allowlisted.
-          // Channels that already use allowlist (whatsapp, imessage)
+          // Channels that already use allowlist (for example WhatsApp)
           // won't have pairing requests, so this is a safe no-op.
           pairing_auto_approve::spawn_auto_approve(&channel);
           HttpResponse::Ok().json(GenericResponse {
@@ -3227,7 +3255,7 @@ pub async fn channel_diagnostics() -> impl Responder {
                   let bh = extract_base_hash(&snap);
                   let dm_policy = match *ch_key {
                     "imessage" => {
-                      r#"{"channels":{"imessage":{"dmPolicy":"allowlist","service":"auto"}}}"#
+                      r#"{"channels":{"imessage":{"dmPolicy":"pairing","service":"auto"}}}"#
                     }
                     _ => &format!(
                       r#"{{"channels":{{"{}": {{"dmPolicy":"pairing"}}}}}}"#,

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -1465,6 +1465,24 @@ function ChannelAllowlistSection({ channel, isConnected }: { channel: string; is
 
   if (!isConnected || !loaded) return null
 
+  const allowlistCopy = channel === 'whatsapp'
+    ? 'Only these contacts can reach the AI. Your linked WhatsApp number is added automatically after connection:'
+    : channel === 'imessage'
+      ? 'Only these contacts can reach the AI. Add the phone number or Apple ID email you will message from:'
+      : 'Only these contacts can reach the AI:'
+  const pairingCopy = channel === 'imessage'
+    ? 'First-time senders receive a pairing code. After approval, Knapsack locks future messages to that sender.'
+    : 'Pre-approved contacts (skip pairing code):'
+  const contactPlaceholder = channel === 'discord'
+    ? 'User ID'
+    : channel === 'slack'
+      ? 'User ID'
+      : channel === 'telegram'
+        ? '@username or user ID'
+        : channel === 'imessage'
+          ? '+1234567890 or appleid@example.com'
+          : '+1234567890'
+
   return (
     <div className="ClawdChannelGuide" style={{ borderTop: '1px solid #e2e8f0', marginTop: 8 }}>
       <div className="ClawdChannelGuideTitle">Who can message</div>
@@ -1494,9 +1512,7 @@ function ChannelAllowlistSection({ channel, isConnected }: { channel: string; is
       {(dmPolicy === 'allowlist' || dmPolicy === 'pairing') && (
         <>
           <div style={{ fontSize: 12, color: '#64748b', marginBottom: 6 }}>
-            {dmPolicy === 'allowlist'
-              ? 'Only these contacts (plus your own number) can reach the AI:'
-              : 'Pre-approved contacts (skip pairing code):'}
+            {dmPolicy === 'allowlist' ? allowlistCopy : pairingCopy}
           </div>
 
           {allowFrom.length > 0 && (
@@ -1522,7 +1538,7 @@ function ChannelAllowlistSection({ channel, isConnected }: { channel: string; is
               value={newContact}
               onChange={e => setNewContact(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter') addContact() }}
-              placeholder={channel === 'discord' ? 'User ID' : channel === 'slack' ? 'User ID' : channel === 'telegram' ? '@username or user ID' : '+1234567890'}
+              placeholder={contactPlaceholder}
               style={{ flex: 1, padding: '4px 8px', fontSize: 12, borderRadius: 4, border: '1px solid #ccc' }}
             />
             <button
@@ -5637,10 +5653,14 @@ ${actualText}`
                       <ol className="ClawdChannelGuideSteps">
                         <li>
                           <span className="ClawdChannelGuideNum">1</span>
-                          <span>Send an iMessage to this Mac from any Apple device. Your assistant will see incoming messages and reply automatically.</span>
+                          <span>From Messages on your iPhone, send an iMessage to yourself or to this Mac. Your assistant will see incoming messages and reply automatically.</span>
                         </li>
                         <li>
                           <span className="ClawdChannelGuideNum">2</span>
+                          <span>If this is your first message, reply with the pairing code Knapsack sends. After that, your sender is approved automatically.</span>
+                        </li>
+                        <li>
+                          <span className="ClawdChannelGuideNum">3</span>
                           <span>You can also ask your assistant in this chat: <em>"Send an iMessage to [name/number]"</em>.</span>
                         </li>
                       </ol>


### PR DESCRIPTION
## Summary
- start iMessage in pairing mode instead of an empty allowlist so first-run inbound messages are not silently blocked
- auto-approve the first iMessage pairing request and then lock the channel back down through the existing pairing watcher
- make iMessage setup trust the gateway runtime snapshot before showing Full Disk Access errors
- update channel access copy so iMessage explains self-message and pairing behavior

## Validation
- Dev build API check: iMessage status returned enabled=true/configured=true, allowlist returned dmPolicy=pairing, setup returned success=true
- /Users/markheynen/knapsack_desktop/src: npm exec -- tsc --noEmit --pretty false
- /Users/markheynen/knapsack_desktop/src: cargo fmt --manifest-path src/src-tauri/Cargo.toml --check
- /tmp/knapsack-imessage-pr/src: node_modules/.bin/tsc --noEmit --pretty false
- /tmp/knapsack-imessage-pr: cargo check --manifest-path src/src-tauri/Cargo.toml
- /tmp/knapsack-imessage-pr: git diff --check

Note: repo-wide cargo fmt --check on origin/main still reports pre-existing formatting diffs across many files, so I did not run formatting over the full tree for this scoped PR.