### PR TITLE
[codex] add Grok xAI provider support

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -85,6 +85,10 @@ struct StoredTokens {
   gemini_model: Option<String>,
   #[serde(default)]
   groq_model: Option<String>,
+  #[serde(default)]
+  xai_api_key: Option<String>,
+  #[serde(default)]
+  xai_model: Option<String>,
   // OpenRouter support
   #[serde(default)]
   openrouter_api_key: Option<String>,
@@ -160,6 +164,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     gemini_api_key: None,
     gemini_model: None,
     groq_model: None,
+    xai_api_key: None,
+    xai_model: None,
     openrouter_api_key: None,
     openrouter_model: None,
     active_provider: None,
@@ -469,6 +475,20 @@ fn groq_key(app_handle: &tauri::AppHandle) -> Option<String> {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.groq_api_key)
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
+fn xai_key(app_handle: &tauri::AppHandle) -> Option<String> {
+  if let Ok(k) = std::env::var("XAI_API_KEY") {
+    let k = k.trim().to_string();
+    if !k.is_empty() {
+      return Some(k);
+    }
+  }
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.xai_api_key)
     .map(|s| s.trim().to_string())
     .filter(|s| !s.is_empty())
 }
@@ -1805,6 +1825,15 @@ pub async fn chat(
         }))
       }
     },
