### PR TITLE
Fix Windows startup browser readiness

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -6080,7 +6080,9 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
 
   let started_at = std::time::Instant::now();
   if startup_ready_browser_start_enabled()
-    && !browser_cdp_port_open(std::time::Duration::from_millis(100)).await
+    && !browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
+      .await
+      .is_available()
   {
     spawn_startup_browser_start_nudge(tokens.gateway_token.clone());
   }
@@ -6151,6 +6153,11 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   let browser_ok = if ready && remaining_ms() > 500 {
     let timeout = std::time::Duration::from_millis(remaining_ms().min(2_000));
     if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
+      true
+    } else if browser_control_status(&tokens.gateway_token, timeout)
+      .await
+      .is_available()
+    {
       true
     } else {
       browser_control_status_cached(&tokens.gateway_token, timeout)

--- a/src/src-tauri/windows/installer.nsi
+++ b/src/src-tauri/windows/installer.nsi
@@ -40,6 +40,7 @@ ${StrLoc}
 !define WEBVIEW2INSTALLERPATH "{{webview2_installer_path}}"
 !define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
 !define MANUPRODUCTKEY "Software\${MANUFACTURER}\${PRODUCTNAME}"
+!define APPPATHKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\${MAINBINARYNAME}.exe"
 !define UNINSTALLERSIGNCOMMAND "{{uninstaller_sign_cmd}}"
 !define ESTIMATEDSIZE "{{estimated_size}}"
 
@@ -580,10 +581,12 @@ Section Install
 
   ; Save current MAINBINARYNAME for future updates from v2 updater
   WriteRegStr SHCTX "${UNINSTKEY}" "MainBinaryName" "${MAINBINARYNAME}.exe"
+  WriteRegStr SHCTX "${APPPATHKEY}" "" "$INSTDIR\${MAINBINARYNAME}.exe"
+  WriteRegStr SHCTX "${APPPATHKEY}" "Path" "$INSTDIR"
 
   ; Registry information for add/remove programs
   WriteRegStr SHCTX "${UNINSTKEY}" "DisplayName" "${PRODUCTNAME}"
-  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayIcon" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\""
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayIcon" "$INSTDIR\${MAINBINARYNAME}.exe,0"
   WriteRegStr SHCTX "${UNINSTKEY}" "DisplayVersion" "${VERSION}"
   WriteRegStr SHCTX "${UNINSTKEY}" "Publisher" "${MANUFACTURER}"
   WriteRegStr SHCTX "${UNINSTKEY}" "InstallLocation" "$\"$INSTDIR$\""
@@ -716,10 +719,13 @@ Section Uninstall
   ; Remove registry information for add/remove programs
   !if "${INSTALLMODE}" == "both"
     DeleteRegKey SHCTX "${UNINSTKEY}"
+    DeleteRegKey SHCTX "${APPPATHKEY}"
   !else if "${INSTALLMODE}" == "perMachine"
     DeleteRegKey HKLM "${UNINSTKEY}"
+    DeleteRegKey HKLM "${APPPATHKEY}"
   !else
     DeleteRegKey HKCU "${UNINSTKEY}"
+    DeleteRegKey HKCU "${APPPATHKEY}"
   !endif
 
   DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
@@ -773,7 +779,7 @@ FunctionEnd
 !macroend
 
 Function CreateDesktopShortcut
-  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "" "$INSTDIR\${MAINBINARYNAME}.exe" 0
   !insertmacro SetLnkAppUserModelId "$DESKTOP\${PRODUCTNAME}.lnk"
 FunctionEnd
 
@@ -781,6 +787,6 @@ Function CreateStartMenuShortcut
   StrCmp "$AppStartMenuFolder" "" 0 +2
     StrCpy $AppStartMenuFolder "${PRODUCTNAME}"
   CreateDirectory "$SMPROGRAMS\$AppStartMenuFolder"
-  CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+  CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "" "$INSTDIR\${MAINBINARYNAME}.exe" 0
   !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
 FunctionEnd


### PR DESCRIPTION
## Summary
- Treat the browser-control HTTP service as startup-ready when it responds directly, even if Chrome CDP has not opened yet.
- Avoid sending startup browser nudges when browser-control is already responsive.
- Keep the Windows installer discoverability/icon fix: register App Paths, set DisplayIcon to `Knapsack.exe,0`, and create shortcuts with the exe icon explicitly.

## QA
- `npx tsc --noEmit` passed.
- `git diff --check` passed for the touched files.
- Live prod evidence before patch: `http://127.0.0.1:18791/` returned `OK` while `/api/clawd/service/startup-ready` still returned `browser_ok:false`; this patch aligns startup-ready with that responsive browser-control state.
- Local Rust build/test was blocked: Cargo repeatedly stalled on Windows with only nested `cargo.exe` processes and no active `rustc`/linker child. A fresh `--target-dir src-tauri/target-codex` build made substantial progress but eventually hit the same no-child Cargo stall before producing a binary.