### PR TITLE
Skip clean Windows gateway cleanup on launch

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -12561,9 +12561,12 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   // Prevent the background health-check task from racing us.
   GATEWAY_RESTART_IN_PROGRESS.store(true, Ordering::Relaxed);
 
-  kill_stale_clawdbot_chromes();
-  kill_process_on_port(18789);
-  std::thread::sleep(std::time::Duration::from_millis(500));
+  if windows_pid_listening_on_port(18800).is_some() {
+    kill_stale_clawdbot_chromes();
+  }
+  if windows_pid_listening_on_port(18789).is_some() {
+    kill_process_on_port(18789);
+  }
 
   // Remove stale gateway lock files so the new process starts without waiting.
   {


### PR DESCRIPTION
## Summary
- avoid killing/checking managed Chrome unless the CDP port is actually listening
- avoid killing the gateway port unless a listener is present
- remove the unconditional 500ms sleep from the clean Windows auto-enable launch path

## Validation
- `git diff --check -- src/src-tauri/src/clawd/service.rs`
- prod v2.2.4 QA showed warmed browser readiness at 15.54s, so this patch targets the remaining clean-launch margin