+    "xai" => match xai_key(&app_handle) {
+      Some(k) => k,
+      None => {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+          "ok": false,
+          "message": "xAI API key is not set. Add it in Settings and Save, then re-enable."
+        }))
+      }
+    },
     "openrouter" => match openrouter_key(&app_handle) {
       Some(k) => k,
       None => {
@@ -2640,7 +2669,7 @@ pub async fn chat(
 
       // Select which coding CLI to use: check user preference first, then fall back to
       // whichever API key is available. Anthropic → claude, OpenAI → codex,
-      // Google → gemini for this piped prompt runner, otherwise OpenCode.
+      // Google → gemini, xAI → grok for this piped prompt runner, otherwise OpenCode.
       // Antigravity (`agy`) is the forward Google coding CLI, but it is a TUI
       // and needs a PTY-backed terminal path rather than this stdout/stderr pipe.
       let coding_agent = {
@@ -2653,6 +2682,7 @@ pub async fn chat(
           if has("ANTHROPIC_API_KEY") { "claude".to_string() }
           else if has("OPENAI_API_KEY") { "codex".to_string() }
           else if has("GEMINI_API_KEY") || has("GOOGLE_API_KEY") { "gemini".to_string() }
+          else if has("XAI_API_KEY") { "grok".to_string() }
           else { "opencode".to_string() }
         }
       };
@@ -2671,7 +2701,7 @@ pub async fn chat(
       // codex:  --approval-mode auto-edit allows file edits non-interactively.
       // gemini: -p (--prompt) triggers prompt mode, returning stdout output without TTY UI.
       // antigravity: launch the TUI when explicitly requested; this path streams output only.
-      // opencode: use npx so the fallback can work even when the binary is not already installed.
+      // opencode/grok: use npx so the fallback can work even when the binary is not already installed.
       // Windows cmd uses double-quotes; Unix shells use single-quotes for safe embedding.
       let claude_cmd = match coding_agent.as_str() {
         "codex" => {
@@ -2692,6 +2722,12 @@ pub async fn chat(
           { format!("npx -y opencode-ai run \"{}\"", prompt.replace('"', "\\\"")) }
           #[cfg(not(target_os = "windows"))]
           { format!("npx -y opencode-ai run '{}'", prompt.replace('\'', "'\\''")) }
+        }
+        "grok" | "xai" => {
+          #[cfg(target_os = "windows")]
+          { format!("npx -y opencode-ai run --model xai/grok-code-fast-1 \"{}\"", prompt.replace('"', "\\\"")) }
+          #[cfg(not(target_os = "windows"))]
+          { format!("npx -y opencode-ai run --model xai/grok-code-fast-1 '{}'", prompt.replace('\'', "'\\''")) }
         }
         _ => {
           #[cfg(target_os = "windows")]
@@ -3945,6 +3981,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
     "anthropic" => super::service::get_anthropic_model(&app_handle),
     "gemini" => super::service::get_gemini_model(&app_handle),
     "groq" => super::service::get_groq_model(&app_handle),
+    "xai" => super::service::get_xai_model(&app_handle),
     "ollama" => ollama_model(&app_handle),
     "openrouter" => super::service::get_openrouter_model(&app_handle),
     _ => super::service::get_openai_model(&app_handle),
@@ -3962,6 +3999,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         "anthropic" => chat_agent::anthropic_chat(key, model, msgs, tls).await,
         "gemini" => chat_agent::gemini_chat(key, model, msgs, tls).await,
         "groq" => chat_agent::groq_chat(key, model, msgs, tls).await,
+        "xai" => chat_agent::openai_compatible_chat(key, model, "https://api.x.ai/v1", msgs, tls).await,
         "ollama" => {
           let base = format!("{}/v1", ollama_base.trim_end_matches('/'));
           chat_agent::openai_compatible_chat(key, model, &base, msgs, tls).await
@@ -4005,16 +4043,17 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, e)}),
           );
         }
-        // Try fallback providers in order: OpenAI → Anthropic → Gemini → Groq → Ollama
+        // Try fallback providers in order: OpenAI → Anthropic → Gemini → Groq → xAI → OpenRouter → Ollama
         // Respects KNAPSACK_DISABLE_PAID_FALLBACK to avoid silent charges on expensive providers
         eprintln!("[clawd/chat] {} hit credit/rate limit: {}", current_provider, err_str);
         let disable_paid = is_paid_fallback_disabled();
         let ollama_key = if ollama_is_enabled(&app_handle) { Some("ollama-local".to_string()) } else { None };
-        let fallbacks: [(&str, Option<String>); 6] = [
+        let fallbacks: [(&str, Option<String>); 7] = [
           ("openai", openai_key(&app_handle)),
           ("anthropic", anthropic_key(&app_handle)),
           ("gemini", gemini_key(&app_handle)),
           ("groq", groq_key(&app_handle)),
+          ("xai", xai_key(&app_handle)),
           ("openrouter", openrouter_key(&app_handle)),
           ("ollama", ollama_key),
         ];
@@ -4032,6 +4071,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               "anthropic" => super::service::get_anthropic_model(&app_handle),
               "gemini" => super::service::get_gemini_model(&app_handle),
               "groq" => super::service::get_groq_model(&app_handle),
+              "xai" => super::service::get_xai_model(&app_handle),
               "ollama" => ollama_model(&app_handle),
               "openrouter" => super::service::get_openrouter_model(&app_handle),
               _ => super::service::get_openai_model(&app_handle),

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -766,6 +766,11 @@ pub fn resolve_default_model() -> String {
         .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
       return format!("groq/{}", model);
     }
+    "xai" if has_key("XAI_API_KEY") => {
+      let model = std::env::var("KNAPSACK_XAI_MODEL")
+        .unwrap_or_else(|_| "grok-code-fast-1".to_string());
+      return format!("xai/{}", model);
+    }
     "gemini" if has_gemini_key() => {
       let model = std::env::var("KNAPSACK_GEMINI_MODEL")
         .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
@@ -787,7 +792,7 @@ pub fn resolve_default_model() -> String {
     .unwrap_or(true);
   // google-gemini-cli is OAuth-based (free tier) — treat it as a free provider
   // so paid fallbacks are not silently selected when the CLI model is unavailable.
-  let active_is_free = matches!(active.as_str(), "groq" | "gemini" | "ollama" | "openrouter" | "google-gemini-cli");
+  let active_is_free = matches!(active.as_str(), "groq" | "xai" | "gemini" | "ollama" | "openrouter" | "google-gemini-cli");
 
   if !disable_paid || !active_is_free {
     if has_key("ANTHROPIC_API_KEY") {
@@ -814,6 +819,11 @@ pub fn resolve_default_model() -> String {
     let model = std::env::var("KNAPSACK_GROQ_MODEL")
       .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
     return format!("groq/{}", model);
+  }
+  if has_key("XAI_API_KEY") {
+    let model = std::env::var("KNAPSACK_XAI_MODEL")
+      .unwrap_or_else(|_| "grok-code-fast-1".to_string());
+    return format!("xai/{}", model);
   }
   if has_gemini_key() {
     let model = std::env::var("KNAPSACK_GEMINI_MODEL")
@@ -851,6 +861,12 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
     let model = std::env::var("KNAPSACK_GROQ_MODEL")
       .unwrap_or_else(|_| "llama-3.3-70b-versatile".to_string());
     fallbacks.push(format!("groq/{}", model));
+  }
+
+  if primary_provider != "xai" && has_key("XAI_API_KEY") {
+    let model = std::env::var("KNAPSACK_XAI_MODEL")
+      .unwrap_or_else(|_| "grok-code-fast-1".to_string());
+    fallbacks.push(format!("xai/{}", model));
   }
 
   // Google/Gemini as fallback when the primary is not already a Google provider.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -61,6 +61,7 @@ fn regenerate_macos_plist_with_current_env(plist_path: &std::path::Path) -> bool
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "GROQ_API_KEY",
+    "XAI_API_KEY",
     "OPENROUTER_API_KEY",
     "OLLAMA_API_KEY",
     "OLLAMA_HOST",
@@ -69,6 +70,7 @@ fn regenerate_macos_plist_with_current_env(plist_path: &std::path::Path) -> bool
     "KNAPSACK_OPENAI_MODEL",
     "KNAPSACK_ANTHROPIC_MODEL",
     "KNAPSACK_GROQ_MODEL",
+    "KNAPSACK_XAI_MODEL",
     "KNAPSACK_OPENROUTER_MODEL",
     "KNAPSACK_OLLAMA_MODEL",
   ];
@@ -3388,13 +3390,17 @@ struct StoredTokens {
   gemini_model: Option<String>,
   #[serde(default)]
   groq_model: Option<String>,
+  #[serde(default)]
+  xai_api_key: Option<String>,
+  #[serde(default)]
+  xai_model: Option<String>,
   // OpenRouter support (access many models via openrouter.ai)
   #[serde(default)]
   openrouter_api_key: Option<String>,
   #[serde(default)]
   openrouter_model: Option<String>,
 
-  /// Which provider is currently selected: "openai", "anthropic", "gemini", "groq", "openrouter", "ollama"
+  /// Which provider is currently selected: "openai", "anthropic", "gemini", "groq", "xai", "openrouter", "ollama"
   #[serde(default)]
   active_provider: Option<String>,
 
@@ -3595,6 +3601,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     gemini_api_key: None,
     gemini_model: None, // Defaults to gemini-3.5-flash
     groq_model: None,   // Defaults to meta-llama/llama-4-scout-17b-16e-instruct
+    xai_api_key: None,
+    xai_model: None, // Defaults to grok-code-fast-1
     openrouter_api_key: None,
     openrouter_model: None, // Defaults to meta-llama/llama-3.3-70b-instruct:free
     active_provider: None,  // Defaults to openai
@@ -3632,6 +3640,12 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
     let k = k.trim();
     if !k.is_empty() {
       std::env::set_var("GROQ_API_KEY", k);
+    }
+  }
+  if let Some(k) = &tokens.xai_api_key {
+    let k = k.trim();
+    if !k.is_empty() {
+      std::env::set_var("XAI_API_KEY", k);
     }
   }
   if let Some(k) = &tokens.openai_api_key {
@@ -3689,6 +3703,12 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
     let m = m.trim();
     if !m.is_empty() {
       std::env::set_var("KNAPSACK_GROQ_MODEL", m);
+    }
+  }
+  if let Some(m) = &tokens.xai_model {
+    let m = m.trim();
+    if !m.is_empty() {
+      std::env::set_var("KNAPSACK_XAI_MODEL", m);
     }
   }
   if let Some(k) = tokens.openrouter_api_key.clone() {
@@ -3818,6 +3838,14 @@ pub fn get_groq_model(app_handle: &tauri::AppHandle) -> String {
     .ok()
     .and_then(|t| t.groq_model)
     .unwrap_or_else(|| "meta-llama/llama-4-scout-17b-16e-instruct".to_string())
+}
+
+/// Get the configured xAI/Grok model (defaults to grok-code-fast-1 if not set)
+pub fn get_xai_model(app_handle: &tauri::AppHandle) -> String {
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.xai_model)
+    .unwrap_or_else(|| "grok-code-fast-1".to_string())
 }
 
 /// Get the configured OpenRouter model (defaults to meta-llama/llama-3.3-70b-instruct:free if not set)
@@ -5696,12 +5724,14 @@ pub struct ApiKeyStatusResponse {
   pub has_anthropic_key: bool,
   pub has_gemini_key: bool,
   pub has_groq_key: bool,
+  pub has_xai_key: bool,
   pub has_openrouter_key: bool,
   pub has_gemini_cli_key: bool,
   pub openai_key_hint: Option<String>,
   pub anthropic_key_hint: Option<String>,
   pub gemini_key_hint: Option<String>,
   pub groq_key_hint: Option<String>,
+  pub xai_key_hint: Option<String>,
   pub openrouter_key_hint: Option<String>,
   pub gemini_cli_email: Option<String>,
   // Ollama (local LLM) status
@@ -5743,12 +5773,14 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         has_anthropic_key: false,
         has_gemini_key: false,
         has_groq_key: false,
+        has_xai_key: false,
         has_openrouter_key: false,
         has_gemini_cli_key: false,
         openai_key_hint: None,
         anthropic_key_hint: None,
         gemini_key_hint: None,
         groq_key_hint: None,
+        xai_key_hint: None,
         openrouter_key_hint: None,
         gemini_cli_email: None,
         ollama_enabled: false,
@@ -5783,6 +5815,11 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     .as_ref()
     .map(|k| !k.trim().is_empty())
     .unwrap_or(false);
+  let has_xai = tokens
+    .xai_api_key
+    .as_ref()
+    .map(|k| !k.trim().is_empty())
+    .unwrap_or(false);
   let has_openrouter = tokens
     .openrouter_api_key
     .as_ref()
@@ -5799,6 +5836,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     || has_anthropic
     || has_gemini
     || has_groq
+    || has_xai
     || has_openrouter
     || ollama_enabled
     || has_gemini_cli
@@ -5824,6 +5862,11 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     .map(|k| mask_key(k));
   let groq_hint = tokens
     .groq_api_key
+    .as_ref()
+    .filter(|k| !k.trim().is_empty())
+    .map(|k| mask_key(k));
+  let xai_hint = tokens
+    .xai_api_key
     .as_ref()
     .filter(|k| !k.trim().is_empty())
     .map(|k| mask_key(k));
@@ -5870,12 +5913,14 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     has_anthropic_key: has_anthropic,
     has_gemini_key: has_gemini,
     has_groq_key: has_groq,
+    has_xai_key: has_xai,
     has_openrouter_key: has_openrouter,
     has_gemini_cli_key: has_gemini_cli,
     openai_key_hint: openai_hint,
     anthropic_key_hint: anthropic_hint,
     gemini_key_hint: gemini_hint,
     groq_key_hint: groq_hint,
+    xai_key_hint: xai_hint,
     openrouter_key_hint: openrouter_hint,
     gemini_cli_email,
     ollama_enabled,
@@ -5893,7 +5938,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 #[derive(Debug, Deserialize)]
 pub struct ValidateApiKeyRequest {
   pub key: String,
-  /// "openai", "anthropic", "gemini", or "groq"
+  /// "openai", "anthropic", "gemini", "groq", or "xai"
   pub provider: Option<String>,
 }
 
@@ -5948,6 +5993,13 @@ pub async fn validate_api_key(payload: web::Json<ValidateApiKeyRequest>) -> impl
     "groq" => {
       client
         .get("https://api.groq.com/openai/v1/models")
+        .bearer_auth(&key)
+        .send()
+        .await
+    }
+    "xai" => {
+      client
+        .get("https://api.x.ai/v1/models")
         .bearer_auth(&key)
         .send()
         .await
@@ -6076,7 +6128,7 @@ pub struct SetApiKeyResponse {
 
 fn normalize_coding_agent(agent: &str) -> Option<String> {
   let agent = agent.trim().to_lowercase();
-  if ["claude", "codex", "antigravity", "agy", "gemini", "opencode"].contains(&agent.as_str()) {
+  if ["claude", "codex", "antigravity", "agy", "gemini", "grok", "opencode"].contains(&agent.as_str()) {
     if agent == "agy" {
       return Some("antigravity".to_string());
     }
@@ -6173,6 +6225,10 @@ pub async fn set_api_key(
         .groq_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
+      "xai" => tokens
+        .xai_api_key
+        .as_ref()
+        .map_or(false, |k| !k.is_empty()),
       "openrouter" => tokens
         .openrouter_api_key
         .as_ref()
@@ -6206,6 +6262,9 @@ pub async fn set_api_key(
         "groq" => {
           tokens.groq_model = Some(model.trim().to_string());
         }
+        "xai" => {
+          tokens.xai_model = Some(model.trim().to_string());
+        }
         "openrouter" => {
           tokens.openrouter_model = Some(model.trim().to_string());
         }
@@ -6224,6 +6283,7 @@ pub async fn set_api_key(
       "anthropic" => "Anthropic",
       "gemini" => "Gemini",
       "groq" => "Groq",
+      "xai" => "Grok (xAI)",
       "openrouter" => "OpenRouter",
       "ollama" => "Ollama",
       "knapsack" => "Knapsack",
@@ -6251,6 +6311,9 @@ pub async fn set_api_key(
     }
     if let Some(k) = &tokens.groq_api_key {
       std::env::set_var("GROQ_API_KEY", k);
+    }
+    if let Some(k) = &tokens.xai_api_key {
+      std::env::set_var("XAI_API_KEY", k);
     }
     if let Some(k) = &tokens.openrouter_api_key {
       let k = k.trim();
@@ -6414,6 +6477,14 @@ pub async fn set_api_key(
       }
       "Groq"
     }
+    "xai" => {
+      tokens.xai_api_key = Some(key);
+      tokens.active_provider = Some("xai".to_string());
+      if let Some(model) = &payload.model {
+        tokens.xai_model = Some(model.trim().to_string());
+      }
+      "Grok (xAI)"
+    }
     "openrouter" => {
       tokens.openrouter_api_key = Some(key);
       tokens.active_provider = Some("openrouter".to_string());
@@ -6500,6 +6571,9 @@ pub async fn set_api_key(
   if let Some(k) = &tokens.groq_api_key {
     std::env::set_var("GROQ_API_KEY", k);
   }
+  if let Some(k) = &tokens.xai_api_key {
+    std::env::set_var("XAI_API_KEY", k);
+  }
   if let Some(k) = &tokens.openai_api_key {
     std::env::set_var("OPENAI_API_KEY", k);
   }
@@ -6536,6 +6610,9 @@ pub async fn set_api_key(
   }
   if let Some(m) = &tokens.groq_model {
     std::env::set_var("KNAPSACK_GROQ_MODEL", m);
+  }
+  if let Some(m) = &tokens.xai_model {
+    std::env::set_var("KNAPSACK_XAI_MODEL", m);
   }
   if let Some(m) = &tokens.openrouter_model {
     std::env::set_var("KNAPSACK_OPENROUTER_MODEL", m);
@@ -7074,9 +7151,11 @@ pub struct GetApiKeyResponse {
   pub openai_key: Option<String>,
   pub anthropic_key: Option<String>,
   pub gemini_key: Option<String>,
+  pub xai_key: Option<String>,
   pub anthropic_model: Option<String>,
   pub gemini_model: Option<String>,
   pub groq_model: Option<String>,
+  pub xai_model: Option<String>,
   pub openrouter_model: Option<String>,
 }
 
@@ -7093,9 +7172,11 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
         openai_key: None,
         anthropic_key: None,
         gemini_key: None,
+        xai_key: None,
         anthropic_model: None,
         gemini_model: None,
         groq_model: None,
+        xai_model: None,
         openrouter_model: None,
       })
     }
@@ -7104,12 +7185,14 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
   let openai_key = tokens.openai_api_key.filter(|k| !k.trim().is_empty());
   let anthropic_key = tokens.anthropic_api_key.filter(|k| !k.trim().is_empty());
   let gemini_key = tokens.gemini_api_key.filter(|k| !k.trim().is_empty());
+  let xai_key = tokens.xai_api_key.filter(|k| !k.trim().is_empty());
 
   // Return the currently active provider's key as `key` for backwards compatibility (voice/TTS)
   let active = tokens.active_provider.as_deref().unwrap_or("openai");
   let key = match active {
     "anthropic" => anthropic_key.clone(),
     "gemini" => gemini_key.clone(),
+    "xai" => xai_key.clone(),
     _ => openai_key.clone(),
   };
 
@@ -7121,9 +7204,11 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
     openai_key,
     anthropic_key,
     gemini_key,
+    xai_key,
     anthropic_model: tokens.anthropic_model,
     gemini_model: tokens.gemini_model,
     groq_model: tokens.groq_model,
+    xai_model: tokens.xai_model,
     openrouter_model: tokens.openrouter_model,
   })
 }
@@ -7202,6 +7287,7 @@ fn any_provider_key_available() -> bool {
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
     "GROQ_API_KEY",
+    "XAI_API_KEY",
     "OPENROUTER_API_KEY",
     "OLLAMA_API_KEY",
   ];
@@ -7228,6 +7314,7 @@ fn model_ref_has_key(model_ref: &str) -> bool {
     "anthropic" => has("ANTHROPIC_API_KEY"),
     "google" | "gemini" | "vertex" => has("GEMINI_API_KEY") || has("GOOGLE_API_KEY"),
     "groq" => has("GROQ_API_KEY"),
+    "xai" => has("XAI_API_KEY"),
     "openrouter" => has("OPENROUTER_API_KEY"),
     "ollama" => has("OLLAMA_API_KEY"),
     _ => true,
@@ -8594,6 +8681,13 @@ async fn prepare_gateway_config(
       env.push(("GROQ_API_KEY".to_string(), k));
     }
   }
+  if let Some(k) = tokens.xai_api_key.clone() {
+    let k = k.trim().to_string();
+    if !k.is_empty() {
+      std::env::set_var("XAI_API_KEY", &k);
+      env.push(("XAI_API_KEY".to_string(), k));
+    }
+  }
   if let Some(k) = tokens.openai_api_key.clone() {
     let k = k.trim().to_string();
     if !k.is_empty() {
@@ -8664,6 +8758,9 @@ async fn prepare_gateway_config(
   }
   if let Some(m) = tokens.groq_model.clone() {
     env.push(("KNAPSACK_GROQ_MODEL".to_string(), m));
+  }
+  if let Some(m) = tokens.xai_model.clone() {
+    env.push(("KNAPSACK_XAI_MODEL".to_string(), m));
   }
   if let Some(m) = tokens.openrouter_model.clone() {
     env.push(("KNAPSACK_OPENROUTER_MODEL".to_string(), m));
@@ -10234,6 +10331,14 @@ pub async fn set_service_enabled(
         }
       }
 
+      if let Some(k) = tokens.xai_api_key.clone() {
+        let k = k.trim().to_string();
+        if !k.is_empty() {
+          std::env::set_var("XAI_API_KEY", &k);
+          env.push(("XAI_API_KEY".to_string(), k));
+        }
+      }
+
       if let Some(k) = tokens.openai_api_key.clone() {
         let k = k.trim().to_string();
         if !k.is_empty() {
@@ -10309,6 +10414,9 @@ pub async fn set_service_enabled(
       }
       if let Some(m) = tokens.groq_model.clone() {
         env.push(("KNAPSACK_GROQ_MODEL".to_string(), m));
+      }
+      if let Some(m) = tokens.xai_model.clone() {
+        env.push(("KNAPSACK_XAI_MODEL".to_string(), m));
       }
       if let Some(m) = tokens.openrouter_model.clone() {
         env.push(("KNAPSACK_OPENROUTER_MODEL".to_string(), m));
@@ -12588,6 +12696,7 @@ mod provider_key_tests {
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
     "GROQ_API_KEY",
+    "XAI_API_KEY",
     "OPENROUTER_API_KEY",
     "OLLAMA_API_KEY",
   ];
@@ -12604,6 +12713,11 @@ mod provider_key_tests {
       normalize_coding_agent(" opencode "),
       Some("opencode".to_string())
     );
+  }
+
+  #[test]
+  fn coding_agent_preference_accepts_grok() {
+    assert_eq!(normalize_coding_agent(" grok "), Some("grok".to_string()));
   }
 
   #[test]
@@ -12646,6 +12760,7 @@ mod provider_key_tests {
     assert!(!model_ref_has_key("anthropic/claude-opus-4-6"));
     assert!(!model_ref_has_key("google/gemini-2.5-pro"));
     assert!(!model_ref_has_key("groq/llama-3.3-70b-versatile"));
+    assert!(!model_ref_has_key("xai/grok-code-fast-1"));
   }
 
   #[test]
@@ -12655,7 +12770,18 @@ mod provider_key_tests {
     std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
     assert!(model_ref_has_key("anthropic/claude-opus-4-6"));
     assert!(!model_ref_has_key("openai/gpt-5.4"));
+    assert!(!model_ref_has_key("xai/grok-code-fast-1"));
     std::env::remove_var("ANTHROPIC_API_KEY");
+  }
+
+  #[test]
+  fn xai_model_ref_recognizes_xai_key() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_all();
+    std::env::set_var("XAI_API_KEY", "xai-test");
+    assert!(model_ref_has_key("xai/grok-code-fast-1"));
+    assert!(!model_ref_has_key("openai/gpt-5.4"));
+    std::env::remove_var("XAI_API_KEY");
   }
 
   #[test]

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -367,6 +367,7 @@ type ApiKeyStatus = {
   has_anthropic_key?: boolean
   has_gemini_key?: boolean
   has_groq_key?: boolean
+  has_xai_key?: boolean
   has_openrouter_key?: boolean
   has_knapsack?: boolean
   knapsack_email?: string
@@ -375,6 +376,7 @@ type ApiKeyStatus = {
   anthropic_key_hint?: string
   gemini_key_hint?: string
   groq_key_hint?: string
+  xai_key_hint?: string
   openrouter_key_hint?: string
   ollama_enabled?: boolean
   ollama_model?: string
@@ -398,7 +400,7 @@ type SkillInfo = {
   homepage?: string // URL for skill detail page (from gateway)
 }
 
-type Provider = 'knapsack' | 'openai' | 'anthropic' | 'gemini' | 'groq' | 'openrouter' | 'ollama'
+type Provider = 'knapsack' | 'openai' | 'anthropic' | 'gemini' | 'groq' | 'xai' | 'openrouter' | 'ollama'
 
 type ProviderOption = {
   id: Provider
@@ -421,6 +423,7 @@ const PROVIDERS: ProviderOption[] = [
   { id: 'anthropic', name: 'Anthropic', description: 'Claude Opus 4.7, Sonnet 4.6, Haiku 4.5', keyPrefix: 'sk-ant-', helpUrl: 'https://console.anthropic.com/settings/keys' },
   { id: 'gemini', name: 'Google', description: 'Gemini 3.1 Pro, 3 Flash, 3.1 Flash Lite', keyPrefix: 'AI', helpUrl: 'https://aistudio.google.com/apikey' },
   { id: 'groq', name: 'Groq', description: 'GPT-OSS, Llama 4, Kimi K2 — ultra-fast', keyPrefix: 'gsk_', helpUrl: 'https://console.groq.com/keys' },
+  { id: 'xai', name: 'Grok (xAI)', description: 'Grok 4.20, Grok 4 Fast, Grok Code Fast', keyPrefix: 'xai-', helpUrl: 'https://console.x.ai/' },
   { id: 'openrouter', name: 'OpenRouter', description: 'Free & paid models from many providers', keyPrefix: 'sk-or-', helpUrl: 'https://openrouter.ai/keys' },
   { id: 'ollama', name: 'Ollama', description: 'Local models — free, private, no API key', keyPrefix: '', helpUrl: 'https://ollama.com' },
 ]
@@ -472,6 +475,22 @@ const GROQ_MODELS: GroqModelOption[] = [
   { id: 'deepseek-r1-distill-llama-70b', name: 'DeepSeek R1 Distill', description: 'Reasoning model, great for logic' },
   { id: 'qwen-qwq-32b', name: 'Qwen QwQ 32B', description: 'Reasoning model, chain-of-thought' },
   { id: 'llama-3.3-70b-versatile', name: 'Llama 3.3 70B', description: 'Versatile general-purpose model' },
+]
+
+type XaiModelOption = {
+  id: string
+  name: string
+  description: string
+  vision?: boolean
+}
+
+const XAI_MODELS: XaiModelOption[] = [
+  { id: 'grok-4.20-beta-latest-reasoning', name: 'Grok 4.20 Reasoning', description: 'Newest Grok reasoning model for complex work', vision: true },
+  { id: 'grok-4.20-beta-latest-non-reasoning', name: 'Grok 4.20 Fast', description: 'Fast Grok 4.20 variant for everyday tasks', vision: true },
+  { id: 'grok-code-fast-1', name: 'Grok Code Fast 1', description: 'xAI coding model for fast agentic code work' },
+  { id: 'grok-4-1-fast', name: 'Grok 4.1 Fast', description: 'Fast Grok with tool-calling support', vision: true },
+  { id: 'grok-4-fast', name: 'Grok 4 Fast', description: 'Low-latency Grok 4 for general tasks', vision: true },
+  { id: 'grok-4', name: 'Grok 4', description: 'Flagship Grok model' },
 ]
 
 type OpenRouterModelOption = {
@@ -538,6 +557,7 @@ const OPENAI_MODEL_STORAGE = 'moltbot_openai_model'
 const ANTHROPIC_MODEL_STORAGE = 'moltbot_anthropic_model'
 const GEMINI_MODEL_STORAGE = 'moltbot_gemini_model'
 const GROQ_MODEL_STORAGE = 'moltbot_groq_model'
+const XAI_MODEL_STORAGE = 'moltbot_xai_model'
 const OPENROUTER_MODEL_STORAGE = 'moltbot_openrouter_model'
 const OLLAMA_MODEL_STORAGE = 'moltbot_ollama_model'
 const TONE_STORAGE = 'moltbot_tone'
@@ -1661,6 +1681,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [selectedGroqModel, setSelectedGroqModel] = useState<string>(() => {
     return localStorage.getItem(GROQ_MODEL_STORAGE) || 'meta-llama/llama-4-scout-17b-16e-instruct'
   })
+  const [selectedXaiModel, setSelectedXaiModel] = useState<string>(() => {
+    return localStorage.getItem(XAI_MODEL_STORAGE) || 'grok-code-fast-1'
+  })
   const [selectedOpenRouterModel, setSelectedOpenRouterModel] = useState<string>(() => {
     return localStorage.getItem(OPENROUTER_MODEL_STORAGE) || 'meta-llama/llama-3.3-70b-instruct:free'
   })
@@ -1998,6 +2021,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           anthropic: keyStatus.anthropic_key_hint,
           gemini: keyStatus.gemini_key_hint,
           groq: keyStatus.groq_key_hint,
+          xai: keyStatus.xai_key_hint,
           openrouter: keyStatus.openrouter_key_hint,
         })
         // Track which providers have saved keys
@@ -2007,6 +2031,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           anthropic: !!keyStatus.has_anthropic_key,
           gemini: !!keyStatus.has_gemini_key,
           groq: !!keyStatus.has_groq_key,
+          xai: !!keyStatus.has_xai_key,
           openrouter: !!keyStatus.has_openrouter_key,
         })
         if (keyStatus.knapsack_email) {
@@ -2045,6 +2070,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
             anthropic_model?: string
             gemini_model?: string
             groq_model?: string
+            xai_model?: string
             openrouter_model?: string
           }>('/api/clawd/service/get-api-key')
           if (fullKeys.anthropic_model) {
@@ -2058,6 +2084,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           if (fullKeys.groq_model) {
             setSelectedGroqModel(fullKeys.groq_model)
             localStorage.setItem(GROQ_MODEL_STORAGE, fullKeys.groq_model)
+          }
+          if (fullKeys.xai_model) {
+            setSelectedXaiModel(fullKeys.xai_model)
+            localStorage.setItem(XAI_MODEL_STORAGE, fullKeys.xai_model)
           }
           if (fullKeys.openrouter_model) {
             setSelectedOpenRouterModel(fullKeys.openrouter_model)
@@ -2475,12 +2505,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       : selectedProvider === 'anthropic' ? ANTHROPIC_MODELS
       : selectedProvider === 'gemini' ? GEMINI_MODELS
       : selectedProvider === 'groq' ? GROQ_MODELS
+      : selectedProvider === 'xai' ? XAI_MODELS
       : selectedProvider === 'openrouter' ? OPENROUTER_MODELS
       : []
     const currentId = selectedProvider === 'openai' ? selectedModel
       : selectedProvider === 'anthropic' ? selectedAnthropicModel
       : selectedProvider === 'gemini' ? selectedGeminiModel
       : selectedProvider === 'groq' ? selectedGroqModel
+      : selectedProvider === 'xai' ? selectedXaiModel
       : selectedProvider === 'openrouter' ? selectedOpenRouterModel
       : ''
     const current = allModels.find(m => m.id === currentId)
@@ -2490,7 +2522,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     const supported = current?.vision ?? false
     const visionModels = allModels.filter(m => m.vision).map(m => m.name)
     return { supported, modelName, visionModels }
-  }, [selectedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedOpenRouterModel])
+  }, [selectedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel])
 
   // File upload handlers
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -2984,6 +3016,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : selectedProvider === 'anthropic' ? selectedAnthropicModel
         : selectedProvider === 'gemini' ? selectedGeminiModel
         : selectedProvider === 'groq' ? selectedGroqModel
+        : selectedProvider === 'xai' ? selectedXaiModel
         : selectedProvider === 'openrouter' ? selectedOpenRouterModel
         : undefined
       await apiPost('/api/clawd/service/set-api-key', {
@@ -3000,6 +3033,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(GEMINI_MODEL_STORAGE, selectedGeminiModel)
       } else if (selectedProvider === 'groq') {
         localStorage.setItem(GROQ_MODEL_STORAGE, selectedGroqModel)
+      } else if (selectedProvider === 'xai') {
+        localStorage.setItem(XAI_MODEL_STORAGE, selectedXaiModel)
       } else if (selectedProvider === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
       }
@@ -3023,6 +3058,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           modelName = ANTHROPIC_MODELS.find(m => m.id === selectedAnthropicModel)?.name || selectedAnthropicModel
         } else if (selectedProvider === 'groq') {
           modelName = GROQ_MODELS.find(m => m.id === selectedGroqModel)?.name || selectedGroqModel
+        } else if (selectedProvider === 'xai') {
+          modelName = XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel
         } else if (selectedProvider === 'openrouter') {
           modelName = OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel
         } else {
@@ -3039,7 +3076,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedOpenRouterModel, selectedOllamaModel, selectedProvider, saveOllamaProvider])
+  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedOllamaModel, selectedProvider, saveOllamaProvider])
 
   // Switch to a provider that already has a saved key (no new key needed)
   const switchProviderModel = useCallback(async (providerId: Provider, alreadyActive = false) => {
@@ -3054,6 +3091,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : providerId === 'anthropic' ? selectedAnthropicModel
         : providerId === 'gemini' ? selectedGeminiModel
         : providerId === 'groq' ? selectedGroqModel
+        : providerId === 'xai' ? selectedXaiModel
         : providerId === 'openrouter' ? selectedOpenRouterModel
         : undefined
       await apiPost('/api/clawd/service/set-api-key', {
@@ -3069,6 +3107,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(GEMINI_MODEL_STORAGE, selectedGeminiModel)
       } else if (providerId === 'groq') {
         localStorage.setItem(GROQ_MODEL_STORAGE, selectedGroqModel)
+      } else if (providerId === 'xai') {
+        localStorage.setItem(XAI_MODEL_STORAGE, selectedXaiModel)
       } else if (providerId === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
       }
@@ -3083,11 +3123,13 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       const models = providerId === 'openai' ? OPENAI_MODELS
         : providerId === 'anthropic' ? ANTHROPIC_MODELS
         : providerId === 'gemini' ? GEMINI_MODELS
+        : providerId === 'xai' ? XAI_MODELS
         : providerId === 'openrouter' ? OPENROUTER_MODELS
         : GROQ_MODELS
       const mv = providerId === 'openai' ? selectedModel
         : providerId === 'anthropic' ? selectedAnthropicModel
         : providerId === 'gemini' ? selectedGeminiModel
+        : providerId === 'xai' ? selectedXaiModel
         : providerId === 'openrouter' ? selectedOpenRouterModel
         : selectedGroqModel
       const modelName = models.find(m => m.id === mv)?.name || mv
@@ -3099,7 +3141,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedOpenRouterModel])
+  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel])
 
   useEffect(() => {
     const init = async () => {
@@ -3820,6 +3862,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : selectedProvider === 'anthropic' ? selectedAnthropicModel
         : selectedProvider === 'gemini' ? selectedGeminiModel
         : selectedProvider === 'groq' ? selectedGroqModel
+        : selectedProvider === 'xai' ? selectedXaiModel
         : selectedProvider === 'openrouter' ? selectedOpenRouterModel
         : selectedModel
       return m ? `${selectedProvider}/${m}` : selectedProvider
@@ -4652,6 +4695,7 @@ ${actualText}`
             {selectedProvider === 'anthropic' ? (ANTHROPIC_MODELS.find(m => m.id === selectedAnthropicModel)?.name || selectedAnthropicModel || 'Anthropic')
               : selectedProvider === 'gemini' ? (GEMINI_MODELS.find(m => m.id === selectedGeminiModel)?.name || selectedGeminiModel || 'Gemini')
               : selectedProvider === 'groq' ? (GROQ_MODELS.find(m => m.id === selectedGroqModel)?.name || selectedGroqModel || 'Groq')
+              : selectedProvider === 'xai' ? (XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel || 'Grok')
               : selectedProvider === 'ollama' ? (selectedOllamaModel || 'Ollama')
               : selectedProvider === 'openrouter' ? (OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel || 'OpenRouter')
               : (OPENAI_MODELS.find(m => m.id === selectedModel)?.name || selectedModel || 'OpenAI')}
@@ -6656,16 +6700,19 @@ ${actualText}`
                 const models = p.id === 'openai' ? OPENAI_MODELS
                   : p.id === 'anthropic' ? ANTHROPIC_MODELS
                   : p.id === 'gemini' ? GEMINI_MODELS
+                  : p.id === 'xai' ? XAI_MODELS
                   : p.id === 'openrouter' ? OPENROUTER_MODELS
                   : GROQ_MODELS
                 const modelValue = p.id === 'openai' ? selectedModel
                   : p.id === 'anthropic' ? selectedAnthropicModel
                   : p.id === 'gemini' ? selectedGeminiModel
+                  : p.id === 'xai' ? selectedXaiModel
                   : p.id === 'openrouter' ? selectedOpenRouterModel
                   : selectedGroqModel
                 const setModelValue = p.id === 'openai' ? setSelectedModel
                   : p.id === 'anthropic' ? setSelectedAnthropicModel
                   : p.id === 'gemini' ? setSelectedGeminiModel
+                  : p.id === 'xai' ? setSelectedXaiModel
                   : p.id === 'openrouter' ? setSelectedOpenRouterModel
                   : setSelectedGroqModel
 
@@ -6700,6 +6747,7 @@ ${actualText}`
                                   const storageKey = p.id === 'openai' ? OPENAI_MODEL_STORAGE
                                     : p.id === 'anthropic' ? ANTHROPIC_MODEL_STORAGE
                                     : p.id === 'gemini' ? GEMINI_MODEL_STORAGE
+                                    : p.id === 'xai' ? XAI_MODEL_STORAGE
                                     : GROQ_MODEL_STORAGE
                                   localStorage.setItem(storageKey, newModel)
                                   if (isActive) {
@@ -7052,6 +7100,7 @@ ${actualText}`
                   <option value="claude">Claude Code (Anthropic)</option>
                   <option value="codex">Codex (OpenAI)</option>
                   <option value="gemini">Gemini CLI (Google)</option>
+                  <option value="grok">Grok Code Fast (xAI)</option>
                   <option value="opencode">OpenCode</option>
                 </select>
               </div>


### PR DESCRIPTION
## Summary
- Adds Grok (xAI) as a first-class provider in the model settings UI, with Grok model choices and `grok-code-fast-1` as the default.
- Persists and propagates `XAI_API_KEY` and `KNAPSACK_XAI_MODEL` through the service, gateway config, browser fallback chat path, and macOS LaunchAgent env generation.
- Adds a Grok Code Fast coding-agent option that routes OpenCode through `xai/grok-code-fast-1`.

## Validation
- `npm run build -- --mode development`
- `cargo test provider_key_tests --manifest-path src/src-tauri/Cargo.toml`

## Notes
- The first fresh-worktree frontend build failed before `npm ci` because `tsc` was missing; after installing app dependencies, the build passed.
- Build output still includes existing Sentry-token, unresolved asset, Sass deprecation, chunk-size, and Rust warning noise.
