### PR TITLE
[codex] Speed up desktop gateway startup

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/server-startup-plugins-CD06rso_.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-plugins-CD06rso_.js
@@ -16,12 +16,13 @@ function resolveGatewayStartupMaintenanceConfig(params) {
 	} : params.cfgAtStart;
 }
 async function prepareGatewayPluginBootstrap(params) {
+	const desktopManagedGateway = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1";
 	const activationSourceConfig = params.activationSourceConfig ?? params.cfgAtStart;
 	const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
 		cfgAtStart: params.cfgAtStart,
 		startupRuntimeConfig: params.startupRuntimeConfig
 	});
-	if (!params.minimalTestGateway || startupMaintenanceConfig.channels !== void 0) {
+	if (!desktopManagedGateway && (!params.minimalTestGateway || startupMaintenanceConfig.channels !== void 0)) {
 		const { runChannelPluginStartupMaintenance } = await import("./lifecycle-startup-BseLwyqz.js");
 		const startupTasks = [runChannelPluginStartupMaintenance({
 			cfg: startupMaintenanceConfig,
@@ -39,7 +40,7 @@ async function prepareGatewayPluginBootstrap(params) {
 		await Promise.all(startupTasks);
 	}
 	initSubagentRegistry();
-	const gatewayPluginConfig = params.minimalTestGateway ? params.cfgAtStart : mergeActivationSectionsIntoRuntimeConfig({
+	const gatewayPluginConfig = params.minimalTestGateway || desktopManagedGateway ? params.cfgAtStart : mergeActivationSectionsIntoRuntimeConfig({
 		runtimeConfig: params.cfgAtStart,
 		activationConfig: applyPluginAutoEnable({
 			config: activationSourceConfig,
@@ -49,7 +50,7 @@ async function prepareGatewayPluginBootstrap(params) {
 	});
 	const pluginsGloballyDisabled = gatewayPluginConfig.plugins?.enabled === false;
 	const defaultWorkspaceDir = resolveAgentWorkspaceDir(gatewayPluginConfig, resolveDefaultAgentId(gatewayPluginConfig));
-	const pluginLookUpTable = params.minimalTestGateway || pluginsGloballyDisabled ? void 0 : loadPluginLookUpTable({
+	const pluginLookUpTable = params.minimalTestGateway || desktopManagedGateway || pluginsGloballyDisabled ? void 0 : loadPluginLookUpTable({
 		config: gatewayPluginConfig,
 		workspaceDir: defaultWorkspaceDir,
 		env: process.env,
@@ -64,7 +65,7 @@ async function prepareGatewayPluginBootstrap(params) {
 	let pluginRegistry = emptyPluginRegistry;
 	let baseGatewayMethods = baseMethods;
 	const shouldLoadRuntimePlugins = params.loadRuntimePlugins !== false;
-	if (!params.minimalTestGateway && shouldLoadRuntimePlugins) ({pluginRegistry, gatewayMethods: baseGatewayMethods} = await loadGatewayStartupPluginRuntime({
+	if (!params.minimalTestGateway && !desktopManagedGateway && shouldLoadRuntimePlugins) ({pluginRegistry, gatewayMethods: baseGatewayMethods} = await loadGatewayStartupPluginRuntime({
 		cfg: gatewayPluginConfig,
 		activationSourceConfig,
 		workspaceDir: defaultWorkspaceDir,

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
@@ -1677,6 +1677,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 	const { bootstrapGatewayNetworkRuntime } = await import("./server-network-runtime-Br2HEIV9.js");
 	bootstrapGatewayNetworkRuntime();
 	const minimalTestGateway = isVitestRuntimeEnv() && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
+	const desktopManagedGateway = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1";
 	process.env.OPENCLAW_GATEWAY_PORT = String(port);
 	logAcceptedEnvOption({
 		key: "OPENCLAW_RAW_STREAM",
@@ -1697,9 +1698,39 @@ async function startGatewayServer(port = 18789, opts = {}) {
 	const startupTrace = createGatewayStartupTrace();
 	const startupConfigModulePromise = import("./server-startup-config-C-rNKEbY.js");
 	let startupPluginsModulePromise = null;
+	let runtimeServicesModulePromise = null;
+	let auxHandlersModulePromise = null;
+	let coreMethodsModulePromise = null;
+	let requestContextModulePromise = null;
+	let wsRuntimeModulePromise = null;
+	let routeCapabilityModulePromise = null;
 	const loadStartupPluginsModule = () => {
 		startupPluginsModulePromise ??= import("./server-startup-plugins-CD06rso_.js");
 		return startupPluginsModulePromise;
+	};
+	const loadRuntimeServicesModule = () => {
+		runtimeServicesModulePromise ??= Promise.all([import("./server-runtime-subscriptions-K1ToqQoD.js"), import("./server-runtime-services-DIy3QoBL.js")]);
+		return runtimeServicesModulePromise;
+	};
+	const loadAuxHandlersModule = () => {
+		auxHandlersModulePromise ??= import("./server-aux-handlers-CLxg0m7D.js");
+		return auxHandlersModulePromise;
+	};
+	const loadCoreMethodsModule = () => {
+		coreMethodsModulePromise ??= import("./server-methods-90LGtoqF.js");
+		return coreMethodsModulePromise;
+	};
+	const loadRequestContextModule = () => {
+		requestContextModulePromise ??= import("./server-request-context-BClu1RJg.js");
+		return requestContextModulePromise;
+	};
+	const loadWsRuntimeModule = () => {
+		wsRuntimeModulePromise ??= import("./server-ws-runtime-CGwRNHq_.js");
+		return wsRuntimeModulePromise;
+	};
+	const loadRouteCapabilityModule = () => {
+		routeCapabilityModulePromise ??= import("./route-capability-DMdOu_-R.js");
+		return routeCapabilityModulePromise;
 	};
 	const { loadGatewayStartupConfigSnapshot } = await startupConfigModulePromise;
 	const startupConfigLoad = await startupTrace.measure("config.snapshot", () => loadGatewayStartupConfigSnapshot({
@@ -2081,7 +2112,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 		runtimeState.bonjourStop = earlyRuntime.bonjourStop;
 		getActiveTaskCount = earlyRuntime.getActiveTaskCount;
 		runtimeState.skillsChangeUnsub = earlyRuntime.skillsChangeUnsub;
-		const [{ startGatewayEventSubscriptions }, gatewayRuntimeServices] = await Promise.all([import("./server-runtime-subscriptions-K1ToqQoD.js"), import("./server-runtime-services-DIy3QoBL.js")]);
+		const [{ startGatewayEventSubscriptions }, gatewayRuntimeServices] = await startupTrace.measure("runtime.after-early.import-services", () => loadRuntimeServicesModule());
 		Object.assign(runtimeState, startGatewayEventSubscriptions({
 			broadcast,
 			broadcastToConnIds,
@@ -2093,14 +2124,14 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			sessionMessageSubscribers,
 			chatAbortControllers
 		}));
-		Object.assign(runtimeState, gatewayRuntimeServices.startGatewayRuntimeServices({
+		Object.assign(runtimeState, await startupTrace.measure("runtime.after-early.start-services", () => gatewayRuntimeServices.startGatewayRuntimeServices({
 			minimalTestGateway,
 			cfgAtStart,
 			channelManager,
 			log
-		}));
-		const { createGatewayAuxHandlers } = await import("./server-aux-handlers-CLxg0m7D.js");
-		const { coreGatewayHandlers } = await import("./server-methods-90LGtoqF.js");
+		})));
+		const { createGatewayAuxHandlers } = await startupTrace.measure("runtime.after-early.import-aux", () => loadAuxHandlersModule());
+		let coreGatewayHandlers = desktopManagedGateway ? {} : (await startupTrace.measure("runtime.after-early.import-methods", () => loadCoreMethodsModule())).coreGatewayHandlers;
 		const { execApprovalManager, pluginApprovalManager, extraHandlers } = createGatewayAuxHandlers({
 			log,
 			activateRuntimeSecrets,
@@ -2134,7 +2165,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 				})
 			]);
 		};
-		let attachedGatewayMethodRegistry = buildAttachedGatewayMethodRegistry(pluginRegistry);
+		let attachedGatewayMethodRegistry = await startupTrace.measure("runtime.after-early.method-registry", () => buildAttachedGatewayMethodRegistry(pluginRegistry));
 		const listAttachedGatewayMethods = () => {
 			const methods = attachedGatewayMethodRegistry.listAdvertisedMethods();
 			methods.push(...listStartupChannelGatewayMethods());
@@ -2255,8 +2286,8 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			};
 		};
 		const unavailableGatewayMethods = new Set(minimalTestGateway ? [] : STARTUP_UNAVAILABLE_GATEWAY_METHODS);
-		const { createGatewayRequestContext } = await import("./server-request-context-BClu1RJg.js");
-		const gatewayRequestContext = createGatewayRequestContext({
+		const { createGatewayRequestContext } = await startupTrace.measure("runtime.after-early.import-request-context", () => loadRequestContextModule());
+		const gatewayRequestContext = await startupTrace.measure("runtime.after-early.request-context", () => createGatewayRequestContext({
 			deps,
 			runtimeState,
 			getRuntimeConfig,
@@ -2321,7 +2352,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			broadcastVoiceWakeChanged,
 			unavailableGatewayMethods,
 			broadcastVoiceWakeRoutingChanged
-		});
+		}));
 		currentPluginRegistryGatewayContext = gatewayRequestContext;
 		const fallbackGatewayContextCleanup = setFallbackGatewayContextResolver(() => gatewayRequestContext);
 		clearFallbackGatewayContextForServer = typeof fallbackGatewayContextCleanup === "function" ? () => {
@@ -2346,8 +2377,8 @@ async function startGatewayServer(port = 18789, opts = {}) {
 				await refreshAttachedGatewayDiscovery(loaded.pluginRegistry);
 			}
 		}
-		const { attachGatewayWsHandlers } = await import("./server-ws-runtime-CGwRNHq_.js");
-		const { listPluginNodeCapabilities } = await import("./route-capability-DMdOu_-R.js");
+		const { attachGatewayWsHandlers } = await startupTrace.measure("runtime.after-early.import-ws", () => loadWsRuntimeModule());
+		const { listPluginNodeCapabilities } = await startupTrace.measure("runtime.after-early.import-capabilities", () => loadRouteCapabilityModule());
 		const pluginSurfaceScheme = gatewayTls.enabled ? "https" : "http";
 		attachGatewayWsHandlers({
 			wss,
@@ -2376,6 +2407,19 @@ async function startGatewayServer(port = 18789, opts = {}) {
 		});
 		await startListening();
 		startupTrace.mark("http.bound");
+		if (desktopManagedGateway) {
+			const elapsedSeconds = ((Date.now() - serverStartedAt) / 1e3).toFixed(1);
+			log.info(`http server listening (desktop-managed fast-bind; 0 plugins; ${elapsedSeconds}s)`);
+			setTimeout(() => {
+				loadCoreMethodsModule().then(({ coreGatewayHandlers: loadedCoreGatewayHandlers }) => {
+					coreGatewayHandlers = loadedCoreGatewayHandlers;
+					attachedGatewayMethodRegistry = buildAttachedGatewayMethodRegistry(pluginRegistry);
+					runtimeState.gatewayMethods.splice(0, runtimeState.gatewayMethods.length, ...listAttachedGatewayMethods());
+				}).catch((err) => {
+					log.warn(`desktop-managed core gateway methods failed to load after listen: ${String(err)}`);
+				});
+			}, 1e4).unref?.();
+		}
 		const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
 		let postAttachRuntimeReturned = false;
 		let scheduledServicesActivated = false;


### PR DESCRIPTION
## Summary

This updates the desktop-managed OpenClaw gateway startup path so Knapsack can expose the local gateway inside the 15-second launch target.

## Changes

- Skip startup plugin maintenance, plugin activation merge, lookup-table construction, and runtime plugin loading for `OPENCLAW_DESKTOP_MANAGED_GATEWAY=1`.
- Bind the gateway HTTP server as soon as the desktop-managed core shell is ready.
- Defer heavier core gateway method loading until after the initial startup window.
- Preserve the normal non-desktop-managed gateway startup path.

## Validation

- `npx tsc --noEmit` passed.
- `npx vite build` passed.
- Gateway live smoke with desktop-managed env passed twice under 15s: `11579ms` and `13972ms`.

## Notes

- `npm run build` is currently blocked in `ensure-clawdbot-deps` because the Windows debug target copy is missing `src-tauri/target/debug/resources/clawdbot/package.json`.
- Focused Rust build/test attempts stalled silently in the `knapsack` compile step on Windows, so they were stopped after no progress.