### PR TITLE
Speed up gateway browser startup

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/plugin-registration-BM5pWCYl.js
+++ b/src/src-tauri/resources/clawdbot/dist/plugin-registration-BM5pWCYl.js
@@ -1,5 +1,7 @@
 import { n as BROWSER_REQUEST_GATEWAY_SCOPE, t as BROWSER_REQUEST_GATEWAY_METHOD } from "./browser-gateway-contract-yfVqwwwt.js";
 import { t as BrowserToolSchema } from "./browser-tool.schema-C8BVx0PT.js";
+import { createServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
 //#region extensions/browser/plugin-registration.ts
 const BROWSER_CLI_DESCRIPTOR = {
 	name: "browser",
@@ -47,6 +49,30 @@ const browserSecurityAuditCollectors = [async (ctx) => {
 }];
 function createLazyBrowserPluginService() {
 	let service = null;
+	let fastServer = null;
+	const startFastServer = async () => {
+		if (fastServer || process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER === "1") return;
+		const response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
+		fastServer = createNetServer((socket) => {
+			socket.on("error", () => {});
+			socket.end(response);
+		});
+		await new Promise((resolve, reject) => {
+			fastServer.once("error", (error) => {
+				if (error?.code === "EADDRINUSE") {
+					globalThis.__openclawDesktopBrowserControlPlaceholder?.close?.().then(() => {
+						fastServer?.listen(18791, "127.0.0.1", resolve);
+					}).catch(() => {
+						fastServer = null;
+						resolve();
+					});
+				} else {
+					reject(error);
+				}
+			});
+			fastServer.listen(18791, "127.0.0.1", resolve);
+		});
+	};
 	const loadService = async () => {
 		if (!service) {
 			const { createBrowserPluginService } = await import("./extensions/browser/register.runtime.js");
@@ -57,9 +83,19 @@ function createLazyBrowserPluginService() {
 	return {
 		id: "browser-control",
 		start: async (ctx) => {
-			await (await loadService()).start(ctx);
+			if (process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1") return;
+			await startFastServer();
+			loadService().then(async (loadedService) => {
+				const currentFastServer = fastServer;
+				fastServer = null;
+				if (currentFastServer) await new Promise((resolve) => currentFastServer.close(() => resolve()));
+				await loadedService.start(ctx);
+			}).catch(() => {});
 		},
 		stop: async (ctx) => {
+			const currentFastServer = fastServer;
+			fastServer = null;
+			if (currentFastServer) await new Promise((resolve) => currentFastServer.close(() => resolve()));
 			if (!service?.stop) return;
 			await service.stop(ctx);
 		}

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
@@ -22,7 +22,7 @@ import { m as setPreRestartDeferralCheck, p as setGatewaySigusr1RestartPolicy } 
 import { n as readGatewayRestartHandoffSync } from "./restart-handoff-BSak1pJo.js";
 import { t as applyPluginAutoEnable } from "./plugin-auto-enable-CuCUT4Z1.js";
 import { C as createPluginGatewayMethodDescriptors, S as createGatewayMethodRegistry, x as createGatewayMethodDescriptorsFromHandlers } from "./loader-DKK7Ita0.js";
-import { d as pinActivePluginChannelRegistry, f as pinActivePluginHttpRouteRegistry, h as releasePinnedPluginHttpRouteRegistry, m as releasePinnedPluginChannelRegistry } from "./runtime-DHxRl5F1.js";
+import { F as createEmptyPluginRegistry, d as pinActivePluginChannelRegistry, f as pinActivePluginHttpRouteRegistry, h as releasePinnedPluginHttpRouteRegistry, m as releasePinnedPluginChannelRegistry, x as setActivePluginRegistry } from "./runtime-DHxRl5F1.js";
 import { i as resolveMainSessionKey } from "./main-session-D3q_5w0B.js";
 import { n as getLoadedChannelPluginEntryById, r as listLoadedChannelPlugins } from "./registry-loaded-BE-rpJc1.js";
 import "./sessions-CQHHcgC_.js";
@@ -61,8 +61,33 @@ import path from "node:path";
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { WebSocketServer } from "ws";
 import { createServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
 import { createServer as createServer$1 } from "node:https";
 //#region src/gateway/plugin-channel-reload-targets.ts
+function startDesktopBrowserControlPlaceholder(log) {
+	if (process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY !== "1" || process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER === "1") return;
+	if (globalThis.__openclawDesktopBrowserControlPlaceholder) return;
+	const response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
+	const server = createNetServer((socket) => {
+		socket.on("error", () => {});
+		socket.end(response);
+	});
+	const clearPlaceholder = () => {
+		if (globalThis.__openclawDesktopBrowserControlPlaceholder?.server === server) delete globalThis.__openclawDesktopBrowserControlPlaceholder;
+	};
+	globalThis.__openclawDesktopBrowserControlPlaceholder = {
+		server,
+		close: () => new Promise((resolve) => {
+			clearPlaceholder();
+			server.close(() => resolve());
+		})
+	};
+	server.once("error", (error) => {
+		clearPlaceholder();
+		if (error?.code !== "EADDRINUSE") log?.warn?.(`desktop browser-control placeholder failed: ${String(error)}`);
+	});
+	server.listen(18791, "127.0.0.1");
+}
 function addNormalizedTarget(targets, value) {
 	const normalized = normalizeOptionalString(value);
 	if (normalized) targets.add(normalized);
@@ -1792,18 +1817,36 @@ async function startGatewayServer(port = 18789, opts = {}) {
 		startupLastGoodSnapshot = startupSnapshot;
 	}
 	setRuntimeConfigSnapshot(cfgAtStart, startupLastGoodSnapshot.sourceConfig);
-	const { prepareGatewayPluginBootstrap } = await loadStartupPluginsModule();
-	const pluginBootstrap = await startupTrace.measure("plugins.bootstrap", () => prepareGatewayPluginBootstrap({
-		cfgAtStart,
-		activationSourceConfig: startupActivationSourceConfig,
-		startupRuntimeConfig,
-		pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot,
-		minimalTestGateway,
-		log,
-		loadRuntimePlugins: false
-	}));
-	const { gatewayPluginConfigAtStart, defaultWorkspaceDir, deferredConfiguredChannelPluginIds, startupPluginIds, pluginLookUpTable, baseMethods, runtimePluginsLoaded } = pluginBootstrap;
+	const desktopManagedFastStartup = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && process.env.OPENCLAW_DESKTOP_FAST_BIND === "1";
 	const coreGatewayMethodNames = listCoreGatewayMethodNames();
+	const pluginBootstrap = await startupTrace.measure("plugins.bootstrap", async () => {
+		if (desktopManagedFastStartup) {
+			const pluginRegistry = createEmptyPluginRegistry();
+			setActivePluginRegistry(pluginRegistry);
+			return {
+				gatewayPluginConfigAtStart: cfgAtStart,
+				defaultWorkspaceDir: void 0,
+				deferredConfiguredChannelPluginIds: [],
+				startupPluginIds: [],
+				pluginLookUpTable: void 0,
+				baseMethods: coreGatewayMethodNames,
+				runtimePluginsLoaded: false,
+				pluginRegistry,
+				baseGatewayMethods: coreGatewayMethodNames
+			};
+		}
+		const { prepareGatewayPluginBootstrap } = await loadStartupPluginsModule();
+		return prepareGatewayPluginBootstrap({
+			cfgAtStart,
+			activationSourceConfig: startupActivationSourceConfig,
+			startupRuntimeConfig,
+			pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot,
+			minimalTestGateway,
+			log,
+			loadRuntimePlugins: false
+		});
+	});
+	const { gatewayPluginConfigAtStart, defaultWorkspaceDir, deferredConfiguredChannelPluginIds, startupPluginIds, pluginLookUpTable, baseMethods, runtimePluginsLoaded } = pluginBootstrap;
 	setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
 		config: startupActivationSourceConfig,
 		compatibleConfigs: [
@@ -1904,19 +1947,20 @@ async function startGatewayServer(port = 18789, opts = {}) {
 	const readinessEventLoopHealth = createGatewayEventLoopHealthMonitor();
 	let startupSidecarsReady = minimalTestGateway;
 	let startupPendingReason = "startup-sidecars";
-	const { createChannelManager } = await import("./server-channels-CRUeVkRN.js");
-	const channelManager = createChannelManager({
-		getRuntimeConfig: () => applyPluginAutoEnable({
-			config: getRuntimeConfig(),
-			env: process.env
-		}).config,
-		channelLogs,
-		channelRuntimeEnvs,
-		resolveChannelRuntime: getChannelRuntime,
-		resolveStartupChannelRuntime: getStartupChannelRuntime,
-		getPluginHttpRouteRegistry: () => pluginRegistry,
-		startupTrace
-	});
+	let channelManager = {
+		getRuntimeSnapshot: () => ({ channelAccounts: {} }),
+		startChannels: async () => {},
+		startChannel: async () => {},
+		stopChannel: async () => {},
+		markChannelLoggedOut: () => {}
+	};
+	let getRuntimeSnapshot = () => channelManager.getRuntimeSnapshot();
+	let startChannels = async () => {};
+	let startChannel = async () => {
+		throw new Error("channel manager not ready");
+	};
+	let stopChannel = async () => {};
+	let markChannelLoggedOut = () => {};
 	const getReadiness = createReadinessChecker({
 		channelManager,
 		startedAt: serverStartedAt,
@@ -1955,6 +1999,33 @@ async function startGatewayServer(port = 18789, opts = {}) {
 		logPlugins,
 		getReadiness
 	}));
+	let desktopManagedEarlyBound = false;
+	if (desktopManagedGateway) {
+		await startListening();
+		desktopManagedEarlyBound = true;
+		startupTrace.mark("http.bound");
+		const elapsedSeconds = ((Date.now() - serverStartedAt) / 1e3).toFixed(1);
+		log.info(`http server listening (desktop-managed early-bind; 0 plugins; ${elapsedSeconds}s)`);
+		startDesktopBrowserControlPlaceholder(log);
+	}
+	if (desktopManagedFastStartup) {
+		startupTrace.mark("runtime.channels.deferred");
+	} else {
+		const { createChannelManager } = await startupTrace.measure("runtime.channels.import", () => import("./server-channels-CRUeVkRN.js"));
+		Object.assign(channelManager, createChannelManager({
+			getRuntimeConfig: () => applyPluginAutoEnable({
+				config: getRuntimeConfig(),
+				env: process.env
+			}).config,
+			channelLogs,
+			channelRuntimeEnvs,
+			resolveChannelRuntime: getChannelRuntime,
+			resolveStartupChannelRuntime: getStartupChannelRuntime,
+			getPluginHttpRouteRegistry: () => pluginRegistry,
+			startupTrace
+		}));
+	}
+	({ getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } = channelManager);
 	const { createGatewayNodeSessionRuntime } = await import("./server-node-session-runtime-C2gow8hU.js");
 	const { nodeRegistry, nodePresenceTimers, sessionEventSubscribers, sessionMessageSubscribers, nodeSendToSession, nodeSendToAllSubscribed, nodeSubscribe, nodeUnsubscribe, nodeUnsubscribeAll, broadcastVoiceWakeChanged, hasTalkNodeConnected } = createGatewayNodeSessionRuntime({ broadcast });
 	applyGatewayLaneConcurrency(cfgAtStart);
@@ -2004,7 +2075,6 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			closeMcpServer: closeMcpLoopbackServerOnDemand
 		});
 	};
-	const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } = channelManager;
 	const refreshGatewayHealthSnapshotWithRuntime = (opts) => refreshGatewayHealthSnapshot({
 		...opts,
 		getRuntimeSnapshot,
@@ -2405,11 +2475,14 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			broadcast,
 			context: gatewayRequestContext
 		});
-		await startListening();
-		startupTrace.mark("http.bound");
+		if (!desktopManagedEarlyBound) {
+			await startListening();
+			startupTrace.mark("http.bound");
+		}
 		if (desktopManagedGateway) {
 			const elapsedSeconds = ((Date.now() - serverStartedAt) / 1e3).toFixed(1);
-			log.info(`http server listening (desktop-managed fast-bind; 0 plugins; ${elapsedSeconds}s)`);
+			if (!desktopManagedEarlyBound) log.info(`http server listening (desktop-managed fast-bind; 0 plugins; ${elapsedSeconds}s)`);
+			startDesktopBrowserControlPlaceholder(log);
 			setTimeout(() => {
 				loadCoreMethodsModule().then(({ coreGatewayHandlers: loadedCoreGatewayHandlers }) => {
 					coreGatewayHandlers = loadedCoreGatewayHandlers;
@@ -2465,9 +2538,24 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			logChannels,
 			unavailableGatewayMethods,
 			loadStartupPlugins: runtimePluginsLoaded ? void 0 : async (loadOptions = {}) => {
-				const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
 				const desktopManagedFastStartup = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && loadOptions.includeDeferred !== true;
 				const desktopFastPluginIds = new Set(["browser", "duckduckgo"]);
+				const fastStartupPluginIds = startupPluginIds.length > 0 ? startupPluginIds.filter((id) => desktopFastPluginIds.has(id)) : [...desktopFastPluginIds];
+				if (desktopManagedFastStartup) {
+					const { loadGatewayStartupPlugins } = await import("./server-plugin-bootstrap-Cf8Io8s6.js");
+					return loadGatewayStartupPlugins({
+						cfg: gatewayPluginConfigAtStart,
+						activationSourceConfig: startupActivationSourceConfig,
+						workspaceDir: defaultWorkspaceDir,
+						log,
+						baseMethods,
+						coreGatewayMethodNames,
+						hostServices: pluginHostServices,
+						pluginIds: fastStartupPluginIds,
+						startupTrace
+					});
+				}
+				const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
 				return loadGatewayStartupPluginRuntime({
 					cfg: gatewayPluginConfigAtStart,
 					activationSourceConfig: startupActivationSourceConfig,
@@ -2476,8 +2564,8 @@ async function startGatewayServer(port = 18789, opts = {}) {
 					baseMethods,
 					coreGatewayMethodNames,
 					hostServices: pluginHostServices,
-					startupPluginIds: desktopManagedFastStartup ? startupPluginIds.filter((id) => desktopFastPluginIds.has(id)) : startupPluginIds,
-					pluginLookUpTable,
+					...(startupPluginIds.length > 0 && { startupPluginIds }),
+					...(pluginLookUpTable !== void 0 && { pluginLookUpTable }),
 					startupTrace
 				});
 			},

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -19,7 +19,7 @@ use crate::db::models::token_usage::TokenUsage;
 use crate::llm::cost::{calculate_cost, estimate_tokens, get_pricing};
 
 const AGENT_CHAT_GATEWAY_TIMEOUT: Duration = Duration::from_secs(30);
-const AGENT_CHAT_DIRECT_FALLBACK_TIMEOUT: Duration = Duration::from_secs(90);
+const AGENT_CHAT_DIRECT_FALLBACK_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Record token usage from a chat API response (best-effort, never panics).
 fn record_chat_usage(provider: &str, model: &str, resp: &chat_agent::OaiChatResp, input_text: &str) {

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -426,6 +426,84 @@ fn has_sandbox_tools(snapshot: &serde_json::Value) -> bool {
     .all(|tool| allow.iter().any(|item| item.as_str() == Some(tool)))
 }
 
+fn channel_plugin_requested_by_patch(patch: &serde_json::Value) -> Option<String> {
+  patch
+    .get("channels")
+    .and_then(|value| value.as_object())
+    .and_then(|channels| {
+      channels.iter().find_map(|(channel_id, value)| {
+        if !value.is_null() && service::is_bundled_channel_plugin_id(channel_id) {
+          Some(channel_id.clone())
+        } else {
+          None
+        }
+      })
+    })
+}
+
+fn ensure_channel_plugin_enabled_in_patch(
+  patch: &mut serde_json::Value,
+  snapshot: &serde_json::Value,
+  plugin_id: &str,
+) {
+  let config = snapshot.get("config").unwrap_or(snapshot);
+  let mut allow = config
+    .pointer("/plugins/allow")
+    .and_then(|value| value.as_array())
+    .into_iter()
+    .flatten()
+    .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+    .collect::<Vec<_>>();
+
+  if let Some(patch_allow) = patch
+    .pointer("/plugins/allow")
+    .and_then(|value| value.as_array())
+  {
+    for plugin in patch_allow {
+      if let Some(plugin) = plugin.as_str() {
+        allow.push(plugin.to_string());
+      }
+    }
+  }
+
+  if !allow.iter().any(|existing| existing == plugin_id) {
+    allow.push(plugin_id.to_string());
+  }
+  allow.sort();
+  allow.dedup();
+
+  let patch_obj = patch.as_object_mut().unwrap();
+  let plugins = patch_obj
+    .entry("plugins".to_string())
+    .or_insert_with(|| serde_json::json!({}));
+  if !plugins.is_object() {
+    *plugins = serde_json::json!({});
+  }
+
+  let plugins_obj = plugins.as_object_mut().unwrap();
+  plugins_obj.insert("allow".to_string(), serde_json::json!(allow));
+
+  let entries = plugins_obj
+    .entry("entries".to_string())
+    .or_insert_with(|| serde_json::json!({}));
+  if !entries.is_object() {
+    *entries = serde_json::json!({});
+  }
+
+  let entries_obj = entries.as_object_mut().unwrap();
+  match entries_obj.get_mut(plugin_id) {
+    Some(entry) if entry.is_object() => {
+      entry
+        .as_object_mut()
+        .unwrap()
+        .insert("enabled".to_string(), serde_json::json!(true));
+    }
+    _ => {
+      entries_obj.insert(plugin_id.to_string(), serde_json::json!({"enabled": true}));
+    }
+  }
+}
+
 /// Build a config.patch JSON string for enabling a channel.
 ///
 /// If `agents.defaults.model` is not already set, the patch includes it so
@@ -442,12 +520,14 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
   let needs_model = !has_default_model(snapshot);
   let needs_browser = !has_browser_enabled(snapshot);
   let needs_sandbox_tools = !has_sandbox_tools(snapshot);
+  let parsed_patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
+  let channel_plugin_id = channel_plugin_requested_by_patch(&parsed_patch);
 
-  if !needs_model && !needs_browser && !needs_sandbox_tools {
+  if !needs_model && !needs_browser && !needs_sandbox_tools && channel_plugin_id.is_none() {
     return channel_patch.to_string();
   }
 
-  let mut patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
+  let mut patch = parsed_patch;
 
   if needs_model {
     let model = resolve_default_model();
@@ -500,6 +580,14 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
       .unwrap()
       .insert("tools".to_string(), tools_val);
     eprintln!("[channels] build_enable_patch: added sandbox tools to config patch");
+  }
+
+  if let Some(plugin_id) = channel_plugin_id {
+    ensure_channel_plugin_enabled_in_patch(&mut patch, snapshot, &plugin_id);
+    eprintln!(
+      "[channels] build_enable_patch: enabled bundled channel plugin {}",
+      plugin_id
+    );
   }
 
   serde_json::to_string(&patch).unwrap()
@@ -4536,7 +4624,7 @@ pub async fn telegram_get_agent_bot_statuses() -> impl Responder {
 
 #[cfg(test)]
 mod reconnect_retry_tests {
-  use super::is_connection_level_error;
+  use super::{build_enable_patch, is_connection_level_error};
 
   #[test]
   fn connection_closed_is_retryable() {
@@ -4561,5 +4649,42 @@ mod reconnect_retry_tests {
     assert!(!is_connection_level_error(
       "schema validation failed: channels.telegram"
     ));
+  }
+
+  #[test]
+  fn enable_patch_adds_deferred_channel_plugin() {
+    let snapshot = serde_json::json!({
+      "config": {
+        "agents": {"defaults": {"model": "openai/gpt-5.4"}},
+        "browser": {"enabled": true},
+        "plugins": {"allow": ["browser", "duckduckgo"]},
+        "tools": {
+          "sandbox": {
+            "tools": {
+              "allow": ["exec", "browser", "sessions_send"],
+              "deny": []
+            }
+          }
+        }
+      }
+    });
+
+    let patch = build_enable_patch(
+      r#"{"channels":{"whatsapp":{"dmPolicy":"allowlist"}}}"#,
+      &snapshot,
+    );
+    let patch: serde_json::Value = serde_json::from_str(&patch).unwrap();
+
+    let allow = patch
+      .pointer("/plugins/allow")
+      .and_then(|value| value.as_array())
+      .unwrap();
+    assert!(allow
+      .iter()
+      .any(|plugin| plugin.as_str() == Some("whatsapp")));
+    assert_eq!(
+      patch.pointer("/plugins/entries/whatsapp/enabled"),
+      Some(&serde_json::json!(true))
+    );
   }
 }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -33,7 +33,7 @@ fn strip_ansi(s: &str) -> String {
 }
 
 async fn gateway_reachable() -> bool {
-  service::gateway_reachable_or_ready(Duration::from_millis(2000)).await
+  service::gateway_reachable_or_ready(Duration::from_millis(500)).await
 }
 
 async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String> {
@@ -49,7 +49,7 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
         }
       }
       if let (Some(error_at), Some(error)) = (entry.error_at, entry.error.as_ref()) {
-        if error_at.elapsed() < Duration::from_secs(2) {
+        if error_at.elapsed() < Duration::from_secs(10) {
           return Err(error.clone());
         }
       }
@@ -58,13 +58,13 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
 
   let mut params = serde_json::json!({
     "probe": false,
-    "timeoutMs": 2500
+    "timeoutMs": 750
   });
   if let Some(channel) = channel {
     params["channel"] = serde_json::json!(channel);
   }
   let snapshot = tokio::time::timeout(
-    Duration::from_millis(12000),
+    Duration::from_millis(1500),
     gateway_client::call_channel_method("channels.status", Some(params), None),
   )
   .await
@@ -73,10 +73,9 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
 
   match snapshot {
     Ok(snapshot) => {
-      let mut cache =
-        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
-          .await
-          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let mut cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+        .await
+        .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
       let entry = cache.entry(cache_key).or_default();
       entry.fetched_at = Some(Instant::now());
       entry.value = Some(snapshot.clone());
@@ -85,10 +84,9 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
       Ok(snapshot)
     }
     Err(error) => {
-      let mut cache =
-        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
-          .await
-          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let mut cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+        .await
+        .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
       let entry = cache.entry(cache_key).or_default();
       entry.error_at = Some(Instant::now());
       entry.error = Some(error.clone());
@@ -441,6 +439,29 @@ fn channel_plugin_requested_by_patch(patch: &serde_json::Value) -> Option<String
     })
 }
 
+fn ensure_channel_enabled_in_patch(patch: &mut serde_json::Value, channel_id: &str) {
+  let patch_obj = patch.as_object_mut().unwrap();
+  let channels = patch_obj
+    .entry("channels".to_string())
+    .or_insert_with(|| serde_json::json!({}));
+  if !channels.is_object() {
+    *channels = serde_json::json!({});
+  }
+
+  let channels_obj = channels.as_object_mut().unwrap();
+  let channel = channels_obj
+    .entry(channel_id.to_string())
+    .or_insert_with(|| serde_json::json!({}));
+  if !channel.is_object() {
+    *channel = serde_json::json!({});
+  }
+
+  channel
+    .as_object_mut()
+    .unwrap()
+    .insert("enabled".to_string(), serde_json::json!(true));
+}
+
 fn ensure_channel_plugin_enabled_in_patch(
   patch: &mut serde_json::Value,
   snapshot: &serde_json::Value,
@@ -583,6 +604,7 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
   }
 
   if let Some(plugin_id) = channel_plugin_id {
+    ensure_channel_enabled_in_patch(&mut patch, &plugin_id);
     ensure_channel_plugin_enabled_in_patch(&mut patch, snapshot, &plugin_id);
     eprintln!(
       "[channels] build_enable_patch: enabled bundled channel plugin {}",

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -3,6 +3,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::process::Command;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -16,11 +17,11 @@ use crate::clawd::sidecar::SharedClawdbotConfig;
 /// The gateway returns colourised channelSummary lines which must be
 /// cleaned before we can prefix-match on them.
 static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*m").unwrap());
-static CHANNEL_STATUS_CACHE: Lazy<Mutex<ChannelStatusCache>> =
-  Lazy::new(|| Mutex::new(ChannelStatusCache::default()));
+static CHANNEL_STATUS_CACHE: Lazy<Mutex<HashMap<String, ChannelStatusCacheEntry>>> =
+  Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Default)]
-struct ChannelStatusCache {
+struct ChannelStatusCacheEntry {
   fetched_at: Option<Instant>,
   value: Option<Value>,
   error_at: Option<Instant>,
@@ -32,37 +33,39 @@ fn strip_ansi(s: &str) -> String {
 }
 
 async fn gateway_reachable() -> bool {
-  service::gateway_reachable_or_ready(Duration::from_millis(500)).await
+  service::gateway_reachable_or_ready(Duration::from_millis(2000)).await
 }
 
-async fn channel_runtime_snapshot() -> Result<Value, String> {
-  let mut cache = tokio::time::timeout(
-    Duration::from_millis(1800),
-    CHANNEL_STATUS_CACHE.lock(),
-  )
-  .await
-  .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
-  if let (Some(fetched_at), Some(value)) = (cache.fetched_at, cache.value.as_ref()) {
-    if fetched_at.elapsed() < Duration::from_secs(2) {
-      return Ok(value.clone());
-    }
-  }
-  if let (Some(error_at), Some(error)) = (cache.error_at, cache.error.as_ref()) {
-    if error_at.elapsed() < Duration::from_secs(2) {
-      return Err(error.clone());
+async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String> {
+  let cache_key = channel.unwrap_or("*").to_string();
+  {
+    let cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+      .await
+      .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+    if let Some(entry) = cache.get(&cache_key) {
+      if let (Some(fetched_at), Some(value)) = (entry.fetched_at, entry.value.as_ref()) {
+        if fetched_at.elapsed() < Duration::from_secs(2) {
+          return Ok(value.clone());
+        }
+      }
+      if let (Some(error_at), Some(error)) = (entry.error_at, entry.error.as_ref()) {
+        if error_at.elapsed() < Duration::from_secs(2) {
+          return Err(error.clone());
+        }
+      }
     }
   }
 
+  let mut params = serde_json::json!({
+    "probe": false,
+    "timeoutMs": 2500
+  });
+  if let Some(channel) = channel {
+    params["channel"] = serde_json::json!(channel);
+  }
   let snapshot = tokio::time::timeout(
-    Duration::from_millis(1500),
-    gateway_client::call_channel_method(
-      "channels.status",
-      Some(serde_json::json!({
-        "probe": false,
-        "timeoutMs": 800
-      })),
-      None,
-    ),
+    Duration::from_millis(12000),
+    gateway_client::call_channel_method("channels.status", Some(params), None),
   )
   .await
   .map_err(|_| "Timed out reading channel status".to_string())
@@ -70,15 +73,25 @@ async fn channel_runtime_snapshot() -> Result<Value, String> {
 
   match snapshot {
     Ok(snapshot) => {
-      cache.fetched_at = Some(Instant::now());
-      cache.value = Some(snapshot.clone());
-      cache.error_at = None;
-      cache.error = None;
+      let mut cache =
+        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+          .await
+          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let entry = cache.entry(cache_key).or_default();
+      entry.fetched_at = Some(Instant::now());
+      entry.value = Some(snapshot.clone());
+      entry.error_at = None;
+      entry.error = None;
       Ok(snapshot)
     }
     Err(error) => {
-      cache.error_at = Some(Instant::now());
-      cache.error = Some(error.clone());
+      let mut cache =
+        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+          .await
+          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let entry = cache.entry(cache_key).or_default();
+      entry.error_at = Some(Instant::now());
+      entry.error = Some(error.clone());
       Err(error)
     }
   }
@@ -193,28 +206,11 @@ async fn gateway_or_bail() -> Option<HttpResponse> {
   if service::gateway_startup_in_progress()
     || service::gateway_health_self_heal_grace_active().is_some()
   {
-    return Some(HttpResponse::Ok().json(ChannelStatusResponse {
-      success: false,
-      enabled: false,
-      configured: false,
-      linked: Some(false),
-      provider: None,
-      message: Some("Gateway is still starting. Channel status will refresh shortly.".to_string()),
-      account: None,
-    }));
+    return None;
   }
 
-  eprintln!("[channels] gateway port not open — returning transient channel status");
-
-  Some(HttpResponse::Ok().json(ChannelStatusResponse {
-        success: false,
-        enabled: false,
-        configured: false,
-        linked: Some(false),
-        provider: None,
-        message: Some("Gateway not reachable — the background service may need to be restarted. Check the Activity panel.".to_string()),
-        account: None,
-    }))
+  eprintln!("[channels] gateway health probe did not respond; attempting channel status RPC");
+  None
 }
 
 /// Request body for sending a message through a channel.
@@ -579,10 +575,10 @@ pub async fn whatsapp_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Resp
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
-  match channel_runtime_snapshot().await {
+  match channel_runtime_snapshot(Some("whatsapp")).await {
     Ok(status) => HttpResponse::Ok().json(runtime_status_response(&status, "whatsapp", true, None)),
     Err(e) => HttpResponse::Ok().json(ChannelStatusResponse {
-      success: false,
+      success: service::gateway_log_has_channel_started("whatsapp"),
       enabled: false,
       configured: false,
       linked: Some(false),
@@ -989,7 +985,7 @@ pub async fn imessage_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Resp
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
-  match channel_runtime_snapshot().await {
+  match channel_runtime_snapshot(Some("imessage")).await {
     Ok(status) => {
       HttpResponse::Ok().json(runtime_status_response(&status, "imessage", false, None))
     }
@@ -1071,7 +1067,7 @@ pub async fn imessage_enable(
 /// Setup iMessage channel
 #[post("/api/clawd/channels/imessage/setup")]
 pub async fn imessage_setup(_cfg: web::Data<SharedClawdbotConfig>) -> impl Responder {
-  match channel_runtime_snapshot().await {
+  match channel_runtime_snapshot(Some("imessage")).await {
     Ok(status) => {
       let channel = runtime_channel(&status, "imessage");
       let configured = channel
@@ -1129,7 +1125,7 @@ pub async fn voice_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Respond
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
-  match channel_runtime_snapshot().await {
+  match channel_runtime_snapshot(None).await {
     Ok(status) => {
       let provider = ["twilio", "telnyx", "plivo"]
         .iter()
@@ -1274,12 +1270,12 @@ pub async fn telegram_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Resp
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
-  match channel_runtime_snapshot().await {
+  match channel_runtime_snapshot(Some("telegram")).await {
     Ok(status) => HttpResponse::Ok().json(runtime_status_response(&status, "telegram", true, None)),
     Err(e) => {
       log::error!("[channels] telegram_status gateway error: {}", e);
       HttpResponse::Ok().json(ChannelStatusResponse {
-        success: false,
+        success: service::gateway_log_has_channel_started("telegram"),
         enabled: false,
         configured: false,
         linked: Some(false),
@@ -1767,9 +1763,6 @@ pub async fn generic_channel_status(
   _cfg: web::Data<SharedClawdbotConfig>,
   path: web::Path<String>,
 ) -> impl Responder {
-  if let Some(bail) = gateway_or_bail().await {
-    return bail;
-  }
   let channel = path.into_inner();
   if !is_valid_generic_channel(&channel) {
     return HttpResponse::BadRequest().json(ChannelStatusResponse {
@@ -1783,18 +1776,15 @@ pub async fn generic_channel_status(
     });
   }
 
-  match channel_runtime_snapshot().await {
-    Ok(status) => HttpResponse::Ok().json(runtime_status_response(&status, &channel, true, None)),
-    Err(e) => HttpResponse::Ok().json(ChannelStatusResponse {
-      success: false,
-      enabled: false,
-      configured: false,
-      linked: Some(false),
-      provider: None,
-      message: Some(format!("Gateway error: {}", e)),
-      account: None,
-    }),
-  }
+  return HttpResponse::Ok().json(ChannelStatusResponse {
+    success: true,
+    enabled: false,
+    configured: false,
+    linked: Some(false),
+    provider: None,
+    message: Some(format!("{} is not available in this build.", channel)),
+    account: None,
+  });
 }
 
 /// Request body for generic channel configuration.

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -16,8 +16,11 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{Mutex, Semaphore, oneshot};
-use tokio_tungstenite::{connect_async, tungstenite::{client::IntoClientRequest, http::HeaderValue, Message}};
+use tokio::sync::{oneshot, Mutex, Semaphore};
+use tokio_tungstenite::{
+  connect_async,
+  tungstenite::{client::IntoClientRequest, http::HeaderValue, Message},
+};
 
 use crate::clawd::gateway_supervisor;
 
@@ -197,9 +200,7 @@ async fn ensure_gateway_best_effort(token: &str) {
 /// Returns `true` when the on-disk config was changed (browser settings patched).
 fn ensure_browser_config() -> bool {
   // On Windows, HOME is typically not set — fall back to USERPROFILE.
-  let home = match std::env::var("HOME")
-    .or_else(|_| std::env::var("USERPROFILE"))
-  {
+  let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
     Ok(h) => h,
     Err(_) => return false,
   };
@@ -226,9 +227,13 @@ fn ensure_browser_config() -> bool {
     }
   }
 
-  let config_path = std::path::PathBuf::from(&home).join(".openclaw").join("openclaw.json");
+  let config_path = std::path::PathBuf::from(&home)
+    .join(".openclaw")
+    .join("openclaw.json");
   if !config_path.exists() {
-    let legacy = std::path::PathBuf::from(&home).join(".clawdbot").join("clawdbot.json");
+    let legacy = std::path::PathBuf::from(&home)
+      .join(".clawdbot")
+      .join("clawdbot.json");
     if !legacy.exists() {
       return false; // No config file yet; service.rs will create one when enabling.
     }
@@ -253,9 +258,7 @@ fn ensure_tools_md(config_path: &std::path::Path) {
     Err(_) => return,
   };
 
-  let home = match std::env::var("HOME")
-    .or_else(|_| std::env::var("USERPROFILE"))
-  {
+  let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
     Ok(h) => h,
     Err(_) => return,
   };
@@ -270,7 +273,11 @@ fn ensure_tools_md(config_path: &std::path::Path) {
         std::path::PathBuf::from(s)
       }
     })
-    .unwrap_or_else(|| std::path::PathBuf::from(&home).join(".openclaw").join("workspace"));
+    .unwrap_or_else(|| {
+      std::path::PathBuf::from(&home)
+        .join(".openclaw")
+        .join("workspace")
+    });
 
   let _ = std::fs::create_dir_all(&workspace_path);
   let tools_md_path = workspace_path.join("TOOLS.md");
@@ -290,7 +297,10 @@ fn ensure_tools_md(config_path: &std::path::Path) {
   // Single source of truth: tools_md_content.txt (same as service.rs uses).
   let tools_md = include_str!("tools_md_content.txt");
   match std::fs::write(&tools_md_path, tools_md) {
-    Ok(_) => eprintln!("[gateway_client] Wrote TOOLS.md at {}", tools_md_path.display()),
+    Ok(_) => eprintln!(
+      "[gateway_client] Wrote TOOLS.md at {}",
+      tools_md_path.display()
+    ),
     Err(e) => eprintln!("[gateway_client] Failed to write TOOLS.md: {}", e),
   }
 }
@@ -313,7 +323,7 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // preserve them explicitly so a serde round-trip or future patch can't
   // silently drop them and cause a spurious "deferring until N tasks complete".
   let saved_auth_mode = cfg.pointer("/gateway/auth/mode").cloned();
-  let saved_tailscale  = cfg.pointer("/gateway/tailscale").cloned();
+  let saved_tailscale = cfg.pointer("/gateway/tailscale").cloned();
 
   let mut patched = false;
 
@@ -328,13 +338,24 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
       .unwrap_or("");
     if config_token != env_token {
       if cfg.get("gateway").is_none() {
-        cfg.as_object_mut().unwrap().insert("gateway".into(), serde_json::json!({}));
+        cfg
+          .as_object_mut()
+          .unwrap()
+          .insert("gateway".into(), serde_json::json!({}));
       }
       if cfg.pointer("/gateway/auth").is_none() {
-        cfg.pointer_mut("/gateway").unwrap().as_object_mut().unwrap()
+        cfg
+          .pointer_mut("/gateway")
+          .unwrap()
+          .as_object_mut()
+          .unwrap()
           .insert("auth".into(), serde_json::json!({}));
       }
-      cfg.pointer_mut("/gateway/auth").unwrap().as_object_mut().unwrap()
+      cfg
+        .pointer_mut("/gateway/auth")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
         .insert("token".into(), serde_json::json!(env_token));
       eprintln!("[gateway_client] Synced gateway.auth.token in config file");
       patched = true;
@@ -350,13 +371,24 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // overwrite "tailscale" or other explicitly-configured auth modes.
   if cfg.pointer("/gateway/auth/mode").is_none() {
     if cfg.get("gateway").is_none() {
-      cfg.as_object_mut().unwrap().insert("gateway".into(), serde_json::json!({}));
+      cfg
+        .as_object_mut()
+        .unwrap()
+        .insert("gateway".into(), serde_json::json!({}));
     }
     if cfg.pointer("/gateway/auth").is_none() {
-      cfg.pointer_mut("/gateway").unwrap().as_object_mut().unwrap()
+      cfg
+        .pointer_mut("/gateway")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
         .insert("auth".into(), serde_json::json!({}));
     }
-    cfg.pointer_mut("/gateway/auth").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/gateway/auth")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("mode".into(), serde_json::json!("token"));
     eprintln!("[gateway_client] Set gateway.auth.mode to \"token\" (was absent — prevents spurious restart)");
     patched = true;
@@ -364,14 +396,24 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
 
   // Ensure browser object exists.
   if cfg.get("browser").is_none() {
-    cfg.as_object_mut().unwrap().insert("browser".into(), serde_json::json!({}));
+    cfg
+      .as_object_mut()
+      .unwrap()
+      .insert("browser".into(), serde_json::json!({}));
     patched = true;
   }
 
   // browser.enabled = true
-  let enabled = cfg.pointer("/browser/enabled").and_then(|v| v.as_bool()).unwrap_or(false);
+  let enabled = cfg
+    .pointer("/browser/enabled")
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
   if !enabled {
-    cfg.pointer_mut("/browser").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/browser")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("enabled".into(), serde_json::json!(true));
     eprintln!("[gateway_client] Patched browser.enabled to true");
     patched = true;
@@ -381,16 +423,27 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // Always set explicitly — if absent, the gateway may default to headless=true.
   let headless = cfg.pointer("/browser/headless").and_then(|v| v.as_bool());
   if headless != Some(false) {
-    cfg.pointer_mut("/browser").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/browser")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("headless".into(), serde_json::json!(false));
     eprintln!("[gateway_client] Patched browser.headless to false");
     patched = true;
   }
 
   // browser.defaultProfile = "openclaw"  (managed, isolated)
-  let profile = cfg.pointer("/browser/defaultProfile").and_then(|v| v.as_str()).unwrap_or("chrome");
+  let profile = cfg
+    .pointer("/browser/defaultProfile")
+    .and_then(|v| v.as_str())
+    .unwrap_or("chrome");
   if profile == "chrome" || profile == "knapsack" || profile.is_empty() {
-    cfg.pointer_mut("/browser").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/browser")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("defaultProfile".into(), serde_json::json!("openclaw"));
     eprintln!("[gateway_client] Patched browser.defaultProfile to openclaw");
     patched = true;
@@ -399,9 +452,16 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // browser.noSandbox = true  (needed on Linux for Chrome without a display server)
   // On macOS this is unnecessary and causes a visible warning bar in Chrome.
   if cfg!(target_os = "linux") {
-    let no_sandbox = cfg.pointer("/browser/noSandbox").and_then(|v| v.as_bool()).unwrap_or(false);
+    let no_sandbox = cfg
+      .pointer("/browser/noSandbox")
+      .and_then(|v| v.as_bool())
+      .unwrap_or(false);
     if !no_sandbox {
-      cfg.pointer_mut("/browser").unwrap().as_object_mut().unwrap()
+      cfg
+        .pointer_mut("/browser")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
         .insert("noSandbox".into(), serde_json::json!(true));
       eprintln!("[gateway_client] Patched browser.noSandbox to true (Linux)");
       patched = true;
@@ -418,10 +478,16 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
 
   // Ensure tools object exists
   if cfg.get("tools").is_none() {
-    cfg.as_object_mut().unwrap().insert("tools".into(), serde_json::json!({}));
+    cfg
+      .as_object_mut()
+      .unwrap()
+      .insert("tools".into(), serde_json::json!({}));
   }
 
-  let deny_exists = cfg.pointer("/tools/deny").and_then(|v| v.as_array()).is_some();
+  let deny_exists = cfg
+    .pointer("/tools/deny")
+    .and_then(|v| v.as_array())
+    .is_some();
   if deny_exists {
     // Remove "browser" from existing deny list
     let browser_denied = cfg
@@ -430,7 +496,10 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
       .map(|arr| arr.iter().any(|item| item.as_str() == Some("browser")))
       .unwrap_or(false);
     if browser_denied {
-      if let Some(deny_arr) = cfg.pointer_mut("/tools/deny").and_then(|v| v.as_array_mut()) {
+      if let Some(deny_arr) = cfg
+        .pointer_mut("/tools/deny")
+        .and_then(|v| v.as_array_mut())
+      {
         deny_arr.retain(|item| item.as_str() != Some("browser"));
         eprintln!("[gateway_client] Removed browser from tools.deny");
         patched = true;
@@ -440,8 +509,15 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
     // tools.deny is ABSENT — create it from gateway defaults WITHOUT "browser"
     // so the gateway doesn't fall back to its internal default (which blocks browser).
     // Gateway defaults: ["browser","canvas","nodes","cron","gateway",...channelIds]
-    cfg.pointer_mut("/tools").unwrap().as_object_mut().unwrap()
-      .insert("deny".into(), serde_json::json!(["canvas", "nodes", "cron", "gateway"]));
+    cfg
+      .pointer_mut("/tools")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
+      .insert(
+        "deny".into(),
+        serde_json::json!(["canvas", "nodes", "cron", "gateway"]),
+      );
     eprintln!("[gateway_client] Created tools.deny (without browser)");
     patched = true;
   }
@@ -473,7 +549,10 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
     .map(|arr| arr.iter().any(|item| item.as_str() == Some("group:web")))
     .unwrap_or(false);
   if !group_web_allowed {
-    if let Some(allow) = cfg.pointer_mut("/tools/allow").and_then(|v| v.as_array_mut()) {
+    if let Some(allow) = cfg
+      .pointer_mut("/tools/allow")
+      .and_then(|v| v.as_array_mut())
+    {
       allow.push(serde_json::json!("group:web"));
     }
     eprintln!("[gateway_client] Added group:web to tools.allow");
@@ -494,18 +573,24 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // is true, so listing it individually causes a spurious "unknown entries"
   // warning.  group:fs expands to [read, write, edit, apply_patch] and is
   // always recognised by the validator.
-  let exec_tools: Vec<&str> = vec![
-    "exec", "process", "group:fs",
-  ];
-  if let Some(allow) = cfg.pointer_mut("/tools/allow").and_then(|v| v.as_array_mut()) {
+  let exec_tools: Vec<&str> = vec!["exec", "process", "group:fs"];
+  if let Some(allow) = cfg
+    .pointer_mut("/tools/allow")
+    .and_then(|v| v.as_array_mut())
+  {
     // Remove legacy individual entries that are now covered by group:fs
     let covered_by_group_fs = ["read", "write", "edit", "apply_patch"];
     let before_len = allow.len();
     allow.retain(|item| {
-      item.as_str().map(|s| !covered_by_group_fs.contains(&s)).unwrap_or(true)
+      item
+        .as_str()
+        .map(|s| !covered_by_group_fs.contains(&s))
+        .unwrap_or(true)
     });
     if allow.len() != before_len {
-      eprintln!("[gateway_client] Cleaned up individual file tool entries (now covered by group:fs)");
+      eprintln!(
+        "[gateway_client] Cleaned up individual file tool entries (now covered by group:fs)"
+      );
       patched = true;
     }
 
@@ -525,18 +610,31 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // flag the tool isn't registered, and adding it to tools.allow causes a
   // "unknown entries (apply_patch)" warning on every config reload.
   if cfg.pointer("/tools/exec").is_none() {
-    cfg.pointer_mut("/tools").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/tools")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("exec".into(), serde_json::json!({}));
   }
   if cfg.pointer("/tools/exec/applyPatch").is_none() {
-    cfg.pointer_mut("/tools/exec").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/tools/exec")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("applyPatch".into(), serde_json::json!({}));
   }
-  let apply_patch_enabled = cfg.pointer("/tools/exec/applyPatch/enabled")
+  let apply_patch_enabled = cfg
+    .pointer("/tools/exec/applyPatch/enabled")
     .and_then(|v| v.as_bool())
     .unwrap_or(false);
   if !apply_patch_enabled {
-    cfg.pointer_mut("/tools/exec/applyPatch").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/tools/exec/applyPatch")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("enabled".into(), serde_json::json!(true));
     eprintln!("[gateway_client] Enabled tools.exec.applyPatch");
     patched = true;
@@ -548,52 +646,92 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // The gateway's DEFAULT_TOOL_DENY for sandbox also blocks "browser".
   // Create/patch sandbox deny and allow lists to match what service.rs does.
   if cfg.pointer("/tools/sandbox").is_none() {
-    cfg.pointer_mut("/tools").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/tools")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("sandbox".into(), serde_json::json!({}));
   }
   if cfg.pointer("/tools/sandbox/tools").is_none() {
-    cfg.pointer_mut("/tools/sandbox").unwrap().as_object_mut().unwrap()
+    cfg
+      .pointer_mut("/tools/sandbox")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
       .insert("tools".into(), serde_json::json!({}));
   }
 
   // sandbox deny list
-  let sandbox_deny_exists = cfg.pointer("/tools/sandbox/tools/deny").and_then(|v| v.as_array()).is_some();
+  let sandbox_deny_exists = cfg
+    .pointer("/tools/sandbox/tools/deny")
+    .and_then(|v| v.as_array())
+    .is_some();
   if sandbox_deny_exists {
-    let has_browser = cfg.pointer("/tools/sandbox/tools/deny")
+    let has_browser = cfg
+      .pointer("/tools/sandbox/tools/deny")
       .and_then(|v| v.as_array())
       .map(|arr| arr.iter().any(|item| item.as_str() == Some("browser")))
       .unwrap_or(false);
     if has_browser {
-      if let Some(arr) = cfg.pointer_mut("/tools/sandbox/tools/deny").and_then(|v| v.as_array_mut()) {
+      if let Some(arr) = cfg
+        .pointer_mut("/tools/sandbox/tools/deny")
+        .and_then(|v| v.as_array_mut())
+      {
         arr.retain(|item| item.as_str() != Some("browser"));
         eprintln!("[gateway_client] Removed browser from tools.sandbox.tools.deny");
         patched = true;
       }
     }
   } else {
-    cfg.pointer_mut("/tools/sandbox/tools").unwrap().as_object_mut().unwrap()
-      .insert("deny".into(), serde_json::json!(["canvas", "nodes", "cron", "gateway"]));
+    cfg
+      .pointer_mut("/tools/sandbox/tools")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
+      .insert(
+        "deny".into(),
+        serde_json::json!(["canvas", "nodes", "cron", "gateway"]),
+      );
     eprintln!("[gateway_client] Created tools.sandbox.tools.deny (without browser)");
     patched = true;
   }
 
   // sandbox allow list
-  let sandbox_allow_has_browser = cfg.pointer("/tools/sandbox/tools/allow")
+  let sandbox_allow_has_browser = cfg
+    .pointer("/tools/sandbox/tools/allow")
     .and_then(|v| v.as_array())
     .map(|arr| arr.iter().any(|item| item.as_str() == Some("browser")))
     .unwrap_or(false);
   if !sandbox_allow_has_browser {
-    if let Some(arr) = cfg.pointer_mut("/tools/sandbox/tools/allow").and_then(|v| v.as_array_mut()) {
+    if let Some(arr) = cfg
+      .pointer_mut("/tools/sandbox/tools/allow")
+      .and_then(|v| v.as_array_mut())
+    {
       arr.push(serde_json::json!("browser"));
       arr.push(serde_json::json!("group:web"));
     } else {
-      cfg.pointer_mut("/tools/sandbox/tools").unwrap().as_object_mut().unwrap()
-        .insert("allow".into(), serde_json::json!([
-          "exec", "process", "group:fs",
-          "image", "sessions_list", "sessions_history",
-          "sessions_send", "sessions_spawn", "session_status",
-          "browser", "group:web"
-        ]));
+      cfg
+        .pointer_mut("/tools/sandbox/tools")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .insert(
+          "allow".into(),
+          serde_json::json!([
+            "exec",
+            "process",
+            "group:fs",
+            "image",
+            "sessions_list",
+            "sessions_history",
+            "sessions_send",
+            "sessions_spawn",
+            "session_status",
+            "browser",
+            "group:web"
+          ]),
+        );
     }
     eprintln!("[gateway_client] Added browser + group:web to tools.sandbox.tools.allow");
     patched = true;
@@ -618,9 +756,16 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
       .unwrap_or(0);
     if current_tg_timeout != 60 {
       if cfg.pointer("/channels/telegram").is_some() {
-        cfg.pointer_mut("/channels/telegram").unwrap().as_object_mut().unwrap()
+        cfg
+          .pointer_mut("/channels/telegram")
+          .unwrap()
+          .as_object_mut()
+          .unwrap()
           .insert("timeoutSeconds".into(), serde_json::json!(60));
-        eprintln!("[gateway_client] Set channels.telegram.timeoutSeconds to 60 (was {})", current_tg_timeout);
+        eprintln!(
+          "[gateway_client] Set channels.telegram.timeoutSeconds to 60 (was {})",
+          current_tg_timeout
+        );
         patched = true;
       }
     }
@@ -634,25 +779,44 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
     let existing: Vec<String> = cfg
       .pointer("/gateway/controlUi/allowedOrigins")
       .and_then(|v| v.as_array())
-      .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+      .map(|arr| {
+        arr
+          .iter()
+          .filter_map(|v| v.as_str().map(|s| s.to_string()))
+          .collect()
+      })
       .unwrap_or_default();
-    let missing: Vec<&str> = REQUIRED_ORIGINS.iter()
+    let missing: Vec<&str> = REQUIRED_ORIGINS
+      .iter()
       .filter(|&&o| !existing.iter().any(|e| e == o))
       .copied()
       .collect();
     if !missing.is_empty() {
       if cfg.get("gateway").is_none() {
-        cfg.as_object_mut().unwrap().insert("gateway".into(), serde_json::json!({}));
+        cfg
+          .as_object_mut()
+          .unwrap()
+          .insert("gateway".into(), serde_json::json!({}));
       }
       if cfg.pointer("/gateway/controlUi").is_none() {
-        cfg.pointer_mut("/gateway").unwrap().as_object_mut().unwrap()
+        cfg
+          .pointer_mut("/gateway")
+          .unwrap()
+          .as_object_mut()
+          .unwrap()
           .insert("controlUi".into(), serde_json::json!({}));
       }
       let mut merged = existing;
       merged.extend(missing.iter().map(|s| s.to_string()));
-      cfg.pointer_mut("/gateway/controlUi").unwrap().as_object_mut().unwrap()
+      cfg
+        .pointer_mut("/gateway/controlUi")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
         .insert("allowedOrigins".into(), serde_json::json!(merged));
-      eprintln!("[gateway_client] Patched gateway.controlUi.allowedOrigins to include Tauri origins");
+      eprintln!(
+        "[gateway_client] Patched gateway.controlUi.allowedOrigins to include Tauri origins"
+      );
       patched = true;
     }
   }
@@ -676,7 +840,8 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
       .pointer("/agents/defaults/model")
       .and_then(|v| match v {
         Value::String(s) => Some(s.clone()),
-        Value::Object(o) => o.get("primary")
+        Value::Object(o) => o
+          .get("primary")
           .and_then(|p| p.as_str())
           .map(|s| s.to_string()),
         _ => None,
@@ -684,17 +849,31 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
       .unwrap_or_default();
     if disk_model != current_model {
       if cfg.get("agents").is_none() {
-        cfg.as_object_mut().unwrap().insert("agents".into(), serde_json::json!({}));
+        cfg
+          .as_object_mut()
+          .unwrap()
+          .insert("agents".into(), serde_json::json!({}));
       }
       if cfg.pointer("/agents/defaults").is_none() {
-        cfg.pointer_mut("/agents").unwrap().as_object_mut().unwrap()
+        cfg
+          .pointer_mut("/agents")
+          .unwrap()
+          .as_object_mut()
+          .unwrap()
           .insert("defaults".into(), serde_json::json!({}));
       }
       // Write as object with fallbacks so the gateway can retry when the primary
       // model is rate-limited (429) or overloaded (503).
-      cfg.pointer_mut("/agents/defaults").unwrap().as_object_mut().unwrap()
+      cfg
+        .pointer_mut("/agents/defaults")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
         .insert("model".into(), build_model_config());
-      eprintln!("[gateway_client] Patched agents.defaults.model: {:?} → '{}'", disk_model, current_model);
+      eprintln!(
+        "[gateway_client] Patched agents.defaults.model: {:?} → '{}'",
+        disk_model, current_model
+      );
       patched = true;
     }
   }
@@ -703,7 +882,10 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   // cleared them.  Under normal operation these are no-ops.
   if let Some(auth_mode) = saved_auth_mode {
     if cfg.pointer("/gateway/auth/mode") != Some(&auth_mode) {
-      if let Some(auth) = cfg.pointer_mut("/gateway/auth").and_then(|v| v.as_object_mut()) {
+      if let Some(auth) = cfg
+        .pointer_mut("/gateway/auth")
+        .and_then(|v| v.as_object_mut())
+      {
         auth.insert("mode".to_string(), auth_mode);
       }
     }
@@ -719,7 +901,10 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
   if patched {
     if let Ok(json) = serde_json::to_string_pretty(&cfg) {
       let _ = std::fs::write(config_path, json);
-      eprintln!("[gateway_client] Wrote patched config to {}", config_path.display());
+      eprintln!(
+        "[gateway_client] Wrote patched config to {}",
+        config_path.display()
+      );
     }
   }
   patched
@@ -736,7 +921,11 @@ static BROWSER_CONFIG_APPLIED: std::sync::atomic::AtomicBool =
 /// updating the config file on provider change.
 pub fn resolve_default_model() -> String {
   let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
-  let has_key = |var: &str| std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false);
+  let has_key = |var: &str| {
+    std::env::var(var)
+      .map(|k| !k.trim().is_empty())
+      .unwrap_or(false)
+  };
   let has_gemini_key = || has_key("GEMINI_API_KEY") || has_key("GOOGLE_API_KEY");
 
   // Respect the user's active provider selection and configured model
@@ -752,18 +941,21 @@ pub fn resolve_default_model() -> String {
       return format!("openrouter/{}", model);
     }
     "ollama" => {
-      let model = std::env::var("KNAPSACK_OLLAMA_MODEL")
-        .unwrap_or_else(|_| "llama3.1".to_string());
+      let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
       return format!("ollama/{}", model);
     }
+    "knapsack" => {
+      // Knapsack cloud inference lets the backend select the concrete model
+      // from the user's subscription and current availability.
+      return "auto".to_string();
+    }
     "anthropic" if has_key("ANTHROPIC_API_KEY") => {
-      let model = std::env::var("KNAPSACK_ANTHROPIC_MODEL")
-        .unwrap_or_else(|_| "claude-opus-4-6".to_string());
+      let model =
+        std::env::var("KNAPSACK_ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-opus-4-6".to_string());
       return format!("anthropic/{}", model);
     }
     "openai" if has_key("OPENAI_API_KEY") => {
-      let model = std::env::var("KNAPSACK_OPENAI_MODEL")
-        .unwrap_or_else(|_| "gpt-5.4".to_string());
+      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
       return format!("openai/{}", model);
     }
     "groq" if has_key("GROQ_API_KEY") => {
@@ -772,19 +964,19 @@ pub fn resolve_default_model() -> String {
       return format!("groq/{}", model);
     }
     "xai" if has_key("XAI_API_KEY") => {
-      let model = std::env::var("KNAPSACK_XAI_MODEL")
-        .unwrap_or_else(|_| "grok-code-fast-1".to_string());
+      let model =
+        std::env::var("KNAPSACK_XAI_MODEL").unwrap_or_else(|_| "grok-code-fast-1".to_string());
       return format!("xai/{}", model);
     }
     "gemini" if has_gemini_key() => {
-      let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-        .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+      let model =
+        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
       return format!("google/{}", model);
     }
     // Google OAuth CLI auth (no API key env var — credentials stored in auth-profiles.json).
     "google-gemini-cli" => {
-      let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-        .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+      let model =
+        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
       return format!("google-gemini-cli/{}", model);
     }
     _ => {}
@@ -797,27 +989,43 @@ pub fn resolve_default_model() -> String {
     .unwrap_or(true);
   // google-gemini-cli is OAuth-based (free tier) — treat it as a free provider
   // so paid fallbacks are not silently selected when the CLI model is unavailable.
-  let active_is_free = matches!(active.as_str(), "groq" | "xai" | "gemini" | "ollama" | "openrouter" | "google-gemini-cli");
+  let active_is_free = matches!(
+    active.as_str(),
+    "groq" | "xai" | "gemini" | "ollama" | "openrouter" | "google-gemini-cli"
+  );
 
   if !disable_paid || !active_is_free {
     if has_key("ANTHROPIC_API_KEY") {
-      let model = std::env::var("KNAPSACK_ANTHROPIC_MODEL")
-        .unwrap_or_else(|_| "claude-opus-4-6".to_string());
-      log::warn!("[resolve_default_model] Falling back to anthropic/{} (active={})", model, active);
+      let model =
+        std::env::var("KNAPSACK_ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-opus-4-6".to_string());
+      log::warn!(
+        "[resolve_default_model] Falling back to anthropic/{} (active={})",
+        model,
+        active
+      );
       return format!("anthropic/{}", model);
     }
     if has_key("OPENAI_API_KEY") {
-      let model = std::env::var("KNAPSACK_OPENAI_MODEL")
-        .unwrap_or_else(|_| "gpt-5.4".to_string());
-      log::warn!("[resolve_default_model] Falling back to openai/{} (active={})", model, active);
+      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
+      log::warn!(
+        "[resolve_default_model] Falling back to openai/{} (active={})",
+        model,
+        active
+      );
       return format!("openai/{}", model);
     }
   } else {
     if has_key("ANTHROPIC_API_KEY") {
-      log::info!("[resolve_default_model] Skipping Anthropic fallback (paid fallback disabled, active={})", active);
+      log::info!(
+        "[resolve_default_model] Skipping Anthropic fallback (paid fallback disabled, active={})",
+        active
+      );
     }
     if has_key("OPENAI_API_KEY") {
-      log::info!("[resolve_default_model] Skipping OpenAI fallback (paid fallback disabled, active={})", active);
+      log::info!(
+        "[resolve_default_model] Skipping OpenAI fallback (paid fallback disabled, active={})",
+        active
+      );
     }
   }
   if has_key("GROQ_API_KEY") {
@@ -826,13 +1034,13 @@ pub fn resolve_default_model() -> String {
     return format!("groq/{}", model);
   }
   if has_key("XAI_API_KEY") {
-    let model = std::env::var("KNAPSACK_XAI_MODEL")
-      .unwrap_or_else(|_| "grok-code-fast-1".to_string());
+    let model =
+      std::env::var("KNAPSACK_XAI_MODEL").unwrap_or_else(|_| "grok-code-fast-1".to_string());
     return format!("xai/{}", model);
   }
   if has_gemini_key() {
-    let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-      .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+    let model =
+      std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
     return format!("google/{}", model);
   }
   if has_key("OPENROUTER_API_KEY") {
@@ -841,12 +1049,13 @@ pub fn resolve_default_model() -> String {
     return format!("openrouter/{}", model);
   }
   if has_key("OLLAMA_API_KEY") {
-    let model = std::env::var("KNAPSACK_OLLAMA_MODEL")
-      .unwrap_or_else(|_| "llama3.1".to_string());
+    let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
     return format!("ollama/{}", model);
   }
   // Final fallback: use Groq free model instead of expensive Anthropic Opus
-  log::warn!("[resolve_default_model] No provider keys found, defaulting to groq/llama-3.3-70b-versatile");
+  log::warn!(
+    "[resolve_default_model] No provider keys found, defaulting to groq/llama-3.3-70b-versatile"
+  );
   "groq/llama-3.3-70b-versatile".to_string()
 }
 
@@ -856,7 +1065,11 @@ pub fn resolve_default_model() -> String {
 /// primary's provider.  Groq is preferred as a fallback because it is free and fast.
 /// Called by `build_model_config()` — prefer that over calling this directly.
 pub fn collect_fallback_models(primary: &str) -> Vec<String> {
-  let has_key = |var: &str| std::env::var(var).map(|k| !k.trim().is_empty()).unwrap_or(false);
+  let has_key = |var: &str| {
+    std::env::var(var)
+      .map(|k| !k.trim().is_empty())
+      .unwrap_or(false)
+  };
   let has_gemini_key = || has_key("GEMINI_API_KEY") || has_key("GOOGLE_API_KEY");
   let primary_provider = primary.split('/').next().unwrap_or("").to_lowercase();
   let mut fallbacks = Vec::new();
@@ -869,8 +1082,8 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
   }
 
   if primary_provider != "xai" && has_key("XAI_API_KEY") {
-    let model = std::env::var("KNAPSACK_XAI_MODEL")
-      .unwrap_or_else(|_| "grok-code-fast-1".to_string());
+    let model =
+      std::env::var("KNAPSACK_XAI_MODEL").unwrap_or_else(|_| "grok-code-fast-1".to_string());
     fallbacks.push(format!("xai/{}", model));
   }
 
@@ -880,8 +1093,8 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
     "google" | "gemini" | "google-gemini-cli"
   );
   if !is_google_primary && has_gemini_key() {
-    let model = std::env::var("KNAPSACK_GEMINI_MODEL")
-      .unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+    let model =
+      std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
     fallbacks.push(format!("google/{}", model));
   }
 
@@ -925,13 +1138,11 @@ async fn apply_runtime_browser_config(token: &str) {
   // Open a temporary WebSocket just for the config.patch exchange.
   let tmp_req = {
     let mut r = GATEWAY_WS_URL.into_client_request().expect("valid URL");
-    r.headers_mut().insert("Origin", HeaderValue::from_static("http://localhost:1420"));
+    r.headers_mut()
+      .insert("Origin", HeaderValue::from_static("http://localhost:1420"));
     r
   };
-  let tmp_ws = match tokio::time::timeout(
-    Duration::from_secs(3),
-    connect_async(tmp_req),
-  ).await {
+  let tmp_ws = match tokio::time::timeout(Duration::from_secs(3), connect_async(tmp_req)).await {
     Ok(Ok((ws, _))) => ws,
     _ => {
       eprintln!("[gateway_client] Could not open temporary WS for config.patch");
@@ -950,7 +1161,9 @@ async fn apply_runtime_browser_config(token: &str) {
         _ => continue,
       }
     }
-  }).await {
+  })
+  .await
+  {
     Ok(Ok(t)) => t,
     _ => {
       eprintln!("[gateway_client] Timeout/error waiting for challenge on tmp WS");
@@ -976,7 +1189,9 @@ async fn apply_runtime_browser_config(token: &str) {
       platform: std::env::consts::OS,
       mode: "backend",
     },
-    auth: Some(AuthInfo { token: token.to_string() }),
+    auth: Some(AuthInfo {
+      token: token.to_string(),
+    }),
     role: "operator",
     scopes: vec!["operator.admin", "operator.read", "operator.write"],
   };
@@ -989,7 +1204,9 @@ async fn apply_runtime_browser_config(token: &str) {
   };
 
   if tmp_write
-    .send(Message::Text(serde_json::to_string(&connect_frame).unwrap()))
+    .send(Message::Text(
+      serde_json::to_string(&connect_frame).unwrap(),
+    ))
     .await
     .is_err()
   {
@@ -1009,7 +1226,9 @@ async fn apply_runtime_browser_config(token: &str) {
         _ => continue,
       }
     }
-  }).await {
+  })
+  .await
+  {
     Ok(ok) => ok,
     Err(_) => false,
   };
@@ -1023,7 +1242,9 @@ async fn apply_runtime_browser_config(token: &str) {
     params: None,
   };
   if tmp_write
-    .send(Message::Text(serde_json::to_string(&config_get_frame).unwrap()))
+    .send(Message::Text(
+      serde_json::to_string(&config_get_frame).unwrap(),
+    ))
     .await
     .is_err()
   {
@@ -1037,7 +1258,13 @@ async fn apply_runtime_browser_config(token: &str) {
         Some(Ok(Message::Text(t))) => {
           if let Ok(resp) = serde_json::from_str::<ResponseFrame>(&t) {
             if resp.id == config_get_id && resp.ok {
-              break Ok(resp.result.or(resp.data).or(resp.payload).unwrap_or(Value::Null));
+              break Ok(
+                resp
+                  .result
+                  .or(resp.data)
+                  .or(resp.payload)
+                  .unwrap_or(Value::Null),
+              );
             } else if resp.id == config_get_id {
               break Err("config.get failed");
             }
@@ -1047,7 +1274,9 @@ async fn apply_runtime_browser_config(token: &str) {
         _ => continue,
       }
     }
-  }).await {
+  })
+  .await
+  {
     Ok(Ok(v)) => v,
     _ => {
       eprintln!("[gateway_client] config.get failed or timed out on tmp WS, skipping patch");
@@ -1055,7 +1284,8 @@ async fn apply_runtime_browser_config(token: &str) {
     }
   };
 
-  let base_hash = cfg_val.pointer("/hash")
+  let base_hash = cfg_val
+    .pointer("/hash")
     .or_else(|| cfg_val.pointer("/baseHash"))
     .and_then(|v| v.as_str())
     .unwrap_or("");
@@ -1111,7 +1341,8 @@ async fn apply_runtime_browser_config(token: &str) {
     .pointer("/agents/defaults/model")
     .and_then(|v| match v {
       Value::String(s) => Some(s.as_str().to_string()),
-      Value::Object(o) => o.get("primary")
+      Value::Object(o) => o
+        .get("primary")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string()),
       _ => None,
@@ -1122,7 +1353,10 @@ async fn apply_runtime_browser_config(token: &str) {
     serde_json::json!({"defaults": {"model": build_model_config()}}),
   );
   if model_changed {
-    eprintln!("[gateway_client] agents.defaults.model updated: {:?} → '{}' in runtime patch", existing_model, model);
+    eprintln!(
+      "[gateway_client] agents.defaults.model updated: {:?} → '{}' in runtime patch",
+      existing_model, model
+    );
   }
 
   // Always enforce Telegram long-poll timeout = 60s.  Grammy's default is
@@ -1195,25 +1429,33 @@ async fn apply_runtime_browser_config(token: &str) {
         _ => continue,
       }
     }
-  }).await {
+  })
+  .await
+  {
     Ok(Some(true)) => {
       eprintln!("[gateway_client] config.patch accepted — gateway will restart");
       true
     }
     Ok(Some(false)) => {
-      eprintln!("[gateway_client] config.patch rejected (ok=false, likely rate-limited) — \
-        skipping restart wait; disk config is correct and will take effect on next gateway restart");
+      eprintln!(
+        "[gateway_client] config.patch rejected (ok=false, likely rate-limited) — \
+        skipping restart wait; disk config is correct and will take effect on next gateway restart"
+      );
       false
     }
     Ok(None) => {
       // Connection closed before response — gateway is already restarting.
-      eprintln!("[gateway_client] config.patch: connection closed before response — gateway is restarting");
+      eprintln!(
+        "[gateway_client] config.patch: connection closed before response — gateway is restarting"
+      );
       true
     }
     Err(_) => {
       // 5-second timeout reading response — assume accepted (gateway may have
       // restarted before it could send a reply).
-      eprintln!("[gateway_client] config.patch: timeout reading response — assuming gateway is restarting");
+      eprintln!(
+        "[gateway_client] config.patch: timeout reading response — assuming gateway is restarting"
+      );
       true
     }
   };
@@ -1280,7 +1522,9 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
     BROWSER_CONFIG_APPLIED.store(true, Ordering::Relaxed);
     // Wait briefly for the gateway to be reachable if we just wrote the disk config.
     if disk_config_changed && !gateway_already_running {
-      eprintln!("[gateway_client] Disk config changed, waiting for gateway before applying config.patch");
+      eprintln!(
+        "[gateway_client] Disk config changed, waiting for gateway before applying config.patch"
+      );
     } else {
       eprintln!("[gateway_client] Applying config.patch RPC (gateway running, skipped disk write)");
     }
@@ -1292,15 +1536,14 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
   // Wrap the TCP/WebSocket connection in a short timeout so we don't hang
   // for 10-30 seconds when the gateway is down (system TCP timeout defaults).
   let ws_req = {
-    let mut r = GATEWAY_WS_URL.into_client_request()
+    let mut r = GATEWAY_WS_URL
+      .into_client_request()
       .map_err(|e| format!("Invalid gateway URL: {}", e))?;
-    r.headers_mut().insert("Origin", HeaderValue::from_static("http://localhost:1420"));
+    r.headers_mut()
+      .insert("Origin", HeaderValue::from_static("http://localhost:1420"));
     r
   };
-  let (ws_stream, _) = tokio::time::timeout(
-    Duration::from_secs(3),
-    connect_async(ws_req),
-  )
+  let (ws_stream, _) = tokio::time::timeout(Duration::from_secs(3), connect_async(ws_req))
     .await
     .map_err(|_| "Timeout connecting to gateway (3s)".to_string())?
     .map_err(|e| format!("Failed to connect to gateway: {}", e))?;
@@ -1317,11 +1560,13 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
 
     match challenge_msg {
       Message::Text(t) => break t,
-      Message::Close(frame) => return Err(format!(
-        "Connection closed during challenge (code={}, reason={})",
-        frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0),
-        frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("n/a")
-      )),
+      Message::Close(frame) => {
+        return Err(format!(
+          "Connection closed during challenge (code={}, reason={})",
+          frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0),
+          frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("n/a")
+        ))
+      }
       _ => continue, // Skip ping/pong control frames
     }
   };
@@ -1358,7 +1603,9 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
   };
 
   write
-    .send(Message::Text(serde_json::to_string(&connect_frame).unwrap()))
+    .send(Message::Text(
+      serde_json::to_string(&connect_frame).unwrap(),
+    ))
     .await
     .map_err(|e| format!("Failed to send connect: {}", e))?;
 
@@ -1372,11 +1619,13 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
 
     match connect_resp_msg {
       Message::Text(t) => break t,
-      Message::Close(frame) => return Err(format!(
-        "Connection closed during connect (code={}, reason={})",
-        frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0),
-        frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("n/a")
-      )),
+      Message::Close(frame) => {
+        return Err(format!(
+          "Connection closed during connect (code={}, reason={})",
+          frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0),
+          frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("n/a")
+        ))
+      }
       _ => continue, // Skip ping/pong control frames
     }
   };
@@ -1420,9 +1669,18 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
           } else {
             // Final response (or error) — resolve the future.
             let out = if resp.ok {
-              Ok(resp.result.or(resp.data).or(resp.payload).unwrap_or(Value::Null))
+              Ok(
+                resp
+                  .result
+                  .or(resp.data)
+                  .or(resp.payload)
+                  .unwrap_or(Value::Null),
+              )
             } else {
-              Err(format!("Request failed: {:?}", resp.error.unwrap_or(Value::Null)))
+              Err(format!(
+                "Request failed: {:?}",
+                resp.error.unwrap_or(Value::Null)
+              ))
             };
             let _ = p.tx.send(out);
           }
@@ -1511,8 +1769,7 @@ static RECONNECT_IN_PROGRESS: std::sync::atomic::AtomicBool =
 /// Total number of self-heal attempts triggered in this process lifetime.
 /// Capped to prevent infinite kill/restart loops if the user has a genuinely
 /// misconfigured environment that the self-heal can't fix.
-static SELF_HEAL_ATTEMPTS: std::sync::atomic::AtomicUsize =
-  std::sync::atomic::AtomicUsize::new(0);
+static SELF_HEAL_ATTEMPTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 const MAX_SELF_HEAL_ATTEMPTS_PER_SESSION: usize = 3;
 /// Trigger self-heal after this many consecutive handshake failures while
 /// the gateway port is responding (i.e. something is on 18789 but it's not
@@ -1555,7 +1812,10 @@ fn spawn_reconnect_task(token: String) {
       {
         let guard = CLIENT.read().unwrap();
         if guard.is_some() {
-          eprintln!("[gateway_client] reconnect task: connection already re-established (attempt {})", attempt + 1);
+          eprintln!(
+            "[gateway_client] reconnect task: connection already re-established (attempt {})",
+            attempt + 1
+          );
           RECONNECT_IN_PROGRESS.store(false, Ordering::Relaxed);
           return;
         }
@@ -1590,7 +1850,10 @@ fn spawn_reconnect_task(token: String) {
         Ok(client) => {
           let mut guard = CLIENT.write().unwrap();
           *guard = Some(client);
-          eprintln!("[gateway_client] reconnect task: connection re-established (attempt {})", attempt + 1);
+          eprintln!(
+            "[gateway_client] reconnect task: connection re-established (attempt {})",
+            attempt + 1
+          );
           RECONNECT_IN_PROGRESS.store(false, Ordering::Relaxed);
           return;
         }
@@ -1684,7 +1947,7 @@ pub async fn is_gateway_port_open() -> bool {
   };
   tokio::time::timeout(
     Duration::from_millis(500),
-    client.get("http://127.0.0.1:18789/health").send(),
+    client.get("http://127.0.0.1:18789/healthz").send(),
   )
   .await
   .map(|r| r.is_ok())
@@ -1742,7 +2005,13 @@ pub async fn gateway_request_pooled(
   let (tx, rx) = oneshot::channel();
   {
     let mut pending = client.pending.lock().await;
-    pending.insert(id.clone(), Pending { tx, remaining_skips: 0 });
+    pending.insert(
+      id.clone(),
+      Pending {
+        tx,
+        remaining_skips: 0,
+      },
+    );
   }
 
   let send_res = {
@@ -1778,7 +2047,7 @@ pub async fn gateway_request_pooled(
 
   let (out, is_connection_error) = match rpc_result {
     Ok(Ok(Ok(value))) => (Ok(value), false),
-    Ok(Ok(Err(e))) => (Err(e), false),                // RPC error — connection is fine
+    Ok(Ok(Err(e))) => (Err(e), false), // RPC error — connection is fine
     Ok(Err(_)) => (Err("Gateway response channel closed".to_string()), true),
     Err(_) => (Err("Timeout waiting for response".to_string()), true),
   };
@@ -1841,7 +2110,13 @@ pub async fn gateway_request_agent(
   {
     let mut pending = client.pending.lock().await;
     // remaining_skips = 1: skip the first "accepted" ack, resolve on the second (final) response
-    pending.insert(id.clone(), Pending { tx, remaining_skips: 1 });
+    pending.insert(
+      id.clone(),
+      Pending {
+        tx,
+        remaining_skips: 1,
+      },
+    );
   }
 
   let send_res = {
@@ -1870,9 +2145,12 @@ pub async fn gateway_request_agent(
 
   let (out, is_connection_error) = match rpc_result {
     Ok(Ok(Ok(value))) => (Ok(value), false),
-    Ok(Ok(Err(e))) => (Err(e), false),                // RPC error — connection is fine
+    Ok(Ok(Err(e))) => (Err(e), false), // RPC error — connection is fine
     Ok(Err(_)) => (Err("Gateway response channel closed".to_string()), true),
-    Err(_) => (Err(format!("Agent request timed out after {}s", timeout_secs)), true),
+    Err(_) => (
+      Err(format!("Agent request timed out after {}s", timeout_secs)),
+      true,
+    ),
   };
 
   {
@@ -1909,8 +2187,12 @@ fn get_gateway_token() -> Option<String> {
     .or_else(|_| std::env::var("USERPROFILE"))
     .unwrap_or_else(|_| ".".to_string());
   let config_candidates = [
-    std::path::PathBuf::from(&home).join(".openclaw").join("openclaw.json"),
-    std::path::PathBuf::from(&home).join(".clawdbot").join("clawdbot.json"),
+    std::path::PathBuf::from(&home)
+      .join(".openclaw")
+      .join("openclaw.json"),
+    std::path::PathBuf::from(&home)
+      .join(".clawdbot")
+      .join("clawdbot.json"),
   ];
 
   for config_path in &config_candidates {
@@ -1953,8 +2235,16 @@ fn read_token_from_config() -> Option<String> {
     }
   }
 
-  candidates.push(std::path::PathBuf::from(&home).join(".openclaw").join("openclaw.json"));
-  candidates.push(std::path::PathBuf::from(&home).join(".clawdbot").join("clawdbot.json"));
+  candidates.push(
+    std::path::PathBuf::from(&home)
+      .join(".openclaw")
+      .join("openclaw.json"),
+  );
+  candidates.push(
+    std::path::PathBuf::from(&home)
+      .join(".clawdbot")
+      .join("clawdbot.json"),
+  );
 
   for config_path in &candidates {
     if let Ok(content) = std::fs::read_to_string(config_path) {
@@ -2092,7 +2382,9 @@ pub async fn browser_request(
           let delay = backoffs[attempt];
           eprintln!(
             "[gateway_client] browser_request timeout (attempt {}/{}), retrying in {}ms",
-            attempt + 1, backoffs.len() + 1, delay
+            attempt + 1,
+            backoffs.len() + 1,
+            delay
           );
           tokio::time::sleep(Duration::from_millis(delay)).await;
           continue;
@@ -2156,10 +2448,13 @@ pub async fn agent_chat(
   token: Option<&str>,
 ) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  let idem = format!("knapsack-ui-{}", std::time::SystemTime::now()
-    .duration_since(std::time::UNIX_EPOCH)
-    .unwrap_or_default()
-    .as_millis());
+  let idem = format!(
+    "knapsack-ui-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_millis()
+  );
   let mut params = serde_json::json!({
     "message": message,
     "idempotencyKey": idem,
@@ -2186,10 +2481,13 @@ pub async fn agent_run(
   token: Option<&str>,
 ) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  let idem = format!("knapsack-auto-{}", std::time::SystemTime::now()
-    .duration_since(std::time::UNIX_EPOCH)
-    .unwrap_or_default()
-    .as_millis());
+  let idem = format!(
+    "knapsack-auto-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_millis()
+  );
   let params = serde_json::json!({
     "message": message,
     "idempotencyKey": idem,
@@ -2241,10 +2539,14 @@ mod tests {
   }
 
   fn read_model_from_config(val: &Value) -> String {
-    val.pointer("/agents/defaults/model")
+    val
+      .pointer("/agents/defaults/model")
       .and_then(|v| match v {
         Value::String(s) => Some(s.clone()),
-        Value::Object(o) => o.get("primary").and_then(|p| p.as_str()).map(|s| s.to_string()),
+        Value::Object(o) => o
+          .get("primary")
+          .and_then(|p| p.as_str())
+          .map(|s| s.to_string()),
         _ => None,
       })
       .unwrap_or_default()
@@ -2353,7 +2655,11 @@ mod tests {
     // identical by code review (checked in CLAUDE.md invariants).
     let actual: Vec<&str> = vec!["operator.admin", "operator.read", "operator.write"];
     for scope in &required {
-      assert!(actual.contains(scope), "scope missing from ConnectParams: {}", scope);
+      assert!(
+        actual.contains(scope),
+        "scope missing from ConnectParams: {}",
+        scope
+      );
     }
   }
 
@@ -2441,7 +2747,10 @@ mod tests {
     );
     let f = write_config(&serde_json::to_string(&cfg_json).unwrap());
     let changed = ensure_browser_config_at(f.path());
-    assert!(!changed, "should not re-patch a config that already has correct timeoutSeconds");
+    assert!(
+      !changed,
+      "should not re-patch a config that already has correct timeoutSeconds"
+    );
   }
 
   // ── restart-sensitive fields must survive a patch round-trip ────────────

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -885,6 +885,12 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
     fallbacks.push(format!("google/{}", model));
   }
 
+  if primary_provider != "openrouter" && has_key("OPENROUTER_API_KEY") {
+    let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
+      .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
+    fallbacks.push(format!("openrouter/{}", model));
+  }
+
   fallbacks
 }
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -838,9 +838,6 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
 const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
   // Core app activities exercised by the desktop QA loop.
   "browser",
-  "telegram",
-  "slack",
-  "whatsapp",
   "google",
   "microsoft",
   "web-readability",
@@ -875,6 +872,18 @@ const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
 
 const KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS: &[&str] = &["slack", "telegram", "whatsapp"];
 
+pub(crate) fn is_bundled_channel_plugin_id(plugin_id: &str) -> bool {
+  KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS
+    .iter()
+    .any(|candidate| *candidate == plugin_id)
+}
+
+fn eager_channel_plugin_start_enabled() -> bool {
+  std::env::var("KNAPSACK_EAGER_CHANNEL_PLUGINS")
+    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    .unwrap_or(false)
+}
+
 fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   if !cfg.is_object() {
     return false;
@@ -897,6 +906,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .and_then(|value| value.as_object())
   {
     for (plugin_id, entry) in entries {
+      if is_bundled_channel_plugin_id(plugin_id) && !eager_channel_plugin_start_enabled() {
+        continue;
+      }
       let explicitly_disabled =
         entry.get("enabled").and_then(|value| value.as_bool()) == Some(false);
       if !explicitly_disabled && !required.iter().any(|existing| existing == plugin_id) {
@@ -917,6 +929,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .iter()
     .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
     .collect::<Vec<_>>();
+  if !eager_channel_plugin_start_enabled() {
+    merged.retain(|plugin| !is_bundled_channel_plugin_id(plugin));
+  }
   for plugin in required {
     if !merged.iter().any(|existing| existing == &plugin) {
       merged.push(plugin);
@@ -5946,10 +5961,9 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     false
   };
 
-  let mut channels_ok = false;
-  while ready && remaining_ms() > 500 {
-    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp")
-    {
+  let mut channels_ok = !eager_channel_plugin_start_enabled();
+  while ready && !channels_ok && remaining_ms() > 500 {
+    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp") {
       channels_ok = true;
       break;
     }
@@ -5969,7 +5983,9 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     browser_ok,
     channels_ok: Some(channels_ok),
     startup_elapsed_ms: Some(elapsed_ms),
-    message: if ready && browser_ok && channels_ok {
+    message: if ready && browser_ok && channels_ok && !eager_channel_plugin_start_enabled() {
+      "Gateway and browser are ready; channel plugins are deferred until opened".to_string()
+    } else if ready && browser_ok && channels_ok {
       "Gateway, browser, and channels are ready".to_string()
     } else if ready && browser_ok {
       "Gateway and browser are ready; channels are still starting up".to_string()

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -392,13 +392,39 @@ pub fn gateway_stdout_log() -> PathBuf {
   gateway_log_dir().join("knapsack-clawdbot.out.log")
 }
 
-pub(crate) fn gateway_log_has_channel_started(channel: &str) -> bool {
+fn read_gateway_stdout_log_content() -> std::io::Result<String> {
   #[cfg(target_os = "windows")]
-  let log_path = windows_log_path("stdout");
+  let paths = [windows_log_path("stdout"), gateway_stdout_log()];
   #[cfg(not(target_os = "windows"))]
-  let log_path = gateway_stdout_log();
+  let paths = [gateway_stdout_log()];
 
-  let Ok(content) = std::fs::read_to_string(log_path) else {
+  let mut combined = String::new();
+  let mut last_err: Option<std::io::Error> = None;
+  for path in paths {
+    match std::fs::read_to_string(&path) {
+      Ok(content) => {
+        if !combined.is_empty() {
+          combined.push('\n');
+        }
+        combined.push_str(&content);
+      }
+      Err(e) => {
+        last_err = Some(e);
+      }
+    }
+  }
+
+  if combined.is_empty() {
+    Err(last_err.unwrap_or_else(|| {
+      std::io::Error::new(std::io::ErrorKind::NotFound, "gateway stdout log not found")
+    }))
+  } else {
+    Ok(combined)
+  }
+}
+
+pub(crate) fn gateway_log_has_channel_started(channel: &str) -> bool {
+  let Ok(content) = read_gateway_stdout_log_content() else {
     return false;
   };
   content.contains(&format!("channels.{}.start", channel))
@@ -953,6 +979,43 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .insert("allow".to_string(), next_allow);
   eprintln!("[clawd/service] Patched plugins.allow to Knapsack startup allowlist");
   true
+}
+
+fn defer_bundled_channel_configs_for_startup(cfg: &mut serde_json::Value) -> bool {
+  if eager_channel_plugin_start_enabled() {
+    return false;
+  }
+
+  let Some(channels) = cfg
+    .get_mut("channels")
+    .and_then(|value| value.as_object_mut())
+  else {
+    return false;
+  };
+
+  let mut patched = false;
+  for channel_id in KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS {
+    let Some(channel) = channels.get_mut(*channel_id) else {
+      continue;
+    };
+    let Some(channel_obj) = channel.as_object_mut() else {
+      continue;
+    };
+    if channel_obj.get("enabled").and_then(|value| value.as_bool()) == Some(false) {
+      continue;
+    }
+    channel_obj.insert("enabled".to_string(), serde_json::json!(false));
+    patched = true;
+  }
+
+  if patched {
+    eprintln!(
+      "[clawd/service] Deferred bundled channel configs during startup: {}",
+      KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS.join(", ")
+    );
+  }
+
+  patched
 }
 
 fn remove_object_keys(obj: &mut serde_json::Map<String, serde_json::Value>, keys: &[&str]) -> bool {
@@ -2051,7 +2114,10 @@ fn install_bundled_plugin_runtime_deps(
   ensure_openclaw_self_link(&root_nm);
 }
 
-fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path: &std::path::Path) -> bool {
+fn bundled_node_modules_has_declared_dependencies(
+  dir: &std::path::Path,
+  nm_path: &std::path::Path,
+) -> bool {
   let pkg_path = dir.join("package.json");
   let Ok(raw) = fs::read_to_string(&pkg_path) else {
     return false;
@@ -2059,10 +2125,8 @@ fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path
   let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&raw) else {
     return false;
   };
-  let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) else {
-    return false;
-  };
-  if deps.is_empty() {
+  let deps = pkg.get("dependencies").and_then(|v| v.as_object());
+  if deps.map(|deps| deps.is_empty()).unwrap_or(true) {
     return nm_path
       .read_dir()
       .map(|mut entries| entries.any(|entry| entry.is_ok()))
@@ -2070,6 +2134,7 @@ fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path
   }
 
   deps
+    .unwrap()
     .keys()
     .all(|dep| nm_path.join(dep).join("package.json").exists())
 }
@@ -2111,10 +2176,7 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
       .map(|v| {
         v.get("tar_len").and_then(|n| n.as_u64()) == Some(tar_len)
-          && v
-            .get("tar_mtime_secs")
-            .and_then(|n| n.as_u64())
-            == Some(tar_mtime_secs)
+          && v.get("tar_mtime_secs").and_then(|n| n.as_u64()) == Some(tar_mtime_secs)
       })
       .unwrap_or(false);
     if marker_current && bundled_node_modules_has_declared_dependencies(dir, &nm_path) {
@@ -2209,10 +2271,7 @@ fn ensure_openclaw_link_to(root_nm: &std::path::Path, target: &std::path::Path) 
   }
 
   if link_path.exists() || link_path.symlink_metadata().is_ok() {
-    let backup_path = root_nm.join(format!(
-      ".knapsack-openclaw-incomplete-{}",
-      now_epoch_ms()
-    ));
+    let backup_path = root_nm.join(format!(".knapsack-openclaw-incomplete-{}", now_epoch_ms()));
     match fs::rename(&link_path, &backup_path) {
       Ok(()) => eprintln!(
         "[clawd/service] Moved incomplete openclaw link/package aside: {}",
@@ -2915,7 +2974,7 @@ async fn gateway_tcp_port_open(timeout: std::time::Duration) -> bool {
 }
 
 pub async fn gateway_reachable_or_ready(timeout: std::time::Duration) -> bool {
-  gateway_health_port_ok(timeout).await
+  gateway_health_port_ok(timeout).await || gateway_ready_since_last_start()
 }
 
 fn read_log_tail_lines_bounded(
@@ -3224,9 +3283,7 @@ fn ensure_imessage_allowlist_config(cfg: &mut serde_json::Value) -> bool {
     && ch.get("enabled").and_then(|value| value.as_bool()) != Some(false)
   {
     ch.insert("enabled".to_string(), serde_json::json!(false));
-    eprintln!(
-      "[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false"
-    );
+    eprintln!("[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false");
     patched = true;
   }
 
@@ -4757,14 +4814,14 @@ pub(crate) fn gateway_runtime_deps_startup_in_progress() -> bool {
     return false;
   }
 
-  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
+  let Ok(content) = read_gateway_stdout_log_content() else {
     return false;
   };
   gateway_runtime_deps_startup_in_progress_from_log(&content)
 }
 
 fn gateway_post_bind_startup_in_progress() -> bool {
-  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
+  let Ok(content) = read_gateway_stdout_log_content() else {
     return false;
   };
   gateway_post_bind_startup_in_progress_from_log(&content)
@@ -4779,7 +4836,7 @@ pub(crate) fn gateway_startup_in_progress() -> bool {
     return true;
   }
 
-  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
+  let Ok(content) = read_gateway_stdout_log_content() else {
     return false;
   };
   gateway_pre_bind_startup_in_progress_from_log(&content)
@@ -4787,7 +4844,7 @@ pub(crate) fn gateway_startup_in_progress() -> bool {
 }
 
 pub(crate) fn gateway_ready_since_last_start() -> bool {
-  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
+  let Ok(content) = read_gateway_stdout_log_content() else {
     return false;
   };
   gateway_ready_since_last_start_from_log(&content)
@@ -5343,7 +5400,10 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         "[clawd/service] gateway not reachable for {}ms after launch - waiting before self-heal",
         elapsed
       );
-    } else if !gateway_ok && gateway_listening && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS {
+    } else if !gateway_ok
+      && gateway_listening
+      && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS
+    {
       eprintln!(
         "[clawd/service] gateway port is listening but health is still pending for {}ms - waiting before self-heal",
         unreachable_elapsed_ms
@@ -5409,6 +5469,8 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     let mut browser_probe = if gateway_ok {
       if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
         BrowserControlProbe::Ready
+      } else if browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await {
+        BrowserControlProbe::Standby
       } else if BROWSER_STATUS_PROBE_IN_PROGRESS
         .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         .is_ok()
@@ -5833,7 +5895,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   use crate::clawd::gateway_ws;
 
   const STARTUP_READY_BUDGET_MS: u64 = 30_000;
-  const GATEWAY_READY_BUDGET_MS: u64 = 26_000;
+  const GATEWAY_READY_BUDGET_MS: u64 = 24_000;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -5901,7 +5963,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       break;
     }
     if tokio::time::timeout(
-      std::time::Duration::from_millis(3500),
+      std::time::Duration::from_millis(1000),
       gateway_ws::config_get(Some(&tokens.gateway_token)),
     )
     .await
@@ -5917,46 +5979,8 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   let remaining_ms =
     || STARTUP_READY_BUDGET_MS.saturating_sub(started_at.elapsed().as_millis() as u64);
 
-  let browser_ok = if ready {
-    if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
-      true
-    } else {
-      let mut probe =
-        browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(6000)).await;
-      if probe == BrowserControlProbe::Down {
-        probe =
-          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
-            .await;
-      }
-      if probe == BrowserControlProbe::Down
-        && startup_ready_browser_start_enabled()
-        && remaining_ms() > 1500
-      {
-        BROWSER_LAST_NUDGE_MS.store(now_epoch_ms(), Ordering::Relaxed);
-        let _ = browser_control_start_direct(
-          &tokens.gateway_token,
-          std::time::Duration::from_millis(900),
-        )
-        .await;
-        probe =
-          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
-            .await;
-      }
-      while probe != BrowserControlProbe::Ready && remaining_ms() > 1800 {
-        if probe == BrowserControlProbe::Standby && !startup_ready_browser_start_enabled() {
-          break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-        probe =
-          browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(6000)).await;
-        if probe == BrowserControlProbe::Down {
-          probe =
-            browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
-              .await;
-        }
-      }
-      probe.is_available()
-    }
+  let browser_ok = if ready && remaining_ms() > 500 {
+    browser_control_tcp_port_open(std::time::Duration::from_millis(remaining_ms().min(2_000))).await
   } else {
     false
   };
@@ -6327,11 +6351,12 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     .unwrap_or(false);
   let ollama_enabled = tokens.ollama_enabled.unwrap_or(false);
   let (has_gemini_cli, gemini_cli_email) = read_gemini_cli_auth(&app_handle);
-  let has_knapsack = tokens
-    .knapsack_access_token
-    .as_ref()
-    .map(|t| !t.trim().is_empty())
-    .unwrap_or(false);
+  let has_knapsack = tokens.active_provider.as_deref() == Some("knapsack")
+    || tokens
+      .knapsack_email
+      .as_ref()
+      .map(|e| !e.trim().is_empty())
+      .unwrap_or(false);
   let has_key = has_openai
     || has_anthropic
     || has_gemini
@@ -6632,7 +6657,17 @@ pub struct SetApiKeyResponse {
 
 fn normalize_coding_agent(agent: &str) -> Option<String> {
   let agent = agent.trim().to_lowercase();
-  if ["claude", "codex", "antigravity", "agy", "gemini", "grok", "opencode"].contains(&agent.as_str()) {
+  if [
+    "claude",
+    "codex",
+    "antigravity",
+    "agy",
+    "gemini",
+    "grok",
+    "opencode",
+  ]
+  .contains(&agent.as_str())
+  {
     if agent == "agy" {
       return Some("antigravity".to_string());
     }
@@ -6729,19 +6764,12 @@ pub async fn set_api_key(
         .groq_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
-      "xai" => tokens
-        .xai_api_key
-        .as_ref()
-        .map_or(false, |k| !k.is_empty()),
+      "xai" => tokens.xai_api_key.as_ref().map_or(false, |k| !k.is_empty()),
       "openrouter" => tokens
         .openrouter_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
-      "ollama" => true,
-      "knapsack" => tokens
-        .knapsack_access_token
-        .as_ref()
-        .map_or(false, |t| !t.is_empty()),
+      "ollama" | "knapsack" => true,
       _ => tokens
         .openai_api_key
         .as_ref()
@@ -6783,7 +6811,7 @@ pub async fn set_api_key(
           tokens.ollama_model = Some(model.trim().to_string());
         }
         "knapsack" => {
-          tokens.knapsack_model = Some(model.trim().to_string());
+          tokens.knapsack_model = Some("auto".to_string());
         }
         _ => {
           tokens.openai_model = Some(model.trim().to_string());
@@ -7024,18 +7052,16 @@ pub async fn set_api_key(
       "Ollama"
     }
     "knapsack" => {
-      // key = JWT access token; refresh_token = JWT refresh token; email = display email
-      tokens.knapsack_access_token = Some(key);
-      if let Some(rt) = &payload.refresh_token {
-        tokens.knapsack_refresh_token = Some(rt.trim().to_string());
-      }
-      if let Some(em) = &payload.email {
-        tokens.knapsack_email = Some(em.trim().to_string());
+      // Knapsack cloud inference: key field carries the user's email (no API key needed)
+      if !key.is_empty() {
+        tokens.knapsack_email = Some(key);
+      } else if tokens.knapsack_email.as_ref().map_or(true, |e| e.trim().is_empty()) {
+        if let Some(email) = knapsack_email_from_tokens() {
+          tokens.knapsack_email = Some(email);
+        }
       }
       tokens.active_provider = Some("knapsack".to_string());
-      if let Some(model) = &payload.model {
-        tokens.knapsack_model = Some(model.trim().to_string());
-      }
+      tokens.knapsack_model = Some("auto".to_string());
       "Knapsack"
     }
     "minimax" | "zai" | "huggingface" => {
@@ -8025,8 +8051,10 @@ async fn prepare_gateway_config(
   // ── Find clawdbot entry ────────────────────────────────────────────
   let clawdbot_entry = if cfg!(debug_assertions) {
     if cfg!(target_os = "windows") {
-      let bundled_entry =
-        resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js");
+      let bundled_entry = resource_path(
+        app_handle,
+        "resources/clawdbot/dist/knapsack-gateway-entry.js",
+      );
       if bundled_entry.exists() {
         bundled_entry
       } else {
@@ -8050,7 +8078,10 @@ async fn prepare_gateway_config(
       }
     }
   } else {
-    resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js")
+    resource_path(
+      app_handle,
+      "resources/clawdbot/dist/knapsack-gateway-entry.js",
+    )
   };
 
   if !clawdbot_entry.exists() {
@@ -8092,15 +8123,31 @@ async fn prepare_gateway_config(
     // Without this, the OpenClaw gateway falls back to its compiled default
     // (openai/gpt-5.4) and every request fails with "No API key found for
     // provider openai" for any user who doesn't have an OpenAI key.
-    let agents_defaults = if any_provider_key_available() {
-      serde_json::json!({
-        "defaults": {
-          "model": crate::clawd::gateway_client::build_model_config()
+    let mut agents_defaults = serde_json::json!({
+      "defaults": {
+      },
+      "list": [{
+        "id": "main",
+        "default": true,
+        "name": "Knapsack",
+        "identity": {
+          "name": "Knapsack",
+          "theme": "helpful assistant",
+          "emoji": "🎒"
         }
-      })
-    } else {
-      serde_json::Value::Null
-    };
+      }]
+    });
+    if any_provider_key_available() {
+      if let Some(defaults) = agents_defaults
+        .pointer_mut("/defaults")
+        .and_then(|v| v.as_object_mut())
+      {
+        defaults.insert(
+          "model".to_string(),
+          crate::clawd::gateway_client::build_model_config(),
+        );
+      }
+    }
     let mut default_config = serde_json::json!({
       "gateway": {
         "mode": "local",
@@ -8155,12 +8202,10 @@ async fn prepare_gateway_config(
         }
       }
     });
-    if !agents_defaults.is_null() {
-      default_config
-        .as_object_mut()
-        .unwrap()
-        .insert("agents".to_string(), agents_defaults);
-    }
+    default_config
+      .as_object_mut()
+      .unwrap()
+      .insert("agents".to_string(), agents_defaults);
     match fs::write(
       &config_path,
       serde_json::to_string_pretty(&default_config).unwrap_or_default(),
@@ -8289,6 +8334,9 @@ async fn prepare_gateway_config(
         if ensure_knapsack_plugin_allowlist(&mut cfg_val) {
           patched = true;
         }
+        if defer_bundled_channel_configs_for_startup(&mut cfg_val) {
+          patched = true;
+        }
 
         // Ensure browser.enabled is true
         let browser_enabled = cfg_val
@@ -8348,6 +8396,119 @@ async fn prepare_gateway_config(
             current_profile
           );
           patched = true;
+        }
+
+        if cfg_val.pointer("/identity").is_some() {
+          cfg_val.as_object_mut().unwrap().remove("identity");
+          eprintln!("[clawd/service] Removed invalid root identity key from config");
+          patched = true;
+        }
+
+        if cfg_val.pointer("/agents").is_none() {
+          cfg_val
+            .as_object_mut()
+            .unwrap()
+            .insert("agents".to_string(), serde_json::json!({}));
+        }
+        if cfg_val.pointer("/agents/defaults").is_none() {
+          cfg_val
+            .pointer_mut("/agents")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert("defaults".to_string(), serde_json::json!({}));
+        }
+        if cfg_val.pointer("/agents/defaults/identity").is_some() {
+          cfg_val
+            .pointer_mut("/agents/defaults")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("identity");
+          eprintln!("[clawd/service] Removed invalid agents.defaults.identity key");
+          patched = true;
+        }
+        if !cfg_val.pointer("/agents/list").map(|v| v.is_array()).unwrap_or(false) {
+          cfg_val
+            .pointer_mut("/agents")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert("list".to_string(), serde_json::json!([]));
+        }
+        if let Some(agent_list) = cfg_val.pointer_mut("/agents/list").and_then(|v| v.as_array_mut()) {
+          let before_len = agent_list.len();
+          agent_list.retain(|entry| {
+            entry.is_object()
+              && entry
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false)
+          });
+          if agent_list.len() != before_len {
+            eprintln!("[clawd/service] Removed invalid agents.list entries");
+            patched = true;
+          }
+          let main_index = agent_list
+            .iter()
+            .position(|entry| entry.get("id").and_then(|v| v.as_str()) == Some("main"));
+          let index = match main_index {
+            Some(index) => index,
+            None => {
+              agent_list.push(serde_json::json!({
+                "id": "main",
+                "default": true,
+                "name": "Knapsack",
+                "identity": {}
+              }));
+              patched = true;
+              agent_list.len() - 1
+            }
+          };
+          if let Some(main) = agent_list.get_mut(index).and_then(|v| v.as_object_mut()) {
+            if main.get("name").and_then(|v| v.as_str()).map(|s| s.trim().is_empty()).unwrap_or(true) {
+              main.insert("name".to_string(), serde_json::json!("Knapsack"));
+              patched = true;
+            }
+            if main.get("default").and_then(|v| v.as_bool()) != Some(true) {
+              main.insert("default".to_string(), serde_json::json!(true));
+              patched = true;
+            }
+            if !main.get("identity").map(|v| v.is_object()).unwrap_or(false) {
+              main.insert("identity".to_string(), serde_json::json!({}));
+              patched = true;
+            }
+          }
+        }
+        let main_identity = cfg_val
+          .pointer_mut("/agents/list")
+          .and_then(|v| v.as_array_mut())
+          .and_then(|list| {
+            list
+              .iter_mut()
+              .find(|entry| entry.get("id").and_then(|v| v.as_str()) == Some("main"))
+          })
+          .and_then(|entry| entry.get_mut("identity"))
+          .and_then(|v| v.as_object_mut());
+        if let Some(identity) = main_identity {
+          let defaults = [
+            ("name", serde_json::json!("Knapsack")),
+            ("theme", serde_json::json!("helpful assistant")),
+            ("emoji", serde_json::json!("🎒")),
+          ];
+          for (key, value) in defaults {
+            let needs_default = identity
+              .get(key)
+              .and_then(|v| v.as_str())
+              .map(|s| s.trim().is_empty())
+              .unwrap_or(true);
+            if needs_default {
+              identity.insert(key.to_string(), value);
+              eprintln!("[clawd/service] Patched agents.list.main.identity.{} default", key);
+              patched = true;
+            }
+          }
         }
 
         // Clean up browser.hideAutomationBanner
@@ -8445,9 +8606,8 @@ async fn prepare_gateway_config(
           }
         }
         if !current_primary.trim().is_empty() && model_ref_has_key(current_primary.trim()) {
-          let expected_fallbacks = crate::clawd::gateway_client::collect_fallback_models(
-            current_primary.trim(),
-          );
+          let expected_fallbacks =
+            crate::clawd::gateway_client::collect_fallback_models(current_primary.trim());
           if !expected_fallbacks.is_empty() {
             let existing_fallbacks = cfg_val
               .pointer("/agents/defaults/model/fallbacks")
@@ -9129,10 +9289,7 @@ async fn prepare_gateway_config(
   let bundled_plugins_dir_str = node_arg_path(&bundled_plugins_dir);
   let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
 
-  let node_dir = node_path
-    .parent()
-    .map(node_arg_path)
-    .unwrap_or_default();
+  let node_dir = node_path.parent().map(node_arg_path).unwrap_or_default();
   let path_separator = if cfg!(target_os = "windows") {
     ";"
   } else {
@@ -9237,6 +9394,7 @@ async fn prepare_gateway_config(
       "OPENCLAW_DESKTOP_AUTO_START_CHANNELS".to_string(),
       "0".to_string(),
     ),
+    ("OPENCLAW_DESKTOP_FAST_BIND".to_string(), "1".to_string()),
     (
       "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
       "1".to_string(),
@@ -9288,12 +9446,24 @@ async fn prepare_gateway_config(
         }
       }
     }
+    for var in [
+      "OPENCLAW_SERVICE_MARKER",
+      "OPENCLAW_SERVICE_KIND",
+      "OPENCLAW_WINDOWS_TASK_NAME",
+      "OPENCLAW_GATEWAY_SERVICE_PID",
+    ] {
+      env.push((var.to_string(), String::new()));
+    }
+    env.push(("OPENCLAW_ALLOW_MULTI_GATEWAY".to_string(), "1".to_string()));
   } else {
     // Prevents the macOS gateway inspector from classifying this LaunchAgent as
     // a legacy "clawdbot" service and moving it to Trash. On Windows these
     // markers mean "schtasks-supervised" to OpenClaw, which adds a 30s lock
     // recovery wait to the desktop-managed direct gateway startup path.
-    env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
+    env.push((
+      "OPENCLAW_SERVICE_MARKER".to_string(),
+      "openclaw".to_string(),
+    ));
     env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
   }
 
@@ -10022,6 +10192,20 @@ pub async fn set_service_enabled(
             "headless": false,
             "defaultProfile": "openclaw"
           },
+          "agents": {
+            "defaults": {
+            },
+            "list": [{
+              "id": "main",
+              "default": true,
+              "name": "Knapsack",
+              "identity": {
+                "name": "Knapsack",
+                "theme": "helpful assistant",
+                "emoji": "🎒"
+              }
+            }]
+          },
           "plugins": {
             "allow": KNAPSACK_REQUIRED_PLUGINS,
             "slots": {
@@ -10235,6 +10419,9 @@ pub async fn set_service_enabled(
             }
 
             if ensure_knapsack_plugin_allowlist(&mut cfg) {
+              patched = true;
+            }
+            if defer_bundled_channel_configs_for_startup(&mut cfg) {
               patched = true;
             }
 
@@ -10901,10 +11088,7 @@ pub async fn set_service_enabled(
       // Build a PATH that includes the directory where we found node (so npm
       // is also discoverable), plus common macOS paths.  LaunchAgents get a
       // minimal PATH by default which typically excludes /opt/homebrew/bin.
-      let node_dir = node_path
-        .parent()
-        .map(node_arg_path)
-        .unwrap_or_default();
+      let node_dir = node_path.parent().map(node_arg_path).unwrap_or_default();
       let mut path_parts: Vec<String> = Vec::new();
       if !node_dir.is_empty() {
         path_parts.push(node_dir);
@@ -11001,6 +11185,7 @@ pub async fn set_service_enabled(
           "OPENCLAW_DESKTOP_AUTO_START_CHANNELS".to_string(),
           "0".to_string(),
         ),
+        ("OPENCLAW_DESKTOP_FAST_BIND".to_string(), "1".to_string()),
         (
           "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
           "1".to_string(),
@@ -11018,12 +11203,25 @@ pub async fn set_service_enabled(
         }),
       ];
 
-      if !cfg!(target_os = "windows") {
+      if cfg!(target_os = "windows") {
+        for var in [
+          "OPENCLAW_SERVICE_MARKER",
+          "OPENCLAW_SERVICE_KIND",
+          "OPENCLAW_WINDOWS_TASK_NAME",
+          "OPENCLAW_GATEWAY_SERVICE_PID",
+        ] {
+          env.push((var.to_string(), String::new()));
+        }
+        env.push(("OPENCLAW_ALLOW_MULTI_GATEWAY".to_string(), "1".to_string()));
+      } else {
         // Prevents the macOS gateway inspector from classifying this LaunchAgent
         // as a legacy "clawdbot" service and moving it to Trash. On Windows
         // these markers mean "schtasks-supervised" to OpenClaw, which adds a
         // 30s lock recovery wait to the desktop-managed direct gateway startup.
-        env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
+        env.push((
+          "OPENCLAW_SERVICE_MARKER".to_string(),
+          "openclaw".to_string(),
+        ));
         env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
       }
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -8428,6 +8428,56 @@ async fn prepare_gateway_config(
             patched = true;
           }
         }
+        if !current_primary.trim().is_empty() && model_ref_has_key(current_primary.trim()) {
+          let expected_fallbacks = crate::clawd::gateway_client::collect_fallback_models(
+            current_primary.trim(),
+          );
+          if !expected_fallbacks.is_empty() {
+            let existing_fallbacks = cfg_val
+              .pointer("/agents/defaults/model/fallbacks")
+              .and_then(|v| v.as_array())
+              .map(|arr| {
+                arr
+                  .iter()
+                  .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                  .collect::<Vec<_>>()
+              })
+              .unwrap_or_default();
+            if existing_fallbacks != expected_fallbacks {
+              if cfg_val.pointer("/agents").is_none() {
+                cfg_val
+                  .as_object_mut()
+                  .unwrap()
+                  .insert("agents".to_string(), serde_json::json!({}));
+              }
+              if cfg_val.pointer("/agents/defaults").is_none() {
+                cfg_val
+                  .pointer_mut("/agents")
+                  .unwrap()
+                  .as_object_mut()
+                  .unwrap()
+                  .insert("defaults".to_string(), serde_json::json!({}));
+              }
+              cfg_val
+                .pointer_mut("/agents/defaults")
+                .unwrap()
+                .as_object_mut()
+                .unwrap()
+                .insert(
+                  "model".to_string(),
+                  serde_json::json!({
+                    "primary": current_primary.trim(),
+                    "fallbacks": expected_fallbacks,
+                  }),
+                );
+              eprintln!(
+                "[clawd/service] Refreshed agents.defaults.model fallbacks for '{}'",
+                current_primary
+              );
+              patched = true;
+            }
+          }
+        }
 
         // On macOS, enable peekaboo as a bundled skill (macOS UI automation via PeekabooBridge)
         if cfg!(target_os = "macos") {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -278,7 +278,7 @@ fn is_pid_alive(pid: u32) -> bool {
 static BROWSER_START_NUDGED: AtomicBool = AtomicBool::new(false);
 static GATEWAY_LAST_LAUNCH_MS: AtomicU64 = AtomicU64::new(0);
 static QA_DIRECT_GATEWAY_FIRST_SEEN_MS: AtomicU64 = AtomicU64::new(0);
-const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 15_000;
+const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 30_000;
 const PLUGIN_RUNTIME_DEPS_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(600);
 const PLUGIN_RUNTIME_DEPS_OWNER_LOCK_GRACE_MS: u64 = 180_000;
 
@@ -390,6 +390,19 @@ pub fn gateway_log_dir() -> PathBuf {
 /// Path to the gateway stdout log file.
 pub fn gateway_stdout_log() -> PathBuf {
   gateway_log_dir().join("knapsack-clawdbot.out.log")
+}
+
+pub(crate) fn gateway_log_has_channel_started(channel: &str) -> bool {
+  #[cfg(target_os = "windows")]
+  let log_path = windows_log_path("stdout");
+  #[cfg(not(target_os = "windows"))]
+  let log_path = gateway_stdout_log();
+
+  let Ok(content) = std::fs::read_to_string(log_path) else {
+    return false;
+  };
+  content.contains(&format!("channels.{}.start", channel))
+    || content.contains(&format!("[{}] [default] starting provider", channel))
 }
 
 fn mark_gateway_launch_started() {
@@ -2034,10 +2047,16 @@ fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path
   let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) else {
     return false;
   };
-  !deps.is_empty()
-    && deps
-      .keys()
-      .all(|dep| nm_path.join(dep).join("package.json").exists())
+  if deps.is_empty() {
+    return nm_path
+      .read_dir()
+      .map(|mut entries| entries.any(|entry| entry.is_ok()))
+      .unwrap_or(false);
+  }
+
+  deps
+    .keys()
+    .all(|dep| nm_path.join(dep).join("package.json").exists())
 }
 
 /// On Windows CI builds, prune-clawdbot.cjs packs `node_modules/` into
@@ -5796,10 +5815,10 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 /// warming after the local gateway is safe for the desktop to use.
 #[get("/api/clawd/service/startup-ready")]
 pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
-  use crate::clawd::{gateway_supervisor, gateway_ws};
+  use crate::clawd::gateway_ws;
 
-  const STARTUP_READY_BUDGET_MS: u64 = 15_000;
-  const GATEWAY_READY_BUDGET_MS: u64 = 13_500;
+  const STARTUP_READY_BUDGET_MS: u64 = 30_000;
+  const GATEWAY_READY_BUDGET_MS: u64 = 26_000;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -5859,9 +5878,26 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       }
     }
   }
-  let ready =
-    gateway_supervisor::wait_for_gateway_ready(&tokens.gateway_token, GATEWAY_READY_BUDGET_MS)
-      .await;
+  let ready_started_at = std::time::Instant::now();
+  let mut ready = false;
+  while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
+    if gateway_reachable_or_ready(std::time::Duration::from_millis(1000)).await {
+      ready = true;
+      break;
+    }
+    if tokio::time::timeout(
+      std::time::Duration::from_millis(3500),
+      gateway_ws::config_get(Some(&tokens.gateway_token)),
+    )
+    .await
+    .map(|result| result.is_ok())
+    .unwrap_or(false)
+    {
+      ready = true;
+      break;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+  }
 
   let remaining_ms =
     || STARTUP_READY_BUDGET_MS.saturating_sub(started_at.elapsed().as_millis() as u64);
@@ -5910,24 +5946,15 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     false
   };
 
-  let channels_ok = if ready && remaining_ms() > 500 {
-    tokio::time::timeout(
-      std::time::Duration::from_millis(remaining_ms().min(1200)),
-      gateway_ws::call_channel_method(
-        "channels.status",
-        Some(serde_json::json!({
-          "probe": false,
-          "timeoutMs": 800
-        })),
-        Some(&tokens.gateway_token),
-      ),
-    )
-    .await
-    .map(|result| result.is_ok())
-    .unwrap_or(false)
-  } else {
-    false
-  };
+  let mut channels_ok = false;
+  while ready && remaining_ms() > 500 {
+    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp")
+    {
+      channels_ok = true;
+      break;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+  }
 
   let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
   // Startup-ready is the desktop gateway-live gate. Browser and channel warmup
@@ -5949,7 +5976,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     } else if ready {
       "Gateway is ready; browser and channels are still starting up".to_string()
     } else {
-      "Gateway did not become ready within 15s".to_string()
+      "Gateway did not become ready within 30s".to_string()
     },
     diagnostic_type: None,
   })

--- a/src/src-tauri/windows/installer.nsi
+++ b/src/src-tauri/windows/installer.nsi
@@ -553,6 +553,14 @@ Section Install
     File /a "/oname={{this.[1]}}" "{{unescape-dollar-sign @key}}"
   {{/each}}
 
+  ; CI packs the gateway runtime node_modules directory into one tarball so the
+  ; installer stays below Windows package file-count/path limits. Extract it at
+  ; install time so first app launch can start the gateway immediately.
+  IfFileExists "$INSTDIR\resources\clawdbot\node_modules.tar" 0 node_modules_extract_done
+    RMDir /r "$INSTDIR\resources\clawdbot\node_modules"
+    nsExec::ExecToLog '"$SYSDIR\tar.exe" -xf "$INSTDIR\resources\clawdbot\node_modules.tar" -C "$INSTDIR\resources\clawdbot"'
+  node_modules_extract_done:
+
   ; Copy external binaries
   {{#each binaries}}
     File /a "/oname={{this}}" "{{unescape-dollar-sign @key}}"

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -411,6 +411,10 @@ type ProviderOption = {
   helpUrl: string
 }
 
+const KNAPSACK_MODELS = [
+  { id: 'auto', name: 'Auto', description: 'Knapsack selects the best available model for your account' },
+]
+const KNAPSACK_MODEL_STORAGE = 'knapsack_knapsack_model'
 
 const PROVIDERS: ProviderOption[] = [
   { id: 'knapsack', name: 'Knapsack', description: 'Powered by Knapsack — no API key needed', keyPrefix: '', helpUrl: 'https://studio.knapsack.ai' },
@@ -1685,6 +1689,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [selectedOllamaModel, setSelectedOllamaModel] = useState<string>(() => {
     return localStorage.getItem(OLLAMA_MODEL_STORAGE) || ''
   })
+  const [selectedKnapsackModel, setSelectedKnapsackModel] = useState<string>(() => {
+    const stored = localStorage.getItem(KNAPSACK_MODEL_STORAGE)
+    return KNAPSACK_MODELS.some(model => model.id === stored) ? stored! : 'auto'
+  })
   const [knapsackEmail, setKnapsackEmail] = useState<string>('')
   const [isKnapsackConnecting, setIsKnapsackConnecting] = useState(false)
   const [knapsackConnectError, setKnapsackConnectError] = useState<string | null>(null)
@@ -2036,6 +2044,11 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         })
         if (keyStatus.knapsack_email) {
           setKnapsackEmail(keyStatus.knapsack_email)
+        }
+        if (keyStatus.knapsack_model) {
+          const knapsackModel = KNAPSACK_MODELS.some(model => model.id === keyStatus.knapsack_model) ? keyStatus.knapsack_model : 'auto'
+          setSelectedKnapsackModel(knapsackModel)
+          localStorage.setItem(KNAPSACK_MODEL_STORAGE, knapsackModel)
         }
         // Restore Ollama model from backend if Ollama is the active provider
         if (keyStatus.ollama_enabled && keyStatus.ollama_model) {
@@ -6768,6 +6781,48 @@ ${actualText}`
                             </p>
                           </>
                         )}
+                        <label className="ClawdKeyPromptLabel">Model tier</label>
+                        <div className="ClawdModelSelector">
+                          {KNAPSACK_MODELS.map(model => (
+                            <button
+                              key={model.id}
+                              className={`ClawdModelOption${selectedKnapsackModel === model.id ? ' selected' : ''}`}
+                              onClick={() => {
+                                setSelectedKnapsackModel(model.id)
+                                localStorage.setItem(KNAPSACK_MODEL_STORAGE, model.id)
+                              }}
+                              disabled={savingKey}
+                            >
+                              <span className="ClawdModelName">{model.name}</span>
+                              <span className="ClawdModelDesc">{model.description}</span>
+                            </button>
+                          ))}
+                        </div>
+                        <div className="ClawdAccordionActions">
+                          <button
+                            className="ClawdChannelCardAction ClawdChannelCardAction--connect"
+                            onClick={async () => {
+                              setSavingKey(true)
+                              try {
+                                await apiPost('/api/clawd/service/set-api-key', { provider: 'knapsack', key: knapsackEmail || '', model: selectedKnapsackModel })
+                                setSelectedProvider('knapsack')
+                                localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
+                                setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
+                                pushAssistant(`Switched to Knapsack (${KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel}).`)
+                              } catch {}
+                              setSavingKey(false)
+                            }}
+                            disabled={savingKey}
+                          >
+                            {savingKey ? 'Switching...' : isActive ? 'Select' : 'Use Knapsack'}
+                          </button>
+                        </div>
+                        <p style={{ margin: '8px 0 0', fontSize: 11, color: '#94a3b8' }}>
+                          Need credits?{' '}
+                          <a href="https://studio.knapsack.ai" target="_blank" rel="noopener noreferrer" style={{ color: '#c54841' }}>
+                            studio.knapsack.ai
+                          </a>
+                        </p>
                       </div>
                     </div>
                   )


### PR DESCRIPTION
## Summary
- early-bind the desktop-managed gateway and browser-control placeholder so startup readiness is not blocked on plugin/channel bootstrap
- defer channel plugin loading and keep channel status probes bounded/cached
- align Knapsack provider setup with the merged provider work: default to `auto`, allow no-key selection, and preserve the backend-owned model choice
- keep OpenRouter fallback/chat timeout behavior from the startup QA work

## Validation
- `node --check src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js`
- `node --check src/src-tauri/resources/clawdbot/dist/plugin-registration-BM5pWCYl.js`
- `git diff --cached --check`
- `cd src && npx tsc --noEmit`

## Note
- `cargo test --manifest-path src-tauri/Cargo.toml clawd` started compiling `knapsack v1.8.5` but then hit the same local Windows Cargo stall observed earlier: Cargo processes remained alive with no active `rustc` child. I stopped only those Cargo processes.