### PR TITLE
[codex] Update Google Gemini coding defaults

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/extensions/google/cli-backend.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/google/cli-backend.js
@@ -2,10 +2,10 @@ import { CLI_FRESH_WATCHDOG_DEFAULTS, CLI_RESUME_WATCHDOG_DEFAULTS } from "openc
 //#region extensions/google/cli-backend.ts
 const GEMINI_MODEL_ALIASES = {
 	pro: "gemini-3.1-pro-preview",
-	flash: "gemini-3.1-flash-preview",
+	flash: "gemini-3.5-flash",
 	"flash-lite": "gemini-3.1-flash-lite-preview"
 };
-const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
+const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3.5-flash";
 function buildGoogleGeminiCliBackend() {
 	return {
 		id: "google-gemini-cli",

--- a/src/src-tauri/resources/clawdbot/dist/extensions/google/gemini-cli-provider.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/google/gemini-cli-provider.js
@@ -7,7 +7,7 @@ import { fetchGeminiUsage } from "openclaw/plugin-sdk/provider-usage";
 //#region extensions/google/gemini-cli-provider.ts
 const PROVIDER_ID = "google-gemini-cli";
 const PROVIDER_LABEL = "Gemini CLI OAuth";
-const DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
+const DEFAULT_MODEL = "google/gemini-3.5-flash";
 const ENV_VARS = [
 	"OPENCLAW_GEMINI_OAUTH_CLIENT_ID",
 	"OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET",

--- a/src/src-tauri/resources/clawdbot/dist/extensions/google/model-id.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/google/model-id.js
@@ -5,7 +5,8 @@ const ANTIGRAVITY_BARE_PRO_IDS = new Set([
 	"gemini-3-1-pro"
 ]);
 function normalizeGoogleModelId(id) {
-	if (id === "gemini-3-pro") return "gemini-3-pro-preview";
+	if (id === "gemini-3-pro") return "gemini-3.1-pro-preview";
+	if (id === "gemini-3.5-flash-preview") return "gemini-3.5-flash";
 	if (id === "gemini-3-flash") return "gemini-3-flash-preview";
 	if (id === "gemini-3.1-pro") return "gemini-3.1-pro-preview";
 	if (id === "gemini-3.1-flash-lite") return "gemini-3.1-flash-lite-preview";

--- a/src/src-tauri/resources/clawdbot/dist/extensions/google/onboard.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/google/onboard.js
@@ -1,9 +1,9 @@
 import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onboard";
 //#region extensions/google/onboard.ts
-const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
+const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.5-flash";
 function applyGoogleGeminiModelDefault(cfg) {
 	const current = cfg.agents?.defaults?.model;
-	if ((typeof current === "string" ? current.trim() || void 0 : current && typeof current === "object" && typeof current.primary === "string" ? (current.primary || "").trim() || void 0 : void 0) === "google/gemini-3.1-pro-preview") return {
+	if ((typeof current === "string" ? current.trim() || void 0 : current && typeof current === "object" && typeof current.primary === "string" ? (current.primary || "").trim() || void 0 : void 0) === "google/gemini-3.5-flash") return {
 		next: cfg,
 		changed: false
 	};

--- a/src/src-tauri/resources/clawdbot/dist/extensions/google/openclaw.plugin.json
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/google/openclaw.plugin.json
@@ -4,31 +4,35 @@
   "providers": [
     "google",
     "google-gemini-cli",
-    "google-vertex"
+    "google-vertex",
+    "google-antigravity"
   ],
   "autoEnableWhenConfiguredProviders": [
-    "google-gemini-cli"
+    "google-gemini-cli",
+    "google-antigravity"
   ],
   "modelIdNormalization": {
     "providers": {
       "google": {
         "aliases": {
-          "gemini-3-pro": "gemini-3-pro-preview",
+          "gemini-3-pro": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
           "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
-          "gemini-3.1-flash-preview": "gemini-3-flash-preview"
+          "gemini-3.1-flash-preview": "gemini-3-flash-preview",
+          "gemini-3.5-flash-preview": "gemini-3.5-flash"
         }
       },
       "google-vertex": {
         "aliases": {
-          "gemini-3-pro": "gemini-3-pro-preview",
+          "gemini-3-pro": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
           "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
-          "gemini-3.1-flash-preview": "gemini-3-flash-preview"
+          "gemini-3.1-flash-preview": "gemini-3-flash-preview",
+          "gemini-3.5-flash-preview": "gemini-3.5-flash"
         }
       }
     }
@@ -36,6 +40,14 @@
   "modelPricing": {
     "providers": {
       "google-gemini-cli": {
+        "openRouter": {
+          "provider": "google"
+        },
+        "liteLLM": {
+          "provider": "google"
+        }
+      },
+      "google-antigravity": {
         "openRouter": {
           "provider": "google"
         },
@@ -77,6 +89,9 @@
       },
       "google-vertex": {
         "family": "google"
+      },
+      "google-antigravity": {
+        "family": "google"
       }
     }
   },
@@ -109,6 +124,16 @@
       "choiceId": "google-gemini-cli",
       "choiceLabel": "Gemini CLI OAuth",
       "choiceHint": "Google OAuth with project-aware token payload",
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini API key + OAuth"
+    },
+    {
+      "provider": "google-antigravity",
+      "method": "oauth",
+      "choiceId": "google-antigravity",
+      "choiceLabel": "Antigravity CLI OAuth",
+      "choiceHint": "Google Antigravity CLI keyring/browser sign-in",
       "groupId": "google",
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth"
@@ -198,6 +223,58 @@
           }
         }
       }
+    }
+  },
+  "modelCatalog": {
+    "providers": {
+      "google": [
+        {
+          "id": "gemini-3.5-flash",
+          "label": "Gemini 3.5 Flash"
+        },
+        {
+          "id": "gemini-3.1-pro-preview",
+          "label": "Gemini 3.1 Pro Preview"
+        },
+        {
+          "id": "gemini-3.1-pro-preview-customtools",
+          "label": "Gemini 3.1 Pro Preview Custom Tools"
+        },
+        {
+          "id": "gemini-3-flash-preview",
+          "label": "Gemini 3 Flash Preview"
+        }
+      ],
+      "google-antigravity": [
+        {
+          "id": "gemini-3.5-flash",
+          "label": "Gemini 3.5 Flash"
+        },
+        {
+          "id": "gemini-3.1-pro-high",
+          "label": "Gemini 3.1 Pro High"
+        },
+        {
+          "id": "gemini-3.1-pro-low",
+          "label": "Gemini 3.1 Pro Low"
+        },
+        {
+          "id": "gemini-3-flash",
+          "label": "Gemini 3 Flash"
+        },
+        {
+          "id": "claude-sonnet-4-6-thinking",
+          "label": "Claude Sonnet 4.6 Thinking"
+        },
+        {
+          "id": "claude-opus-4-6-thinking",
+          "label": "Claude Opus 4.6 Thinking"
+        },
+        {
+          "id": "gpt-oss-120b",
+          "label": "GPT OSS 120B"
+        }
+      ]
     }
   }
 }

--- a/src/src-tauri/resources/clawdbot/dist/extensions/google/provider-models.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/google/provider-models.js
@@ -6,6 +6,7 @@ const GOOGLE_ANTIGRAVITY_PROVIDER_ID = "google-antigravity";
 const GEMINI_2_5_PRO_PREFIX = "gemini-2.5-pro";
 const GEMINI_2_5_FLASH_LITE_PREFIX = "gemini-2.5-flash-lite";
 const GEMINI_2_5_FLASH_PREFIX = "gemini-2.5-flash";
+const GEMINI_3_5_FLASH_PREFIX = "gemini-3.5-flash";
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
@@ -16,10 +17,11 @@ const GEMMA_PREFIX = "gemma-";
 const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"];
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"];
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"];
-const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"];
+const GEMINI_3_5_FLASH_TEMPLATE_IDS = ["gemini-3.5-flash"];
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview"];
 const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"];
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"];
-const GEMINI_3_PRO_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-pro-low", "gemini-3-pro-high"];
+const GEMINI_3_PRO_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3.1-pro-low", "gemini-3.1-pro-high"];
 const GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-flash"];
 const GEMMA_TEMPLATE_IDS = GEMINI_3_1_FLASH_TEMPLATE_IDS;
 function cloneGoogleTemplateModel(params) {
@@ -81,6 +83,11 @@ function resolveGoogleGeminiForwardCompatModel(params) {
 		cliTemplateIds: GEMINI_3_1_FLASH_TEMPLATE_IDS,
 		preferExternalFirstForCli: true
 	};
+	else if (lower.startsWith(GEMINI_3_5_FLASH_PREFIX)) family = {
+		googleTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS,
+		cliTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS,
+		antigravityTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS
+	};
 	else if (lower.startsWith(GEMINI_3_1_PRO_PREFIX) || lower === GEMINI_PRO_LATEST_ID) {
 		family = {
 			googleTemplateIds: GEMINI_3_1_PRO_TEMPLATE_IDS,
@@ -123,7 +130,7 @@ function resolveGoogleGeminiForwardCompatModel(params) {
 }
 function isModernGoogleModel(modelId) {
 	const lower = normalizeOptionalLowercaseString(modelId) ?? "";
-	return lower.startsWith("gemini-2.5") || lower.startsWith("gemini-3") || lower === GEMINI_PRO_LATEST_ID || lower === GEMINI_FLASH_LATEST_ID || lower === GEMINI_FLASH_LITE_LATEST_ID || lower.startsWith(GEMMA_PREFIX);
+	return lower.startsWith("gemini-2.5") || lower.startsWith("gemini-3") || lower.startsWith("gemini-3.5") || lower === GEMINI_PRO_LATEST_ID || lower === GEMINI_FLASH_LATEST_ID || lower === GEMINI_FLASH_LITE_LATEST_ID || lower.startsWith(GEMMA_PREFIX);
 }
 //#endregion
 export { isModernGoogleModel, resolveGoogleGeminiForwardCompatModel };

--- a/src/src-tauri/resources/clawdbot/dist/io-CFdEhZuM.js
+++ b/src/src-tauri/resources/clawdbot/dist/io-CFdEhZuM.js
@@ -1145,8 +1145,8 @@ const DEFAULT_MODEL_ALIASES = {
 	gpt: "openai/gpt-5.4",
 	"gpt-mini": "openai/gpt-5.4-mini",
 	"gpt-nano": "openai/gpt-5.4-nano",
-	gemini: "google/gemini-3.1-pro-preview",
-	"gemini-flash": "google/gemini-3-flash-preview",
+	gemini: "google/gemini-3.5-flash",
+	"gemini-flash": "google/gemini-3.5-flash",
 	"gemini-flash-lite": "google/gemini-3.1-flash-lite-preview"
 };
 const DEFAULT_MODEL_COST = {

--- a/src/src-tauri/resources/clawdbot/dist/plugin-sdk/src/plugins/provider-model-defaults.d.ts
+++ b/src/src-tauri/resources/clawdbot/dist/plugin-sdk/src/plugins/provider-model-defaults.d.ts
@@ -7,7 +7,7 @@ export declare const OPENAI_DEFAULT_TTS_MODEL = "gpt-4o-mini-tts";
 export declare const OPENAI_DEFAULT_TTS_VOICE = "alloy";
 export declare const OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL = "gpt-4o-transcribe";
 export declare const OPENAI_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
-export declare const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
+export declare const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.5-flash";
 export declare const OLLAMA_DEFAULT_BASE_URL = "http://127.0.0.1:11434";
 export declare const OPENCODE_GO_DEFAULT_MODEL_REF = "opencode-go/kimi-k2.6";
 export declare function applyGoogleGeminiModelDefault(cfg: OpenClawConfig): {

--- a/src/src-tauri/resources/clawdbot/dist/provider-model-shared-Bqo51Ufw.js
+++ b/src/src-tauri/resources/clawdbot/dist/provider-model-shared-Bqo51Ufw.js
@@ -119,7 +119,8 @@ const ANTIGRAVITY_BARE_PRO_IDS = new Set([
 	"gemini-3-1-pro"
 ]);
 function normalizeGooglePreviewModelId(id) {
-	if (id === "gemini-3-pro") return "gemini-3-pro-preview";
+	if (id === "gemini-3-pro") return "gemini-3.1-pro-preview";
+	if (id === "gemini-3.5-flash-preview") return "gemini-3.5-flash";
 	if (id === "gemini-3-flash") return "gemini-3-flash-preview";
 	if (id === "gemini-3.1-pro") return "gemini-3.1-pro-preview";
 	if (id === "gemini-3.1-flash-lite") return "gemini-3.1-flash-lite-preview";

--- a/src/src-tauri/resources/clawdbot/docs/concepts/model-providers.md
+++ b/src/src-tauri/resources/clawdbot/docs/concepts/model-providers.md
@@ -193,37 +193,28 @@ Anthropic staff told us OpenClaw-style Claude CLI usage is allowed again, so Ope
 - Provider: `google`
 - Auth: `GEMINI_API_KEY`
 - Optional rotation: `GEMINI_API_KEYS`, `GEMINI_API_KEY_1`, `GEMINI_API_KEY_2`, `GOOGLE_API_KEY` fallback, and `OPENCLAW_LIVE_GEMINI_KEY` (single override)
-- Example models: `google/gemini-3.1-pro-preview`, `google/gemini-3-flash-preview`
-- Compatibility: legacy OpenClaw config using `google/gemini-3.1-flash-preview` is normalized to `google/gemini-3-flash-preview`
+- Example models: `google/gemini-3.5-flash`, `google/gemini-3.1-pro-preview`
+- Compatibility: legacy OpenClaw config using `google/gemini-3.5-flash-preview` is normalized to `google/gemini-3.5-flash`
 - CLI: `openclaw onboard --auth-choice gemini-api-key`
 - Thinking: `/think adaptive` uses Google dynamic thinking. Gemini 3/3.1 omit a fixed `thinkingLevel`; Gemini 2.5 sends `thinkingBudget: -1`.
 - Direct Gemini runs also accept `agents.defaults.models["google/<model>"].params.cachedContent` (or legacy `cached_content`) to forward a provider-native `cachedContents/...` handle; Gemini cache hits surface as OpenClaw `cacheRead`
 
-### Google Vertex and Gemini CLI
+### Google Vertex, Antigravity CLI, and Gemini CLI
 
-- Providers: `google-vertex`, `google-gemini-cli`
-- Auth: Vertex uses gcloud ADC; Gemini CLI uses its OAuth flow
+- Providers: `google-vertex`, `google-antigravity`, `google-gemini-cli`
+- Auth: Vertex uses gcloud ADC; Antigravity CLI uses keyring/browser Google Sign-In; legacy Gemini CLI uses its OAuth flow
 
 <Warning>
-Gemini CLI OAuth in OpenClaw is an unofficial integration. Some users have reported Google account restrictions after using third-party clients. Review Google terms and use a non-critical account if you choose to proceed.
+Antigravity CLI OAuth in OpenClaw is an unofficial integration. Some users have reported Google account restrictions after using third-party clients. Review Google terms and use a non-critical account if you choose to proceed.
 </Warning>
 
-Gemini CLI OAuth is shipped as part of the bundled `google` plugin.
+Antigravity CLI OAuth is shipped as part of the bundled `google` plugin.
 
 <Steps>
-  <Step title="Install Gemini CLI">
-    <Tabs>
-      <Tab title="brew">
-        ```bash
-        brew install gemini-cli
-        ```
-      </Tab>
-      <Tab title="npm">
-        ```bash
-        npm install -g @google/gemini-cli
-        ```
-      </Tab>
-    </Tabs>
+  <Step title="Install Antigravity CLI">
+    ```bash
+    curl -fsSL https://antigravity.google/cli/install.sh | bash
+    ```
   </Step>
   <Step title="Enable plugin">
     ```bash
@@ -235,7 +226,7 @@ Gemini CLI OAuth is shipped as part of the bundled `google` plugin.
     openclaw models auth login --provider google-gemini-cli --set-default
     ```
 
-    Default model: `google-gemini-cli/gemini-3-flash-preview`. You do **not** paste a client id or secret into `openclaw.json`. The CLI login flow stores tokens in auth profiles on the gateway host.
+    Default model: `google-gemini-cli/gemini-3.5-flash`. You do **not** paste a client id or secret into `openclaw.json`. The CLI login flow stores tokens in auth profiles on the gateway host.
 
   </Step>
   <Step title="Set project (if needed)">

--- a/src/src-tauri/resources/clawdbot/docs/gateway/config-agents.md
+++ b/src/src-tauri/resources/clawdbot/docs/gateway/config-agents.md
@@ -417,8 +417,8 @@ model, see [Agent runtimes](/concepts/agent-runtimes).
 | `gpt`               | `openai/gpt-5.5` or `openai-codex/gpt-5.5` |
 | `gpt-mini`          | `openai/gpt-5.4-mini`                      |
 | `gpt-nano`          | `openai/gpt-5.4-nano`                      |
-| `gemini`            | `google/gemini-3.1-pro-preview`            |
-| `gemini-flash`      | `google/gemini-3-flash-preview`            |
+| `gemini`            | `google/gemini-3.5-flash`            |
+| `gemini-flash`      | `google/gemini-3.5-flash`            |
 | `gemini-flash-lite` | `google/gemini-3.1-flash-lite-preview`     |
 
 Your configured aliases always win over defaults.

--- a/src/src-tauri/resources/clawdbot/docs/help/faq-first-run.md
+++ b/src/src-tauri/resources/clawdbot/docs/help/faq-first-run.md
@@ -638,17 +638,15 @@ and troubleshooting see the main [FAQ](/help/faq).
 
   </Accordion>
 
-  <Accordion title="How do I set up Gemini CLI OAuth?">
-    Gemini CLI uses a **plugin auth flow**, not a client id or secret in `openclaw.json`.
+  <Accordion title="How do I set up Antigravity CLI OAuth?">
+    Antigravity CLI uses a **plugin auth flow**, not a client id or secret in `openclaw.json`.
 
     Steps:
 
-    1. Install Gemini CLI locally so `gemini` is on `PATH`
-       - Homebrew: `brew install gemini-cli`
-       - npm: `npm install -g @google/gemini-cli`
+    1. Install Antigravity CLI locally so `agy` is on `PATH`: `curl -fsSL https://antigravity.google/cli/install.sh | bash`
     2. Enable the plugin: `openclaw plugins enable google`
     3. Login: `openclaw models auth login --provider google-gemini-cli --set-default`
-    4. Default model after login: `google-gemini-cli/gemini-3-flash-preview`
+    4. Default model after login: `google-gemini-cli/gemini-3.5-flash`
     5. If requests fail, set `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` on the gateway host
 
     This stores OAuth tokens in auth profiles on the gateway host. Details: [Model providers](/concepts/model-providers).

--- a/src/src-tauri/resources/clawdbot/docs/help/faq-models.md
+++ b/src/src-tauri/resources/clawdbot/docs/help/faq-models.md
@@ -269,8 +269,8 @@ troubleshooting, see the main [FAQ](/help/faq).
     - `gpt` → `openai/gpt-5.5` for API-key setups, or `openai-codex/gpt-5.5` when configured for Codex OAuth
     - `gpt-mini` → `openai/gpt-5.4-mini`
     - `gpt-nano` → `openai/gpt-5.4-nano`
-    - `gemini` → `google/gemini-3.1-pro-preview`
-    - `gemini-flash` → `google/gemini-3-flash-preview`
+    - `gemini` → `google/gemini-3.5-flash`
+    - `gemini-flash` → `google/gemini-3.5-flash`
     - `gemini-flash-lite` → `google/gemini-3.1-flash-lite-preview`
 
     If you set your own alias with the same name, your value wins.

--- a/src/src-tauri/resources/clawdbot/docs/help/testing-live.md
+++ b/src/src-tauri/resources/clawdbot/docs/help/testing-live.md
@@ -342,25 +342,25 @@ Narrow, explicit allowlists are fastest and least flaky:
   - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Tool calling across several providers:
-  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3-flash-preview,deepseek/deepseek-v4-flash,zai/glm-5.1,minimax/MiniMax-M2.7" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3.5-flash,deepseek/deepseek-v4-flash,zai/glm-5.1,minimax/MiniMax-M2.7" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Google focus (Gemini API key + Antigravity):
-  - Gemini (API key): `OPENCLAW_LIVE_GATEWAY_MODELS="google/gemini-3-flash-preview" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
-  - Antigravity (OAuth): `OPENCLAW_LIVE_GATEWAY_MODELS="google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-pro-high" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+  - Gemini (API key): `OPENCLAW_LIVE_GATEWAY_MODELS="google/gemini-3.5-flash" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+  - Antigravity (OAuth): `OPENCLAW_LIVE_GATEWAY_MODELS="google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3.1-pro-high" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Google adaptive thinking smoke:
   - If local keys live in shell profile: `source ~/.profile`
-  - Gemini 3 dynamic default: `pnpm openclaw qa manual --provider-mode live-frontier --model google/gemini-3.1-pro-preview --alt-model google/gemini-3.1-pro-preview --message '/think adaptive Reply exactly: GEMINI_ADAPTIVE_OK' --timeout-ms 180000`
+  - Gemini 3 dynamic default: `pnpm openclaw qa manual --provider-mode live-frontier --model google/gemini-3.5-flash --alt-model google/gemini-3.5-flash --message '/think adaptive Reply exactly: GEMINI_ADAPTIVE_OK' --timeout-ms 180000`
   - Gemini 2.5 dynamic budget: `pnpm openclaw qa manual --provider-mode live-frontier --model google/gemini-2.5-flash --alt-model google/gemini-2.5-flash --message '/think adaptive Reply exactly: GEMINI25_ADAPTIVE_OK' --timeout-ms 180000`
 
 Notes:
 
 - `google/...` uses the Gemini API (API key).
 - `google-antigravity/...` uses the Antigravity OAuth bridge (Cloud Code Assist-style agent endpoint).
-- `google-gemini-cli/...` uses the local Gemini CLI on your machine (separate auth + tooling quirks).
-- Gemini API vs Gemini CLI:
+- `google-gemini-cli/...` is legacy Gemini CLI compatibility; `google-antigravity/...` is the forward Antigravity OAuth bridge.
+- Gemini API vs Antigravity CLI:
   - API: OpenClaw calls Google’s hosted Gemini API over HTTP (API key / profile auth); this is what most users mean by “Gemini”.
-  - CLI: OpenClaw shells out to a local `gemini` binary; it has its own auth and can behave differently (streaming/tool support/version skew).
+  - CLI: Antigravity uses `agy` and its own auth/session state; legacy Gemini CLI uses `gemini` and can behave differently (streaming/tool support/version skew).
 
 ## Live: model matrix (what we cover)
 
@@ -373,14 +373,14 @@ This is the “common models” run we expect to keep working:
 - OpenAI (non-Codex): `openai/gpt-5.2`
 - OpenAI Codex OAuth: `openai-codex/gpt-5.2`
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-6`)
-- Google (Gemini API): `google/gemini-3.1-pro-preview` and `google/gemini-3-flash-preview` (avoid older Gemini 2.x models)
+- Google (Gemini API): `google/gemini-3.5-flash` and `google/gemini-3.1-pro-preview` (avoid older Gemini 2.x models)
 - Google (Antigravity): `google-antigravity/claude-opus-4-6-thinking` and `google-antigravity/gemini-3-flash`
 - DeepSeek: `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`
 - Z.AI (GLM): `zai/glm-5.1`
 - MiniMax: `minimax/MiniMax-M2.7`
 
 Run gateway smoke with tools + image:
-`OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3.1-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,deepseek/deepseek-v4-flash,zai/glm-5.1,minimax/MiniMax-M2.7" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+`OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3.5-flash,google/gemini-3.1-pro-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,deepseek/deepseek-v4-flash,zai/glm-5.1,minimax/MiniMax-M2.7" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 ### Baseline: tool calling (Read + optional Exec)
 
@@ -388,7 +388,7 @@ Pick at least one per provider family:
 
 - OpenAI: `openai/gpt-5.2`
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-6`)
-- Google: `google/gemini-3-flash-preview` (or `google/gemini-3.1-pro-preview`)
+- Google: `google/gemini-3.5-flash` (or `google/gemini-3.1-pro-preview`)
 - DeepSeek: `deepseek/deepseek-v4-flash`
 - Z.AI (GLM): `zai/glm-5.1`
 - MiniMax: `minimax/MiniMax-M2.7`

--- a/src/src-tauri/resources/clawdbot/docs/providers/google.md
+++ b/src/src-tauri/resources/clawdbot/docs/providers/google.md
@@ -14,7 +14,7 @@ Gemini Grounding.
 - Auth: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - API: Google Gemini API
 - Runtime option: `agents.defaults.agentRuntime.id: "google-gemini-cli"`
-  reuses Gemini CLI OAuth while keeping model refs canonical as `google/*`.
+  reuses Antigravity CLI OAuth while keeping model refs canonical as `google/*`.
 
 ## Getting started
 
@@ -44,7 +44,7 @@ Choose your preferred auth method and follow the setup steps.
         {
           agents: {
             defaults: {
-              model: { primary: "google/gemini-3.1-pro-preview" },
+              model: { primary: "google/gemini-3.5-flash" },
             },
           },
         }
@@ -63,8 +63,8 @@ Choose your preferred auth method and follow the setup steps.
 
   </Tab>
 
-  <Tab title="Gemini CLI (OAuth)">
-    **Best for:** reusing an existing Gemini CLI login via PKCE OAuth instead of a separate API key.
+  <Tab title="Antigravity CLI (OAuth)">
+    **Best for:** reusing an existing Antigravity CLI login via PKCE OAuth instead of a separate API key.
 
     <Warning>
     The `google-gemini-cli` provider is an unofficial integration. Some users
@@ -72,19 +72,15 @@ Choose your preferred auth method and follow the setup steps.
     </Warning>
 
     <Steps>
-      <Step title="Install the Gemini CLI">
-        The local `gemini` command must be available on `PATH`.
+      <Step title="Install Antigravity CLI">
+        The local `agy` command must be available on `PATH`.
 
         ```bash
-        # Homebrew
-        brew install gemini-cli
-
-        # or npm
-        npm install -g @google/gemini-cli
+        curl -fsSL https://antigravity.google/cli/install.sh | bash
         ```
 
-        OpenClaw supports both Homebrew installs and global npm installs, including
-        common Windows/npm layouts.
+        OpenClaw keeps legacy `google-gemini-cli` refs for compatibility, while
+        the forward Google coding CLI surface is Antigravity CLI.
       </Step>
       <Step title="Log in via OAuth">
         ```bash
@@ -98,7 +94,7 @@ Choose your preferred auth method and follow the setup steps.
       </Step>
     </Steps>
 
-    - Default model: `google/gemini-3.1-pro-preview`
+    - Default model: `google/gemini-3.5-flash`
     - Runtime: `google-gemini-cli`
     - Alias: `gemini-cli`
 
@@ -110,18 +106,18 @@ Choose your preferred auth method and follow the setup steps.
     (Or the `GEMINI_CLI_*` variants.)
 
     <Note>
-    If Gemini CLI OAuth requests fail after login, set `GOOGLE_CLOUD_PROJECT` or
+    If Antigravity CLI OAuth requests fail after login, set `GOOGLE_CLOUD_PROJECT` or
     `GOOGLE_CLOUD_PROJECT_ID` on the gateway host and retry.
     </Note>
 
     <Note>
-    If login fails before the browser flow starts, make sure the local `gemini`
+    If login fails before the browser flow starts, make sure the local `agy`
     command is installed and on `PATH`.
     </Note>
 
     `google-gemini-cli/*` model refs are legacy compatibility aliases. New
     configs should use `google/*` model refs plus the `google-gemini-cli`
-    runtime when they want local Gemini CLI execution.
+    runtime when they want local Antigravity CLI execution.
 
   </Tab>
 </Tabs>

--- a/src/src-tauri/resources/clawdbot/docs/providers/models.md
+++ b/src/src-tauri/resources/clawdbot/docs/providers/models.md
@@ -54,7 +54,8 @@ model as `provider/model`.
 
 - `anthropic-vertex` - implicit Anthropic on Google Vertex support when Vertex credentials are available; no separate onboarding auth choice
 - `copilot-proxy` - local VS Code Copilot Proxy bridge; use `openclaw onboard --auth-choice copilot-proxy`
-- `google-gemini-cli` - unofficial Gemini CLI OAuth flow; requires a local `gemini` install (`brew install gemini-cli` or `npm install -g @google/gemini-cli`); default model `google-gemini-cli/gemini-3-flash-preview`; use `openclaw onboard --auth-choice google-gemini-cli` or `openclaw models auth login --provider google-gemini-cli --set-default`
+- `google-antigravity` - Antigravity OAuth bridge with models such as `google-antigravity/gemini-3.5-flash`, `google-antigravity/gemini-3.1-pro-high`, and `google-antigravity/gemini-3.1-pro-low`.
+- `google-gemini-cli` - legacy Gemini CLI OAuth compatibility flow; default model `google-gemini-cli/gemini-3.5-flash`; use `openclaw onboard --auth-choice google-gemini-cli` or `openclaw models auth login --provider google-gemini-cli --set-default`
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
 see [Model providers](/concepts/model-providers).

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2640,7 +2640,9 @@ pub async fn chat(
 
       // Select which coding CLI to use: check user preference first, then fall back to
       // whichever API key is available. Anthropic → claude, OpenAI → codex,
-      // Google → gemini, otherwise OpenCode.
+      // Google → gemini for this piped prompt runner, otherwise OpenCode.
+      // Antigravity (`agy`) is the forward Google coding CLI, but it is a TUI
+      // and needs a PTY-backed terminal path rather than this stdout/stderr pipe.
       let coding_agent = {
         let pref = std::env::var("KNAPSACK_CODING_AGENT").unwrap_or_default();
         let pref = pref.trim().to_lowercase();
@@ -2667,9 +2669,9 @@ pub async fn chat(
       // Build the command string for the chosen CLI.
       // claude: --yes auto-accepts tool use so it can read/write files without prompting.
       // codex:  --approval-mode auto-edit allows file edits non-interactively.
-      // gemini: -p (--prompt) triggers headless mode, returning stdout output without TTY UI.
+      // gemini: -p (--prompt) triggers prompt mode, returning stdout output without TTY UI.
+      // antigravity: launch the TUI when explicitly requested; this path streams output only.
       // opencode: use npx so the fallback can work even when the binary is not already installed.
-      //         Note: Antigravity (`agy`) is an IDE, not a headless CLI — use `gemini` instead.
       // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
       let claude_cmd = match coding_agent.as_str() {
         "codex" => {
@@ -2684,6 +2686,7 @@ pub async fn chat(
           #[cfg(not(target_os = "windows"))]
           { format!("gemini -p '{}'", prompt.replace('\'', "'\\''")) }
         }
+        "antigravity" | "agy" => "agy".to_string(),
         "opencode" => {
           #[cfg(target_os = "windows")]
           { format!("npx -y opencode-ai run \"{}\"", prompt.replace('"', "\\\"")) }

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -737,6 +737,7 @@ static BROWSER_CONFIG_APPLIED: std::sync::atomic::AtomicBool =
 pub fn resolve_default_model() -> String {
   let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
   let has_key = |var: &str| std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false);
+  let has_gemini_key = || has_key("GEMINI_API_KEY") || has_key("GOOGLE_API_KEY");
 
   // Respect the user's active provider selection and configured model
   match active.as_str() {
@@ -765,15 +766,15 @@ pub fn resolve_default_model() -> String {
         .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
       return format!("groq/{}", model);
     }
-    "gemini" if has_key("GEMINI_API_KEY") => {
+    "gemini" if has_gemini_key() => {
       let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-        .unwrap_or_else(|_| "gemini-2.0-flash".to_string());
+        .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
       return format!("google/{}", model);
     }
     // Google OAuth CLI auth (no API key env var — credentials stored in auth-profiles.json).
     "google-gemini-cli" => {
       let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-        .unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+        .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
       return format!("google-gemini-cli/{}", model);
     }
     _ => {}
@@ -814,9 +815,9 @@ pub fn resolve_default_model() -> String {
       .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
     return format!("groq/{}", model);
   }
-  if has_key("GEMINI_API_KEY") {
+  if has_gemini_key() {
     let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-      .unwrap_or_else(|_| "gemini-2.0-flash".to_string());
+      .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
     return format!("google/{}", model);
   }
   if has_key("OPENROUTER_API_KEY") {
@@ -841,6 +842,7 @@ pub fn resolve_default_model() -> String {
 /// Called by `build_model_config()` — prefer that over calling this directly.
 pub fn collect_fallback_models(primary: &str) -> Vec<String> {
   let has_key = |var: &str| std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false);
+  let has_gemini_key = || has_key("GEMINI_API_KEY") || has_key("GOOGLE_API_KEY");
   let primary_provider = primary.split('/').next().unwrap_or("").to_lowercase();
   let mut fallbacks = Vec::new();
 
@@ -856,9 +858,9 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
     primary_provider.as_str(),
     "google" | "gemini" | "google-gemini-cli"
   );
-  if !is_google_primary && has_key("GEMINI_API_KEY") {
+  if !is_google_primary && has_gemini_key() {
     let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-      .unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+      .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
     fallbacks.push(format!("google/{}", model));
   }
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3230,9 +3230,9 @@ struct StoredTokens {
   #[serde(default)]
   extra_provider_keys: Option<std::collections::HashMap<String, String>>,
 
-  /// Preferred coding CLI when multiple keys are available: "claude", "codex", "gemini" (Google Gemini CLI), or "opencode".
+  /// Preferred coding CLI when multiple keys are available: "claude", "codex", "antigravity" (Google Antigravity CLI), "gemini" (legacy Google Gemini CLI), or "opencode".
   /// When unset, auto-selects based on which API key is present
-  /// (Anthropic → claude, OpenAI → codex, Google → gemini).
+  /// (Anthropic → claude, OpenAI → codex, Google → antigravity where interactive terminal support is available).
   #[serde(default)]
   preferred_coding_agent: Option<String>,
 
@@ -3411,7 +3411,7 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     anthropic_api_key: None,
     anthropic_model: None, // Defaults to claude-sonnet-4-5-20250929
     gemini_api_key: None,
-    gemini_model: None, // Defaults to gemini-2.5-flash
+    gemini_model: None, // Defaults to gemini-3.5-flash
     groq_model: None,   // Defaults to meta-llama/llama-4-scout-17b-16e-instruct
     openrouter_api_key: None,
     openrouter_model: None, // Defaults to meta-llama/llama-3.3-70b-instruct:free
@@ -3622,12 +3622,12 @@ pub fn get_anthropic_model(app_handle: &tauri::AppHandle) -> String {
     .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string())
 }
 
-/// Get the configured Gemini model (defaults to gemini-2.5-flash if not set)
+/// Get the configured Gemini model (defaults to gemini-3.5-flash if not set)
 pub fn get_gemini_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.gemini_model)
-    .unwrap_or_else(|| "gemini-2.5-flash".to_string())
+    .unwrap_or_else(|| "gemini-3.5-flash".to_string())
 }
 
 /// Get the configured Groq model (defaults to meta-llama/llama-4-scout-17b-16e-instruct if not set)
@@ -5868,7 +5868,7 @@ pub struct SetApiKeyRequest {
   /// For extra providers: the environment variable name to store the key under.
   /// e.g. "MINIMAX_API_KEY", "ZAI_API_KEY", "HF_TOKEN"
   pub env_var: Option<String>,
-  /// Preferred coding CLI agent: "claude", "codex", "gemini", or "opencode".
+  /// Preferred coding CLI agent: "claude", "codex", "antigravity", "gemini", or "opencode".
   /// When provided alongside or without a key change, updates the stored preference.
   pub preferred_coding_agent: Option<String>,
 }
@@ -5881,7 +5881,10 @@ pub struct SetApiKeyResponse {
 
 fn normalize_coding_agent(agent: &str) -> Option<String> {
   let agent = agent.trim().to_lowercase();
-  if ["claude", "codex", "gemini", "opencode"].contains(&agent.as_str()) {
+  if ["claude", "codex", "antigravity", "agy", "gemini", "opencode"].contains(&agent.as_str()) {
+    if agent == "agy" {
+      return Some("antigravity".to_string());
+    }
     Some(agent)
   } else {
     None
@@ -12292,7 +12295,7 @@ mod provider_key_tests {
     clear_all();
     std::env::set_var("GOOGLE_API_KEY", "AIzaTest");
     assert!(model_ref_has_key("google/gemini-2.5-pro"));
-    assert!(model_ref_has_key("gemini/gemini-2.5-flash"));
+    assert!(model_ref_has_key("gemini/gemini-3.5-flash"));
     std::env::remove_var("GOOGLE_API_KEY");
     std::env::set_var("GEMINI_API_KEY", "AIzaTest");
     assert!(model_ref_has_key("google/gemini-2.5-pro"));

--- a/src/src-tauri/src/heartbeat/engine.rs
+++ b/src/src-tauri/src/heartbeat/engine.rs
@@ -575,7 +575,7 @@ struct HeartbeatProvider {
 ///
 /// Cheapest models per provider:
 ///   Groq: free (llama-3.3-70b-versatile)
-///   Gemini: gemini-2.5-flash (~$0.15/1M input)
+///   Gemini: gemini-3.5-flash (fast, low-cost)
 ///   OpenAI: gpt-4o-mini (~$0.15/1M input)
 ///   Anthropic: claude-haiku-4-5 (~$0.25/1M input)
 ///   OpenRouter: free tier model
@@ -589,7 +589,10 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
         .unwrap_or(true);
 
     let groq_key = std::env::var("GROQ_API_KEY").ok().filter(|k| !k.trim().is_empty());
-    let gemini_key = std::env::var("GEMINI_API_KEY").ok().filter(|k| !k.trim().is_empty());
+    let gemini_key = std::env::var("GEMINI_API_KEY")
+        .or_else(|_| std::env::var("GOOGLE_API_KEY"))
+        .ok()
+        .filter(|k| !k.trim().is_empty());
     let openai_key = std::env::var("OPENAI_API_KEY").ok().filter(|k| !k.trim().is_empty());
     let anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.trim().is_empty());
     let openrouter_key = std::env::var("OPENROUTER_API_KEY").ok().filter(|k| !k.trim().is_empty());
@@ -609,7 +612,7 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
             return Ok(HeartbeatProvider {
                 name: "gemini".into(),
                 api_key: gemini_key.unwrap(),
-                model: "gemini-2.5-flash".into(),
+                model: "gemini-3.5-flash".into(),
                 base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
                 is_anthropic: false,
             });
@@ -659,7 +662,7 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
     if let Some(key) = gemini_key {
         return Ok(HeartbeatProvider {
             name: "gemini".into(), api_key: key,
-            model: "gemini-2.5-flash".into(),
+            model: "gemini-3.5-flash".into(),
             base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
             is_anthropic: false,
         });

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -49,13 +49,16 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
   let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
   let openai_key = std::env::var("OPENAI_API_KEY").ok().filter(|k| !k.trim().is_empty());
   let anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.trim().is_empty());
-  let gemini_key = std::env::var("GEMINI_API_KEY").ok().filter(|k| !k.trim().is_empty());
+  let gemini_key = std::env::var("GEMINI_API_KEY")
+    .or_else(|_| std::env::var("GOOGLE_API_KEY"))
+    .ok()
+    .filter(|k| !k.trim().is_empty());
   let groq_key = std::env::var("GROQ_API_KEY").ok().filter(|k| !k.trim().is_empty());
   let openrouter_key = std::env::var("OPENROUTER_API_KEY").ok().filter(|k| !k.trim().is_empty());
   let ollama_key = std::env::var("OLLAMA_API_KEY").ok().filter(|k| !k.trim().is_empty());
   let openai_model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
   let anthropic_model = std::env::var("KNAPSACK_ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
-  let gemini_model = std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+  let gemini_model = std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
 
   // Try the user's active provider first
   match active.as_str() {
@@ -263,7 +266,7 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
         let (new_model, label) = match provider.name.as_str() {
             "openai" => ("o3-mini".to_string(), "o3-mini"),
             "anthropic" => ("claude-haiku-4-5-20251001".to_string(), "Haiku"),
-            "gemini" => ("gemini-2.5-flash".to_string(), "Flash"), // already cheap
+            "gemini" => ("gemini-3.5-flash".to_string(), "Flash"), // already cheap
             "groq" => (provider.model.clone(), "Groq"),           // already cheap
             "openrouter" => (provider.model.clone(), "OpenRouter"), // user chose this
             "ollama" => (provider.model.clone(), "Ollama"),       // local, no cost
@@ -757,11 +760,14 @@ pub async fn multi_provider_completion(
 
       let fb_openai_key = std::env::var("OPENAI_API_KEY").ok().filter(|k| !k.trim().is_empty());
       let fb_anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.trim().is_empty());
-      let fb_gemini_key = std::env::var("GEMINI_API_KEY").ok().filter(|k| !k.trim().is_empty());
+      let fb_gemini_key = std::env::var("GEMINI_API_KEY")
+        .or_else(|_| std::env::var("GOOGLE_API_KEY"))
+        .ok()
+        .filter(|k| !k.trim().is_empty());
       let fb_groq_key = std::env::var("GROQ_API_KEY").ok().filter(|k| !k.trim().is_empty());
       let fb_openai_model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
       let fb_anthropic_model = std::env::var("KNAPSACK_ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
-      let fb_gemini_model = std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+      let fb_gemini_model = std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
 
       let fallbacks: Vec<(&str, &Option<String>, String, &str, bool)> = vec![
         ("openai", &fb_openai_key, fb_openai_model, "https://api.openai.com/v1", false),


### PR DESCRIPTION
## Summary

- Updates Google/Gemini defaults to Gemini 3.5 Flash for API-key users.
- Adds Google Antigravity model catalog entries and normalizes current Gemini 3 model aliases.
- Accepts both GEMINI_API_KEY and GOOGLE_API_KEY across backend default, fallback, notes, and heartbeat paths.
- Allows antigravity/agy as a saved coding-agent preference while keeping the existing piped runner on Gemini CLI until a PTY-backed path is available.
- Refreshes Google provider docs for Antigravity and current model names.

## Validation

- Parsed src/src-tauri/resources/clawdbot/dist/extensions/google/openclaw.plugin.json with Node.
- Ran git diff --check.
- Attempted OpenClaw model-list smoke in a clean worktree; blocked because the fresh worktree does not include ignored bundled node_modules such as https-proxy-agent.
