### PR TITLE
Fix gateway resilience for fatal channel errors

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/probe-BhYFPpIH.js
+++ b/src/src-tauri/resources/clawdbot/dist/probe-BhYFPpIH.js
@@ -16,6 +16,19 @@ import { createInterface } from "node:readline";
 const DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS = 1e4;
 //#endregion
 //#region extensions/imessage/src/client.ts
+function normalizeIMessageRpcText(value) {
+	return String(value ?? "").trim();
+}
+function isIMessagePermissionDeniedText(value) {
+	const text = normalizeIMessageRpcText(value).toLowerCase();
+	return text.includes("permissiondenied(") || text.includes("authorization denied") || text.includes("operation not permitted");
+}
+function formatIMessagePermissionError(value) {
+	const text = normalizeIMessageRpcText(value);
+	const pathMatch = text.match(/path:\s*"([^"]+)"/i);
+	const path = pathMatch?.[1] ?? "~/Library/Messages/chat.db";
+	return `iMessage requires Full Disk Access to read ${path}. Grant Full Disk Access to Knapsack, then restart the gateway.`;
+}
 function isTestEnv() {
 	const vitest = normalizeLowercaseStringOrEmpty(process.env.VITEST);
 	return Boolean(vitest);
@@ -118,6 +131,13 @@ var IMessageRpcClient = class {
 		try {
 			parsed = JSON.parse(line);
 		} catch (err) {
+			if (isIMessagePermissionDeniedText(line)) {
+				const error = new Error(formatIMessagePermissionError(line));
+				this.runtime?.error?.(`imsg rpc: ${error.message}`);
+				this.failAll(error);
+				this.stop().catch(() => {});
+				return;
+			}
 			const detail = formatErrorMessage(err);
 			this.runtime?.error?.(`imsg rpc: failed to parse ${line}: ${detail}`);
 			return;
@@ -231,9 +251,15 @@ async function probeIMessage(timeoutMs, opts = {}) {
 		await client.request("chats.list", { limit: 1 }, { timeoutMs: effectiveTimeout });
 		return { ok: true };
 	} catch (err) {
+		const message = formatErrorMessage(err);
+		if (isIMessagePermissionDeniedText(message)) return {
+			ok: false,
+			error: formatIMessagePermissionError(message),
+			fatal: true
+		};
 		return {
 			ok: false,
-			error: String(err)
+			error: message
 		};
 	} finally {
 		await client.stop();

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
@@ -1811,6 +1811,14 @@ const CHANNEL_RESTART_POLICY = {
 };
 const MAX_RESTART_ATTEMPTS = 10;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5e3;
+function isFatalChannelRuntimeError(channelId, message) {
+	const lower = String(message ?? "").toLowerCase();
+	if (!lower) return false;
+	if (channelId === "imessage" && (lower.includes("full disk access") || lower.includes("permissiondenied(") || lower.includes("authorization denied") || lower.includes("/library/messages/chat.db"))) return true;
+	if (channelId === "whatsapp" && (lower.includes("401") || lower.includes("unauthorized") || lower.includes("logged out") || lower.includes("connection failure"))) return true;
+	if (channelId === "telegram" && (lower.includes("missing scope") || lower.includes("operator.read") || lower.includes("unauthorized") || lower.includes("invalid token"))) return true;
+	return false;
+}
 function createRuntimeStore() {
 	return {
 		aborts: /* @__PURE__ */ new Map(),
@@ -1956,6 +1964,7 @@ function createChannelManager(opts) {
 			const abort = new AbortController();
 			store.aborts.set(id, abort);
 			let handedOffTask = false;
+			let terminalChannelError = false;
 			const log = channelLogs[channelId];
 			let scopedChannelRuntime = null;
 			let channelRuntimeForTask;
@@ -2044,11 +2053,16 @@ function createChannelManager(opts) {
 					...channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}
 				})).catch((err) => {
 					const message = formatErrorMessage(err);
+					terminalChannelError = isFatalChannelRuntimeError(channelId, message);
 					setRuntime(channelId, id, {
 						accountId: id,
-						lastError: message
+						lastError: message,
+						...terminalChannelError ? {
+							restartPending: false,
+							reconnectAttempts: 0
+						} : {}
 					});
-					log.error?.(`[${id}] channel exited: ${message}`);
+					log.error?.(`[${id}] channel exited${terminalChannelError ? " (fatal; restart suppressed)" : ""}: ${message}`);
 				}).finally(async () => {
 					await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
 					setRuntime(channelId, id, {
@@ -2058,6 +2072,15 @@ function createChannelManager(opts) {
 					});
 				}).then(async () => {
 					if (manuallyStopped.has(rKey)) return;
+					if (terminalChannelError) {
+						manuallyStopped.add(rKey);
+						setRuntime(channelId, id, {
+							accountId: id,
+							restartPending: false,
+							reconnectAttempts: 0
+						});
+						return;
+					}
 					const attempt = (restartAttempts.get(rKey) ?? 0) + 1;
 					restartAttempts.set(rKey, attempt);
 					if (attempt > MAX_RESTART_ATTEMPTS) {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3663,6 +3663,7 @@ fn gateway_runtime_deps_startup_in_progress_from_log(content: &str) -> bool {
   let staging = tail.rfind("staging bundled runtime deps");
   let installed = tail.rfind("installed bundled runtime deps");
   let listening = tail.rfind("http server listening");
+  let ready = tail.rfind("[gateway] ready");
   let terminated = tail.rfind("received SIGTERM; shutting down");
   let loading = tail.rfind("[gateway] loading configuration");
 
@@ -3672,6 +3673,7 @@ fn gateway_runtime_deps_startup_in_progress_from_log(content: &str) -> bool {
 
   installed.unwrap_or(0) < staging_idx
     && listening.unwrap_or(0) < staging_idx
+    && ready.unwrap_or(0) < staging_idx
     && terminated.unwrap_or(0) < staging_idx
     && loading.unwrap_or(0) < staging_idx
 }
@@ -11109,6 +11111,14 @@ mod crash_classifier_tests {
     );
     assert!(!gateway_runtime_deps_startup_in_progress_from_log(
       &listening
+    ));
+
+    let ready = format!(
+      "{}\n2026-05-13T10:44:52 [gateway] ready",
+      staging
+    );
+    assert!(!gateway_runtime_deps_startup_in_progress_from_log(
+      &ready
     ));
 
     let terminated = format!(


### PR DESCRIPTION
## Summary
- fail iMessage RPC probes fast with a clear Full Disk Access error when macOS denies Messages DB access
- suppress automatic channel restarts for terminal auth/permission failures in iMessage, WhatsApp, and Telegram so one bad channel does not destabilize the gateway
- avoid stale runtime-deps diagnostics after the gateway has already emitted ready

## Validation
- node --check src/src-tauri/resources/clawdbot/dist/probe-BhYFPpIH.js
- node --check src/src-tauri/resources/clawdbot/dist/server.impl-hNr66nDN.js
- node scripts/verify-clawdbot-bundle.cjs
- cargo test --manifest-path src/src-tauri/Cargo.toml runtime_deps_staging_is_startup_progress_until_completion
- npm exec -- tsc --noEmit --pretty false

Note: full vite build was attempted after the prebuild verifier passed, but the local clean worktree used a borrowed node_modules symlink and Vite/Tailwind hung scanning too broadly. CI should run in a clean dependency layout.