### PR TITLE
Fix Slack runtime deps and Google add-account links

### DIFF
--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -257,6 +257,15 @@ if (fs.existsSync(extensionsDir)) {
       errors++;
     }
   }
+
+  const slackExtensionDir = path.join(extensionsDir, 'slack');
+  for (const requiredDep of ['@slack/bolt', '@slack/web-api', '@slack/types']) {
+    if (!extensionDependencyExists(slackExtensionDir, requiredDep)) {
+      console.error(`[verify-clawdbot] CRITICAL: Slack bundled dependency missing: ${requiredDep}`);
+      errors++;
+    }
+  }
+
   const whatsappPkgPath = path.join(extensionsDir, 'whatsapp', 'package.json');
   if (fs.existsSync(whatsappPkgPath)) {
     const whatsappPkg = JSON.parse(fs.readFileSync(whatsappPkgPath, 'utf8'));
@@ -572,6 +581,7 @@ if (isWindows) {
 // failures → stuck sessions → gateway reconnection loop.
 const REQUIRED_STAGE_RUNTIME_DEPS_PLUGINS = [
   'browser',   // playwright-core — core browser/navigate tool
+  'slack',     // @slack/web-api / Bolt SDK — Slack plugin registration
 ];
 
 if (fs.existsSync(extensionsDir)) {

--- a/src/src-tauri/resources/clawdbot/dist/extensions/slack/npm-shrinkwrap.json
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/slack/npm-shrinkwrap.json
@@ -7,6 +7,14 @@
     "": {
       "name": "@openclaw/slack",
       "version": "2026.5.22",
+      "bundleDependencies": [
+        "@slack/bolt",
+        "@slack/types",
+        "@slack/web-api",
+        "https-proxy-agent",
+        "typebox",
+        "zod"
+      ],
       "dependencies": {
         "@slack/bolt": "4.7.2",
         "@slack/types": "2.21.1",
@@ -28,6 +36,7 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.7.2.tgz",
       "integrity": "sha512-ALHtaS2iaP2WAWgX08yXsoCxEDitC6AqZs26ot6smXJQzBFMM4slVP+w3blLwzUV551xZ/+9RlBmWHsZDJJ5HA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.1",
@@ -53,6 +62,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
       "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=18"
@@ -66,6 +76,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.5.tgz",
       "integrity": "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.1",
@@ -83,6 +94,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.7.tgz",
       "integrity": "sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.1",
@@ -101,6 +113,7 @@
       "version": "2.21.1",
       "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.21.1.tgz",
       "integrity": "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
@@ -111,6 +124,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.16.0.tgz",
       "integrity": "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.1",
@@ -135,7 +149,9 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -145,7 +161,9 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -154,7 +172,9 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -165,7 +185,9 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -177,12 +199,15 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT"
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
       "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*",
@@ -193,12 +218,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -208,25 +235,32 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "license": "MIT"
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT"
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -235,7 +269,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -245,6 +281,7 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -254,6 +291,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -267,6 +305,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
       "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -276,12 +315,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -293,6 +334,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -317,12 +359,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -332,6 +376,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -345,6 +390,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -361,6 +407,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -373,6 +420,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -386,6 +434,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -395,6 +444,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -404,6 +454,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -413,6 +464,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -430,6 +482,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -439,6 +492,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -448,6 +502,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -462,6 +517,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -471,12 +527,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -486,6 +544,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -495,6 +554,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -504,6 +564,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -516,6 +577,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -531,12 +593,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -546,12 +610,14 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -595,6 +661,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -622,6 +689,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -633,27 +701,27 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.4.tgz",
-      "integrity": "sha512-Y/3MmRiR8Nd+0CUtrbvcKtKzLWiUfpQ7DFVggH8PwmGt/0r7RSy32GuP4hpCJlQNEBusisSx1DLtD8uD386HJQ==",
-      "deprecated": "This version has an incorrect dependency; please use v2.5.5",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "has-own": "^1.0.1",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -663,6 +731,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -675,6 +744,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -684,6 +754,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -693,6 +764,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "inBundle": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -702,6 +774,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -726,6 +799,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -739,6 +813,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -747,17 +822,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-own": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.1.tgz",
-      "integrity": "sha512-RDKhzgQTQfMaLvIFhjahU+2gGnRBK6dYOd5Gd9BzkmnBneOCRYjRC003RIMrdAbH52+l+CnMS4bBCXGer8tEhg==",
-      "deprecated": "This project is not maintained. Use Object.hasOwn() instead.",
-      "license": "MIT"
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -770,6 +839,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -785,6 +855,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -797,6 +868,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -817,6 +889,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
       "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "9.0.0",
@@ -830,6 +903,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -846,12 +920,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -861,18 +937,21 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -885,6 +964,7 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "jws": "^4.0.1",
@@ -907,6 +987,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -918,6 +999,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -928,48 +1010,56 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -979,6 +1069,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -988,6 +1079,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1000,6 +1092,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1009,6 +1102,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -1025,12 +1119,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1040,6 +1136,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1052,6 +1149,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -1064,6 +1162,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1073,6 +1172,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -1082,6 +1182,7 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.4",
@@ -1098,12 +1199,14 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
@@ -1117,6 +1220,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "p-finally": "^1.0.0"
@@ -1129,6 +1233,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1138,6 +1243,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
       "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "inBundle": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1148,6 +1254,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -1161,6 +1268,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1170,6 +1278,7 @@
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
       "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1185,6 +1294,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1194,6 +1304,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -1209,6 +1320,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -1218,6 +1330,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1248,18 +1361,21 @@
           "url": "https://feross.org/support"
         }
       ],
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "inBundle": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1272,6 +1388,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1298,6 +1415,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -1317,12 +1435,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1342,6 +1462,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1358,6 +1479,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -1376,6 +1498,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -1395,6 +1518,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1404,6 +1528,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -1413,6 +1538,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
@@ -1422,6 +1548,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -1440,6 +1567,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1453,18 +1581,21 @@
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1474,6 +1605,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1483,12 +1615,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1510,6 +1644,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "inBundle": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/src-tauri/resources/clawdbot/dist/extensions/slack/package.json
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/slack/package.json
@@ -67,6 +67,9 @@
       "openclawVersion": "2026.5.22",
       "bundledDist": false
     },
+    "bundle": {
+      "stageRuntimeDependencies": true
+    },
     "release": {
       "publishToClawHub": true,
       "publishToNpm": true

--- a/src/src-tauri/src/connections/api.rs
+++ b/src/src-tauri/src/connections/api.rs
@@ -14,6 +14,7 @@ use serde_json::json;
 use tokio::sync::Mutex;
 
 use crate::db::models::user_connection::UserConnection;
+use crate::db::models::user::User;
 use crate::memory::semantic::SemanticService;
 use crate::connections::utils::get_knapsack_api_connection;
 
@@ -41,6 +42,13 @@ pub struct GetConnectionsResponse {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetConnectionsParams {
   email: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetUserEmailResponse {
+  success: bool,
+  email: Option<String>,
+  message: Option<String>,
 }
 
 #[derive(Hash, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -132,6 +140,22 @@ async fn signout(
     data.reset();
     
     HttpResponse::Ok().json(SuccessResponse { success: true })
+}
+
+#[get("/api/knapsack/get_user_email")]
+async fn get_user_email() -> impl Responder {
+  match User::find_first_with_email() {
+    Ok(user) => HttpResponse::Ok().json(GetUserEmailResponse {
+      success: true,
+      email: Some(user.email),
+      message: None,
+    }),
+    Err(_) => HttpResponse::NotFound().json(GetUserEmailResponse {
+      success: false,
+      email: None,
+      message: Some("No user email found".to_string()),
+    }),
+  }
 }
 
 #[get("/api/knapsack/connections")]

--- a/src/src-tauri/src/db/models/user.rs
+++ b/src/src-tauri/src/db/models/user.rs
@@ -26,6 +26,22 @@ impl User {
     Ok(user)
   }
 
+  pub fn find_first_with_email() -> Result<User> {
+    let connection = get_db_conn();
+    let mut stmt = connection.prepare(
+      "SELECT id, email, uuid FROM users WHERE email != '' ORDER BY id DESC LIMIT 1",
+    )?;
+    let user = stmt.query_row([], |row| {
+      Ok(User {
+        id: row.get(0)?,
+        email: row.get(1)?,
+        uuid: row.get(2)?,
+      })
+    })?;
+
+    Ok(user)
+  }
+
   pub fn create(&self) -> Result<(), Error> {
     if self.id.is_some() {
       return Err(Error::KSError(

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -270,6 +270,7 @@ pub async fn start_server<'a>(
       .service(connections::microsoft::outlook::reply_to_email)
       .service(connections::microsoft::profile::fetch_microsoft_profile_api)
       .service(connections::api::get_connections)
+      .service(connections::api::get_user_email)
       .service(connections::api::get_is_connections_syncing)
       .service(connections::api::delete_connection)
       .service(connections::api::signout)

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -18,6 +18,7 @@ import { useChannelStatus } from 'src/hooks/channels/useChannelStatus'
 import KNAnalytics from 'src/utils/KNAnalytics'
 import { logError } from 'src/utils/errorHandling'
 import { BaseException } from 'src/utils/exceptions/base'
+import { KN_API_GET_USER_EMAIL } from 'src/utils/constants'
 import { setIsFilesEnabled } from 'src/utils/permissions/files'
 import {
   arePushNotificationsOSEnabledAndWantedByUser,
@@ -279,6 +280,68 @@ export const SettingsDialog = ({
   const [ollamaModels, setOllamaModels] = useState<OllamaModel[]>([])
   const [ollamaBusy, setOllamaBusy] = useState(false)
   const [selectedOllamaModel, setSelectedOllamaModel] = useState('')
+  const [backendPrimaryEmail, setBackendPrimaryEmail] = useState('')
+  const googlePrimaryEmail =
+    email ||
+    profile?.email ||
+    backendPrimaryEmail ||
+    getGoogleDriveConnections(connections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
+    getGoogleGmailConnections(connections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
+    getGoogleCalendarConnections(connections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
+    ''
+
+  const requireGooglePrimaryEmail = useCallback((flow: string) => {
+    if (googlePrimaryEmail) return googlePrimaryEmail
+
+    const error = new Error('Missing primary Google email for add-account flow')
+    logError(error, {
+      additionalInfo: flow,
+      error: error.message,
+    })
+    console.error(error.message, flow)
+    return null
+  }, [googlePrimaryEmail])
+
+  const handleAddGoogleDrive = useCallback(() => {
+    const primaryEmail = requireGooglePrimaryEmail('drive')
+    if (primaryEmail) openAddGoogleDriveScreen(primaryEmail)
+  }, [requireGooglePrimaryEmail])
+
+  const handleAddGoogleGmail = useCallback(() => {
+    const primaryEmail = requireGooglePrimaryEmail('gmail')
+    if (primaryEmail) openAddGoogleGmailScreen(primaryEmail)
+  }, [requireGooglePrimaryEmail])
+
+  const handleAddGoogleCalendar = useCallback(() => {
+    const primaryEmail = requireGooglePrimaryEmail('calendar')
+    if (primaryEmail) {
+      openAddGoogleCalendarScreen(
+        primaryEmail,
+        'https://www.googleapis.com/auth/calendar.readonly',
+      )
+    }
+  }, [requireGooglePrimaryEmail])
+
+  const getGoogleAccountLabel = useCallback(
+    (item: Connection) => item.calendarAccountEmail || googlePrimaryEmail || 'unknown account',
+    [googlePrimaryEmail],
+  )
+
+  useEffect(() => {
+    if (!isOpen || email || profile?.email || backendPrimaryEmail) return
+
+    fetch(KN_API_GET_USER_EMAIL)
+      .then(response => (response.ok ? response.json() : null))
+      .then(data => {
+        if (data?.email) setBackendPrimaryEmail(data.email)
+      })
+      .catch(error => {
+        logError(new Error('Failed to load fallback user email'), {
+          additionalInfo: 'Settings add Google account',
+          error: error.message,
+        })
+      })
+  }, [backendPrimaryEmail, email, isOpen, profile?.email])
 
   useEffect(() => {
     if(profile && profile.provider){
@@ -1082,7 +1145,7 @@ export const SettingsDialog = ({
                 key={`drive-${item.id}-${item.calendarAccountEmail}`}
               >
                 <Typography>
-                  Drive, {item.calendarAccountEmail || email}
+                  Drive, {getGoogleAccountLabel(item)}
                 </Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
@@ -1100,7 +1163,7 @@ export const SettingsDialog = ({
                 key={`gmail-${item.id}-${item.calendarAccountEmail}`}
               >
                 <Typography>
-                  Gmail, {item.calendarAccountEmail || email}
+                  Gmail, {getGoogleAccountLabel(item)}
                 </Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
@@ -1118,7 +1181,7 @@ export const SettingsDialog = ({
                 key={`cal-${item.id}-${item.calendarAccountEmail}`}
               >
                 <Typography>
-                  Calendar, {item.calendarAccountEmail || email}
+                  Calendar, {getGoogleAccountLabel(item)}
                 </Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
@@ -1177,7 +1240,7 @@ export const SettingsDialog = ({
                 <Typography>Google Drive</Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
-                  onClick={() => { if (email) openAddGoogleDriveScreen(email) }}
+                  onClick={handleAddGoogleDrive}
                 >
                   {getGoogleDriveConnections(connections).length > 0 ? 'Add another' : 'Add'}
                 </Typography>
@@ -1190,7 +1253,7 @@ export const SettingsDialog = ({
                 <Typography>Gmail</Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
-                  onClick={() => { if (email) openAddGoogleGmailScreen(email) }}
+                  onClick={handleAddGoogleGmail}
                 >
                   {getGoogleGmailConnections(connections).length > 0 ? 'Add another' : 'Add'}
                 </Typography>
@@ -1203,14 +1266,7 @@ export const SettingsDialog = ({
                 <Typography>Google Calendar</Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
-                  onClick={() => {
-                    if (email) {
-                      openAddGoogleCalendarScreen(
-                        email,
-                        'https://www.googleapis.com/auth/calendar.readonly',
-                      )
-                    }
-                  }}
+                  onClick={handleAddGoogleCalendar}
                 >
                   {getGoogleCalendarConnections(connections).length > 0
                     ? 'Add another'

--- a/src/src/utils/permissions/google.tsx
+++ b/src/src/utils/permissions/google.tsx
@@ -19,6 +19,8 @@ type PendingAddAccountFlow = {
 }
 
 let _pendingAddAccountFlow: PendingAddAccountFlow | null = null
+const ADD_ACCOUNT_STATE_PREFIX = 'knapsack_add_account'
+const ADD_ACCOUNT_STORAGE_PREFIX = 'KN_GOOGLE_ADD_ACCOUNT_FLOW'
 
 /** Store the primary user email and connection type before triggering an add-account OAuth flow. */
 export const setPendingAddAccountFlow = (primaryEmail: string, type: 'calendar' | 'drive' | 'gmail'): void => {
@@ -32,25 +34,54 @@ export const consumePendingAddAccountFlow = (): PendingAddAccountFlow | null => 
   return flow
 }
 
-const buildAddAccountState = (primaryEmail: string, type: PendingAddAccountFlow['type']) =>
-  `knapsack_add_account:${type}:${encodeURIComponent(primaryEmail)}`
+const createAddAccountNonce = (): string => {
+  const bytes = new Uint8Array(16)
+  window.crypto?.getRandomValues(bytes)
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+const addAccountStorageKey = (nonce: string) => `${ADD_ACCOUNT_STORAGE_PREFIX}:${nonce}`
+
+const buildAddAccountState = (primaryEmail: string, type: PendingAddAccountFlow['type']) => {
+  const nonce = createAddAccountNonce()
+  window.sessionStorage.setItem(
+    addAccountStorageKey(nonce),
+    JSON.stringify({ primaryEmail, type }),
+  )
+  return `${ADD_ACCOUNT_STATE_PREFIX}:${type}:${nonce}`
+}
 
 export const parsePendingAddAccountState = (state?: string | null): PendingAddAccountFlow | null => {
-  if (!state?.startsWith('knapsack_add_account:')) {
+  if (!state?.startsWith(`${ADD_ACCOUNT_STATE_PREFIX}:`)) {
     return null
   }
 
-  const [, type, encodedPrimaryEmail] = state.split(':')
+  const [, type, value] = state.split(':')
   if (
     (type !== 'calendar' && type !== 'drive' && type !== 'gmail') ||
-    !encodedPrimaryEmail
+    !value
   ) {
     return null
   }
 
+  const storedFlow = window.sessionStorage.getItem(addAccountStorageKey(value))
+  if (storedFlow) {
+    window.sessionStorage.removeItem(addAccountStorageKey(value))
+    try {
+      const parsed = JSON.parse(storedFlow) as PendingAddAccountFlow
+      if (parsed.primaryEmail && parsed.type === type) {
+        return parsed
+      }
+    } catch {
+      return null
+    }
+  }
+
+  // Backward-compatible parser for any in-flight links opened by builds that
+  // encoded the primary email directly in state.
   try {
     return {
-      primaryEmail: decodeURIComponent(encodedPrimaryEmail),
+      primaryEmail: decodeURIComponent(value),
       type,
     }
   } catch {
@@ -100,17 +131,39 @@ export const openGoogleAuthScreen = (scope: string, state?: string) => {
   console.log('[Google OAuth] Opening URL:', fullUrl)
   console.log('[Google OAuth] redirect_uri:', KN_API_GOOGLE_SIGNIN_REDIRECT)
 
-  const popup = window.open(fullUrl, '_blank', 'noopener,noreferrer')
-  if (!popup) {
-    try {
-      open(fullUrl)
-    } catch (error: any) {
-      logError(new Error('Error opening Google Auth screen:'), {
-        additionalInfo: '',
+  const openInBrowser = () => {
+    const popup = window.open(fullUrl, '_blank', 'noopener,noreferrer')
+    if (!popup) {
+      throw new GoogleAuthError('Unable to open Google Auth screen.')
+    }
+  }
+
+  const logOpenError = (error: any, additionalInfo = '') => {
+    logError(new Error('Error opening Google Auth screen:'), {
+      additionalInfo,
+      error: error.message,
+    })
+    console.error('Error opening Google Auth screen:', error)
+  }
+
+  try {
+    void open(fullUrl).catch((error: any) => {
+      logError(new Error('Error opening Google Auth screen with Tauri shell:'), {
+        additionalInfo: 'Falling back to window.open',
         error: error.message,
       })
-      console.error('Error opening Google Auth screen:', error)
-      throw error
+      try {
+        openInBrowser()
+      } catch (fallbackError: any) {
+        logOpenError(fallbackError, 'Tauri shell open failed; window.open fallback also failed')
+      }
+    })
+  } catch (error: any) {
+    try {
+      openInBrowser()
+    } catch (fallbackError: any) {
+      logOpenError(fallbackError, error.message)
+      throw fallbackError
     }
   }
 }


### PR DESCRIPTION
## Summary
- stage Slack extension runtime dependencies so the packaged gateway can load @slack/web-api / Bolt modules
- add verifier coverage for Slack staged deps
- make Google add-account actions resolve the primary email before opening OAuth, and prefer Tauri shell open for OAuth URLs

## Validation
- npm run build
- cargo build --no-default-features
- node scripts/verify-clawdbot-bundle.cjs
- direct Slack extension import smoke