### PR TITLE
feat: Knapsack provider integration improvements

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -16,6 +16,7 @@
 # Default points to the knap.ai cloud backend (used by official DMG releases).
 # For self-hosted mode, set GOOGLE_CLIENT_SECRET instead (see README).
 VITE_KN_API_SERVER=https://api.knapsack.ai
+VITE_KN_STUDIO_SERVER=https://studio.knapsack.ai
 
 # ---------------------------------------------------------------------------
 # Optional -- Microsoft integration

--- a/src/src-tauri/Info.plist
+++ b/src/src-tauri/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>ai.knap.knapsack.auth</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>knapsack-auth</string>
+            </array>
+        </dict>
+    </array>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app requires access to the microphone to record audio.</string>
     <key>NSAudioOutputUsageDescription</key>

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -1839,6 +1839,17 @@ pub async fn chat(
         }))
       }
     },
+    "knapsack" => {
+      let token = std::env::var("KNAPSACK_ACCESS_TOKEN").unwrap_or_default();
+      if !token.trim().is_empty() {
+        token.trim().to_string()
+      } else {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+          "ok": false,
+          "message": "Knapsack account not connected. Sign in via Settings → Provider."
+        }))
+      }
+    },
     _ => match openai_key(&app_handle) {
       Some(k) => k,
       None => {
@@ -3980,6 +3991,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
     "xai" => super::service::get_xai_model(&app_handle),
     "ollama" => ollama_model(&app_handle),
     "openrouter" => super::service::get_openrouter_model(&app_handle),
+    "knapsack" => "auto".to_string(),
     _ => super::service::get_openai_model(&app_handle),
   };
   let current_ollama_base = ollama_base_url(&app_handle);
@@ -4002,6 +4014,10 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         },
         "openrouter" => {
           chat_agent::openai_compatible_chat(key, model, "https://openrouter.ai/api/v1", msgs, tls).await
+        },
+        "knapsack" => {
+          let base = option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai");
+          chat_agent::openai_compatible_chat(key, model, base, msgs, tls).await
         },
         _ => chat_agent::openai_chat(key, model, msgs, tls).await,
       }

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -741,6 +741,11 @@ pub fn resolve_default_model() -> String {
 
   // Respect the user's active provider selection and configured model
   match active.as_str() {
+    // Knapsack cloud inference: the backend selects the best model based on
+    // the user's subscription — the desktop always sends "auto".
+    "knapsack" => {
+      return "auto".to_string();
+    }
     "openrouter" => {
       let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
         .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -7,6 +7,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tauri::Manager;
 
 use crate::clawd::gateway_client;
 use crate::clawd::sidecar::SharedClawdbotConfig;
@@ -3431,7 +3432,12 @@ struct StoredTokens {
   #[serde(default)]
   preferred_coding_agent: Option<String>,
 
-  // Knapsack cloud inference (no API key — uses the user's Knapsack JWT)
+  // Knapsack cloud inference — authenticated via studio.knapsack.ai deep link
+  #[serde(default)]
+  knapsack_access_token: Option<String>,
+  #[serde(default)]
+  knapsack_refresh_token: Option<String>,
+  /// Email shown in the UI; decoded from the JWT at sign-in time.
   #[serde(default)]
   knapsack_email: Option<String>,
   #[serde(default)]
@@ -3618,6 +3624,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     ollama_base_url: None,
     extra_provider_keys: None,
     preferred_coding_agent: None,
+    knapsack_access_token: None,
+    knapsack_refresh_token: None,
     knapsack_email: None,
     knapsack_model: None,
   };
@@ -3761,7 +3769,19 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
       }
     }
   }
