### PR TITLE
[codex] Fix macOS release gateway PID compile

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -17,7 +17,6 @@ pub(crate) const IMESSAGE_OWNER_UNCONFIGURED_SENTINEL: &str =
 // ── Windows process management ──────────────────────────────────────────
 // On Windows we spawn the gateway as a child process (no launchd/launchctl).
 // Track the PID so we can check status and kill it on disable.
-#[cfg(target_os = "windows")]
 static GATEWAY_PID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
 /// Stores the last successful ServiceSetup so the background restart task can


### PR DESCRIPTION
## Summary
- Make the gateway PID tracker available to shared Rust startup code on all platforms.

## Why
The Windows startup readiness PR added a shared `gateway_launch_grace_active()` check that reads `GATEWAY_PID`, but the static was still gated to Windows. Windows tests passed, but the release macOS universal build failed with `cannot find value GATEWAY_PID in this scope`.

## Validation
- `cd src && cargo test --manifest-path src-tauri/Cargo.toml clawd`
- `cd src && cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-apple-darwin` progressed past the previous `GATEWAY_PID` error and stopped at local Windows host toolchain setup (`cc` unavailable for Apple target), which is expected outside the macOS runner.