### PR TITLE
Speed up desktop channel startup

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/extensions/whatsapp/dist/channel.setup-vWI0fm8Y.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/whatsapp/dist/channel.setup-vWI0fm8Y.js
@@ -2,6 +2,10 @@ import { a as resolveWhatsAppGroupRequireMention, i as whatsappSetupWizardProxy,
 import { t as detectWhatsAppLegacyStateMigrations } from "./state-migrations-D_BmQUR9.js";
 //#region extensions/whatsapp/src/channel.setup.ts
 async function isWhatsAppAuthConfigured(account) {
+	if (process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1") {
+		const { r: hasWebCredsSync } = await import("./creds-files-B1kSWtBg.js");
+		return hasWebCredsSync(account.authDir);
+	}
 	const { readWebAuthState } = await import("./auth-store-GTQvJznL.js").then((n) => n.i);
 	return await readWebAuthState(account.authDir) === "linked";
 }

--- a/src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js
@@ -578,9 +578,10 @@ function createChannelManager(opts) {
 		}));
 	};
 	const startChannels = async () => {
+		const startupPlugins = [...listChannelPlugins()].sort((a, b) => a.id === "whatsapp" ? -1 : b.id === "whatsapp" ? 1 : 0);
 		await runTasksWithConcurrency({
 			limit: CHANNEL_STARTUP_CONCURRENCY,
-			tasks: [...listChannelPlugins()].map((plugin) => async () => {
+			tasks: startupPlugins.map((plugin) => async () => {
 				try {
 					await measureStartup(`channels.${plugin.id}.start`, () => startChannel(plugin.id));
 				} catch (err) {


### PR DESCRIPTION
## Summary
- Use a cheap WhatsApp credential-file check during desktop-managed startup instead of the full async auth-state read.
- Prefer starting WhatsApp channel preflight first so the slowest channel gets the earliest slot.

## Validation
- `node --check src/src-tauri/resources/clawdbot/dist/extensions/whatsapp/dist/channel.setup-vWI0fm8Y.js`
- `node --check src/src-tauri/resources/clawdbot/dist/server-channels-CRUeVkRN.js`
- `cd src && npx tsc --noEmit`
- `git diff --check`

Note: local Rust/Tauri build validation on this Windows machine has been unreliable because the Tauri build script stalls while scanning bundled resources; this change is confined to bundled gateway JS resources.