### PR TITLE
Fix Windows gateway startup readiness

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
@@ -320,6 +320,7 @@ function schedulePrimaryModelPrewarm(params, prewarm = prewarmConfiguredPrimaryM
 async function startGatewaySidecars(params) {
 	const postReadySidecars = [];
 	const internalHooksConfigured = hasConfiguredInternalHooks(params.cfg);
+	const deferredDesktopChannels = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && process.env.OPENCLAW_DESKTOP_AUTO_START_CHANNELS === "0";
 	await measureStartup(params.startupTrace, "sidecars.internal-hooks", async () => {
 		try {
 			if (internalHooksConfigured) {
@@ -359,7 +360,25 @@ async function startGatewaySidecars(params) {
 				log: params.log,
 				startupTrace: params.startupTrace
 			}, params.prewarmPrimaryModel);
-			await measureStartup(params.startupTrace, "sidecars.channel-start", () => params.startChannels());
+			if (deferredDesktopChannels) {
+				params.logChannels.info("deferring channel startup until after gateway readiness");
+				const delayMs = Number.parseInt(process.env.OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS ?? "5000", 10);
+				setTimeout(() => {
+					(async () => {
+						try {
+							if (params.loadStartupPlugins) {
+								params.onStartupPluginsLoading?.();
+								const loaded = await measureStartup(params.startupTrace, "plugins.runtime-post-ready", () => params.loadStartupPlugins({ includeDeferred: true }));
+								params.startupTrace?.detail("plugins.runtime-post-ready", [["loadedPluginCount", loaded.pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length], ["gatewayMethodCount", loaded.gatewayMethods.length]]);
+								await params.onStartupPluginsLoaded?.(loaded);
+							}
+							await measureStartup(params.startupTrace, "sidecars.channel-start.deferred", () => params.startChannels());
+						} catch (err) {
+							params.logChannels.error(`deferred channel startup failed: ${String(err)}`);
+						}
+					})();
+				}, Number.isFinite(delayMs) && delayMs >= 0 ? delayMs : 5000).unref?.();
+			} else await measureStartup(params.startupTrace, "sidecars.channel-start", () => params.startChannels());
 		} catch (err) {
 			params.logChannels.error(`channel startup failed: ${String(err)}`);
 		}
@@ -626,6 +645,9 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 			logHooks: params.logHooks,
 			logChannels: params.logChannels,
 			startupTrace: params.startupTrace,
+			loadStartupPlugins: params.loadStartupPlugins,
+			onStartupPluginsLoading: params.onStartupPluginsLoading,
+			onStartupPluginsLoaded: params.onStartupPluginsLoaded,
 			onPluginServices: reportPluginServices
 		}));
 		const loaderStatsAfter = getPluginModuleLoaderStats();

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
@@ -2464,8 +2464,10 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			logHooks,
 			logChannels,
 			unavailableGatewayMethods,
-			loadStartupPlugins: runtimePluginsLoaded ? void 0 : async () => {
+			loadStartupPlugins: runtimePluginsLoaded ? void 0 : async (loadOptions = {}) => {
 				const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
+				const desktopManagedFastStartup = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && loadOptions.includeDeferred !== true;
+				const desktopFastPluginIds = new Set(["browser", "duckduckgo"]);
 				return loadGatewayStartupPluginRuntime({
 					cfg: gatewayPluginConfigAtStart,
 					activationSourceConfig: startupActivationSourceConfig,
@@ -2474,7 +2476,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 					baseMethods,
 					coreGatewayMethodNames,
 					hostServices: pluginHostServices,
-					startupPluginIds,
+					startupPluginIds: desktopManagedFastStartup ? startupPluginIds.filter((id) => desktopFastPluginIds.has(id)) : startupPluginIds,
 					pluginLookUpTable,
 					startupTrace
 				});

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -177,6 +177,31 @@ fn kill_process_on_port(port: u16) {
   );
 }
 
+#[cfg(target_os = "windows")]
+fn windows_pid_listening_on_port(port: u16) -> Option<u32> {
+  use std::os::windows::process::CommandExt;
+  const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+  let output = std::process::Command::new("netstat")
+    .args(["-ano", "-p", "tcp"])
+    .creation_flags(CREATE_NO_WINDOW)
+    .output()
+    .ok()?;
+  let text = String::from_utf8_lossy(&output.stdout);
+  for line in text.lines() {
+    if line.contains(&format!(":{} ", port)) && line.to_uppercase().contains("LISTENING") {
+      if let Some(pid_str) = line.split_whitespace().last() {
+        if let Ok(pid) = pid_str.parse::<u32>() {
+          if pid > 0 {
+            return Some(pid);
+          }
+        }
+      }
+    }
+  }
+  None
+}
+
 /// On Unix/macOS, kill a process listening on the given TCP port.
 /// Enhanced with retry logic to ensure the port is actually freed.
 #[cfg(not(target_os = "windows"))]
@@ -382,9 +407,23 @@ fn gateway_launch_grace_active() -> Option<u64> {
     if process_is_alive(pid) {
       return Some(elapsed);
     }
+    #[cfg(target_os = "windows")]
+    if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
+      if process_is_alive(listening_pid) {
+        GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
+        return Some(elapsed);
+      }
+    }
     GATEWAY_PID.store(0, Ordering::Relaxed);
     GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
     return None;
+  }
+  #[cfg(target_os = "windows")]
+  if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
+    if process_is_alive(listening_pid) {
+      GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
+      return Some(elapsed);
+    }
   }
   if elapsed >= GATEWAY_PRE_BIND_STARTUP_GRACE_MS {
     GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
@@ -5124,6 +5163,21 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     } else {
       gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
     };
