### PR TITLE
Tighten Windows startup readiness

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js
@@ -156,7 +156,7 @@ const MAX_RESTART_ATTEMPTS = 10;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5e3;
 const CHANNEL_STARTUP_CONCURRENCY = 4;
 function waitForChannelStartupHandoff() {
-	const delayMs = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" ? Number.parseInt(process.env.OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS ?? "5000", 10) : 0;
+	const delayMs = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" ? Number.parseInt(process.env.OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS ?? "0", 10) : 0;
 	return new Promise((resolve) => {
 		if (Number.isFinite(delayMs) && delayMs > 0) setTimeout(resolve, delayMs).unref?.();
 		else setImmediate(resolve).unref?.();

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
@@ -362,7 +362,7 @@ async function startGatewaySidecars(params) {
 			}, params.prewarmPrimaryModel);
 			if (deferredDesktopChannels) {
 				params.logChannels.info("deferring channel startup until after gateway readiness");
-				const delayMs = Number.parseInt(process.env.OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS ?? "5000", 10);
+				const delayMs = Number.parseInt(process.env.OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS ?? "0", 10);
 				setTimeout(() => {
 					(async () => {
 						try {
@@ -665,7 +665,7 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 		if (params.providerAuthPrewarm?.enabled !== false) gatewayLifetimeSidecars.push(scheduleProviderAuthStatePrewarm({
 			getConfig: params.providerAuthPrewarm?.getConfig ?? (() => params.cfgAtStart),
 			log: params.log,
-			delayMs: params.providerAuthPrewarm?.delayMs
+			delayMs: params.providerAuthPrewarm?.delayMs ?? (desktopManagedGateway ? 60000 : void 0)
 		}));
 		params.onPostReadySidecars?.(postReadySidecars);
 		params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5154,15 +5154,23 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       }
     };
 
-    // Gateway health is intentionally unauthenticated. A bound TCP port is not
-    // enough: during startup the gateway can accept connections while the Node
-    // event loop is still too busy to answer `/health`.
-    let gateway_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
+    // Gateway health is intentionally unauthenticated. Prefer the HTTP probe,
+    // but accept the gateway listener once browser control is also listening;
+    // channel startup can temporarily starve `/health` after the usable
+    // gateway/browser path is already online.
+    let gateway_http_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
+    let mut gateway_ok = gateway_http_ok;
     let gateway_listening = if gateway_ok {
       true
     } else {
       gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
     };
+    if !gateway_ok
+      && gateway_listening
+      && browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
+    {
+      gateway_ok = true;
+    }
     #[cfg(target_os = "windows")]
     if !gateway_ok && gateway_listening {
       if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
@@ -9070,6 +9078,10 @@ async fn prepare_gateway_config(
       "3000".to_string(),
     ),
     (
+      "OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS".to_string(),
+      "0".to_string(),
+    ),
+    (
       "OPENCLAW_DEFER_STARTUP_SIDECARS".to_string(),
       "1".to_string(),
     ),
@@ -10828,6 +10840,10 @@ pub async fn set_service_enabled(
         (
           "OPENCLAW_CHANNEL_STARTUP_HANDOFF_TIMEOUT_MS".to_string(),
           "3000".to_string(),
+        ),
+        (
+          "OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS".to_string(),
+          "0".to_string(),
         ),
         (
           "OPENCLAW_DEFER_STARTUP_SIDECARS".to_string(),

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -166,6 +166,15 @@ fn setup_handler(
 
   let app_handle = app.handle();
 
+  // Start the gateway as early as possible so it warms in parallel with
+  // app-local config and key propagation.
+  let auto_enable_handle = app.handle();
+  std::thread::spawn(move || {
+    tokio::runtime::Runtime::new()
+      .unwrap()
+      .block_on(clawd::service::auto_enable_if_needed(&auto_enable_handle));
+  });
+
   config::init_knapsack_config(
     app_handle
       .path_resolver()
@@ -176,15 +185,6 @@ fn setup_handler(
   // Load saved LLM API keys into env vars early, before the actix server
   // starts, so that llm_complete (meeting notes) and transcribe can use them.
   clawd::service::propagate_llm_keys_to_env(&app_handle);
-
-  // Auto-register the LaunchAgent on first launch so the user never sees
-  // "LaunchAgent plist not found — try toggling Enable in Settings."
-  let auto_enable_handle = app.handle();
-  std::thread::spawn(move || {
-    tokio::runtime::Runtime::new()
-      .unwrap()
-      .block_on(clawd::service::auto_enable_if_needed(&auto_enable_handle));
-  });
 
   let actix_app_handle = app.handle();
   let server_error_handle = actix_app_handle.clone();


### PR DESCRIPTION
## Summary
- Start the Windows gateway auto-enable path earlier in Tauri setup so it warms in parallel with app config/key initialization.
- Remove the desktop-managed channel handoff delay so post-ready channel initialization starts immediately.
- Delay desktop-managed provider-auth prewarm to 60s so it does not block gateway health during the launch window.
- Treat the gateway as app-healthy when the gateway listener and browser-control listener are both up, even if `/health` is temporarily starved by channel startup.

## QA / Validation
- Latest public prod `v2.2.5` signed installer downloaded and verified: signer `Knap, Inc.`, Authenticode valid.
- Installed prod build to per-user path: `C:\Users\markh\AppData\Local\Knapsack\Knapsack.exe`, version `2.2.5`.
- Prod QA before this patch:
  - Pass 1: app 6.520s, gateway port 13.159s, browser port 15.937s, gateway `/health` 17.531s, Telegram/WhatsApp startup traces ~15.94s gateway-total.
  - Warm pass: app 5.211s, gateway port 12.683s, browser port 14.019s, gateway `/health` 15.469s, Telegram 14.661s gateway-total, WhatsApp 15.213s gateway-total.
- Behavior-only patched installed-resource probes showed browser/gateway listener path improved but channel startup can still starve direct `/health`; this PR includes the compiled health fallback and earlier auto-enable change that need CI/signed-build validation.
- `node --check` passed for edited bundled JS files.
- `npx tsc --noEmit` passed.
- `git diff --check` passed for edited files.
- Local Rust test/build could not complete: Tauri `build-script-build` resource scan stayed active for minutes with no test output/artifact, matching the earlier local Windows build-script stall. CI release build should be used for the signed artifact QA loop.

## Notes
- `AGENTS.md` remains untracked locally and is not part of this PR.
- WhatsApp on this machine has previously reported a logged-out/unauthorized session, so channel "active" may still depend on account state after startup initializes.