### PR TITLE
Default iMessage to owner allowlist

### DIFF
--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -1018,13 +1018,22 @@ pub async fn imessage_enable(
     Ok(config_snapshot) => {
       let base_hash = extract_base_hash(&config_snapshot);
 
-      // iMessage does not expose a reliable "self" handle we can pre-allow.
-      // Start in pairing mode so the first sender can be approved, then the
-      // auto-approve watcher switches the channel back to allowlist.
+      // Default iMessage to allowlist mode. Pairing mode can send codes into
+      // real conversations, which is awkward and unsafe for a desktop app.
       // Also ensures agents.defaults.model is set so auto-reply actually works.
       let patch = if body.enabled {
+        let allow_from = service::safe_default_imessage_allow_from();
+        let patch_value = serde_json::json!({
+          "channels": {
+            "imessage": {
+              "dmPolicy": "allowlist",
+              "allowFrom": allow_from,
+              "service": "auto"
+            }
+          }
+        });
         build_enable_patch(
-          r#"{"channels": {"imessage": {"dmPolicy": "pairing", "service": "auto"}}}"#,
+          &serde_json::to_string(&patch_value).unwrap(),
           &config_snapshot,
         )
       } else {
@@ -1032,21 +1041,16 @@ pub async fn imessage_enable(
       };
 
       match gateway_client::config_patch(&patch, &base_hash, None).await {
-        Ok(_) => {
-          if body.enabled {
-            pairing_auto_approve::spawn_auto_approve("imessage");
-          }
-          HttpResponse::Ok().json(GenericResponse {
-            success: true,
-            message: Some(if body.enabled {
-              "iMessage enabled".to_string()
-            } else {
-              "iMessage disabled".to_string()
-            }),
-            configured: None,
-            linked: None,
-          })
-        }
+        Ok(_) => HttpResponse::Ok().json(GenericResponse {
+          success: true,
+          message: Some(if body.enabled {
+            "iMessage enabled".to_string()
+          } else {
+            "iMessage disabled".to_string()
+          }),
+          configured: None,
+          linked: None,
+        }),
         Err(e) => HttpResponse::Ok().json(GenericResponse {
           success: false,
           message: Some(format!("Failed to update config: {}", e)),
@@ -1081,7 +1085,6 @@ pub async fn imessage_setup(_cfg: web::Data<SharedClawdbotConfig>) -> impl Respo
         .trim();
 
       if configured {
-        pairing_auto_approve::spawn_auto_approve("imessage");
         HttpResponse::Ok().json(GenericResponse {
           success: true,
           message: Some("iMessage is configured".to_string()),
@@ -2812,6 +2815,11 @@ fn read_channel_allowlist(config: &serde_json::Value, channel: &str) -> (String,
         .unwrap_or_default(),
     )
   };
+  let allow = if channel == "imessage" {
+    service::visible_imessage_allow_from(allow)
+  } else {
+    allow
+  };
   (policy, allow)
 }
 
@@ -2870,6 +2878,14 @@ pub async fn channel_allowlist_update(
           patch_inner.insert("dmPolicy".to_string(), serde_json::json!(policy));
         }
         if let Some(ref allow) = body.allow_from {
+          let allow = if channel == "imessage"
+            && body.dm_policy.as_deref().unwrap_or("allowlist") == "allowlist"
+            && allow.is_empty()
+          {
+            service::safe_default_imessage_allow_from()
+          } else {
+            allow.clone()
+          };
           patch_inner.insert("allowFrom".to_string(), serde_json::json!(allow));
         }
       }
@@ -3253,16 +3269,23 @@ pub async fn channel_diagnostics() -> impl Responder {
                 let re_snapshot = gateway_client::config_get(None).await;
                 if let Ok(snap) = re_snapshot {
                   let bh = extract_base_hash(&snap);
-                  let dm_policy = match *ch_key {
-                    "imessage" => {
-                      r#"{"channels":{"imessage":{"dmPolicy":"pairing","service":"auto"}}}"#
-                    }
-                    _ => &format!(
+                  let patch = match *ch_key {
+                    "imessage" => serde_json::to_string(&serde_json::json!({
+                      "channels": {
+                        "imessage": {
+                          "dmPolicy": "allowlist",
+                          "allowFrom": service::safe_default_imessage_allow_from(),
+                          "service": "auto"
+                        }
+                      }
+                    }))
+                    .unwrap(),
+                    _ => format!(
                       r#"{{"channels":{{"{}": {{"dmPolicy":"pairing"}}}}}}"#,
                       ch_key
                     ),
                   };
-                  match gateway_client::config_patch(dm_policy, &bh, None).await {
+                  match gateway_client::config_patch(&patch, &bh, None).await {
                     Ok(_) => repairs.push(format!("Added channel config for '{}'", ch_key)),
                     Err(e) => issues.push(format!("Failed to repair channel '{}': {}", ch_key, e)),
                   }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -10,6 +10,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use crate::clawd::gateway_client;
 use crate::clawd::sidecar::SharedClawdbotConfig;
 
+pub(crate) const IMESSAGE_OWNER_UNCONFIGURED_SENTINEL: &str =
+  "knapsack-owner-not-configured@invalid.localhost";
+
 // ── Windows process management ──────────────────────────────────────────
 // On Windows we spawn the gateway as a child process (no launchd/launchctl).
 // Track the PID so we can check status and kill it on disable.
@@ -2294,6 +2297,128 @@ fn is_empty_allow_from(value: Option<&serde_json::Value>) -> bool {
   }
 }
 
+fn normalize_imessage_owner_identifier(raw: &str) -> Option<String> {
+  let trimmed = raw.trim();
+  if trimmed.is_empty() {
+    return None;
+  }
+  if trimmed == IMESSAGE_OWNER_UNCONFIGURED_SENTINEL {
+    return Some(trimmed.to_string());
+  }
+  if trimmed.contains('@') {
+    return Some(trimmed.to_lowercase());
+  }
+  Some(trimmed.replace(char::is_whitespace, ""))
+}
+
+fn push_imessage_owner_identifier(entries: &mut Vec<String>, raw: &str) {
+  let Some(normalized) = normalize_imessage_owner_identifier(raw) else {
+    return;
+  };
+  if !entries.iter().any(|entry| entry == &normalized) {
+    entries.push(normalized);
+  }
+}
+
+fn knapsack_profile_email_from_disk() -> Option<String> {
+  let home_dir = dirs::home_dir()?;
+  let profile_path = home_dir.join(".knapsack").join("profile.dat");
+  let raw = fs::read_to_string(profile_path).ok()?;
+  let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+  json
+    .get("KN_PROFILE")
+    .and_then(|profile| profile.get("email"))
+    .and_then(|email| email.as_str())
+    .and_then(normalize_imessage_owner_identifier)
+}
+
+fn knapsack_email_from_tokens() -> Option<String> {
+  let home = default_clawdbot_home_from_env()?;
+  let raw = fs::read_to_string(home.join("tokens.json")).ok()?;
+  let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+  json
+    .get("knapsack_email")
+    .and_then(|email| email.as_str())
+    .and_then(normalize_imessage_owner_identifier)
+}
+
+/// Safe default for iMessage DM access. Prefer the signed-in Knapsack email
+/// because it is often also the user's Apple ID. If no owner identifier is
+/// discoverable, use a non-matching sentinel so the gateway remains in
+/// allowlist mode and never sends pairing codes to arbitrary contacts.
+pub(crate) fn safe_default_imessage_allow_from() -> Vec<String> {
+  let mut entries = Vec::new();
+
+  if let Ok(raw) = std::env::var("KNAPSACK_IMESSAGE_ALLOW_FROM") {
+    for part in raw.split(',') {
+      push_imessage_owner_identifier(&mut entries, part);
+    }
+  }
+  if let Ok(raw) = std::env::var("KNAPSACK_USER_EMAIL") {
+    push_imessage_owner_identifier(&mut entries, &raw);
+  }
+  if let Some(email) = knapsack_email_from_tokens() {
+    push_imessage_owner_identifier(&mut entries, &email);
+  }
+  if let Some(email) = knapsack_profile_email_from_disk() {
+    push_imessage_owner_identifier(&mut entries, &email);
+  }
+
+  if entries.is_empty() {
+    entries.push(IMESSAGE_OWNER_UNCONFIGURED_SENTINEL.to_string());
+  }
+
+  entries
+}
+
+pub(crate) fn visible_imessage_allow_from(entries: Vec<String>) -> Vec<String> {
+  entries
+    .into_iter()
+    .filter(|entry| entry != IMESSAGE_OWNER_UNCONFIGURED_SENTINEL)
+    .collect()
+}
+
+fn ensure_imessage_allowlist_config(cfg: &mut serde_json::Value) -> bool {
+  let Some(ch) = cfg
+    .pointer_mut("/channels/imessage")
+    .and_then(|value| value.as_object_mut())
+  else {
+    return false;
+  };
+
+  let mut patched = false;
+  let current_policy = ch
+    .get("dmPolicy")
+    .and_then(|value| value.as_str())
+    .unwrap_or("allowlist")
+    .to_string();
+
+  if current_policy != "disabled" && current_policy != "allowlist" {
+    ch.insert("dmPolicy".to_string(), serde_json::json!("allowlist"));
+    eprintln!(
+      "[clawd/service] Migrated iMessage dmPolicy from {:?} to allowlist to avoid pairing-code exposure",
+      current_policy
+    );
+    patched = true;
+  }
+
+  let needs_allow_from = ch
+    .get("allowFrom")
+    .map(|value| is_empty_allow_from(Some(value)))
+    .unwrap_or(true);
+
+  if current_policy != "disabled" && needs_allow_from {
+    ch.insert(
+      "allowFrom".to_string(),
+      serde_json::json!(safe_default_imessage_allow_from()),
+    );
+    eprintln!("[clawd/service] Seeded iMessage allowFrom with the owner identity default");
+    patched = true;
+  }
+
+  patched
+}
+
 /// Auto-heal OpenClaw channel configs where `dmPolicy="allowlist"` but
 /// `allowFrom` is missing or empty. Such configs fail Zod validation and
 /// cause fatal CLI errors ("openclaw logs", "status", etc.).
@@ -2326,7 +2451,7 @@ fn downgrade_streaming_if_object(val: &serde_json::Value) -> Option<serde_json::
 ///
 /// Returns `true` if any fields were modified (caller should persist config).
 fn sanitize_channel_allowlist_configs(cfg: &mut serde_json::Value) -> bool {
-  let mut patched = false;
+  let mut patched = ensure_imessage_allowlist_config(cfg);
 
   let channel_names: Vec<String> = cfg
     .get("channels")
@@ -11087,6 +11212,45 @@ mod crash_classifier_tests {
       Some("peekaboo")
     );
     assert!(cfg.pointer("/agents/defaults/model").is_some());
+  }
+
+  #[test]
+  fn imessage_pairing_is_migrated_to_seeded_allowlist() {
+    let mut cfg = serde_json::json!({
+      "channels": {
+        "imessage": {
+          "dmPolicy": "pairing",
+          "service": "auto"
+        }
+      }
+    });
+
+    assert!(sanitize_channel_allowlist_configs(&mut cfg));
+    assert_eq!(
+      cfg
+        .pointer("/channels/imessage/dmPolicy")
+        .and_then(|v| v.as_str()),
+      Some("allowlist")
+    );
+    assert!(
+      cfg
+        .pointer("/channels/imessage/allowFrom")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false),
+      "iMessage allowlist should be seeded so the gateway does not fall back to pairing"
+    );
+  }
+
+  #[test]
+  fn imessage_sentinel_is_hidden_from_ui_allowlist() {
+    assert_eq!(
+      visible_imessage_allow_from(vec![
+        IMESSAGE_OWNER_UNCONFIGURED_SENTINEL.to_string(),
+        "owner@example.com".to_string()
+      ]),
+      vec!["owner@example.com".to_string()]
+    );
   }
 
   #[test]

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -1468,10 +1468,10 @@ function ChannelAllowlistSection({ channel, isConnected }: { channel: string; is
   const allowlistCopy = channel === 'whatsapp'
     ? 'Only these contacts can reach the AI. Your linked WhatsApp number is added automatically after connection:'
     : channel === 'imessage'
-      ? 'Only these contacts can reach the AI. Add the phone number or Apple ID email you will message from:'
+      ? 'Only these contacts can reach the AI. Your Knapsack email is added when available; add the phone number or Apple ID email you will message from:'
       : 'Only these contacts can reach the AI:'
   const pairingCopy = channel === 'imessage'
-    ? 'First-time senders receive a pairing code. After approval, Knapsack locks future messages to that sender.'
+    ? 'Pairing sends approval codes into real iMessage conversations. Use allowlist mode unless you are deliberately approving a new sender.'
     : 'Pre-approved contacts (skip pairing code):'
   const contactPlaceholder = channel === 'discord'
     ? 'User ID'
@@ -5657,7 +5657,7 @@ ${actualText}`
                         </li>
                         <li>
                           <span className="ClawdChannelGuideNum">2</span>
-                          <span>If this is your first message, reply with the pairing code Knapsack sends. After that, your sender is approved automatically.</span>
+                          <span>Only allowlisted senders can reach the AI. Add the phone number or Apple ID email you will message from below if it is not already listed.</span>
                         </li>
                         <li>
                           <span className="ClawdChannelGuideNum">3</span>


### PR DESCRIPTION
## Summary
- default iMessage enable/repair flows to allowlist mode instead of pairing mode
- seed the iMessage allowlist from the signed-in Knapsack owner identity when available, with a non-matching hidden sentinel fallback so pairing codes are never sent by default
- migrate existing iMessage pairing/open configs to allowlist during config sanitization and update the channel settings copy

## Validation
- ./node_modules/.bin/tsc --noEmit --pretty false
- cargo test --manifest-path src/src-tauri/Cargo.toml imessage_