### PR TITLE
Fix agent chat recovery from poisoned Gemini sessions

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/transport-stream-Cwyk9QuW.js
+++ b/src/src-tauri/resources/clawdbot/dist/transport-stream-Cwyk9QuW.js
@@ -49,8 +49,18 @@ function isJsonLikeThoughtSignature(value) {
 }
 const GEMINI_THOUGHT_SIGNATURE_ELLIPSIS_RE = /[\u2026]|\.\.\./;
 const GEMINI_THOUGHT_SIGNATURE_BASE64_RE = /^[A-Za-z0-9+/=]+$/;
-function hasGeminiThoughtSignatureTruncationFootprint(value) {
-	return GEMINI_THOUGHT_SIGNATURE_ELLIPSIS_RE.test(value) || GEMINI_THOUGHT_SIGNATURE_BASE64_RE.test(value) && value.length % 4 !== 0;
+function isValidGeminiThoughtSignatureBase64(value) {
+	if (!GEMINI_THOUGHT_SIGNATURE_BASE64_RE.test(value)) return false;
+	if (value.length % 4 !== 0) return false;
+	if (/=/.test(value.replace(/=+$/, ""))) return false;
+	if (typeof atob === "function") {
+		try {
+			atob(value);
+		} catch {
+			return false;
+		}
+	}
+	return true;
 }
 function sanitizeGeminiThoughtSignature(thoughtSignature) {
 	if (typeof thoughtSignature !== "string") return;
@@ -59,7 +69,8 @@ function sanitizeGeminiThoughtSignature(thoughtSignature) {
 	if (isJsonLikeThoughtSignature(trimmed)) return;
 	const lowered = normalizeLowercaseStringOrEmpty(trimmed);
 	if (lowered === "reasoning" || lowered === normalizeLowercaseStringOrEmpty(GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP)) return;
-	if (hasGeminiThoughtSignatureTruncationFootprint(trimmed)) return;
+	if (GEMINI_THOUGHT_SIGNATURE_ELLIPSIS_RE.test(trimmed)) return;
+	if (!isValidGeminiThoughtSignatureBase64(trimmed)) return;
 	return trimmed;
 }
 function isSameGoogleTransportRoute(source, model) {

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -18,8 +18,8 @@ use crate::clawd::sidecar::SharedClawdbotConfig;
 use crate::db::models::token_usage::TokenUsage;
 use crate::llm::cost::{calculate_cost, estimate_tokens, get_pricing};
 
-const AGENT_CHAT_GATEWAY_TIMEOUT: Duration = Duration::from_secs(75);
-const AGENT_CHAT_DIRECT_FALLBACK_TIMEOUT: Duration = Duration::from_secs(45);
+const AGENT_CHAT_GATEWAY_TIMEOUT: Duration = Duration::from_secs(30);
+const AGENT_CHAT_DIRECT_FALLBACK_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Record token usage from a chat API response (best-effort, never panics).
 fn record_chat_usage(provider: &str, model: &str, resp: &chat_agent::OaiChatResp, input_text: &str) {
@@ -1409,14 +1409,10 @@ pub async fn agent_chat(
       }
       Err(_) => {
         eprintln!(
-          "[clawd/agent-chat] Gateway agent request timed out after {:?}; not starting direct fallback",
+          "[clawd/agent-chat] Gateway agent request timed out after {:?}; falling back to direct chat",
           AGENT_CHAT_GATEWAY_TIMEOUT
         );
-        return HttpResponse::Ok().json(serde_json::json!({
-          "ok": false,
-          "noFallback": true,
-          "message": "The gateway agent did not finish in time. Please try again in a moment.",
-        }));
+        None
       }
     }
   } else {

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -4277,11 +4277,9 @@ ${actualText}`
 
         // Try gateway agent-chat first (shared session with Telegram/WhatsApp/iMessage),
         // fall back to direct chat if gateway is unavailable.
-        // Keep the frontend timeout longer than the backend request budget. If
-        // the backend times out a gateway turn, it returns noFallback so the UI
-        // does not start duplicate direct-chat work after the gateway committed
-        // the user turn. The user's abort controller still cancels immediately
-        // if they click Stop.
+        // Keep the frontend timeout longer than the backend request budget.
+        // If the shared gateway session is slow or poisoned, the backend falls
+        // back to direct chat so desktop users still get a timely answer.
         let useDirectChat = false
 
         if (!useDirectChat) {


### PR DESCRIPTION
## Summary
- reject invalid Gemini thought_signature values before replaying shared OpenClaw session history
- let /agent-chat fall back to direct chat after a gateway turn timeout instead of returning noFallback
- extend the direct fallback budget so desktop users still get an answer when the shared gateway session is slow or poisoned

## QA
- installed production v2.1.9 from release asset; SHA matched digest; codesign and Gatekeeper passed
- production QA: startup/browser/channels/search/email passed, but /api/clawd/agent-chat timed out for both 'plan for my day tomorrow' and 'check ai news' while direct /api/clawd/chat succeeded
- root-caused the timeout to a persisted Gemini history replay failure: invalid thought_signature in the shared OpenClaw main session
- npm run build
- cargo check --manifest-path src/src-tauri/Cargo.toml
- git diff --check
- dev app validation with Computer Use available: app running, service using patched local OpenClaw entry
- dev focused QA: repeated /service/health stayed browser healthy; /agent-chat 'check ai news' returned ok:true in 24s; /agent-chat 'plan for my day tomorrow' returned ok:true in 23s