### PR TITLE
Skip slow Windows gateway preflight

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -12540,11 +12540,13 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   use std::os::windows::process::CommandExt;
   const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-  // Fast path: if the gateway is already healthy, just save setup for future
-  // background restarts and return.
-  let already_healthy = crate::clawd::gateway_supervisor::is_gateway_healthy("").await;
-  if already_healthy {
-    eprintln!("[clawd/service] auto_enable (Windows): gateway already running, caching setup");
+  // Fast path: if a gateway listener already exists, save setup for future
+  // background restarts and return. Use a short TCP probe here; the HTTP
+  // health probe can spend the whole startup budget waiting for a missing
+  // gateway before we spawn the one this app owns.
+  let already_listening = gateway_tcp_port_open(std::time::Duration::from_millis(50)).await;
+  if already_listening {
+    eprintln!("[clawd/service] auto_enable (Windows): gateway already listening, caching setup");
     let cfg: crate::clawd::sidecar::SharedClawdbotConfig = std::sync::Arc::new(
       tokio::sync::RwLock::new(crate::clawd::sidecar::ClawdbotConfig::default()),
     );


### PR DESCRIPTION
## Summary
- Replace the Windows auto-enable startup fast-path HTTP health probe with a 50ms TCP listener probe.
- This avoids spending launch budget waiting for `/healthz` when the gateway is absent and we need to spawn it immediately.

## QA / Context
- Signed public `v2.2.6` prod QA after PR #461 still missed the 15s goal from app launch:
  - First pass: app 7.426s, gateway port 14.084s, browser port 18.002s, service health 23.340s.
  - Warm pass: app 5.510s, gateway port 13.485s, browser port 15.067s, service health 20.547s.
- Gateway-internal trace showed browser control ready about 6.1s after gateway startup; the miss was the app-launch-to-gateway-start gap.
- The old Windows preflight used `is_gateway_healthy("")`, which has a 1s HTTP timeout on a missing gateway. This PR changes that preflight to a short TCP listener check before spawning.
- `node --check` passed for edited bundled JS files from the previous PR.
- `npx tsc --noEmit` passed.
- `git diff --check` passed for edited files.

## Notes
- This PR is intentionally tiny and sits on top of the current `main` after `v2.2.6`.
- Local Rust package/test remains impractical on this Windows machine because Tauri build-script resource scanning stalls; use CI release build for signed artifact QA.