### PR TITLE
Improve meeting prep brief UI

### DIFF
--- a/src/src/components/organisms/MeetingNotesMode/index.tsx
+++ b/src/src/components/organisms/MeetingNotesMode/index.tsx
@@ -12,6 +12,7 @@ import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import debounce from 'lodash/debounce'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
+import { getDocumentInfos, getDriveDocumentsIds } from 'src/api/data_source'
 import { FeedItem } from 'src/api/feed_items'
 import { isRecordingStatus, statusRecordByThreadID } from 'src/api/recording'
 import { IThread, ThreadType } from 'src/api/threads'
@@ -21,7 +22,10 @@ import { Meeting } from 'src/hooks/dataSources/useCalendar'
 import { IFeed } from 'src/hooks/feed/useFeed'
 import { useMeetingSynthesis } from 'src/hooks/useMeetingMode'
 import { KN_API_NOTES } from 'src/utils/constants'
+import DataFetcher from 'src/utils/data_fetch'
+import { extractExternalEmails, extractInternalEmails, extractWorkDomains } from 'src/utils/emails'
 import { logError } from 'src/utils/errorHandling'
+import { KNFileType } from 'src/utils/KNSearchFilters'
 import KNAnalytics from 'src/utils/KNAnalytics'
 import { getEventUrl } from 'src/utils/meetingUtils'
 import { shouldSaveTranscript } from 'src/utils/settings'
@@ -101,7 +105,8 @@ interface MeetingNotesModeProps {
   handleOpenInsights?: (threadId: number | undefined) => void
   onEmailClick?: (notesMarkdown: string, meeting: Meeting | undefined) => void
   onLibraryWorkspaceOpen?: (ws: Workspace) => void
-  onAttendeeClick?: (email: string, name: string) => void
+  hasEmailContext?: boolean
+  onConnectEmail?: () => void
   userEmail?: string
   userName?: string
 }
@@ -130,7 +135,8 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   handleOpenInsights,
   onEmailClick,
   onLibraryWorkspaceOpen,
-  onAttendeeClick,
+  hasEmailContext = false,
+  onConnectEmail,
   userEmail,
   userName,
 }) => {
@@ -141,6 +147,9 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   const [notesMarkdown, setNotesMarkdown] = useState<string>('')
   const [personWorkspaces, setPersonWorkspaces] = useState<Record<string, Workspace>>({})
   const [isMeetingChatOpen, setIsMeetingChatOpen] = useState(false)
+  const [meetingChatInitialInput, setMeetingChatInitialInput] = useState(
+    'What should I pay attention to in this meeting?',
+  )
   const [meetingTranscriptContext, setMeetingTranscriptContext] = useState('')
 
   useEffect(() => {
@@ -189,6 +198,7 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   }
 
   const openMeetingChat = () => {
+    setMeetingChatInitialInput('What should I pay attention to in this meeting?')
     setIsMeetingChatOpen(true)
   }
 
@@ -211,6 +221,7 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
       .join(', ') || 'Unknown'
     const lines = [
       'You are answering from the inline meeting chat. Use the full Knapsack gateway, tools, memory, and normal chat context, but prioritize the meeting context below over broader context when there is a conflict.',
+      `The user is ${userName || 'the signed-in user'}${userEmail ? ` (${userEmail})` : ''}. Address the user directly and do not confuse them with external attendees.`,
       '',
       'Meeting details:',
       `- Title: ${meeting?.title || thread.subtitle || 'Meeting'}`,
@@ -227,7 +238,7 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
       meetingTranscriptContext || (thread.savedTranscript ? 'Transcript is being loaded or unavailable.' : 'No saved transcript yet. If the meeting is still live, rely on current notes and meeting details.'),
     ]
     return lines.filter(line => line !== '').join('\n')
-  }, [meeting, meetingTranscriptContext, notesMarkdown, recordingHandlers, thread.id, thread.savedTranscript, thread.subtitle])
+  }, [meeting, meetingTranscriptContext, notesMarkdown, recordingHandlers, thread.id, thread.savedTranscript, thread.subtitle, userEmail, userName])
 
   const [transcribingTextIndex, setTranscribingTextIndex] = useState(0)
   const transcribingTexts = [
@@ -243,12 +254,17 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
   const [isPrepGenerating, setIsPrepGenerating] = useState(false)
   const [suggestedCalendarEvent, setSuggestedCalendarEvent] = useState<Meeting | null>(null)
   const [showCalendarPicker, setShowCalendarPicker] = useState(false)
+  const [showAttendeePicker, setShowAttendeePicker] = useState(false)
   const calendarPickerRef = useRef<HTMLDivElement>(null)
+  const attendeePickerRef = useRef<HTMLDivElement>(null)
 
   const [inlineInsights, setInlineInsights] = useState<Array<{id: number; mins: number; text: string}>>([])
   const [briefPrepContent, setBriefPrepContent] = useState('')
   const [isBriefPrepGenerating, setIsBriefPrepGenerating] = useState(false)
   const [briefPrepDismissed, setBriefPrepDismissed] = useState(false)
+  const [briefPrepExpanded, setBriefPrepExpanded] = useState(true)
+  const [emailContextBannerDismissed, setEmailContextBannerDismissed] = useState(false)
+  const [briefPrepSources, setBriefPrepSources] = useState<string[]>(['Calendar'])
   const briefPrepTriggeredRef = useRef(false)
 
   const sameDayMeetings = useMemo(() => {
@@ -259,16 +275,94 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     ).sort((a, b) => a.start - b.start)
   }, [feed.meetings, timestamp, meeting])
 