+    #[cfg(target_os = "windows")]
+    if !gateway_ok && gateway_listening {
+      if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
+        if process_is_alive(listening_pid) {
+          let tracked_pid = GATEWAY_PID.load(Ordering::Relaxed);
+          if tracked_pid != listening_pid {
+            GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
+            eprintln!(
+              "[clawd/service] adopted live gateway listener pid {} while health is pending",
+              listening_pid
+            );
+          }
+        }
+      }
+    }
     let gateway_probe_failed = !gateway_ok;
 
     // Track gateway state transitions for recovery logic.
@@ -5226,6 +5280,11 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       eprintln!(
         "[clawd/service] gateway not reachable for {}ms after launch - waiting before self-heal",
         elapsed
+      );
+    } else if !gateway_ok && gateway_listening && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS {
+      eprintln!(
+        "[clawd/service] gateway port is listening but health is still pending for {}ms - waiting before self-heal",
+        unreachable_elapsed_ms
       );
     } else if !gateway_ok
       && !was_healthy
@@ -5569,21 +5628,38 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       // Windows-specific diagnostics: check tracked PID
       #[cfg(target_os = "windows")]
       {
-        let pid = GATEWAY_PID.load(Ordering::Relaxed);
-        if pid == 0 {
-          message.push_str("\n[diagnostic] No gateway process tracked — service may not be enabled. Try toggling Enable.");
-          eprintln!("[clawd/service] gateway down: no PID tracked");
-        } else if !is_pid_alive(pid) {
-          message.push_str(&format!(
-            "\n[diagnostic] Gateway process (pid {}) is no longer running. Try re-enabling.",
-            pid
-          ));
-          eprintln!("[clawd/service] gateway down: tracked pid {} is dead", pid);
+        let listening_pid = if gateway_listening {
+          windows_pid_listening_on_port(18789)
         } else {
-          eprintln!(
-            "[clawd/service] gateway down: process pid {} alive but not responding on port 18789",
-            pid
+          None
+        };
+        if let Some(listening_pid) = listening_pid {
+          GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
+          message.push_str(
+            "\n[diagnostic] Gateway process is listening on port 18789 but /health is still blocked by startup work.",
           );
+          diagnostic_type = Some("gateway_starting".to_string());
+          eprintln!(
+            "[clawd/service] gateway down: listener pid {} alive but /health is pending",
+            listening_pid
+          );
+        } else {
+          let pid = GATEWAY_PID.load(Ordering::Relaxed);
+          if pid == 0 {
+            message.push_str("\n[diagnostic] No gateway process tracked — service may not be enabled. Try toggling Enable.");
+            eprintln!("[clawd/service] gateway down: no PID tracked");
+          } else if !is_pid_alive(pid) {
+            message.push_str(&format!(
+              "\n[diagnostic] Gateway process (pid {}) is no longer running. Try re-enabling.",
+              pid
+            ));
+            eprintln!("[clawd/service] gateway down: tracked pid {} is dead", pid);
+          } else {
+            eprintln!(
+              "[clawd/service] gateway down: process pid {} alive but not responding on port 18789",
+              pid
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- adopt the live Windows gateway listener while health is pending to avoid duplicate self-heal starts
- keep desktop-managed readiness on fast startup plugins, then defer channel provider runtime startup until after gateway readiness
- preserve post-ready channel startup with startup trace markers for runtime plugin load and deferred channel start

## Validation
- `npx tsc --noEmit`
- `node --check` on the edited gateway bundles
- `git diff --check` on the edited files

Note: local `cargo test --manifest-path src-tauri/Cargo.toml clawd` and `cargo check --manifest-path src-tauri/Cargo.toml -q` were stopped after the Tauri build script spent several minutes scanning resources without completing on this Windows checkout; CI should run the full native build/test path.