### PR TITLE
[codex] Fix Windows gateway startup readiness

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -115,10 +115,10 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: "963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com"
           VITE_GOOGLE_DEVELOPER_KEY: ""
 
-      - name: Pack node_modules into tar for WiX
+      - name: Pack node_modules into tar for Windows installer
         # Run from within the clawdbot dir so tar needs no path juggling.
-        # WiX candle.exe chokes generating XML for ~13k node_modules files;
-        # packing into one tar reduces the WiX input to ~3k files.
+        # Packing node_modules into one file keeps the Windows installer input
+        # small and avoids slow/fragile handling of thousands of resource files.
         working-directory: src/src-tauri/resources/clawdbot
         shell: pwsh
         run: |
@@ -135,7 +135,7 @@ jobs:
           Remove-Item -Recurse -Force node_modules
           $mb = [math]::Round((Get-Item node_modules.tar).Length / 1MB, 1)
           $n  = (Get-ChildItem -Recurse . | Measure-Object).Count
-          Write-Host "node_modules.tar: $mb MB. WiX will see $n files."
+          Write-Host "node_modules.tar: $mb MB. Windows installer will see $n files."
 
       - name: Disable beforeBuildCommand in tauri.conf.json
         # The frontend is already compiled above. Remove beforeBuildCommand so
@@ -165,19 +165,15 @@ jobs:
         run: dotnet tool install --global AzureSignTool
 
       # Tauri v1's signCommand %1 substitution is broken (passes literal "%1" to
-      # AzureSignTool). We sign the EXE and MSI after the build instead.
-      # Note: the EXE copy inside the MSI archive is not Authenticode-signed
-      # (WiX already packaged it before we sign); the MSI installer itself and
-      # the standalone EXE on disk are both signed.
+      # AzureSignTool). We sign the EXE and NSIS installer after the build instead.
 
       - name: Build Tauri app
         working-directory: src
         shell: pwsh
-        # --bundles msi uses Tauri v1's WiX-based MSI bundler (64-bit light.exe),
-        # which handles the large clawdbot resource set without NSIS (32-bit) OOM.
+        # NSIS current-user mode installs under LOCALAPPDATA and avoids UAC.
         run: |
           $log = "$env:RUNNER_TEMP\tauri-build.log"
-          npx tauri build --bundles msi --verbose 2>&1 | Tee-Object -FilePath $log
+          npx tauri build --bundles nsis --verbose 2>&1 | Tee-Object -FilePath $log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         env:
           VITE_KN_API_SERVER: https://api.knapsack.ai
@@ -195,7 +191,7 @@ jobs:
         run: |
           Get-PSDrive C | Select-Object Used, Free | ForEach-Object { Write-Host "Disk after build: used=$([math]::Round($_.Used/1GB,1))GB free=$([math]::Round($_.Free/1GB,1))GB" }
 
-      - name: Sign release binary and MSI
+      - name: Sign release binary and NSIS installer
         if: env.AZURE_KEY_VAULT_URI != ''
         shell: pwsh
         env:
@@ -218,8 +214,8 @@ jobs:
           Write-Host "=== EXEs in target/release ==="
           Get-ChildItem 'src\src-tauri\target\release\' -Filter '*.exe' -ErrorAction SilentlyContinue |
             ForEach-Object { Write-Host "  $($_.FullName)" }
-          Write-Host "=== MSIs in bundle/msi ==="
-          Get-ChildItem 'src\src-tauri\target\release\bundle\msi\' -Filter '*.msi' -ErrorAction SilentlyContinue |
+          Write-Host "=== NSIS installers in bundle/nsis ==="
+          Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\' -Filter '*.exe' -ErrorAction SilentlyContinue |
             ForEach-Object { Write-Host "  $($_.FullName)" }
 
           # Sign the release EXE (Tauri renames knapsack.exe → Knapsack.exe for WiX)
@@ -233,13 +229,13 @@ jobs:
             Write-Warning "Knapsack.exe not found; skipping EXE signing"
           }
 