+  const attendeeEmails = useMemo(
+    () => meeting?.participants.map(p => p.email).filter(Boolean) ?? [],
+    [meeting?.participants],
+  )
+
+  const attendeeNames = useMemo(
+    () => meeting?.participants.map(p => p.name || p.email.split('@')[0]).filter(Boolean) ?? [],
+    [meeting?.participants],
+  )
+
+  const otherParticipants = useMemo(
+    () => meeting?.participants.filter(p => !userEmail || p.email !== userEmail) ?? [],
+    [meeting?.participants, userEmail],
+  )
+
+  const externalDomains = useMemo(() => {
+    if (!userEmail || attendeeEmails.length === 0) return []
+    return Array.from(new Set(extractWorkDomains(userEmail, attendeeEmails)))
+  }, [attendeeEmails, userEmail])
+
+  const buildBriefPrepDocuments = useCallback(async () => {
+    if (!meeting || !userEmail || attendeeEmails.length === 0) {
+      return { documents: [] as number[], sources: ['Calendar'] }
+    }
+
+    const dataFetcher = new DataFetcher()
+    const internalEmails = extractInternalEmails(userEmail, attendeeEmails)
+    const externalEmails = extractExternalEmails(userEmail, attendeeEmails)
+    const sourceSet = new Set<string>(['Calendar'])
+    const documents = new Set<number>()
+
+    try {
+      const emailDocs = (
+        await Promise.all([
+          internalEmails.length
+            ? dataFetcher.getGmailSearchResultsByAddresses(internalEmails)
+            : Promise.resolve([]),
+          externalEmails.length
+            ? dataFetcher.getGmailSearchResultsByAddresses(externalEmails)
+            : Promise.resolve([]),
+        ])
+      ).flat()
+
+      emailDocs.forEach(doc => {
+        if (doc.documentId) documents.add(doc.documentId)
+      })
+      if (emailDocs.length > 0) sourceSet.add('Email')
+    } catch {
+      // Briefs should still render from calendar/search context if mail search is unavailable.
+    }
+
+    try {
+      const driveIds = await getDriveDocumentsIds(attendeeEmails, userEmail)
+      const driveDocuments = driveIds.length
+        ? await getDocumentInfos(
+            driveIds,
+            driveIds.map(() => KNFileType.DRIVE_FILE),
+            userEmail,
+          )
+        : []
+
+      driveDocuments.forEach(doc => {
+        if (doc.documentId) documents.add(doc.documentId)
+      })
+      if (driveDocuments.length > 0) sourceSet.add('Drive')
+    } catch {
+      // Drive is opportunistic context; do not block the meeting surface on it.
+    }
+
+    sourceSet.add('Previous notes')
+    if (externalDomains.length > 0) sourceSet.add('Web')
+
+    return { documents: Array.from(documents).slice(0, 12), sources: Array.from(sourceSet) }
+  }, [attendeeEmails, externalDomains.length, meeting, userEmail])
+
   useEffect(() => {
-    if (!showCalendarPicker) return
+    if (!showCalendarPicker && !showAttendeePicker) return
     const handler = (e: MouseEvent) => {
       if (calendarPickerRef.current && !calendarPickerRef.current.contains(e.target as Node)) {
         setShowCalendarPicker(false)
       }
+      if (attendeePickerRef.current && !attendeePickerRef.current.contains(e.target as Node)) {
+        setShowAttendeePicker(false)
+      }
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
-  }, [showCalendarPicker])
+  }, [showAttendeePicker, showCalendarPicker])
 
   const templatePrompt: MeetingTemplatePrompt = useMemo(() => {
     if (thread.promptTemplate) {
@@ -579,35 +673,79 @@ const MeetingNotesMode: React.FC<MeetingNotesModeProps> = ({
     if (!meeting?.event_id || thread.recorded || briefPrepTriggeredRef.current) return
     briefPrepTriggeredRef.current = true
     setIsBriefPrepGenerating(true)
+    setBriefPrepSources(['Calendar'])
     // Safety timeout: if the gateway doesn't respond within 30s, clear the spinner
     const briefPrepTimeout = setTimeout(() => setIsBriefPrepGenerating(false), 30000)
     const participantList = meeting.participants
       .map(p => p.name ? `${p.name} (${p.email})` : p.email)
       .join(', ')
+    const otherParticipantList = otherParticipants
+      .map(p => p.name ? `${p.name} (${p.email})` : p.email)
+      .join(', ')
+    const startTime = meeting.start
+      ? dayjs.unix(meeting.start).format('MMM D, YYYY h:mm A')
+      : 'unknown time'
     const desc = meeting.description ? ` Context: ${meeting.description}.` : ''
-    addToLLMQueue({
-      prompt: `You are preparing someone for a meeting. Write exactly 3 sentences of plain text — no bullet points, no headers, no markdown formatting. Sentence 1: explain the real reason this meeting is happening and what's at stake. Sentence 2: what the person should focus on or do to make this meeting successful. Sentence 3: the single most important thing to watch out for or remember going in. Be sharp and specific.
+    buildBriefPrepDocuments().then(({ documents, sources }) => {
+      if (sources.length > 0) setBriefPrepSources(sources)
+      addToLLMQueue({
+        prompt: `You are preparing ${userName || 'the signed-in user'}${userEmail ? ` (${userEmail})` : ''} for a meeting. Always write to this user as "you". Do not treat the user as an external customer, prospect, vendor, or attendee to research.
+
+Use the provided calendar details, prior notes, email, drive, and semantic-search context when available.
+
+Write a concise meeting brief in markdown with no preamble and exactly this structure:
+
+**Why this meeting matters:** one sharp sentence from the user's point of view.
+
+**Open threads:** 2-3 bullets about commitments, unresolved topics, recent interactions, or likely stakes for the user. If context is thin, say what is known from the calendar instead of inventing.
+
+**People to know:** 1-3 bullets naming attendees other than the user and what the user should remember about them.
+
+**Best move:** one direct recommendation for how the user should approach the conversation.
 
 Meeting: ${meeting.title || thread.subtitle || 'Meeting'}
-Participants: ${participantList}${desc}
+Time: ${startTime}
+User: ${userName || 'Unknown'}${userEmail ? ` <${userEmail}>` : ''}
+All participants: ${participantList}
+Participants other than the user: ${otherParticipantList || 'unknown'}${desc}
+External domains: ${externalDomains.join(', ') || 'none'}
 
-Output only the 3 sentences, nothing else.`,
-      semanticSearchQuery: `meeting purpose ${meeting.title || thread.subtitle || ''}`,
-      documents: [],
-      messageStreamCallback: (chunk) => setBriefPrepContent(prev => prev + chunk),
-      messageFinishCallback: async (response) => {
-        clearTimeout(briefPrepTimeout)
-        setBriefPrepContent(response)
-        setIsBriefPrepGenerating(false)
-        return undefined
-      },
-      errorCallback: () => {
-        clearTimeout(briefPrepTimeout)
-        setIsBriefPrepGenerating(false)
-      },
+Be specific, compact, and useful while the user is joining the call.`,
+        semanticSearchQuery: [
+          meeting.title || thread.subtitle || 'meeting',
+          otherParticipantList || participantList,
+          externalDomains.join(' '),
+          userName || '',
+          'previous meeting notes recent email open threads agenda action items',
+        ].filter(Boolean).join(' '),
+        documents,
+        messageStreamCallback: (chunk) => setBriefPrepContent(prev => prev + chunk),
+        messageFinishCallback: async (response) => {
+          clearTimeout(briefPrepTimeout)
+          setBriefPrepContent(response)
+          setIsBriefPrepGenerating(false)
+          return undefined
+        },
+        errorCallback: () => {
+          clearTimeout(briefPrepTimeout)
+          setIsBriefPrepGenerating(false)
+        },
+      })
+    }).catch(() => {
+      clearTimeout(briefPrepTimeout)
+      setIsBriefPrepGenerating(false)
     })
     return () => clearTimeout(briefPrepTimeout)
-  }, [meeting?.event_id])
+  }, [
+    meeting?.event_id,
+    buildBriefPrepDocuments,
+    externalDomains,
+    otherParticipants,
+    thread.recorded,
+    thread.subtitle,
+    userEmail,
+    userName,
+  ])
 
   const getRunParamObject = () => {
     if (runParam) {
@@ -1019,6 +1157,23 @@ Output only the 3 sentences, nothing else.`,
     setIsEditing(!isEditing)
   }
 
+  const getAttendeeLabel = (participant: { name: string; email: string }) =>
+    participant.name || participant.email.split('@')[0]
+
+  const getAttendeeInitials = (participant: { name: string; email: string }) => {
+    const label = getAttendeeLabel(participant).trim()
+    const parts = label.split(/\s+/).filter(Boolean)
+    if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase()
+    return label.slice(0, 2).toUpperCase()
+  }
+
+  const handleAttendeeSelect = (participant: { name: string; email: string }) => {
+    const workspace = personWorkspaces[participant.email?.toLowerCase()]
+    if (!workspace || !onLibraryWorkspaceOpen) return
+    setShowAttendeePicker(false)
+    onLibraryWorkspaceOpen(workspace)
+  }
+
   const generatePrep = () => {
     if (!meeting || isPrepGenerating) return
     setIsPrepGenerating(true)
@@ -1118,14 +1273,66 @@ Be direct, specific, and concise. No filler text.`
                   {dayjs(new Date()).isSame(dayjs(meeting?.start ? meeting.start * 1000 : undefined), 'day') ? 'Today' : dayjs(meeting?.start ? meeting.start * 1000 : undefined).format('MMM D')}
                 </span>
                 {meeting?.participants && meeting.participants.length > 0 && (
-                  <span className="notetaker-note__meta-item">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                      <circle cx="9" cy="7" r="4" />
-                    </svg>
-                    {meeting.participants.slice(0, 3).map(p => p.name || p.email.split('@')[0]).join(', ')}
-                    {meeting.participants.length > 3 && ` +${meeting.participants.length - 3}`}
-                  </span>
+                  <div className="notetaker-note__attendees-wrap" ref={attendeePickerRef}>
+                    <button
+                      type="button"
+                      className="notetaker-note__meta-item notetaker-note__attendees-chip"
+                      onClick={() => setShowAttendeePicker(prev => !prev)}
+                      title="View attendees"
+                    >
+                      <span className="notetaker-note__attendee-stack" aria-hidden="true">
+                        {meeting.participants.slice(0, 3).map((participant, index) => (
+                          <span
+                            key={`${participant.email}-${index}`}
+                            className="notetaker-note__attendee-avatar"
+                          >
+                            {getAttendeeInitials(participant)}
+                          </span>
+                        ))}
+                      </span>
+                      <span className="notetaker-note__attendees-chip-text">
+                        {meeting.participants.length} attendees
+                      </span>
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="6 9 12 15 18 9" />
+                      </svg>
+                    </button>
+                    {showAttendeePicker && (
+                      <div className="notetaker-note__attendees-popover">
+                        <div className="notetaker-note__attendees-popover-header">
+                          <span>Attendees</span>
+                          <span>{meeting.participants.length}</span>
+                        </div>
+                        <div className="notetaker-note__attendees-list">
+                          {meeting.participants.map((participant, index) => {
+                            const label = getAttendeeLabel(participant)
+                            const workspace = personWorkspaces[participant.email?.toLowerCase()]
+                            return (
+                              <button
+                                key={`${participant.email}-${index}`}
+                                type="button"
+                                className={`notetaker-note__attendee-row ${workspace ? '' : 'notetaker-note__attendee-row--disabled'}`}
+                                onClick={() => handleAttendeeSelect(participant)}
+                                disabled={!workspace || !onLibraryWorkspaceOpen}
+                                title={workspace ? `Open ${label}'s library record` : 'No library entry yet'}
+                              >
+                                <span className="notetaker-note__attendee-row-avatar">
+                                  {getAttendeeInitials(participant)}
+                                </span>
+                                <span className="notetaker-note__attendee-row-copy">
+                                  <span className="notetaker-note__attendee-row-name">{label}</span>
+                                  <span className="notetaker-note__attendee-row-email">{participant.email}</span>
+                                </span>
+                                <span className="notetaker-note__attendee-row-action">
+                                  {workspace ? 'Open' : 'No entry'}
+                                </span>
+                              </button>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 )}
                 {thread.recorded && !meeting && sameDayMeetings.length > 0 && (
                   <div className="notetaker-note__link-event-wrap" ref={calendarPickerRef}>
@@ -1332,30 +1539,87 @@ Be direct, specific, and concise. No filler text.`
           />
         )}
 
-        {/* Brief meeting prep — auto-generated on open, hidden once recording starts, dismissable */}
-        {meeting && !thread.recorded && !recordingHandlers.isRecording(thread.id) && !briefPrepDismissed && (briefPrepContent || isBriefPrepGenerating) && (
-          <div className="notetaker-note__brief-prep-card">
-            <div className="notetaker-note__brief-prep-card-header">
-              <span className="notetaker-note__brief-prep-card-label">
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
-                </svg>
-                Meeting Brief
-              </span>
+        {/* Meeting brief drawer — auto-generated on open and kept available while recording */}
+        {meeting && !thread.recorded && !briefPrepDismissed && (briefPrepContent || isBriefPrepGenerating) && (
+          <div className={`notetaker-note__brief-drawer ${briefPrepExpanded ? 'notetaker-note__brief-drawer--expanded' : 'notetaker-note__brief-drawer--collapsed'}`}>
+            <div className="notetaker-note__brief-drawer-header">
               <button
-                className="notetaker-note__brief-prep-card-dismiss"
-                onClick={() => setBriefPrepDismissed(true)}
-                title="Dismiss"
+                className="notetaker-note__brief-drawer-toggle"
+                onClick={() => setBriefPrepExpanded(prev => !prev)}
+                title={briefPrepExpanded ? 'Collapse brief' : 'Expand brief'}
               >
-                <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-                  <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points={briefPrepExpanded ? '18 15 12 9 6 15' : '6 9 12 15 18 9'} />
                 </svg>
               </button>
+              <div className="notetaker-note__brief-drawer-title-wrap">
+                <span className="notetaker-note__brief-drawer-label">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
+                  </svg>
+                  Your brief
+                </span>
+                <span className="notetaker-note__brief-drawer-subtitle">
+                  {attendeeNames.length > 0
+                    ? `${attendeeNames.slice(0, 2).join(', ')}${attendeeNames.length > 2 ? ` +${attendeeNames.length - 2}` : ''}`
+                    : 'Prepared from meeting context'}
+                </span>
+              </div>
+              <div className="notetaker-note__brief-drawer-actions">
+                <button
+                  className="notetaker-note__brief-drawer-miss"
+                  onClick={() => {
+                    setMeetingChatInitialInput('What did I miss? Compare the brief, current notes, and available meeting context.')
+                    setIsMeetingChatOpen(true)
+                    setBriefPrepExpanded(false)
+                  }}
+                >
+                  What did I miss?
+                </button>
+                <button
+                  className="notetaker-note__brief-drawer-dismiss"
+                  onClick={() => setBriefPrepDismissed(true)}
+                  title="Dismiss"
+                >
+                  <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                    <path d="M1 1L13 13M1 13L13 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                  </svg>
+                </button>
+              </div>
             </div>
-            {isBriefPrepGenerating && !briefPrepContent ? (
-              <p className="notetaker-note__brief-prep-card-loading">Preparing your meeting brief...</p>
-            ) : (
-              <p className="notetaker-note__brief-prep-card-text">{briefPrepContent}</p>
+            {briefPrepExpanded && (
+              <div className="notetaker-note__brief-drawer-body">
+                <div className="notetaker-note__brief-drawer-sources">
+                  {briefPrepSources.map(source => (
+                    <span key={source} className="notetaker-note__brief-source-chip">{source}</span>
+                  ))}
+                </div>
+                {isBriefPrepGenerating && !briefPrepContent ? (
+                  <p className="notetaker-note__brief-prep-card-loading">Preparing your meeting brief...</p>
+                ) : (
+                  <div className="notetaker-note__brief-prep-card-text">
+                    <MarkdownDisplay markdown={briefPrepContent} onChange={() => {}} />
+                  </div>
+                )}
+                {!hasEmailContext && !emailContextBannerDismissed && onConnectEmail && (
+                  <div className="notetaker-note__brief-email-banner">
+                    <div className="notetaker-note__brief-email-copy">
+                      <strong>Missing email context?</strong>
+                      <span>Connect mail to include recent threads with attendees.</span>
+                    </div>
+                    <button className="notetaker-note__brief-email-connect" onClick={onConnectEmail}>
+                      Connect
+                    </button>
+                    <button
+                      className="notetaker-note__brief-email-dismiss"
+                      onClick={() => setEmailContextBannerDismissed(true)}
+                      title="Dismiss"
+                    >
+                      ×
+                    </button>
+                  </div>
+                )}
+              </div>
             )}
           </div>
         )}
@@ -1535,18 +1799,6 @@ Be direct, specific, and concise. No filler text.`
                           </button>
                         )
                       }
-                      if (onAttendeeClick) {
-                        return (
-                          <button
-                            key={i}
-                            className="notetaker-note__prep-chip notetaker-note__prep-chip--clickable"
-                            onClick={() => onAttendeeClick(p.email, label)}
-                            title={p.email}
-                          >
-                            {label}
-                          </button>
-                        )
-                      }
                       return (
                         <span key={i} className="notetaker-note__prep-chip">
                           {label}
@@ -1596,7 +1848,7 @@ Be direct, specific, and concise. No filler text.`
               compact
               title="Meeting Chat"
               contextPrefix={meetingChatContext}
-              initialInput="What should I pay attention to in this meeting?"
+              initialInput={meetingChatInitialInput}
             />
           </div>
         </div>

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/tauri'
 
 import { IThread, ThreadType } from 'src/api/threads'
-import { Connection, ConnectionKeys, hasGoogleCalendar } from 'src/api/connections'
+import {
+  Connection,
+  ConnectionKeys,
+  getGoogleGmailConnections,
+  hasGoogleCalendar,
+} from 'src/api/connections'
 import { LLMParams } from 'src/App'
 import { IFeed } from 'src/hooks/feed/useFeed'
 import { Meeting } from 'src/hooks/dataSources/useCalendar'
@@ -53,9 +58,9 @@ interface MeetingsTabViewProps {
   recordingHandlers: RecordingContextProps
   connections?: Record<string, Connection>
   onConnectCalendar?: () => void
+  onConnectEmail?: () => void
   onBack?: () => void
   onEmailClick?: (notesMarkdown: string, meeting?: Meeting) => void
-  onAttendeeClick?: (email: string, name: string) => void
   onLibraryWorkspaceOpen?: (ws: Workspace) => void
   userEmail?: string
   userName?: string
@@ -69,9 +74,9 @@ const MeetingsTabView = ({
   recordingHandlers,
   connections,
   onConnectCalendar,
+  onConnectEmail,
   onBack,
   onEmailClick,
-  onAttendeeClick,
   onLibraryWorkspaceOpen,
   userEmail,
   userName,
@@ -387,8 +392,13 @@ const MeetingsTabView = ({
                       handleOpenTasks={handleOpenTasks}
                       handleOpenInsights={handleOpenInsights}
                       onEmailClick={onEmailClick}
-                      onAttendeeClick={onAttendeeClick}
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
+                      hasEmailContext={
+                        !!connections &&
+                        (getGoogleGmailConnections(connections).length > 0 ||
+                          !!connections[ConnectionKeys.MICROSOFT_OUTLOOK])
+                      }
+                      onConnectEmail={onConnectEmail}
                       userEmail={userEmail}
                       userName={userName}
                     />

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -102,7 +102,7 @@ function Home({
   const [autopilotForceOpen, setAutopilotForceOpen] = useState(false)
   const [isChatBusy, setIsChatBusy] = useState(false)
   const [meetingSubView, setMeetingSubView] = useState<'meetings' | 'chat'>('meetings')
-  const [chatInitialInput, setChatInitialInput] = useState('')
+  const [chatInitialInput] = useState('')
   const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null)
   const isResizingRef = useRef(false)
 
@@ -657,14 +657,17 @@ function Home({
                   recordingHandlers={recordingHandlers}
                   connections={connections}
                   onConnectCalendar={() => onConnectAccountClick([ConnectionKeys.GOOGLE_CALENDAR])}
+                  onConnectEmail={() => {
+                    const key =
+                      auth.profile?.provider === ConnectionKeys.MICROSOFT_PROFILE
+                        ? ConnectionKeys.MICROSOFT_OUTLOOK
+                        : ConnectionKeys.GOOGLE_GMAIL
+                    onConnectAccountClick([key])
+                  }}
                   userEmail={userEmail}
                   userName={userName}
                   onBack={() => {
                     // Back from note view returns to sidebar
-                  }}
-                  onAttendeeClick={(email, name) => {
-                    setChatInitialInput(`Tell me about ${name || email}`)
-                    setMeetingSubView('chat')
                   }}
                   onLibraryWorkspaceOpen={(ws) => {
                     setCurrentTab(TabChoices.Library)

--- a/src/src/main.css
+++ b/src/src/main.css
@@ -351,6 +351,188 @@ html, body {
   color: #969595;
 }
 
+.notetaker-note__attendees-wrap {
+  position: relative;
+}
+
+.notetaker-note__attendees-chip {
+  border: 1px solid #E3E2E2;
+  cursor: pointer;
+  color: #333333;
+  background: #FFFFFF;
+  transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.notetaker-note__attendees-chip:hover {
+  background: #F8F7F7;
+  border-color: #D4D1D0;
+  box-shadow: 0 1px 6px rgba(35, 35, 35, 0.06);
+}
+
+.notetaker-note__attendee-stack {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 2px;
+}
+
+.notetaker-note__attendee-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-left: -5px;
+  border-radius: 50%;
+  border: 1.5px solid #FFFFFF;
+  background: #EAF0FB;
+  color: #4A6FA5;
+  font-family: 'Inter', sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.notetaker-note__attendee-avatar:first-child {
+  margin-left: 0;
+}
+
+.notetaker-note__attendee-avatar:nth-child(2) {
+  background: #EEF5E8;
+  color: #5F7F2D;
+}
+
+.notetaker-note__attendee-avatar:nth-child(3) {
+  background: #F7EDE6;
+  color: #9A5F35;
+}
+
+.notetaker-note__attendees-chip-text {
+  white-space: nowrap;
+}
+
+.notetaker-note__attendees-popover {
+  position: absolute;
+  top: calc(100% + 7px);
+  left: 0;
+  z-index: 220;
+  width: min(320px, calc(100vw - 40px));
+  max-height: 320px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #FFFFFF;
+  border: 1px solid #E3E2E2;
+  border-radius: 10px;
+  box-shadow: 0 10px 28px rgba(35, 35, 35, 0.14);
+}
+
+.notetaker-note__attendees-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid #EFEDED;
+  color: #6A6969;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.notetaker-note__attendees-list {
+  overflow-y: auto;
+  padding: 5px;
+}
+
+.notetaker-note__attendee-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 48px;
+  padding: 7px 8px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.notetaker-note__attendee-row:hover {
+  background: #F7F7F7;
+}
+
+.notetaker-note__attendee-row--disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.notetaker-note__attendee-row--disabled:hover {
+  background: transparent;
+}
+
+.notetaker-note__attendee-row-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: #EEF1FA;
+  color: #58649D;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+  flex-shrink: 0;
+}
+
+.notetaker-note__attendee-row-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.notetaker-note__attendee-row-name,
+.notetaker-note__attendee-row-email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Inter', sans-serif;
+}
+
+.notetaker-note__attendee-row-name {
+  color: #333333;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.notetaker-note__attendee-row-email {
+  color: #969595;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.notetaker-note__attendee-row-action {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #F0EFEF;
+  color: #6A6969;
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.notetaker-note__attendee-row--disabled .notetaker-note__attendee-row-action {
+  background: #F8F7F7;
+  color: #ABA9A9;
+}
+
 .notetaker-note__editor {
   border: 1px solid #E3E2E2;
   border-radius: 8px;
@@ -952,6 +1134,216 @@ html, body {
   color: #4A3808;
   line-height: 1.65;
   margin: 0;
+}
+
+.notetaker-note__brief-drawer {
+  position: absolute;
+  left: 50%;
+  bottom: 56px;
+  z-index: 24;
+  width: min(45rem, calc(100% - 48px));
+  max-height: min(48vh, 420px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid #E3E2E2;
+  border-radius: 12px 12px 0 0;
+  box-shadow: 0 -12px 28px rgba(35, 35, 35, 0.12);
+  transform: translateX(-50%);
+  transition: max-height 0.16s ease, box-shadow 0.16s ease;
+}
+
+.notetaker-note__brief-drawer--collapsed {
+  max-height: 48px;
+  box-shadow: 0 -6px 18px rgba(35, 35, 35, 0.08);
+}
+
+.notetaker-note__brief-drawer-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 9px 12px;
+  border-bottom: 1px solid #EFEDED;
+  flex-shrink: 0;
+}
+
+.notetaker-note__brief-drawer-toggle,
+.notetaker-note__brief-drawer-dismiss,
+.notetaker-note__brief-email-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: #747170;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.notetaker-note__brief-drawer-toggle:hover,
+.notetaker-note__brief-drawer-dismiss:hover,
+.notetaker-note__brief-email-dismiss:hover {
+  background: #F0EFEF;
+  color: #333333;
+}
+
+.notetaker-note__brief-drawer-title-wrap {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.notetaker-note__brief-drawer-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #333333;
+  font-family: 'Inter', sans-serif;
+  line-height: 1.25;
+}
+
+.notetaker-note__brief-drawer-label svg {
+  color: #6A8A35;
+  flex-shrink: 0;
+}
+
+.notetaker-note__brief-drawer-subtitle {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #777372;
+  font-family: 'Inter', sans-serif;
+  line-height: 1.25;
+}
+
+.notetaker-note__brief-drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.notetaker-note__brief-drawer-miss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid #E3E2E2;
+  border-radius: 999px;
+  background: #FFFFFF;
+  color: #333333;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.notetaker-note__brief-drawer-miss:hover {
+  background: #F8F7F7;
+}
+
+.notetaker-note__brief-drawer-body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px 16px 14px;
+}
+
+.notetaker-note__brief-drawer-sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.notetaker-note__brief-source-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #F0EFEF;
+  color: #6A6969;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.notetaker-note__brief-prep-card-text h1,
+.notetaker-note__brief-prep-card-text h2,
+.notetaker-note__brief-prep-card-text h3,
+.notetaker-note__brief-prep-card-text p,
+.notetaker-note__brief-prep-card-text li {
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  line-height: 1.58;
+  color: #3E3A39;
+}
+
+.notetaker-note__brief-prep-card-text strong {
+  color: #292625;
+}
+
+.notetaker-note__brief-prep-card-text ul {
+  margin-top: 4px;
+  margin-bottom: 10px;
+}
+
+.notetaker-note__brief-email-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: #ECF4FF;
+  border: 1px solid #D5E6FA;
+}
+
+.notetaker-note__brief-email-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+  color: #34445A;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.notetaker-note__brief-email-copy strong {
+  color: #202E43;
+  font-size: 12px;
+}
+
+.notetaker-note__brief-email-connect {
+  min-height: 30px;
+  padding: 5px 14px;
+  border: none;
+  border-radius: 999px;
+  background: #333333;
+  color: #FFFFFF;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.notetaker-note__brief-email-connect:hover {
+  background: #1F1F1F;
 }
 
 /* Inline insight cards — collected during recording, dismissable */


### PR DESCRIPTION
Summary:
- Move generated meeting prep into a persistent bottom drawer with source chips and a quick “What did I miss?” chat handoff.
- Upgrade attendee controls with stacked avatars, a popover, and click-through to existing library entries.
- Make meeting-prep prompts explicitly aware of the signed-in user and only show the email-context CTA when mail is not connected.

Tests:
- ./node_modules/.bin/tsc --noEmit
- npm run tauri dev (desktop dev build launched; authenticated app data loaded from localhost:1420)