-  // Propagate Knapsack cloud inference settings (active when user chose Knapsack as provider)
+  // Propagate Knapsack cloud inference settings
+  if let Some(t) = &tokens.knapsack_access_token {
+    let t = t.trim();
+    if !t.is_empty() {
+      std::env::set_var("KNAPSACK_ACCESS_TOKEN", t);
+    }
+  }
+  if let Some(rt) = &tokens.knapsack_refresh_token {
+    let rt = rt.trim();
+    if !rt.is_empty() {
+      std::env::set_var("KNAPSACK_REFRESH_TOKEN", rt);
+    }
+  }
   if let Some(e) = &tokens.knapsack_email {
     let e = e.trim();
     if !e.is_empty() {
@@ -5992,9 +6012,9 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
   let ollama_enabled = tokens.ollama_enabled.unwrap_or(false);
   let (has_gemini_cli, gemini_cli_email) = read_gemini_cli_auth(&app_handle);
   let has_knapsack = tokens
-    .knapsack_email
+    .knapsack_access_token
     .as_ref()
-    .map(|e| !e.trim().is_empty())
+    .map(|t| !t.trim().is_empty())
     .unwrap_or(false);
   let has_key = has_openai
     || has_anthropic
@@ -6282,6 +6302,10 @@ pub struct SetApiKeyRequest {
   /// Preferred coding CLI agent: "claude", "codex", "antigravity", "gemini", or "opencode".
   /// When provided alongside or without a key change, updates the stored preference.
   pub preferred_coding_agent: Option<String>,
+  /// Knapsack provider: the JWT refresh token (stored alongside the access token in `key`).
+  pub refresh_token: Option<String>,
+  /// Knapsack provider: the user's email, for display only.
+  pub email: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -6399,9 +6423,9 @@ pub async fn set_api_key(
         .map_or(false, |k| !k.is_empty()),
       "ollama" => true,
       "knapsack" => tokens
-        .knapsack_email
+        .knapsack_access_token
         .as_ref()
-        .map_or(false, |e| !e.is_empty()),
+        .map_or(false, |t| !t.is_empty()),
       _ => tokens
         .openai_api_key
         .as_ref()
@@ -6413,6 +6437,13 @@ pub async fn set_api_key(
         message: "API key cannot be empty".to_string(),
       });
     }
+    // If the provider isn't actually changing, skip the gateway restart — it's
+    // already running with the correct configuration.  A restart here would
+    // fail in dev mode (launchctl exit 37) and trigger a destructive self-heal.
+    let already_active = tokens
+      .active_provider
+      .as_deref()
+      .unwrap_or("openai") == provider.as_str();
     // Switch active provider and update model only
     tokens.active_provider = Some(provider.clone());
     if let Some(model) = &payload.model {
@@ -6548,6 +6579,16 @@ pub async fn set_api_key(
     // updates the default model but does NOT re-run provider discovery, so
     // the old provider (e.g. Ollama) stays in the catalog and the gateway
     // keeps routing requests through it.
+    if already_active {
+      eprintln!(
+        "[clawd/service] Provider '{}' is already active — skipping gateway restart",
+        provider
+      );
+      return HttpResponse::Ok().json(SetApiKeyResponse {
+        success: true,
+        message: format!("Switched to {}", provider_name),
+      });
+    }
     let switch_model = crate::clawd::gateway_client::resolve_default_model();
     eprintln!(
       "[clawd/service] Provider switch to '{}' (model: {}) — restarting gateway for provider re-discovery",
@@ -6667,8 +6708,14 @@ pub async fn set_api_key(
       "Ollama"
     }
     "knapsack" => {
-      // Knapsack cloud inference: key field carries the user's email (no API key needed)
-      tokens.knapsack_email = Some(key);
+      // key = JWT access token; refresh_token = JWT refresh token; email = display email
+      tokens.knapsack_access_token = Some(key);
+      if let Some(rt) = &payload.refresh_token {
+        tokens.knapsack_refresh_token = Some(rt.trim().to_string());
+      }
+      if let Some(em) = &payload.email {
+        tokens.knapsack_email = Some(em.trim().to_string());
+      }
       tokens.active_provider = Some("knapsack".to_string());
       if let Some(model) = &payload.model {
         tokens.knapsack_model = Some(model.trim().to_string());
@@ -7178,6 +7225,10 @@ pub async fn ollama_configure(
       let _ = std::process::Command::new("launchctl")
         .args(["kickstart", "-k", &service])
         .status();
+      // Mark the gateway as launched so set_service_enabled (called by the
+      // frontend immediately after) sees the grace period active and returns
+      // early instead of doing a second full restart with blocking sleeps.
+      mark_gateway_launch_started();
     }
   }
 
@@ -12259,6 +12310,197 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub async fn auto_enable_if_needed(_app_handle: &tauri::AppHandle) {
   // No-op on non-macOS/Windows platforms.
+}
+
+/// Parse a single query parameter value from a URL string.
+fn parse_deep_link_param(url: &str, key: &str) -> Option<String> {
+  let query_start = url.find('?')?;
+  let query = &url[query_start + 1..];
+  for pair in query.split('&') {
+    if let Some((k, v)) = pair.split_once('=') {
+      if k == key {
+        // Percent-decode the value (handles %40 → @ for emails, etc.)
+        let decoded = v.replace("%40", "@").replace("%2B", "+").replace("%20", " ").replace("+", " ");
+        return Some(decoded);
+      }
+    }
+  }
+  None
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct DesktopSignInApiResponse {
+  access_token: String,
+  refresh_token: String,
+  email: String,
+}
+
+/// Exchange a one-shot code for JWT tokens, store them, and emit
+/// `knapsack-connected` (or `knapsack-auth-error`) to the frontend.
+/// Returns Ok(email) on success or Err(user-visible message) on failure.
+async fn exchange_and_store_knapsack_code(
+  app_handle: &tauri::AppHandle,
+  code: &str,
+) -> Result<String, String> {
+  let api_base = option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai");
+  let client = reqwest::Client::new();
+  let resp = client
+    .post(format!("{}/api/authentication/desktop-sign-in", api_base))
+    .json(&serde_json::json!({ "code": code }))
+    .send()
+    .await
+    .map_err(|e| {
+      log::error!("[knapsack_auth] exchange request failed: {}", e);
+      format!("Connection failed: {}", e)
+    })?;
+
+  let status = resp.status();
+  let body_text = resp.text().await.unwrap_or_default();
+
+  if !status.is_success() {
+    log::error!("[knapsack_auth] exchange endpoint returned {}: {}", status, body_text);
+    return Err(format!("Sign-in failed ({})", status));
+  }
+
+  let sign_in: DesktopSignInApiResponse = serde_json::from_str(&body_text).map_err(|e| {
+    log::error!("[knapsack_auth] failed to parse exchange response: {}", e);
+    "Invalid server response".to_string()
+  })?;
+
+  let mut tokens = load_or_create_tokens(app_handle).map_err(|e| {
+    log::error!("[knapsack_auth] failed to load tokens for storage: {}", e);
+    "Failed to save credentials".to_string()
+  })?;
+
+  tokens.knapsack_access_token = Some(sign_in.access_token.clone());
+  tokens.knapsack_refresh_token = Some(sign_in.refresh_token.clone());
+  tokens.knapsack_email = Some(sign_in.email.clone());
+  tokens.active_provider = Some("knapsack".to_string());
+  if tokens.knapsack_model.is_none() {
+    tokens.knapsack_model = Some("anthropic/claude-haiku-4-5".to_string());
+  }
+
+  if let Err(e) = save_tokens(app_handle, &tokens) {
+    log::error!("[knapsack_auth] failed to save tokens: {}", e);
+  }
+
+  std::env::set_var("KNAPSACK_ACCESS_TOKEN", &sign_in.access_token);
+  std::env::set_var("KNAPSACK_REFRESH_TOKEN", &sign_in.refresh_token);
+  std::env::set_var("KNAPSACK_USER_EMAIL", &sign_in.email);
+  std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "knapsack");
+  if let Some(m) = &tokens.knapsack_model {
+    std::env::set_var("KNAPSACK_KNAPSACK_MODEL", m);
+  }
+
+  log::info!("[knapsack_auth] connected as {}", sign_in.email);
+  let _ = app_handle.emit_all(
+    "knapsack-connected",
+    serde_json::json!({
+      "email": sign_in.email,
+      "model": tokens.knapsack_model.clone().unwrap_or_default(),
+    }),
+  );
+
+  Ok(sign_in.email)
+}
+
+/// GET /api/auth/knapsack-callback?code=<one-shot-code>
+/// Called by studio.knapsack.ai after the user authenticates.
+/// Returns an HTML page the user can close.
+#[derive(Deserialize)]
+pub struct KnapsackCallbackQuery {
+  pub code: Option<String>,
+}
+
+#[get("/api/auth/knapsack-callback")]
+pub async fn knapsack_auth_callback(
+  app_handle: web::Data<tauri::AppHandle>,
+  query: web::Query<KnapsackCallbackQuery>,
+) -> impl Responder {
+  let code = match query.code.as_deref().filter(|c| !c.is_empty()) {
+    Some(c) => c.to_string(),
+    None => return oauth_html_page(false, "Missing authorization code."),
+  };
+
+  match exchange_and_store_knapsack_code(&app_handle, &code).await {
+    Ok(_) => oauth_html_page(true, "Knapsack"),
+    Err(msg) => {
+      let _ = app_handle.emit_all("knapsack-auth-error", serde_json::json!({"error": msg}));
+      oauth_html_page(false, &msg)
+    }
+  }
+}
+
+/// POST /api/clawd/service/knapsack-disconnect
+/// Clears the stored Knapsack credentials and switches the active provider
+/// to whatever other provider has a saved key (fallback: openai).
+#[post("/api/clawd/service/knapsack-disconnect")]
+pub async fn knapsack_disconnect(
+  app_handle: web::Data<tauri::AppHandle>,
+) -> impl Responder {
+  let mut tokens = match load_or_create_tokens(&app_handle) {
+    Ok(t) => t,
+    Err(e) => {
+      return HttpResponse::InternalServerError().json(
+        serde_json::json!({"ok": false, "message": e})
+      )
+    }
+  };
+
+  // Clear all Knapsack credential fields
+  tokens.knapsack_access_token = None;
+  tokens.knapsack_refresh_token = None;
+  tokens.knapsack_email = None;
+
+  // Pick a fallback provider that already has a saved key
+  let fallback = if tokens.anthropic_api_key.as_deref().map(|k| !k.is_empty()).unwrap_or(false) {
+    "anthropic"
+  } else if tokens.gemini_api_key.as_deref().map(|k| !k.is_empty()).unwrap_or(false) {
+    "gemini"
+  } else if tokens.groq_api_key.as_deref().map(|k| !k.is_empty()).unwrap_or(false) {
+    "groq"
+  } else {
+    "openai"
+  };
+  tokens.active_provider = Some(fallback.to_string());
+
+  if let Err(e) = save_tokens(&app_handle, &tokens) {
+    return HttpResponse::InternalServerError().json(
+      serde_json::json!({"ok": false, "message": e})
+    );
+  }
+
+  // Clear env vars so in-process consumers stop using the old token
+  std::env::remove_var("KNAPSACK_ACCESS_TOKEN");
+  std::env::remove_var("KNAPSACK_REFRESH_TOKEN");
+  std::env::remove_var("KNAPSACK_USER_EMAIL");
+  std::env::remove_var("KNAPSACK_KNAPSACK_MODEL");
+  std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", fallback);
+
+  log::info!("[knapsack_disconnect] disconnected, fallback provider = {}", fallback);
+  let _ = app_handle.emit_all(
+    "knapsack-disconnected",
+    serde_json::json!({"fallback_provider": fallback}),
+  );
+
+  HttpResponse::Ok().json(serde_json::json!({"ok": true, "fallback_provider": fallback}))
+}
+
+/// Handle a `knapsack-auth://connect?code=<code>` deep link (URL scheme fallback).
+pub async fn handle_knapsack_deep_link(app_handle: &tauri::AppHandle, url: &str) {
+  log::info!("[knapsack_auth] deep link received: {}", &url[..url.len().min(80)]);
+
+  let code = match parse_deep_link_param(url, "code") {
+    Some(c) => c,
+    None => {
+      log::error!("[knapsack_auth] missing 'code' in deep link URL");
+      return;
+    }
+  };
+
+  if let Err(msg) = exchange_and_store_knapsack_code(app_handle, &code).await {
+    let _ = app_handle.emit_all("knapsack-auth-error", serde_json::json!({"error": msg}));
+  }
 }
 
 #[cfg(test)]

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -113,15 +113,13 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
       });
     }
     "knapsack" => {
-      let email = std::env::var("KNAPSACK_USER_EMAIL").unwrap_or_default();
-      if !email.trim().is_empty() {
-        let model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
-          .unwrap_or_else(|_| "anthropic/claude-haiku-4-5".to_string());
+      let access_token = std::env::var("KNAPSACK_ACCESS_TOKEN").unwrap_or_default();
+      if !access_token.trim().is_empty() {
         return Ok(ResolvedProvider {
           name: "knapsack".into(),
-          api_key: email,
-          model,
-          base_url: "https://api.knapsack.ai".into(),
+          api_key: access_token,
+          model: "auto".into(),
+          base_url: option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai").into(),
           is_anthropic: false,
         });
       }
@@ -349,8 +347,34 @@ fn parse_retry_after(text: &str, attempt: u32) -> f64 {
   (2u64.pow(attempt + 1) as f64).min(60.0)
 }
 
+/// Refresh the Knapsack JWT access token using the stored refresh token.
+/// Returns the new access token string on success, or None on any failure.
+async fn refresh_knapsack_token() -> Option<String> {
+  let refresh_token = std::env::var("KNAPSACK_REFRESH_TOKEN").ok()?;
+  if refresh_token.trim().is_empty() {
+    return None;
+  }
+  let client = reqwest::Client::new();
+  let resp = client
+    .get(format!("{}/api/authentication/refresh/app", option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai")))
+    .header("refresh-token", refresh_token.trim())
+    .send()
+    .await
+    .ok()?;
+  if !resp.status().is_success() {
+    log::warn!("[knapsack_refresh] token refresh failed: {}", resp.status());
+    return None;
+  }
+  let json: serde_json::Value = resp.json().await.ok()?;
+  let new_token = json["access_token"].as_str()?.to_string();
+  std::env::set_var("KNAPSACK_ACCESS_TOKEN", &new_token);
+  log::info!("[knapsack_refresh] access token refreshed");
+  Some(new_token)
+}
+
 /// Call an OpenAI-compatible chat completions endpoint (works for OpenAI, Groq, Gemini).
 /// Retries up to 3 times on transient failures with exponential backoff.
+/// For the knapsack provider a 401 triggers one token refresh + retry.
 async fn openai_compatible_completion(
   provider: &ResolvedProvider,
   messages: &[LlmMessage],
@@ -392,7 +416,9 @@ async fn openai_compatible_completion(
       provider.name
     )));
   }
-  if key_len > 256 || provider.api_key.contains(' ') || provider.api_key.starts_with('#') {
+  // JWT tokens (used by the knapsack provider) are longer than typical API keys but valid.
+  let max_key_len = if provider.name == "knapsack" { 2048 } else { 256 };
+  if key_len > max_key_len || provider.api_key.contains(' ') || provider.api_key.starts_with('#') {
     return Err(LLMError::ChatCompletionFailed(format!(
       "{} API key looks malformed (len={}, may contain prose/markdown). Please re-enter your API key in Settings.",
       provider.name, key_len
@@ -462,6 +488,37 @@ async fn openai_compatible_completion(
 
     // Non-retryable error or final attempt
     if status == reqwest::StatusCode::UNAUTHORIZED {
+      // For Knapsack: attempt one token refresh then retry immediately
+      if provider.name == "knapsack" && attempt == 0 {
+        log::info!("[completion] knapsack 401 — attempting token refresh");
+        if let Some(new_token) = refresh_knapsack_token().await {
+          // Update body with new bearer and retry (loop continues with attempt=1)
+          last_error = format!("knapsack 401 (refreshed token, retrying)");
+          // Re-issue the request directly with the new token so we don't wait for next loop
+          let retry_resp = match client.post(&url)
+            .header("Authorization", format!("Bearer {}", new_token))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+          {
+            Ok(r) => r,
+            Err(e) => return Err(LLMError::ChatCompletionFailed(format!("knapsack retry failed: {}", e))),
+          };
+          let retry_status = retry_resp.status();
+          let retry_text = retry_resp.text().await.unwrap_or_default();
+          if retry_status.is_success() {
+            let json: serde_json::Value = serde_json::from_str(&retry_text)
+              .map_err(|e| LLMError::ChatCompletionFailed(format!("knapsack JSON parse: {}", e)))?;
+            let content = json["choices"][0]["message"]["content"]
+              .as_str()
+              .map(|s| s.to_string())
+              .ok_or_else(|| LLMError::ChatCompletionFailed("knapsack: no content after refresh retry".into()))?;
+            return Ok(content);
+          }
+          return Err(LLMError::ChatCompletionFailed(format!("knapsack error after refresh ({}): {}", retry_status, retry_text)));
+        }
+      }
       let key_preview = if key_len > 8 {
         format!("{}...{}", &provider.api_key[..4], &provider.api_key[key_len-4..])
       } else {

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -301,9 +301,11 @@ pub async fn start_server<'a>(
       .service(clawd::service::set_api_key)
       .service(clawd::service::delete_extra_provider_key)
       .service(clawd::service::get_api_key)
-      // OAuth provider login (OpenRouter browser-based auth)
+      // OAuth provider login (OpenRouter browser-based auth) + Knapsack studio auth
       .service(clawd::service::start_oauth_login)
       .service(clawd::service::oauth_callback)
+      .service(clawd::service::knapsack_auth_callback)
+      .service(clawd::service::knapsack_disconnect)
       .service(clawd::service::gemini_connect)
       // Ollama (local LLM) endpoints
       .service(clawd::service::ollama_status)

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { openBesideApp } from 'src/utils/openBesideApp'
 import { emit, listen as tauriListen } from '@tauri-apps/api/event'
+import { open as shellOpen } from '@tauri-apps/api/shell'
 import { convertFileSrc } from '@tauri-apps/api/tauri'
 import dayjs from 'dayjs'
 import { QRCodeSVG } from 'qrcode.react'
@@ -410,12 +411,6 @@ type ProviderOption = {
   helpUrl: string
 }
 
-const KNAPSACK_MODELS = [
-  { id: 'anthropic/claude-haiku-4-5', name: 'Standard', description: 'Fast, efficient — great for everyday tasks' },
-  { id: 'anthropic/claude-sonnet-4-5', name: 'Plus', description: 'Balanced performance and capability' },
-  { id: 'anthropic/claude-opus-4-7', name: 'Premium', description: 'Most powerful — best for complex work' },
-]
-const KNAPSACK_MODEL_STORAGE = 'knapsack_knapsack_model'
 
 const PROVIDERS: ProviderOption[] = [
   { id: 'knapsack', name: 'Knapsack', description: 'Powered by Knapsack — no API key needed', keyPrefix: '', helpUrl: 'https://studio.knapsack.ai' },
@@ -1690,11 +1685,15 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [selectedOllamaModel, setSelectedOllamaModel] = useState<string>(() => {
     return localStorage.getItem(OLLAMA_MODEL_STORAGE) || ''
   })
-  const [selectedKnapsackModel, setSelectedKnapsackModel] = useState<string>(() => {
-    return localStorage.getItem(KNAPSACK_MODEL_STORAGE) || 'anthropic/claude-haiku-4-5'
-  })
   const [knapsackEmail, setKnapsackEmail] = useState<string>('')
+  const [isKnapsackConnecting, setIsKnapsackConnecting] = useState(false)
+  const [knapsackConnectError, setKnapsackConnectError] = useState<string | null>(null)
   const [selectedProvider, setSelectedProvider] = useState<Provider>(() => {
+    return (localStorage.getItem(ACTIVE_PROVIDER_STORAGE) as Provider) || 'openai'
+  })
+  // Tracks the backend-confirmed active provider separately from selectedProvider,
+  // which also changes when the user opens an accordion (before any save).
+  const [confirmedProvider, setConfirmedProvider] = useState<Provider>(() => {
     return (localStorage.getItem(ACTIVE_PROVIDER_STORAGE) as Provider) || 'openai'
   })
   const [savingKey, setSavingKey] = useState(false)
@@ -2013,6 +2012,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         }
         if (keyStatus.active_provider) {
           setSelectedProvider(keyStatus.active_provider as Provider)
+          setConfirmedProvider(keyStatus.active_provider as Provider)
           localStorage.setItem(ACTIVE_PROVIDER_STORAGE, keyStatus.active_provider)
         }
         // Store masked key hints for placeholders
@@ -2036,10 +2036,6 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         })
         if (keyStatus.knapsack_email) {
           setKnapsackEmail(keyStatus.knapsack_email)
-        }
-        if (keyStatus.knapsack_model) {
-          setSelectedKnapsackModel(keyStatus.knapsack_model)
-          localStorage.setItem(KNAPSACK_MODEL_STORAGE, keyStatus.knapsack_model)
         }
         // Restore Ollama model from backend if Ollama is the active provider
         if (keyStatus.ollama_enabled && keyStatus.ollama_model) {
@@ -2866,6 +2862,34 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         },
       )
       cleanups.push(unlistenCompose)
+
+      // Knapsack deep-link auth callback from the OS URL scheme handler
+      const unlistenKnapsackConnected = await tauriListen<{ email: string }>(
+        'knapsack-connected',
+        (event) => {
+          if (cancelled) return
+          const { email } = event.payload
+          setKnapsackEmail(email)
+          setIsKnapsackConnecting(false)
+          setKnapsackConnectError(null)
+          setSelectedProvider('knapsack')
+          setConfirmedProvider('knapsack')
+          localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
+          setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
+          pushAssistant(`Connected to Knapsack as **${email}**.`)
+        },
+      )
+      cleanups.push(unlistenKnapsackConnected)
+
+      const unlistenKnapsackError = await tauriListen<{ error: string }>(
+        'knapsack-auth-error',
+        (event) => {
+          if (cancelled) return
+          setIsKnapsackConnecting(false)
+          setKnapsackConnectError(event.payload.error || 'Connection failed')
+        },
+      )
+      cleanups.push(unlistenKnapsackError)
     })()
 
     return () => {
@@ -2989,6 +3013,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         model: selectedOllamaModel,
       })
       localStorage.setItem(OLLAMA_MODEL_STORAGE, selectedOllamaModel)
+      setConfirmedProvider('ollama')
+      localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'ollama')
       setShowKeyPrompt(false)
       setHasCompletedOnboarding(true)
       localStorage.setItem(ONBOARDING_VERSION_STORAGE, APP_VERSION)
@@ -3038,6 +3064,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       } else if (selectedProvider === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
       }
+      setConfirmedProvider(selectedProvider)
+      localStorage.setItem(ACTIVE_PROVIDER_STORAGE, selectedProvider)
       setShowKeyPrompt(false)
       setEditingProviderKey(false)
       setHasCompletedOnboarding(true)
@@ -3858,6 +3886,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     // messages reflect the model that was actually selected when sent, not the
     // model in localStorage (which can lag behind UI state changes).
     const activeModelAtSend = (() => {
+      if (selectedProvider === 'knapsack') return 'knapsack'
       const m = selectedProvider === 'ollama' ? selectedOllamaModel
         : selectedProvider === 'anthropic' ? selectedAnthropicModel
         : selectedProvider === 'gemini' ? selectedGeminiModel
@@ -4288,11 +4317,12 @@ ${actualText}`
           console.warn('[chat] agent-chat timed out after 300s, falling back to direct chat')
           agentTimeout.abort()
         }, 300_000) : null
-        // Combine user abort + timeout abort
+        // Combine user abort + timeout abort. Fallback to user signal so stop
+        // always works in environments where AbortSignal.any is unavailable.
         const agentSignal = agentTimeout
           ? (typeof AbortSignal !== 'undefined' && 'any' in AbortSignal
               ? (AbortSignal as any).any([controller.signal, agentTimeout.signal])
-              : agentTimeout.signal)
+              : controller.signal)
           : controller.signal
         try {
           const agentRes = await fetch(apiUrl('/api/clawd/agent-chat'), {
@@ -4690,12 +4720,13 @@ ${actualText}`
             {proactiveMode ? '🔔 Proactive' : '🔕 Reactive'}
           </button>
           <button disabled={busy} onClick={() => { const opening = !showKeyPrompt; setShowKeyPrompt(opening); setShowSkillsPanel(false); setShowChannelsPanel(false); if (opening && externalActivityPanel && onCloseActivity) onCloseActivity() }} className={showKeyPrompt ? 'toggle-on' : ''} title="Change AI provider, API key, or model">
-            {selectedProvider === 'anthropic' ? (ANTHROPIC_MODELS.find(m => m.id === selectedAnthropicModel)?.name || selectedAnthropicModel || 'Anthropic')
-              : selectedProvider === 'gemini' ? (GEMINI_MODELS.find(m => m.id === selectedGeminiModel)?.name || selectedGeminiModel || 'Gemini')
-              : selectedProvider === 'groq' ? (GROQ_MODELS.find(m => m.id === selectedGroqModel)?.name || selectedGroqModel || 'Groq')
-              : selectedProvider === 'xai' ? (XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel || 'Grok')
-              : selectedProvider === 'ollama' ? (selectedOllamaModel || 'Ollama')
-              : selectedProvider === 'openrouter' ? (OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel || 'OpenRouter')
+            {confirmedProvider === 'anthropic' ? (ANTHROPIC_MODELS.find(m => m.id === selectedAnthropicModel)?.name || selectedAnthropicModel || 'Anthropic')
+              : confirmedProvider === 'gemini' ? (GEMINI_MODELS.find(m => m.id === selectedGeminiModel)?.name || selectedGeminiModel || 'Gemini')
+              : confirmedProvider === 'groq' ? (GROQ_MODELS.find(m => m.id === selectedGroqModel)?.name || selectedGroqModel || 'Groq')
+              : confirmedProvider === 'xai' ? (XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel || 'Grok')
+              : confirmedProvider === 'ollama' ? (selectedOllamaModel || 'Ollama')
+              : confirmedProvider === 'openrouter' ? (OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel || 'OpenRouter')
+              : confirmedProvider === 'knapsack' ? 'Knapsack'
               : (OPENAI_MODELS.find(m => m.id === selectedModel)?.name || selectedModel || 'OpenAI')}
           </button>
           <button disabled={busy} onClick={() => setShowToneSelector(true)}>
@@ -6642,54 +6673,101 @@ ${actualText}`
                         <svg className="ClawdAccordionChevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
                       </button>
                       <div className="ClawdAccordionBody">
-                        {knapsackEmail && (
-                          <p style={{ margin: '0 0 10px', fontSize: 12, color: '#64748b' }}>
-                            Signed in as <strong>{knapsackEmail}</strong>
-                          </p>
+                        {knapsackEmail ? (
+                          <>
+                            <p style={{ margin: '0 0 10px', fontSize: 12, color: '#64748b' }}>
+                              Signed in as <strong>{knapsackEmail}</strong>
+                            </p>
+                            <div className="ClawdAccordionActions">
+                              <button
+                                className="ClawdChannelCardAction ClawdChannelCardAction--connect"
+                                onClick={async () => {
+                                  if (confirmedProvider === 'knapsack') return
+                                  setSavingKey(true)
+                                  try {
+                                    await apiPost('/api/clawd/service/set-api-key', {
+                                      provider: 'knapsack',
+                                      key: '',
+                                    })
+                                    setSelectedProvider('knapsack')
+                                    setConfirmedProvider('knapsack')
+                                    localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
+                                    setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
+                                    pushAssistant('Switched to Knapsack.')
+                                  } catch {}
+                                  setSavingKey(false)
+                                }}
+                                disabled={savingKey || confirmedProvider === 'knapsack'}
+                              >
+                                {savingKey ? 'Switching...' : confirmedProvider === 'knapsack' ? 'Active' : 'Use Knapsack'}
+                              </button>
+                              <button
+                                className="ClawdChannelCardAction"
+                                style={{ marginLeft: 8, opacity: 0.7 }}
+                                onClick={async () => {
+                                  try {
+                                    const res = await apiPost<{ ok: boolean; fallback_provider?: string }>(
+                                      '/api/clawd/service/knapsack-disconnect', {}
+                                    )
+                                    const next = (res?.fallback_provider || 'openai') as Provider
+                                    setSelectedProvider(next)
+                                    setConfirmedProvider(next)
+                                    localStorage.setItem(ACTIVE_PROVIDER_STORAGE, next)
+                                  } catch {}
+                                  setKnapsackEmail('')
+                                  setKnapsackConnectError(null)
+                                }}
+                                disabled={savingKey}
+                              >
+                                Disconnect
+                              </button>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            {knapsackConnectError && (
+                              <p style={{ margin: '0 0 10px', fontSize: 12, color: '#92400e', background: '#fef3c7', border: '1px solid #fcd34d', borderRadius: 6, padding: '8px 10px' }}>
+                                {knapsackConnectError}
+                              </p>
+                            )}
+                            {isKnapsackConnecting ? (
+                              <p style={{ margin: '0 0 12px', fontSize: 12, color: '#64748b' }}>
+                                Waiting for sign-in from your browser…{' '}
+                                <button
+                                  style={{ background: 'none', border: 'none', color: '#c54841', cursor: 'pointer', padding: 0, fontSize: 12, textDecoration: 'underline' }}
+                                  onClick={() => setIsKnapsackConnecting(false)}
+                                >
+                                  Cancel
+                                </button>
+                              </p>
+                            ) : (
+                              <p style={{ margin: '0 0 12px', fontSize: 12, color: '#64748b' }}>
+                                Sign in with your Knapsack account to use the cloud AI — no API key needed.
+                              </p>
+                            )}
+                            <div className="ClawdAccordionActions">
+                              <button
+                                className="ClawdChannelCardAction ClawdChannelCardAction--connect"
+                                disabled={isKnapsackConnecting}
+                                onClick={() => {
+                                  setIsKnapsackConnecting(true)
+                                  setKnapsackConnectError(null)
+                                  const callbackUrl = encodeURIComponent('http://127.0.0.1:8897/api/auth/knapsack-callback')
+                                  const studioBase = import.meta.env.VITE_KN_STUDIO_SERVER || 'https://studio.knapsack.ai'
+                                  const studioUrl = `${studioBase}/desktop-connect?callback=${callbackUrl}`
+                                  shellOpen(studioUrl).catch(() => {
+                                    window.open(studioUrl, '_blank')
+                                  })
+                                }}
+                              >
+                                {isKnapsackConnecting ? 'Waiting…' : 'Connect with Knapsack'}
+                              </button>
+                            </div>
+                            <p style={{ margin: '8px 0 0', fontSize: 11, color: '#94a3b8' }}>
+                              A browser window will open. Sign in and click "Connect Desktop" — you'll be redirected back automatically.
+                            </p>
+                          </>
                         )}
-                        <label className="ClawdKeyPromptLabel">Model tier</label>
-                        <div className="ClawdModelSelector">
-                          {KNAPSACK_MODELS.map(model => (
-                            <button
-                              key={model.id}
-                              className={`ClawdModelOption${selectedKnapsackModel === model.id ? ' selected' : ''}`}
-                              onClick={() => {
-                                setSelectedKnapsackModel(model.id)
-                                localStorage.setItem(KNAPSACK_MODEL_STORAGE, model.id)
-                              }}
-                              disabled={savingKey}
-                            >
-                              <span className="ClawdModelName">{model.name}</span>
-                              <span className="ClawdModelDesc">{model.description}</span>
-                            </button>
-                          ))}
-                        </div>
-                        <div className="ClawdAccordionActions">
-                          <button
-                            className="ClawdChannelCardAction ClawdChannelCardAction--connect"
-                            onClick={async () => {
-                              if (!knapsackEmail) return
-                              setSavingKey(true)
-                              try {
-                                await apiPost('/api/clawd/service/set-api-key', { provider: 'knapsack', key: knapsackEmail, model: selectedKnapsackModel })
-                                setSelectedProvider('knapsack')
-                                localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
-                                setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
-                                pushAssistant(`Switched to Knapsack (${KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel}).`)
-                              } catch {}
-                              setSavingKey(false)
-                            }}
-                            disabled={savingKey || !knapsackEmail}
-                          >
-                            {savingKey ? 'Switching...' : isActive ? 'Select' : 'Use Knapsack'}
-                          </button>
-                        </div>
-                        <p style={{ margin: '8px 0 0', fontSize: 11, color: '#94a3b8' }}>
-                          Need credits?{' '}
-                          <a href="https://studio.knapsack.ai" target="_blank" rel="noopener noreferrer" style={{ color: '#c54841' }}>
-                            studio.knapsack.ai
-                          </a>
-                        </p>
                       </div>
                     </div>
                   )


### PR DESCRIPTION
## Summary

- **Model delegation**: Knapsack provider now sends `"auto"` as the model so the Knapsack backend selects the best available model per subscription, instead of hardcoding `gpt-5.4` or `anthropic/claude-haiku-4-5`
- **Active provider button**: Shows the confirmed backend-active provider label (not the accordion-open provider), fixing the stale `gpt-5.4` display next to the Reactive button
- **`confirmedProvider` state**: Separates accordion open state from backend-confirmed active provider so opening the Knapsack accordion no longer permanently disables the "Use Knapsack" button
- **Stop button fix**: `AbortSignal.any` fallback was using only the timeout signal, dropping the user's abort signal — fixed to fall back to `controller.signal` so stop always works
- **Disconnect**: New `/api/clawd/service/knapsack-disconnect` endpoint properly clears the access token, refresh token, and env vars, then switches to the next available provider
- **Ollama switch crash**: `ollama_configure` now calls `mark_gateway_launch_started()` after `kickstart -k` so `set_service_enabled` sees the grace period and skips the second blocking restart that was stalling the tokio runtime

## Test plan

- [ ] Connect Knapsack account — "Active" button shows, provider button shows "Knapsack" (not a model name)
- [ ] Open a different provider accordion — provider button label stays "Knapsack"
- [ ] Send a message with Knapsack active — no `gpt-5.4` in error messages
- [ ] Press Stop during a Knapsack response — request aborts immediately
- [ ] Switch to Ollama — app does not crash/quit
- [ ] Switch back to Knapsack from Ollama — "Use Knapsack" button is enabled and clickable
- [ ] Click Disconnect — token is cleared, provider switches to next available

🤖 Generated with [Claude Code](https://claude.com/claude-code)