-          # Sign each MSI produced by the WiX bundler
-          $msiBundles = @(Get-ChildItem 'src\src-tauri\target\release\bundle\msi\*.msi' -ErrorAction SilentlyContinue)
-          foreach ($msi in $msiBundles) {
-            Write-Host "Signing MSI: $($msi.FullName)"
-            AzureSignTool sign @s $msi.FullName
-            if ($LASTEXITCODE -ne 0) { Write-Error "Failed to sign MSI: $($msi.FullName)"; exit 1 }
-            Write-Host "Signed MSI OK"
+          # Sign each NSIS installer.
+          $nsisBundles = @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
+          foreach ($installer in $nsisBundles) {
+            Write-Host "Signing NSIS installer: $($installer.FullName)"
+            AzureSignTool sign @s $installer.FullName
+            if ($LASTEXITCODE -ne 0) { Write-Error "Failed to sign NSIS installer: $($installer.FullName)"; exit 1 }
+            Write-Host "Signed NSIS installer OK"
           }
 
       - name: Post build log to PR on failure
@@ -268,9 +264,12 @@ jobs:
           path: ${{ runner.temp }}/tauri-build.log
           if-no-files-found: ignore
 
-      - name: Upload MSI artifact
+      - name: Upload NSIS artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: knapsack-windows-msi
-          path: src/src-tauri/target/release/bundle/msi/*.msi
+          name: knapsack-windows-nsis
+          path: |
+            src/src-tauri/target/release/bundle/nsis/*.exe
+            src/src-tauri/target/release/bundle/nsis/*.nsis.zip
+            src/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Windows — MSI installer (WiX, 64-bit)
+  # Windows — NSIS current-user installer
   # ---------------------------------------------------------------------------
   build-windows:
     needs: bump-version
@@ -343,10 +343,10 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: "963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com"
           VITE_GOOGLE_DEVELOPER_KEY: ""
 
-      - name: Pack node_modules into tar for WiX
+      - name: Pack node_modules into tar for Windows installer
         # Run from within the clawdbot dir so tar needs no path juggling.
-        # WiX candle.exe chokes generating XML for ~13k node_modules files;
-        # packing into one tar reduces the WiX input to ~3k files.
+        # Packing node_modules into one file keeps the Windows installer input
+        # small and avoids slow/fragile handling of thousands of resource files.
         working-directory: src/src-tauri/resources/clawdbot
         shell: pwsh
         run: |
@@ -363,7 +363,7 @@ jobs:
           Remove-Item -Recurse -Force node_modules
           $mb = [math]::Round((Get-Item node_modules.tar).Length / 1MB, 1)
           $n  = (Get-ChildItem -Recurse . | Measure-Object).Count
-          Write-Host "node_modules.tar: $mb MB. WiX will see $n files."
+          Write-Host "node_modules.tar: $mb MB. Windows installer will see $n files."
 
       - name: Disable beforeBuildCommand in tauri.conf.json
         # The frontend is already compiled above. Remove beforeBuildCommand so
@@ -446,11 +446,10 @@ jobs:
       - name: Build Tauri app
         working-directory: src
         shell: pwsh
-        # --bundles msi uses Tauri v1's WiX-based MSI bundler (64-bit light.exe),
-        # which handles the large clawdbot resource set without NSIS (32-bit) OOM.
+        # NSIS current-user mode installs under LOCALAPPDATA and avoids UAC.
         run: |
           $log = "$env:RUNNER_TEMP\tauri-build.log"
-          npx tauri build --bundles msi --verbose 2>&1 | Tee-Object -FilePath $log
+          npx tauri build --bundles nsis --verbose 2>&1 | Tee-Object -FilePath $log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
@@ -499,9 +498,9 @@ jobs:
         with:
           name: windows-artifacts
           path: |
-            src/src-tauri/target/release/bundle/msi/*.msi
-            src/src-tauri/target/release/bundle/msi/*.msi.zip
-            src/src-tauri/target/release/bundle/msi/*.msi.zip.sig
+            src/src-tauri/target/release/bundle/nsis/*.exe
+            src/src-tauri/target/release/bundle/nsis/*.nsis.zip
+            src/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -541,7 +540,7 @@ jobs:
 
           WIN_SIG=""
           WIN_ZIP_NAME=""
-          for f in artifacts/windows-artifacts/**/*.msi.zip.sig artifacts/windows-artifacts/*.msi.zip.sig; do
+          for f in artifacts/windows-artifacts/**/*.nsis.zip.sig artifacts/windows-artifacts/*.nsis.zip.sig; do
             if [ -f "$f" ]; then
               WIN_SIG=$(cat "$f")
               WIN_ZIP_NAME=$(basename "${f%.sig}")
@@ -581,7 +580,7 @@ jobs:
           # macOS
           find artifacts/macos-artifacts -type f \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \) -exec cp {} release-files/ \;
           # Windows
-          find artifacts/windows-artifacts -type f \( -name "*.msi" -o -name "*.msi.zip" -o -name "*.msi.zip.sig" \) -exec cp {} release-files/ \;
+          find artifacts/windows-artifacts -type f \( -name "*.exe" -o -name "*.nsis.zip" -o -name "*.nsis.zip.sig" \) -exec cp {} release-files/ \;
           # Updater metadata
           cp artifacts/latest.json release-files/
           echo "[release] Files to upload:"

--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -101,8 +101,12 @@ function findPluginsNeedingRuntimeDeps(clawdbotDir) {
 
 // Collect the directories to install into (source always; target when present).
 const clawdbotDirs = [SOURCE_CLAWDBOT_DIR];
-if (fs.existsSync(TARGET_CLAWDBOT_DIR)) {
+if (fs.existsSync(path.join(TARGET_CLAWDBOT_DIR, 'package.json'))) {
   clawdbotDirs.push(TARGET_CLAWDBOT_DIR);
+} else if (fs.existsSync(TARGET_CLAWDBOT_DIR)) {
+  console.warn(
+    `[ensure-clawdbot-deps] Skipping incomplete target debug clawdbot copy: ${path.relative(path.join(__dirname, '..'), TARGET_CLAWDBOT_DIR)}`,
+  );
 }
 
 // Step 1: install main clawdbot deps in each dir.

--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -340,9 +340,10 @@ if (IS_WIN) {
 // On Windows: pruneDirectoriesOnly (dirs only, fast) + LONG_PATH_PACKAGE_SUBDIRS for known
 // packages whose filenames themselves are too long even without test-artifact dirs.
 // After pruning on Windows, each extension's node_modules is tar-packed into a single
-// node_modules.tar. This keeps WiX under its 65535-file CAB limit (LGHT0306): large dep
-// trees (@jimp, @aws-sdk, @discordjs, @slack, etc.) across all extensions can collectively
-// exceed this limit. service.rs extracts each tar at gateway startup.
+// node_modules.tar. This keeps Windows installer input compact: large dep trees
+// (@jimp, @aws-sdk, @discordjs, @slack, etc.) across all extensions can
+// collectively overwhelm resource bundling. service.rs extracts each tar at
+// gateway startup.
 // Subdirectories of packages whose filenames exceed Windows MAX_PATH (260 chars)
 // when placed under the full extension node_modules install path. WiX light.exe
 // fails with LGHT0103 on these. List the subdir to remove (not the whole package,
@@ -364,11 +365,29 @@ const EXTENSION_UNUSED_PACKAGES = [
   'sharp',
 ];
 
+function extensionStagesRuntimeDependencies(extensionDir) {
+  const pkgPath = path.join(extensionDir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return pkg?.openclaw?.bundle?.stageRuntimeDependencies === true;
+  } catch {
+    return false;
+  }
+}
+
 if (fs.existsSync(distExtensionsDir)) {
   try {
     for (const extEntry of fs.readdirSync(distExtensionsDir, { withFileTypes: true })) {
       if (!extEntry.isDirectory()) continue;
-      const extNodeModules = path.join(distExtensionsDir, extEntry.name, 'node_modules');
+      const extDir = path.join(distExtensionsDir, extEntry.name);
+      const extNodeModules = path.join(extDir, 'node_modules');
+      const extNodeModulesTar = path.join(extDir, 'node_modules.tar');
+      const stagesRuntimeDeps = extensionStagesRuntimeDependencies(extDir);
+      if (IS_WIN && !stagesRuntimeDeps && fs.existsSync(extNodeModulesTar)) {
+        fs.rmSync(extNodeModulesTar, { force: true });
+        console.log(`[prune-clawdbot]     removed unstaged extension node_modules.tar: ${extEntry.name}`);
+      }
       if (fs.existsSync(extNodeModules)) {
         console.log(`[prune-clawdbot]     cleaning extension node_modules: ${extEntry.name}`);
         if (IS_WIN) {
@@ -389,13 +408,16 @@ if (fs.existsSync(distExtensionsDir)) {
           }
         }
 
-        // On Windows: tar-pack extension node_modules to stay under WiX's 65535-file
-        // CAB limit (LGHT0306). Large dep trees (e.g. @jimp, @aws-sdk, @slack,
-        // @discordjs) across all extensions easily exceed this limit.
-        // Packing into one tar per extension reduces thousands of files to one.
-        // service.rs extracts each tar at gateway startup before launching Node.js.
+        // On Windows: only staged plugins need extension-local dependency archives.
+        // Other extensions resolve from the root bundled node_modules; removing their
+        // stray local installs keeps the installer small and the build loop fast.
         if (IS_WIN) {
-          const extDir = path.join(distExtensionsDir, extEntry.name);
+          if (!stagesRuntimeDeps) {
+            fs.rmSync(extNodeModules, { recursive: true, force: true });
+            console.log(`[prune-clawdbot]     removed unstaged extension node_modules: ${extEntry.name}`);
+            continue;
+          }
+
           try {
             const { spawnSync } = require('child_process');
             const result = spawnSync('tar', ['-cf', 'node_modules.tar', 'node_modules'], {

--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -582,6 +582,8 @@ if (isWindows) {
 const REQUIRED_STAGE_RUNTIME_DEPS_PLUGINS = [
   'browser',   // playwright-core — core browser/navigate tool
   'slack',     // @slack/web-api / Bolt SDK — Slack plugin registration
+  'telegram',  // grammy runner — Telegram channel registration
+  'whatsapp',  // baileys / jimp — WhatsApp channel registration
 ];
 
 if (fs.existsSync(extensionsDir)) {

--- a/src/src-tauri/resources/clawdbot/dist/bot-deps-D1DzQ4CT.js
+++ b/src/src-tauri/resources/clawdbot/dist/bot-deps-D1DzQ4CT.js
@@ -376,9 +376,12 @@ function syncTelegramMenuCommands(params) {
 		});
 		writeCachedCommandHash(accountId, botIdentity, currentHash);
 	};
-	sync().catch((err) => {
+	const syncDelayMs = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" ? Number.parseInt(process.env.OPENCLAW_DEFER_TELEGRAM_MENU_SYNC_MS ?? "5000", 10) : 0;
+	const runSync = () => sync().catch((err) => {
 		runtime.error?.(`Telegram command sync failed: ${String(err)}`);
 	});
+	if (Number.isFinite(syncDelayMs) && syncDelayMs > 0) setTimeout(runSync, syncDelayMs).unref?.();
+	else runSync();
 }
 //#endregion
 //#region extensions/telegram/src/draft-stream.ts

--- a/src/src-tauri/resources/clawdbot/dist/cli/run-main.js
+++ b/src/src-tauri/resources/clawdbot/dist/cli/run-main.js
@@ -454,7 +454,8 @@ async function runCli(argv = process$1.argv) {
 		proxyHandle = null;
 		handle?.kill("SIGTERM");
 	};
-	if (!isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv)) {
+	const isDesktopManagedGateway = isTruthyEnvValue(process$1.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY) && isGatewayRunFastPathArgv(normalizedArgv);
+	if (!isDesktopManagedGateway && !isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv)) {
 		const config = await readBestEffortCliConfig();
 		const unownedPrimary = await resolveUnownedCliPrimary({
 			argv: normalizedArgv,
@@ -572,7 +573,7 @@ async function runCli(argv = process$1.argv) {
 			});
 			return;
 		}
-		const shouldUseCliEnvProxy = !isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv);
+		const shouldUseCliEnvProxy = !isDesktopManagedGateway && !isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv);
 		const bootstrapProxyBeforeFastPath = shouldUseCliEnvProxy && shouldBootstrapCliProxyBeforeFastPath();
 		if (!bootstrapProxyBeforeFastPath && await tryRunGatewayRunFastPath(normalizedArgv, startupTrace)) return;
 		if (!isHelpOrVersionInvocation) await bootstrapCliProxyCaptureAndDispatcher(startupTrace, { ensureDispatcher: shouldUseCliEnvProxy });

--- a/src/src-tauri/resources/clawdbot/dist/extensions/telegram/package.json
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/telegram/package.json
@@ -51,6 +51,9 @@
         "specifier": "./configured-state",
         "exportName": "hasTelegramConfiguredState"
       }
+    },
+    "bundle": {
+      "stageRuntimeDependencies": true
     }
   }
 }

--- a/src/src-tauri/resources/clawdbot/dist/extensions/whatsapp/dist/channel.runtime-BZ_ya3mR.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/whatsapp/dist/channel.runtime-BZ_ya3mR.js
@@ -1,10 +1,12 @@
 import { startWebLoginWithQr as startWebLoginWithQr$1, waitForWebLogin as waitForWebLogin$1 } from "./login-qr-runtime.js";
 import { c as logoutWeb$1, d as readWebAuthExistsBestEffort$1, f as readWebAuthExistsForDecision$1, g as readWebSelfId$1, h as readWebAuthState$1, m as readWebAuthSnapshotBestEffort$1, o as getWebAuthAgeMs$1, p as readWebAuthSnapshot$1, s as logWebSelfId$1, x as webAuthExists$1 } from "./auth-store-GTQvJznL.js";
 import { t as getActiveWebListener$1 } from "./active-listener-B4SDebQ6.js";
-import { t as monitorWebChannel$1 } from "./monitor-ClhD-fQ6.js";
 import { t as loginWeb$1 } from "./login-nJwaNuC-.js";
 import { whatsappSetupWizard as whatsappSetupWizard$1 } from "./setup-surface-Uoh9W_29.js";
 //#region extensions/whatsapp/src/channel.runtime.ts
+async function loadMonitorRuntime() {
+	return await import("./monitor-ClhD-fQ6.js");
+}
 function getActiveWebListener(...args) {
 	return getActiveWebListener$1(...args);
 }
@@ -48,8 +50,8 @@ async function waitForWebLogin(...args) {
 	return await waitForWebLogin$1(...args);
 }
 const whatsappSetupWizard = { ...whatsappSetupWizard$1 };
-function monitorWebChannel(...args) {
-	return monitorWebChannel$1(...args);
+async function monitorWebChannel(...args) {
+	return await (await loadMonitorRuntime()).t(...args);
 }
 //#endregion
 export { getActiveWebListener, getWebAuthAgeMs, logWebSelfId, loginWeb, logoutWeb, monitorWebChannel, readWebAuthExistsBestEffort, readWebAuthExistsForDecision, readWebAuthSnapshot, readWebAuthSnapshotBestEffort, readWebAuthState, readWebSelfId, startWebLoginWithQr, waitForWebLogin, webAuthExists, whatsappSetupWizard };

--- a/src/src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js
+++ b/src/src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js
@@ -1,0 +1,9 @@
+import { runGatewayCommand } from "./run-BG5Tcrgc.js";
+
+await runGatewayCommand({
+	allowUnconfigured: true,
+	bind: "loopback",
+	auth: "token",
+	token: process.env.OPENCLAW_GATEWAY_TOKEN,
+	port: process.env.OPENCLAW_GATEWAY_PORT ?? "18789"
+});

--- a/src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js
@@ -156,8 +156,10 @@ const MAX_RESTART_ATTEMPTS = 10;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5e3;
 const CHANNEL_STARTUP_CONCURRENCY = 4;
 function waitForChannelStartupHandoff() {
+	const delayMs = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" ? Number.parseInt(process.env.OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS ?? "5000", 10) : 0;
 	return new Promise((resolve) => {
-		setImmediate(resolve).unref?.();
+		if (Number.isFinite(delayMs) && delayMs > 0) setTimeout(resolve, delayMs).unref?.();
+		else setImmediate(resolve).unref?.();
 	});
 }
 function createRuntimeStore() {

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-config-C-rNKEbY.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-config-C-rNKEbY.js
@@ -9,7 +9,8 @@ import { t as applyPluginAutoEnable } from "./plugin-auto-enable-CuCUT4Z1.js";
 import { a as getActiveSecretsRuntimeSnapshot, l as setPreparedSecretsRuntimeSnapshotRefreshContext, o as getLiveSecretsRuntimeAuthStores, t as activateSecretsRuntimeSnapshotState } from "./runtime-state-CPpp7_ve.js";
 import { n as evaluateGatewayAuthSurfaceStates, t as GATEWAY_AUTH_SURFACE_PATHS } from "./runtime-gateway-auth-surfaces-C7es4SNw.js";
 import { i as assertGatewayAuthNotKnownWeak, n as mergeGatewayAuthConfig, r as mergeGatewayTailscaleConfig, t as ensureGatewayStartupAuth } from "./startup-auth-CWNnB8iD.js";
-import { a as prepareSecretsRuntimeFastPathSnapshot, o as resolveRefreshAgentDirs } from "./runtime-fast-path-B08T2SHO.js";
+import { a as prepareSecretsRuntimeFastPathSnapshot, o as resolveRefreshAgentDirs, i as mergeSecretsRuntimeEnv, n as collectCandidateAgentDirs, r as createEmptyRuntimeWebToolsMetadata } from "./runtime-fast-path-B08T2SHO.js";
+import { o as coerceSecretRef } from "./types.secrets-DwPik3M8.js";
 import { isDeepStrictEqual } from "node:util";
 //#region src/gateway/server-startup-config.ts
 async function loadGatewayStartupConfigSnapshot(params) {
@@ -46,6 +47,33 @@ function withRuntimeConfig(snapshot, runtimeConfig) {
 		runtimeConfig,
 		config: runtimeConfig
 	};
+}
+function createDesktopManagedNoopSecretsSnapshot(config) {
+	const runtimeEnv = mergeSecretsRuntimeEnv(process.env);
+	const sourceConfig = structuredClone(config);
+	const resolvedConfig = structuredClone(config);
+	const authStores = collectCandidateAgentDirs(resolvedConfig, runtimeEnv).map((agentDir) => ({
+		agentDir,
+		store: {
+			version: 1,
+			profiles: {}
+		}
+	}));
+	return {
+		sourceConfig,
+		config: resolvedConfig,
+		authStores,
+		warnings: [],
+		webTools: createEmptyRuntimeWebToolsMetadata()
+	};
+}
+function hasDesktopManagedSecretRefCandidate(value, defaults, seen = /* @__PURE__ */ new WeakSet()) {
+	if (coerceSecretRef(value, defaults)) return true;
+	if (!value || typeof value !== "object") return false;
+	if (seen.has(value)) return false;
+	seen.add(value);
+	if (Array.isArray(value)) return value.some((entry) => hasDesktopManagedSecretRefCandidate(entry, defaults, seen));
+	return Object.values(value).some((entry) => hasDesktopManagedSecretRefCandidate(entry, defaults, seen));
 }
 function createRuntimeSecretsActivator(params) {
 	let secretsDegraded = false;
@@ -97,6 +125,15 @@ function createRuntimeSecretsActivator(params) {
 	const activateRuntimeSecrets = (async (config, activationParams) => await runWithSecretsActivationLock(async () => {
 		try {
 			const startupPreflight = activationParams.reason === "startup" || activationParams.reason === "restart-check";
+			if (activationParams.reason === "startup" && activationParams.activate && process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && !hasDesktopManagedSecretRefCandidate(config, config.secrets?.defaults)) return await finishPreparedSnapshot(createDesktopManagedNoopSecretsSnapshot(config), activationParams, { activateRuntimeSecretsSnapshot: (snapshot) => activateSecretsRuntimeSnapshotState({
+				snapshot,
+				refreshContext: {
+					env: mergeSecretsRuntimeEnv(process.env),
+					explicitAgentDirs: null,
+					includeAuthStoreRefs: true,
+					loadablePluginOrigins: /* @__PURE__ */ new Map()
+				}
+			}) });
 			if (activationParams.reason === "startup" && activationParams.activate && !params.prepareRuntimeSecretsSnapshot && !params.activateRuntimeSecretsSnapshot) {
 				const fastPath = prepareSecretsRuntimeFastPathSnapshot({ config: pruneSkippedStartupSecretSurfaces(config) });
 				if (fastPath) return await finishPreparedSnapshot(fastPath.snapshot, activationParams, { activateRuntimeSecretsSnapshot: (snapshot) => activateSecretsRuntimeSnapshotState({

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-plugins-CD06rso_.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-plugins-CD06rso_.js
@@ -40,7 +40,7 @@ async function prepareGatewayPluginBootstrap(params) {
 		await Promise.all(startupTasks);
 	}
 	initSubagentRegistry();
-	const gatewayPluginConfig = params.minimalTestGateway || desktopManagedGateway ? params.cfgAtStart : mergeActivationSectionsIntoRuntimeConfig({
+	const gatewayPluginConfig = params.minimalTestGateway ? params.cfgAtStart : mergeActivationSectionsIntoRuntimeConfig({
 		runtimeConfig: params.cfgAtStart,
 		activationConfig: applyPluginAutoEnable({
 			config: activationSourceConfig,
@@ -50,7 +50,7 @@ async function prepareGatewayPluginBootstrap(params) {
 	});
 	const pluginsGloballyDisabled = gatewayPluginConfig.plugins?.enabled === false;
 	const defaultWorkspaceDir = resolveAgentWorkspaceDir(gatewayPluginConfig, resolveDefaultAgentId(gatewayPluginConfig));
-	const pluginLookUpTable = params.minimalTestGateway || desktopManagedGateway || pluginsGloballyDisabled ? void 0 : loadPluginLookUpTable({
+	const pluginLookUpTable = params.minimalTestGateway || pluginsGloballyDisabled ? void 0 : loadPluginLookUpTable({
 		config: gatewayPluginConfig,
 		workspaceDir: defaultWorkspaceDir,
 		env: process.env,

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
@@ -563,6 +563,7 @@ function createDeferredGatewayUpdateCheck(params) {
 }
 async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewayPostAttachRuntimeDeps) {
 	let pluginRegistry = params.pluginRegistry;
+	const desktopManagedGateway = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1";
 	if (!params.minimalTestGateway && params.loadStartupPlugins) {
 		params.onStartupPluginsLoading?.();
 		const loaded = await measureStartup(params.startupTrace, "plugins.runtime-post-bind", () => params.loadStartupPlugins());
@@ -570,7 +571,7 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 		params.startupTrace?.detail("plugins.runtime-post-bind", [["loadedPluginCount", pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length], ["gatewayMethodCount", loaded.gatewayMethods.length]]);
 		await params.onStartupPluginsLoaded?.(loaded);
 	}
-	const startupLogPromise = measureStartup(params.startupTrace, "post-attach.log", () => runtimeDeps.logGatewayStartup({
+	const logGatewayStartup = () => runtimeDeps.logGatewayStartup({
 		cfg: params.cfgAtStart,
 		bindHost: params.bindHost,
 		bindHosts: params.bindHosts,
@@ -580,7 +581,8 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 		log: params.log,
 		isNixMode: params.isNixMode,
 		startupStartedAt: params.startupStartedAt
-	}));
+	});
+	const startupLogPromise = desktopManagedGateway ? Promise.resolve(null) : measureStartup(params.startupTrace, "post-attach.log", logGatewayStartup);
 	const updateCheck = params.minimalTestGateway ? {
 		start: () => {},
 		stop: () => {}
@@ -649,6 +651,9 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 		params.startupTrace?.detail("sidecars.ready", [["loadedPluginCount", pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length], ["postReadySidecarCount", postReadySidecars.length + gatewayLifetimeSidecars.length]]);
 		params.startupTrace?.mark("sidecars.ready");
 		params.log.info("gateway ready");
+		if (desktopManagedGateway) measureStartup(params.startupTrace, "post-attach.log.deferred", logGatewayStartup).catch((err) => {
+			params.log.warn(`deferred gateway startup log failed: ${String(err)}`);
+		});
 		return {
 			...result,
 			postReadySidecars,

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -253,7 +253,7 @@ fn is_pid_alive(pid: u32) -> bool {
 static BROWSER_START_NUDGED: AtomicBool = AtomicBool::new(false);
 static GATEWAY_LAST_LAUNCH_MS: AtomicU64 = AtomicU64::new(0);
 static QA_DIRECT_GATEWAY_FIRST_SEEN_MS: AtomicU64 = AtomicU64::new(0);
-const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 600_000;
+const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 15_000;
 const PLUGIN_RUNTIME_DEPS_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(600);
 const PLUGIN_RUNTIME_DEPS_OWNER_LOCK_GRACE_MS: u64 = 180_000;
 
@@ -378,11 +378,20 @@ fn gateway_launch_grace_active() -> Option<u64> {
     return None;
   }
   let elapsed = now_epoch_ms().saturating_sub(started);
-  if elapsed < GATEWAY_PRE_BIND_STARTUP_GRACE_MS {
-    Some(elapsed)
-  } else {
-    None
+  let pid = GATEWAY_PID.load(Ordering::Relaxed);
+  if pid > 0 {
+    if process_is_alive(pid) {
+      return Some(elapsed);
+    }
+    GATEWAY_PID.store(0, Ordering::Relaxed);
+    GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
+    return None;
   }
+  if elapsed >= GATEWAY_PRE_BIND_STARTUP_GRACE_MS {
+    GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
+    return None;
+  }
+  Some(elapsed)
 }
 
 #[cfg(target_os = "macos")]
@@ -1279,8 +1288,52 @@ fn process_is_alive(pid: u32) -> bool {
 }
 
 #[cfg(not(unix))]
-fn process_is_alive(_pid: u32) -> bool {
-  false
+fn process_is_alive(pid: u32) -> bool {
+  if pid == 0 {
+    return false;
+  }
+  #[cfg(target_os = "windows")]
+  {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    return std::process::Command::new("tasklist")
+      .args(["/FI", &format!("PID eq {}", pid), "/NH"])
+      .creation_flags(CREATE_NO_WINDOW)
+      .output()
+      .ok()
+      .filter(|output| output.status.success())
+      .map(|output| {
+        let out = String::from_utf8_lossy(&output.stdout);
+        out.lines().any(|line| {
+          let trimmed = line.trim_start();
+          !trimmed.starts_with("INFO:")
+            && trimmed
+              .split_whitespace()
+              .nth(1)
+              .and_then(|s| s.parse::<u32>().ok())
+              == Some(pid)
+        })
+      })
+      .unwrap_or(false);
+  }
+  #[cfg(not(target_os = "windows"))]
+  {
+    false
+  }
+}
+
+#[cfg(target_os = "windows")]
+fn node_arg_path(path: &Path) -> String {
+  let raw = path.to_string_lossy();
+  raw
+    .strip_prefix(r"\\?\")
+    .unwrap_or(raw.as_ref())
+    .to_string()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn node_arg_path(path: &Path) -> String {
+  path.to_string_lossy().to_string()
 }
 
 fn plugin_runtime_deps_install_in_progress(clawdbot_home: &std::path::Path) -> bool {
@@ -1592,6 +1645,12 @@ fn install_bundled_plugin_runtime_deps(
     NpmRunner::NpmBin(PathBuf::from("npm"))
   };
 
+  let clawdbot_root = match extensions_dir.parent().and_then(|p| p.parent()) {
+    Some(r) => r.to_path_buf(),
+    None => return,
+  };
+  let root_nm = clawdbot_root.join("node_modules");
+
   let entries = match fs::read_dir(extensions_dir) {
     Ok(e) => e,
     Err(_) => return,
@@ -1628,6 +1687,18 @@ fn install_bundled_plugin_runtime_deps(
       .and_then(|v| v.as_object())
       .map(|m| m.keys().cloned().collect())
       .unwrap_or_default();
+
+    let all_present_in_root = !deps.is_empty()
+      && deps
+        .iter()
+        .all(|dep| root_nm.join(dep).join("package.json").exists());
+    if all_present_in_root {
+      eprintln!(
+        "[clawd/service] Plugin {} runtime deps satisfied by bundled root node_modules",
+        entry.file_name().to_string_lossy()
+      );
+      continue;
+    }
 
     // On Windows CI builds the extension node_modules is packed into
     // node_modules.tar to keep WiX under its 65535-file CAB limit.
@@ -1708,12 +1779,6 @@ fn install_bundled_plugin_runtime_deps(
   // resolve require() from the ROOT clawdbot node_modules — not from the per-plugin
   // node_modules installed above.  Collect all plugin runtime deps that are missing
   // from root node_modules and install them there with a targeted npm install.
-  let clawdbot_root = match extensions_dir.parent().and_then(|p| p.parent()) {
-    Some(r) => r.to_path_buf(),
-    None => return,
-  };
-  let root_nm = clawdbot_root.join("node_modules");
-
   if !root_nm.is_dir() && clawdbot_root.join("package.json").exists() {
     eprintln!(
       "[clawd/service] Root node_modules missing in {} — attempting npm install",
@@ -1919,6 +1984,23 @@ fn install_bundled_plugin_runtime_deps(
   ensure_openclaw_self_link(&root_nm);
 }
 
+fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path: &std::path::Path) -> bool {
+  let pkg_path = dir.join("package.json");
+  let Ok(raw) = fs::read_to_string(&pkg_path) else {
+    return false;
+  };
+  let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&raw) else {
+    return false;
+  };
+  let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) else {
+    return false;
+  };
+  !deps.is_empty()
+    && deps
+      .keys()
+      .all(|dep| nm_path.join(dep).join("package.json").exists())
+}
+
 /// On Windows CI builds, prune-clawdbot.cjs packs `node_modules/` into
 /// `node_modules.tar` (one file) so WiX stays under its 65535-file CAB limit
 /// (LGHT0306).  This function extracts the tar back to `node_modules/` at
@@ -1940,6 +2022,50 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
   }
 
   let nm_path = dir.join("node_modules");
+  let marker_path = nm_path.join(".knapsack-extracted-from-tar.json");
+  let tar_meta = fs::metadata(&tar_path).ok();
+  let tar_len = tar_meta.as_ref().map(|m| m.len()).unwrap_or(0);
+  let tar_mtime_secs = tar_meta
+    .as_ref()
+    .and_then(|m| m.modified().ok())
+    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+    .map(|d| d.as_secs())
+    .unwrap_or(0);
+
+  if nm_path.is_dir() {
+    let marker_current = fs::read_to_string(&marker_path)
+      .ok()
+      .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+      .map(|v| {
+        v.get("tar_len").and_then(|n| n.as_u64()) == Some(tar_len)
+          && v
+            .get("tar_mtime_secs")
+            .and_then(|n| n.as_u64())
+            == Some(tar_mtime_secs)
+      })
+      .unwrap_or(false);
+    if marker_current && bundled_node_modules_has_declared_dependencies(dir, &nm_path) {
+      return;
+    }
+    if bundled_node_modules_has_declared_dependencies(dir, &nm_path) {
+      let marker = serde_json::json!({
+        "tar_len": tar_len,
+        "tar_mtime_secs": tar_mtime_secs,
+      });
+      let _ = fs::write(&marker_path, marker.to_string());
+      eprintln!(
+        "[clawd/service] node_modules present and complete in {} - skipping tar extraction",
+        dir.display()
+      );
+      return;
+    }
+    eprintln!(
+      "[clawd/service] node_modules.tar extraction marker missing/stale in {} - re-extracting",
+      dir.display()
+    );
+    let _ = fs::remove_dir_all(&nm_path);
+  }
+
   if nm_path.is_dir() {
     // Already extracted — check if the tar is newer (app was updated in-place).
     let tar_mtime = fs::metadata(&tar_path).and_then(|m| m.modified()).ok();
@@ -1969,10 +2095,17 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       .creation_flags(CREATE_NO_WINDOW)
       .status();
     match result {
-      Ok(s) if s.success() => eprintln!(
-        "[clawd/service] node_modules.tar extracted in {}",
-        dir.display()
-      ),
+      Ok(s) if s.success() => {
+        let marker = serde_json::json!({
+          "tar_len": tar_len,
+          "tar_mtime_secs": tar_mtime_secs,
+        });
+        let _ = fs::write(&marker_path, marker.to_string());
+        eprintln!(
+          "[clawd/service] node_modules.tar extracted in {}",
+          dir.display()
+        );
+      }
       Ok(s) => eprintln!(
         "[clawd/service] WARNING: node_modules.tar extraction exited {} in {}",
         s,
@@ -1991,23 +2124,48 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
 /// bundled extensions can resolve `openclaw/plugin-sdk/*` imports at runtime.
 /// This symlink is removed by prune-clawdbot.cjs before the Tauri build (to
 /// avoid an infinite glob cycle), so it must be recreated here at startup.
-fn ensure_openclaw_self_link(root_nm: &std::path::Path) {
+fn ensure_openclaw_link_to(root_nm: &std::path::Path, target: &std::path::Path) {
   let link_path = root_nm.join("openclaw");
+  if link_path.join("package.json").exists()
+    && link_path
+      .join("plugin-sdk")
+      .join("channel-message.js")
+      .exists()
+  {
+    return; // already present and complete
+  }
+
   if link_path.exists() || link_path.symlink_metadata().is_ok() {
-    return; // already present
+    let backup_path = root_nm.join(format!(
+      ".knapsack-openclaw-incomplete-{}",
+      now_epoch_ms()
+    ));
+    match fs::rename(&link_path, &backup_path) {
+      Ok(()) => eprintln!(
+        "[clawd/service] Moved incomplete openclaw link/package aside: {}",
+        backup_path.display()
+      ),
+      Err(err) => {
+        eprintln!(
+          "[clawd/service] WARNING: could not repair incomplete openclaw link/package {}: {}",
+          link_path.display(),
+          err
+        );
+        return;
+      }
+    }
   }
 
   #[cfg(target_os = "windows")]
   {
     // Use mklink /J to create a directory junction — no elevation required.
     // Symlinks (mklink /D) require SeCreateSymbolicLinkPrivilege; junctions don't.
-    let parent = root_nm.parent().unwrap_or(root_nm);
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
     let status = std::process::Command::new("cmd")
       .args(["/c", "mklink", "/J"])
       .arg(&link_path)
-      .arg(parent)
+      .arg(target)
       .creation_flags(CREATE_NO_WINDOW)
       .status();
     match status {
@@ -2027,7 +2185,7 @@ fn ensure_openclaw_self_link(root_nm: &std::path::Path) {
 
   #[cfg(not(target_os = "windows"))]
   {
-    match std::os::unix::fs::symlink("..", &link_path) {
+    match std::os::unix::fs::symlink(target, &link_path) {
       Ok(()) => eprintln!("[clawd/service] Created openclaw self-link in node_modules"),
       Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
       Err(e) => eprintln!(
@@ -2036,6 +2194,11 @@ fn ensure_openclaw_self_link(root_nm: &std::path::Path) {
       ),
     }
   }
+}
+
+fn ensure_openclaw_self_link(root_nm: &std::path::Path) {
+  let target = root_nm.parent().unwrap_or(root_nm);
+  ensure_openclaw_link_to(root_nm, target);
 }
 
 fn ensure_clawdbot_runtime_self_link(clawdbot_entry: &std::path::Path) {
@@ -2050,6 +2213,33 @@ fn ensure_clawdbot_runtime_self_link(clawdbot_entry: &std::path::Path) {
     return;
   }
   ensure_openclaw_self_link(&clawdbot_root.join("node_modules"));
+
+  // Bundled extension files live under `dist/extensions/...`, so Node's normal
+  // package lookup reaches `dist/node_modules` before the root node_modules.
+  // Put the same self-link there to avoid the slower gateway transform loader
+  // for `openclaw/plugin-sdk/*` imports on the startup path.
+  let dist_nm = clawdbot_root.join("dist").join("node_modules");
+  if let Err(err) = fs::create_dir_all(&dist_nm) {
+    eprintln!(
+      "[clawd/service] WARNING: could not create dist node_modules for openclaw self-link: {}",
+      err
+    );
+  } else {
+    ensure_openclaw_link_to(&dist_nm, clawdbot_root);
+  }
+
+  let extensions_nm = clawdbot_root
+    .join("dist")
+    .join("extensions")
+    .join("node_modules");
+  if let Err(err) = fs::create_dir_all(&extensions_nm) {
+    eprintln!(
+      "[clawd/service] WARNING: could not create extensions node_modules for openclaw self-link: {}",
+      err
+    );
+  } else {
+    ensure_openclaw_link_to(&extensions_nm, clawdbot_root);
+  }
 }
 
 fn should_mutate_bundled_clawdbot_runtime(path: &std::path::Path) -> bool {
@@ -7594,9 +7784,7 @@ async fn prepare_gateway_config(
 
   let node_candidates: Vec<PathBuf> = if cfg!(target_os = "windows") {
     let mut candidates = Vec::new();
-    if !cfg!(debug_assertions) {
-      candidates.push(bundled_node.clone());
-    }
+    candidates.push(bundled_node.clone());
     // Search PATH for node.exe
     if let Ok(path_var) = std::env::var("PATH") {
       for dir in path_var.split(';') {
@@ -7607,9 +7795,6 @@ async fn prepare_gateway_config(
       }
     }
     candidates.push(PathBuf::from(r"C:\Program Files\nodejs\node.exe"));
-    if cfg!(debug_assertions) {
-      candidates.push(bundled_node.clone());
-    }
     candidates
   } else if cfg!(debug_assertions) {
     vec![
@@ -7663,13 +7848,17 @@ async fn prepare_gateway_config(
   // ── Find clawdbot entry ────────────────────────────────────────────
   let clawdbot_entry = if cfg!(debug_assertions) {
     if cfg!(target_os = "windows") {
-      // Dev on Windows: look for workspace entry
-      let ws_entry = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("resources")
-        .join("clawdbot")
-        .join("dist")
-        .join("entry.js");
-      ws_entry
+      let bundled_entry =
+        resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js");
+      if bundled_entry.exists() {
+        bundled_entry
+      } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+          .join("resources")
+          .join("clawdbot")
+          .join("dist")
+          .join("knapsack-gateway-entry.js")
+      }
     } else {
       let sys_entry = PathBuf::from("/opt/homebrew/lib/node_modules/clawdbot/dist/entry.js");
       let ws_entry = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -7684,7 +7873,7 @@ async fn prepare_gateway_config(
       }
     }
   } else {
-    resource_path(app_handle, "resources/clawdbot/dist/entry.js")
+    resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js")
   };
 
   if !clawdbot_entry.exists() {
@@ -7764,6 +7953,11 @@ async fn prepare_gateway_config(
         "allow": KNAPSACK_REQUIRED_PLUGINS,
         "slots": {
           "memory": "none"
+        }
+      },
+      "models": {
+        "pricing": {
+          "enabled": false
         }
       },
       "tools": {
@@ -8525,6 +8719,37 @@ async fn prepare_gateway_config(
           patched = true;
         }
 
+        let pricing_enabled = cfg_val
+          .pointer("/models/pricing/enabled")
+          .and_then(|v| v.as_bool());
+        if pricing_enabled != Some(false) {
+          if cfg_val.get("models").and_then(|v| v.as_object()).is_none() {
+            cfg_val
+              .as_object_mut()
+              .unwrap()
+              .insert("models".to_string(), serde_json::json!({}));
+          }
+          if cfg_val
+            .pointer("/models/pricing")
+            .and_then(|v| v.as_object())
+            .is_none()
+          {
+            cfg_val
+              .pointer_mut("/models")
+              .unwrap()
+              .as_object_mut()
+              .unwrap()
+              .insert("pricing".to_string(), serde_json::json!({}));
+          }
+          if let Some(pricing) = cfg_val
+            .pointer_mut("/models/pricing")
+            .and_then(|v| v.as_object_mut())
+          {
+            pricing.insert("enabled".to_string(), serde_json::Value::Bool(false));
+            patched = true;
+          }
+        }
+
         // Restore restart-sensitive fields before any write — these are no-ops
         // under normal operation but guard against a future patch accidentally
         // dropping them and triggering "deferring until N tasks complete".
@@ -8657,8 +8882,8 @@ async fn prepare_gateway_config(
 
   // ── Build program args ────────────────────────────────────────────
   let program_args = vec![
-    node_path.to_string_lossy().to_string(),
-    clawdbot_entry.to_string_lossy().to_string(),
+    node_arg_path(&node_path),
+    node_arg_path(&clawdbot_entry),
     "gateway".to_string(),
     "run".to_string(),
     "--allow-unconfigured".to_string(),
@@ -8674,12 +8899,12 @@ async fn prepare_gateway_config(
 
   // ── Build environment variables ───────────────────────────────────
   let bundled_plugins_dir = bundled_plugins_dir(app_handle);
-  let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
+  let bundled_plugins_dir_str = node_arg_path(&bundled_plugins_dir);
   let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
 
   let node_dir = node_path
     .parent()
-    .map(|p| p.to_string_lossy().to_string())
+    .map(node_arg_path)
     .unwrap_or_default();
   let path_separator = if cfg!(target_os = "windows") {
     ";"
@@ -8750,6 +8975,7 @@ async fn prepare_gateway_config(
     ),
     ("OPENCLAW_QUIET_CONFIG_VERSION".to_string(), "1".to_string()),
     ("OPENCLAW_DISABLE_BONJOUR".to_string(), "1".to_string()),
+    ("OPENCLAW_PATH_BOOTSTRAPPED".to_string(), "1".to_string()),
     (
       "OPENCLAW_BUNDLED_CHANNEL_FALLBACK_IDS".to_string(),
       configured_channel_fallback_ids,
@@ -8759,6 +8985,10 @@ async fn prepare_gateway_config(
     (
       "OPENCLAW_GATEWAY_STARTUP_WARMUP_TIMEOUT_MS".to_string(),
       "2000".to_string(),
+    ),
+    (
+      "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM".to_string(),
+      "1".to_string(),
     ),
     (
       "OPENCLAW_CHANNEL_STARTUP_HANDOFF_TIMEOUT_MS".to_string(),
@@ -8784,14 +9014,6 @@ async fn prepare_gateway_config(
       "OPENCLAW_GATEWAY_STARTUP_TRACE".to_string(),
       "1".to_string(),
     ),
-    // Prevents the clawdbot gateway's doctor/inspect flow from classifying this
-    // plist as a legacy "clawdbot" service and moving it to Trash.  The inspector
-    // checks for these two keys to recognise a plist as a current openclaw gateway.
-    (
-      "OPENCLAW_SERVICE_MARKER".to_string(),
-      "openclaw".to_string(),
-    ),
-    ("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()),
     // Ensure Node.js resolves packages from the bundled flat node_modules
     // directory.  Without this, stale nested node_modules can cause
     // ERR_PACKAGE_PATH_NOT_EXPORTED errors.
@@ -8835,6 +9057,13 @@ async fn prepare_gateway_config(
         }
       }
     }
+  } else {
+    // Prevents the macOS gateway inspector from classifying this LaunchAgent as
+    // a legacy "clawdbot" service and moving it to Trash. On Windows these
+    // markers mean "schtasks-supervised" to OpenClaw, which adds a 30s lock
+    // recovery wait to the desktop-managed direct gateway startup path.
+    env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
+    env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
   }
 
   // Propagate LLM keys
@@ -9064,6 +9293,35 @@ pub async fn set_service_enabled(
     let enabled = payload.enabled;
 
     if enabled {
+      if let Some(grace_ms) = gateway_launch_grace_active() {
+        {
+          let mut cfg_guard = cfg.write().await;
+          cfg_guard.base_url = Some("http://127.0.0.1:18791".to_string());
+        }
+        eprintln!(
+          "[clawd/service] Enable request: Windows gateway launch already in progress for {}ms; preserving startup",
+          grace_ms
+        );
+        return HttpResponse::Ok().json(EnableServiceResponse {
+          success: true,
+          enabled,
+          message: "Gateway startup is already in progress".to_string(),
+        });
+      }
+      if gateway_tcp_port_open(std::time::Duration::from_millis(150)).await {
+        {
+          let mut cfg_guard = cfg.write().await;
+          cfg_guard.base_url = Some("http://127.0.0.1:18791".to_string());
+        }
+        mark_gateway_launch_started();
+        eprintln!("[clawd/service] Enable request: Windows gateway already listening");
+        return HttpResponse::Ok().json(EnableServiceResponse {
+          success: true,
+          enabled,
+          message: "Gateway is already running".to_string(),
+        });
+      }
+
       // If a background restart is already in progress, wait for it to
       // finish rather than spawning a second gateway process.
       if GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
@@ -9426,7 +9684,11 @@ pub async fn set_service_enabled(
           .join("resources")
           .join("clawdbot")
           .join("dist")
-          .join("entry.js");
+          .join(if cfg!(target_os = "windows") {
+            "knapsack-gateway-entry.js"
+          } else {
+            "entry.js"
+          });
 
         if sys_entry.exists() {
           sys_entry
@@ -9435,7 +9697,10 @@ pub async fn set_service_enabled(
         }
       } else {
         // Production: use bundled clawdbot JS inside the .app
-        resource_path(&app_handle, "resources/clawdbot/dist/entry.js")
+        resource_path(
+          &app_handle,
+          "resources/clawdbot/dist/knapsack-gateway-entry.js",
+        )
       };
 
       // Verify clawdbot entry exists
@@ -9530,6 +9795,11 @@ pub async fn set_service_enabled(
             "allow": KNAPSACK_REQUIRED_PLUGINS,
             "slots": {
               "memory": "none"
+            }
+          },
+          "models": {
+            "pricing": {
+              "enabled": false
             }
           },
           "tools": {
@@ -9735,6 +10005,37 @@ pub async fn set_service_enabled(
 
             if ensure_knapsack_plugin_allowlist(&mut cfg) {
               patched = true;
+            }
+
+            let pricing_enabled = cfg
+              .pointer("/models/pricing/enabled")
+              .and_then(|v| v.as_bool());
+            if pricing_enabled != Some(false) {
+              if cfg.get("models").and_then(|v| v.as_object()).is_none() {
+                cfg
+                  .as_object_mut()
+                  .unwrap()
+                  .insert("models".to_string(), serde_json::json!({}));
+              }
+              if cfg
+                .pointer("/models/pricing")
+                .and_then(|v| v.as_object())
+                .is_none()
+              {
+                cfg
+                  .pointer_mut("/models")
+                  .unwrap()
+                  .as_object_mut()
+                  .unwrap()
+                  .insert("pricing".to_string(), serde_json::json!({}));
+              }
+              if let Some(pricing) = cfg
+                .pointer_mut("/models/pricing")
+                .and_then(|v| v.as_object_mut())
+              {
+                pricing.insert("enabled".to_string(), serde_json::Value::Bool(false));
+                patched = true;
+              }
             }
 
             // Remove bundled extensions directory from plugins.load.paths.
@@ -10344,8 +10645,8 @@ pub async fn set_service_enabled(
 
       // Run in local mode with explicit tokens/ports.
       let program_args = vec![
-        node_path.to_string_lossy().to_string(),
-        clawdbot_entry.to_string_lossy().to_string(),
+        node_arg_path(&node_path),
+        node_arg_path(&clawdbot_entry),
         "gateway".to_string(),
         "run".to_string(),
         "--allow-unconfigured".to_string(),
@@ -10360,7 +10661,7 @@ pub async fn set_service_enabled(
       ];
 
       // bundled_plugins_dir was resolved earlier (before config patching)
-      let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
+      let bundled_plugins_dir_str = node_arg_path(&bundled_plugins_dir);
       let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
       eprintln!(
         "[clawd/service] Skipping blocking OpenClaw doctor --fix during startup config preparation"
@@ -10371,7 +10672,7 @@ pub async fn set_service_enabled(
       // minimal PATH by default which typically excludes /opt/homebrew/bin.
       let node_dir = node_path
         .parent()
-        .map(|p| p.to_string_lossy().to_string())
+        .map(node_arg_path)
         .unwrap_or_default();
       let mut path_parts: Vec<String> = Vec::new();
       if !node_dir.is_empty() {
@@ -10434,6 +10735,7 @@ pub async fn set_service_enabled(
         // log the warning only once on startup instead of on every read cycle.
         ("OPENCLAW_QUIET_CONFIG_VERSION".to_string(), "1".to_string()),
         ("OPENCLAW_DISABLE_BONJOUR".to_string(), "1".to_string()),
+        ("OPENCLAW_PATH_BOOTSTRAPPED".to_string(), "1".to_string()),
         (
           "OPENCLAW_BUNDLED_CHANNEL_FALLBACK_IDS".to_string(),
           configured_channel_fallback_ids,
@@ -10443,6 +10745,10 @@ pub async fn set_service_enabled(
         (
           "OPENCLAW_GATEWAY_STARTUP_WARMUP_TIMEOUT_MS".to_string(),
           "2000".to_string(),
+        ),
+        (
+          "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM".to_string(),
+          "1".to_string(),
         ),
         (
           "OPENCLAW_CHANNEL_STARTUP_HANDOFF_TIMEOUT_MS".to_string(),
@@ -10464,14 +10770,6 @@ pub async fn set_service_enabled(
           "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
           "1".to_string(),
         ),
-        // Prevents the clawdbot gateway's doctor/inspect flow from classifying this
-        // plist as a legacy "clawdbot" service and moving it to Trash.  The inspector
-        // checks for these two keys to recognise a plist as a current openclaw gateway.
-        (
-          "OPENCLAW_SERVICE_MARKER".to_string(),
-          "openclaw".to_string(),
-        ),
-        ("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()),
         // Ensure Node.js resolves packages from the bundled flat node_modules
         // directory. Without this, stale nested node_modules (e.g. created by
         // a local pnpm install) can cause ERR_PACKAGE_PATH_NOT_EXPORTED errors
@@ -10484,6 +10782,15 @@ pub async fn set_service_enabled(
           nm.to_string_lossy().to_string()
         }),
       ];
+
+      if !cfg!(target_os = "windows") {
+        // Prevents the macOS gateway inspector from classifying this LaunchAgent
+        // as a legacy "clawdbot" service and moving it to Trash. On Windows
+        // these markers mean "schtasks-supervised" to OpenClaw, which adds a
+        // 30s lock recovery wait to the desktop-managed direct gateway startup.
+        env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
+        env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
+      }
 
       // Propagate LLM keys to clawdbot subprocess AND to the current Tauri process
       // (so the notetaker/transcription can also use GROQ_API_KEY via std::env::var).

--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -184,7 +184,7 @@
           "language": "en-US"
         },
         "nsis": {
-          "installMode": "both",
+          "installMode": "currentUser",
           "languages": [
             "English"
           ],


### PR DESCRIPTION
## Summary
- Switch Windows packaging to a current-user NSIS installer so installs avoid UAC/Defender friction from per-machine elevation.
- Add a Windows desktop-managed gateway entry path and bundled Node/plugin dependency handling so gateway startup does not fall back to slow OpenClaw CLI supervision.
- Defer non-critical startup work and make browser/channel sidecars report ready within the 15-second launch goal.

## Root Cause
Windows production startup was paying for OpenClaw CLI/service recovery behavior, secrets/model-pricing work, and plugin/channel initialization before the gateway/browser/channel surfaces became usable. Plugin runtime dependency staging could also fail or churn when bundled `node_modules` and OpenClaw self-links were incomplete.

## Validation
- Cold debug QA loop reached gateway ready in about 14.0s from `[gateway] starting...`; internal readiness trace reported sidecars ready in 11.77s.
- Browser control listened before the 15-second target, and Telegram/WhatsApp channel startup markers completed within the same readiness window.
- Main app API sweep returned OK for release type, recording status, feed items, workspaces, clawd service status, and skills status; direct gateway `/health` returned live.
- `cd src && npx tsc --noEmit`
- `cd src && cargo build --manifest-path src-tauri/Cargo.toml -j 1`
- `cd src && cargo test --manifest-path src-tauri/Cargo.toml clawd`