### PR TITLE
Fix gateway Telegram network crashes and browser tab reuse

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/routes-Cxt2X5Du.js
+++ b/src/src-tauri/resources/clawdbot/dist/routes-Cxt2X5Du.js
@@ -3422,6 +3422,19 @@ function parseRequiredTargetId(res, rawTargetId) {
 function readOptionalTabLabel(body) {
 	return toStringOrEmpty(body?.label) || void 0;
 }
+function normalizeTabUrlForReuse(rawUrl) {
+	try {
+		const parsed = new URL(rawUrl);
+		parsed.hash = "";
+		return parsed.toString();
+	} catch {
+		return toStringOrEmpty(rawUrl).trim();
+	}
+}
+function findReusableTabForUrl(tabs, url) {
+	const target = normalizeTabUrlForReuse(url);
+	return tabs.find((tab) => normalizeTabUrlForReuse(tab.url) === target);
+}
 async function runTabTargetMutation(params) {
 	await withTabsProfileRoute({
 		req: params.req,
@@ -3472,6 +3485,16 @@ function registerBrowserTabRoutes(app, ctx) {
 					...browserNavigationPolicyForProfile(ctx, profileCtx)
 				});
 				await profileCtx.ensureBrowserAvailable();
+				try {
+					const existing = findReusableTabForUrl(await profileCtx.listTabs(), url);
+					if (existing?.targetId) {
+						await profileCtx.focusTab(existing.targetId);
+						return res.json({
+							...existing,
+							reused: true
+						});
+					}
+				} catch {}
 				const tab = await profileCtx.openTab(url, { label });
 				res.json(tab);
 			}

--- a/src/src-tauri/resources/clawdbot/dist/session-tab-registry-BXl_ZBre.js
+++ b/src/src-tauri/resources/clawdbot/dist/session-tab-registry-BXl_ZBre.js
@@ -292,7 +292,32 @@ async function browserDeleteProfile(baseUrl, profile) {
 async function browserTabs(baseUrl, opts) {
 	return (await fetchBrowserJson(withBaseUrl(baseUrl, `/tabs${buildProfileQuery(opts?.profile)}`), { timeoutMs: typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs) ? Math.max(1, Math.floor(opts.timeoutMs)) : 3e3 })).tabs ?? [];
 }
+function normalizeTabUrlForReuse(rawUrl) {
+	try {
+		const parsed = new URL(rawUrl);
+		parsed.hash = "";
+		return parsed.toString();
+	} catch {
+		return typeof rawUrl === "string" ? rawUrl.trim() : "";
+	}
+}
 async function browserOpenTab(baseUrl, url, opts) {
+	try {
+		const existing = (await browserTabs(baseUrl, {
+			profile: opts?.profile,
+			timeoutMs: opts?.timeoutMs
+		})).find((tab) => normalizeTabUrlForReuse(tab.url) === normalizeTabUrlForReuse(url));
+		if (existing?.targetId) {
+			await browserFocusTab(baseUrl, existing.targetId, {
+				profile: opts?.profile,
+				timeoutMs: opts?.timeoutMs
+			});
+			return {
+				...existing,
+				reused: true
+			};
+		}
+	} catch {}
 	return await fetchBrowserJson(withBaseUrl(baseUrl, `/tabs/open${buildProfileQuery(opts?.profile)}`), {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },

--- a/src/src-tauri/resources/clawdbot/dist/telegram-ingress-worker.runtime.js
+++ b/src/src-tauri/resources/clawdbot/dist/telegram-ingress-worker.runtime.js
@@ -24,6 +24,37 @@ function formatErrorMessage(err) {
 function resolveBackoff(attempt) {
 	return Math.min(retryMaxMs, retryInitialMs * 2 ** Math.max(0, attempt - 1));
 }
+function handleRecoverableOutOfBandNetworkError(err, label) {
+	if (!isRecoverableTelegramNetworkError(err, { context: "polling" })) return false;
+	const message = formatErrorMessage(err);
+	post({
+		type: "poll-error",
+		message: `${label}: ${message}`,
+		finishedAt: Date.now()
+	});
+	activeController?.abort(new Error(`${label}: ${message}`));
+	return true;
+}
+process.on("uncaughtException", (err) => {
+	if (handleRecoverableOutOfBandNetworkError(err, "uncaught network error")) return;
+	post({
+		type: "poll-error",
+		message: formatErrorMessage(err),
+		finishedAt: Date.now()
+	});
+	parentPort?.close();
+	process.exit(1);
+});
+process.on("unhandledRejection", (err) => {
+	if (handleRecoverableOutOfBandNetworkError(err, "unhandled network rejection")) return;
+	post({
+		type: "poll-error",
+		message: formatErrorMessage(err),
+		finishedAt: Date.now()
+	});
+	parentPort?.close();
+	process.exit(1);
+});
 parentPort?.on("message", (message) => {
 	if (message?.type !== "stop") return;
 	stopped = true;


### PR DESCRIPTION
## Summary
- contain recoverable out-of-band Telegram polling network errors inside the ingress worker instead of letting a TLSSocket error terminate the gateway
- reuse existing OpenClaw browser tabs for exact URL opens to avoid duplicate Calendar/browser tabs during automation
- keep browser reuse best-effort so failures fall back to the existing open-tab behavior

## Validation
- node --check src/src-tauri/resources/clawdbot/dist/telegram-ingress-worker.runtime.js
- node --check src/src-tauri/resources/clawdbot/dist/routes-Cxt2X5Du.js
- node --check src/src-tauri/resources/clawdbot/dist/session-tab-registry-BXl_ZBre.js
- git diff --check HEAD~1 HEAD
- npm run qa:dev launched the dev app and direct dev gateway
- focused Telegram worker probe against unreachable Telegram API route emitted poll-error and exited cleanly after stop
- dev gateway stayed healthy through Telegram fetch fallback/timeouts
- /api/clawd/browser/open opened Calendar once, then reused the same targetId on a second open instead of creating a second page tab