### PR TITLE
Surface Gemini 3.5 Flash in the UI

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -421,7 +421,7 @@ const PROVIDERS: ProviderOption[] = [
   { id: 'knapsack', name: 'Knapsack', description: 'Powered by Knapsack — no API key needed', keyPrefix: '', helpUrl: 'https://studio.knapsack.ai' },
   { id: 'openai', name: 'OpenAI', description: 'GPT-5.5, GPT-5.4, o3', keyPrefix: 'sk-', helpUrl: 'https://platform.openai.com/api-keys' },
   { id: 'anthropic', name: 'Anthropic', description: 'Claude Opus 4.7, Sonnet 4.6, Haiku 4.5', keyPrefix: 'sk-ant-', helpUrl: 'https://console.anthropic.com/settings/keys' },
-  { id: 'gemini', name: 'Google', description: 'Gemini 3.1 Pro, 3 Flash, 3.1 Flash Lite', keyPrefix: 'AI', helpUrl: 'https://aistudio.google.com/apikey' },
+  { id: 'gemini', name: 'Google', description: 'Gemini 3.1 Pro, 3.5 Flash, 3 Flash', keyPrefix: 'AI', helpUrl: 'https://aistudio.google.com/apikey' },
   { id: 'groq', name: 'Groq', description: 'GPT-OSS, Llama 4, Kimi K2 — ultra-fast', keyPrefix: 'gsk_', helpUrl: 'https://console.groq.com/keys' },
   { id: 'xai', name: 'Grok (xAI)', description: 'Grok 4.20, Grok 4 Fast, Grok Code Fast', keyPrefix: 'xai-', helpUrl: 'https://console.x.ai/' },
   { id: 'openrouter', name: 'OpenRouter', description: 'Free & paid models from many providers', keyPrefix: 'sk-or-', helpUrl: 'https://openrouter.ai/keys' },
@@ -453,6 +453,7 @@ type GeminiModelOption = {
 
 const GEMINI_MODELS: GeminiModelOption[] = [
   { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: 'Most intelligent, state-of-the-art reasoning', vision: true },
+  { id: 'gemini-3.5-flash', name: 'Gemini 3.5 Flash', description: 'Latest fast multimodal Gemini model', vision: true },
   { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Fast frontier-class performance', vision: true },
   { id: 'gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', description: 'Cost-efficient for high-volume tasks', vision: true },
   { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Stable, excellent reasoning and coding', vision: true },
@@ -1676,7 +1677,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     return localStorage.getItem(ANTHROPIC_MODEL_STORAGE) || 'claude-sonnet-4-5-20250929'
   })
   const [selectedGeminiModel, setSelectedGeminiModel] = useState<string>(() => {
-    return localStorage.getItem(GEMINI_MODEL_STORAGE) || 'gemini-2.5-flash'
+    return localStorage.getItem(GEMINI_MODEL_STORAGE) || 'gemini-3.5-flash'
   })
   const [selectedGroqModel, setSelectedGroqModel] = useState<string>(() => {
     return localStorage.getItem(GROQ_MODEL_STORAGE) || 'meta-llama/llama-4-scout-17b-16e-instruct'

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -98,17 +98,18 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
   {
     id: 'gemini',
     name: 'Gemini',
-    description: 'Gemini 3.1 Pro, 3 Flash — sign in with Google',
+    description: 'Gemini 3.1 Pro, 3.5 Flash — sign in with Google',
     keyPrefix: 'AIza',
     helpUrl: 'https://aistudio.google.com/apikey',
     helpLabel: 'aistudio.google.com/apikey',
     models: [
       { id: 'gemini/gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: 'Most intelligent, state-of-the-art reasoning' },
+      { id: 'gemini/gemini-3.5-flash', name: 'Gemini 3.5 Flash', description: 'Latest fast multimodal Gemini model' },
       { id: 'gemini/gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Fast frontier-class performance' },
       { id: 'gemini/gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', description: 'Cost-efficient for high-volume tasks' },
       { id: 'gemini/gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Stable, excellent reasoning and coding' },
     ],
-    defaultModel: 'gemini/gemini-3.1-pro-preview',
+    defaultModel: 'gemini/gemini-3.5-flash',
   },
 ]
 


### PR DESCRIPTION
## Summary
- add Gemini 3.5 Flash to the chat model picker
- make Gemini 3.5 Flash the default Gemini UI selection when no saved preference exists
- update the provider sign-in dialog model list/default and Google provider copy

## Validation
- npm run build
- npm run tauri build -- --debug --bundles app
- verified the built renderer bundle contains Gemini 3.5 Flash display text, gemini-3.5-flash, gemini/gemini-3.5-flash, and updated Google provider copy

## Note
Computer Use validation was attempted against the dev app. macOS repeatedly routed the shared Knapsack bundle id back to /Applications/Knapsack.app, so I validated the actual branch renderer and debug bundle artifacts instead of accepting the production window as proof.