### PR TITLE
Validate Windows release installers

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -176,15 +176,16 @@ jobs:
         run: dotnet tool install --global AzureSignTool
 
       # Tauri v1's signCommand %1 substitution is broken (passes literal "%1" to
-      # AzureSignTool). We sign the EXE and NSIS installer after the build instead.
+      # AzureSignTool). We sign the EXE and Windows installers after the build instead.
 
       - name: Build Tauri app
         working-directory: src
         shell: pwsh
         # NSIS current-user mode installs under LOCALAPPDATA and avoids UAC.
+        # MSI is still produced because several release/QA flows expect it.
         run: |
           $log = "$env:RUNNER_TEMP\tauri-build.log"
-          npx tauri build --bundles nsis --verbose 2>&1 | Tee-Object -FilePath $log
+          npx tauri build --bundles nsis,msi --verbose 2>&1 | Tee-Object -FilePath $log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         env:
           VITE_KN_API_SERVER: https://api.knapsack.ai
@@ -202,7 +203,7 @@ jobs:
         run: |
           Get-PSDrive C | Select-Object Used, Free | ForEach-Object { Write-Host "Disk after build: used=$([math]::Round($_.Used/1GB,1))GB free=$([math]::Round($_.Free/1GB,1))GB" }
 
-      - name: Sign release binary and NSIS installer
+      - name: Sign release binary and Windows installers
         if: env.AZURE_KEY_VAULT_URI != ''
         shell: pwsh
         env:
@@ -228,6 +229,9 @@ jobs:
           Write-Host "=== NSIS installers in bundle/nsis ==="
           Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\' -Filter '*.exe' -ErrorAction SilentlyContinue |
             ForEach-Object { Write-Host "  $($_.FullName)" }
+          Write-Host "=== MSI installers in bundle/msi ==="
+          Get-ChildItem 'src\src-tauri\target\release\bundle\msi\' -Filter '*.msi' -ErrorAction SilentlyContinue |
+            ForEach-Object { Write-Host "  $($_.FullName)" }
 
           # Sign the release EXE (Tauri renames knapsack.exe → Knapsack.exe for WiX)
           $exe = 'src\src-tauri\target\release\Knapsack.exe'
@@ -240,13 +244,29 @@ jobs:
             Write-Warning "Knapsack.exe not found; skipping EXE signing"
           }
 
-          # Sign each NSIS installer.
-          $nsisBundles = @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
-          foreach ($installer in $nsisBundles) {
-            Write-Host "Signing NSIS installer: $($installer.FullName)"
+          # Sign each Windows installer.
+          $installers = @()
+          $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
+          $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\msi\*.msi' -ErrorAction SilentlyContinue)
+          foreach ($installer in $installers) {
+            Write-Host "Signing Windows installer: $($installer.FullName)"
             AzureSignTool sign @s $installer.FullName
-            if ($LASTEXITCODE -ne 0) { Write-Error "Failed to sign NSIS installer: $($installer.FullName)"; exit 1 }
-            Write-Host "Signed NSIS installer OK"
+            if ($LASTEXITCODE -ne 0) { Write-Error "Failed to sign Windows installer: $($installer.FullName)"; exit 1 }
+            Write-Host "Signed Windows installer OK"
+          }
+
+      - name: Verify Windows installer artifacts
+        shell: pwsh
+        run: |
+          $installers = @()
+          $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
+          $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\msi\*.msi' -ErrorAction SilentlyContinue)
+          if ($installers.Count -eq 0) {
+            Write-Error "No Windows installers were produced"
+            exit 1
+          }
+          foreach ($installer in $installers) {
+            & 'src\scripts\verify-windows-installer.ps1' -InstallerPath $installer.FullName -InstallDir "$env:RUNNER_TEMP\ks-install-qa-$($installer.BaseName)"
           }
 
       - name: Post build log to PR on failure
@@ -283,4 +303,12 @@ jobs:
             src/src-tauri/target/release/bundle/nsis/*.exe
             src/src-tauri/target/release/bundle/nsis/*.nsis.zip
             src/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig
+          if-no-files-found: warn
+
+      - name: Upload MSI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: knapsack-windows-msi
+          path: |
+            src/src-tauri/target/release/bundle/msi/*.msi
           if-no-files-found: warn

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -258,6 +258,7 @@ jobs:
       - name: Verify Windows installer artifacts
         shell: pwsh
         run: |
+          $verifyLog = "$env:RUNNER_TEMP\windows-installer-verify.log"
           $installers = @()
           $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
           $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\msi\*.msi' -ErrorAction SilentlyContinue)
@@ -266,7 +267,13 @@ jobs:
             exit 1
           }
           foreach ($installer in $installers) {
-            & 'src\scripts\verify-windows-installer.ps1' -InstallerPath $installer.FullName -InstallDir "$env:RUNNER_TEMP\ks-install-qa-$($installer.BaseName)"
+            try {
+              & 'src\scripts\verify-windows-installer.ps1' -InstallerPath $installer.FullName -InstallDir "$env:RUNNER_TEMP\ks-install-qa-$($installer.BaseName)" 2>&1 |
+                Tee-Object -FilePath $verifyLog -Append
+            } catch {
+              $_ | Tee-Object -FilePath $verifyLog -Append
+              exit 1
+            }
           }
 
       - name: Post build log to PR on failure
@@ -279,7 +286,11 @@ jobs:
           $repo = "${{ github.repository }}"
           $run  = "${{ github.run_id }}"
           $log  = "$env:RUNNER_TEMP\tauri-build.log"
-          if (Test-Path $log) {
+          $verifyLog = "$env:RUNNER_TEMP\windows-installer-verify.log"
+          if (Test-Path $verifyLog) {
+            $tail = (Get-Content $verifyLog -Tail 120) -join "`n"
+            $body = "**[Windows CI] installer verification failed (run $run)**`n``````text`n$tail`n``````"
+          } elseif (Test-Path $log) {
             $tail = (Get-Content $log -Tail 100) -join "`n"
             $body = "**[Windows CI] build-windows failed (run $run)**`n``````text`n$tail`n``````"
           } else {
@@ -292,10 +303,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: tauri-build-log
-          path: ${{ runner.temp }}/tauri-build.log
+          path: |
+            ${{ runner.temp }}/tauri-build.log
+            ${{ runner.temp }}/windows-installer-verify.log
           if-no-files-found: ignore
 
       - name: Upload NSIS artifacts
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: knapsack-windows-nsis
@@ -306,6 +320,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload MSI artifacts
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: knapsack-windows-msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,6 +482,7 @@ jobs:
       - name: Verify Windows installer artifacts
         shell: pwsh
         run: |
+          $verifyLog = "$env:RUNNER_TEMP\windows-installer-verify.log"
           $installers = @()
           $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
           $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\msi\*.msi' -ErrorAction SilentlyContinue)
@@ -490,7 +491,13 @@ jobs:
             exit 1
           }
           foreach ($installer in $installers) {
-            & 'src\scripts\verify-windows-installer.ps1' -InstallerPath $installer.FullName -InstallDir "$env:RUNNER_TEMP\ks-install-qa-$($installer.BaseName)"
+            try {
+              & 'src\scripts\verify-windows-installer.ps1' -InstallerPath $installer.FullName -InstallDir "$env:RUNNER_TEMP\ks-install-qa-$($installer.BaseName)" 2>&1 |
+                Tee-Object -FilePath $verifyLog -Append
+            } catch {
+              $_ | Tee-Object -FilePath $verifyLog -Append
+              exit 1
+            }
           }
 
       - name: Post build log to PR on failure
@@ -503,7 +510,11 @@ jobs:
           $repo = "${{ github.repository }}"
           $run  = "${{ github.run_id }}"
           $log  = "$env:RUNNER_TEMP\tauri-build.log"
-          if (Test-Path $log) {
+          $verifyLog = "$env:RUNNER_TEMP\windows-installer-verify.log"
+          if (Test-Path $verifyLog) {
+            $tail = (Get-Content $verifyLog -Tail 120) -join "`n"
+            $body = "**[Windows CI] installer verification failed (run $run)**`n``````text`n$tail`n``````"
+          } elseif (Test-Path $log) {
             $tail = (Get-Content $log -Tail 100) -join "`n"
             $body = "**[Windows CI] build-windows failed (run $run)**`n``````text`n$tail`n``````"
           } else {
@@ -516,10 +527,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: tauri-build-log
-          path: ${{ runner.temp }}/tauri-build.log
+          path: |
+            ${{ runner.temp }}/tauri-build.log
+            ${{ runner.temp }}/windows-installer-verify.log
           if-no-files-found: ignore
 
       - name: Upload Windows artifacts
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: windows-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Windows — NSIS current-user installer
+  # Windows — NSIS current-user installer plus MSI compatibility artifact
   # ---------------------------------------------------------------------------
   build-windows:
     needs: bump-version
@@ -458,9 +458,10 @@ jobs:
         working-directory: src
         shell: pwsh
         # NSIS current-user mode installs under LOCALAPPDATA and avoids UAC.
+        # MSI is also produced because several release/QA flows expect it.
         run: |
           $log = "$env:RUNNER_TEMP\tauri-build.log"
-          npx tauri build --bundles nsis --verbose 2>&1 | Tee-Object -FilePath $log
+          npx tauri build --bundles nsis,msi --verbose 2>&1 | Tee-Object -FilePath $log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
@@ -477,6 +478,20 @@ jobs:
         shell: pwsh
         run: |
           Get-PSDrive C | Select-Object Used, Free | ForEach-Object { Write-Host "Disk after build: used=$([math]::Round($_.Used/1GB,1))GB free=$([math]::Round($_.Free/1GB,1))GB" }
+
+      - name: Verify Windows installer artifacts
+        shell: pwsh
+        run: |
+          $installers = @()
+          $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\nsis\*.exe' -ErrorAction SilentlyContinue)
+          $installers += @(Get-ChildItem 'src\src-tauri\target\release\bundle\msi\*.msi' -ErrorAction SilentlyContinue)
+          if ($installers.Count -eq 0) {
+            Write-Error "No Windows installers were produced"
+            exit 1
+          }
+          foreach ($installer in $installers) {
+            & 'src\scripts\verify-windows-installer.ps1' -InstallerPath $installer.FullName -InstallDir "$env:RUNNER_TEMP\ks-install-qa-$($installer.BaseName)"
+          }
 
       - name: Post build log to PR on failure
         if: failure() && github.event.pull_request.number != ''
@@ -512,6 +527,7 @@ jobs:
             src/src-tauri/target/release/bundle/nsis/*.exe
             src/src-tauri/target/release/bundle/nsis/*.nsis.zip
             src/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig
+            src/src-tauri/target/release/bundle/msi/*.msi
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -591,7 +607,7 @@ jobs:
           # macOS
           find artifacts/macos-artifacts -type f \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \) -exec cp {} release-files/ \;
           # Windows
-          find artifacts/windows-artifacts -type f \( -name "*.exe" -o -name "*.nsis.zip" -o -name "*.nsis.zip.sig" \) -exec cp {} release-files/ \;
+          find artifacts/windows-artifacts -type f \( -name "*.exe" -o -name "*.msi" -o -name "*.nsis.zip" -o -name "*.nsis.zip.sig" \) -exec cp {} release-files/ \;
           # Updater metadata
           cp artifacts/latest.json release-files/
           echo "[release] Files to upload:"

--- a/src/scripts/verify-windows-installer.ps1
+++ b/src/scripts/verify-windows-installer.ps1
@@ -46,8 +46,8 @@ if (-not (Test-Path $InstallerPath)) {
   throw "Installer not found: $InstallerPath"
 }
 
-if (Test-Path $InstallDir) {
-  Remove-Item -Recurse -Force $InstallDir
+if (Test-Path -LiteralPath $InstallDir) {
+  Remove-Item -LiteralPath $InstallDir -Recurse -Force
 }
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
@@ -121,6 +121,10 @@ if (Test-Path $uninstaller) {
   }
 }
 
-if (Test-Path $InstallDir) {
-  Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue
+try {
+  if (Test-Path -LiteralPath $InstallDir) {
+    Remove-Item -LiteralPath $InstallDir -Recurse -Force -ErrorAction Stop
+  }
+} catch {
+  Write-Warning "Unable to remove test install directory ${InstallDir}: $_"
 }

--- a/src/scripts/verify-windows-installer.ps1
+++ b/src/scripts/verify-windows-installer.ps1
@@ -1,0 +1,126 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+
+  [string]$InstallDir = (Join-Path $(if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { $env:TEMP }) "knapsack-install-qa"),
+
+  [int]$TimeoutSeconds = 180
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-AppRoot {
+  param([string]$Root)
+
+  $directExe = Join-Path $Root "Knapsack.exe"
+  if (Test-Path $directExe) {
+    return $Root
+  }
+
+  $exe = Get-ChildItem -Path $Root -Recurse -Filter "Knapsack.exe" -File -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if (-not $exe) {
+    throw "Knapsack.exe was not installed or extracted under $Root"
+  }
+  return $exe.DirectoryName
+}
+
+function Assert-File {
+  param(
+    [string]$AppRoot,
+    [string]$RelativePath
+  )
+
+  $path = Join-Path $AppRoot $RelativePath
+  if (-not (Test-Path $path)) {
+    throw "Missing installed file: $RelativePath"
+  }
+  $item = Get-Item $path
+  if ($item.Length -eq 0) {
+    throw "Installed file is empty: $RelativePath"
+  }
+  Write-Host "verified $RelativePath ($($item.Length) bytes)"
+}
+
+if (-not (Test-Path $InstallerPath)) {
+  throw "Installer not found: $InstallerPath"
+}
+
+if (Test-Path $InstallDir) {
+  Remove-Item -Recurse -Force $InstallDir
+}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+$ext = [System.IO.Path]::GetExtension($InstallerPath).ToLowerInvariant()
+Write-Host "Verifying Windows installer artifact: $InstallerPath"
+Write-Host "Install/extract target: $InstallDir"
+
+if ($ext -eq ".msi") {
+  $args = @("/a", $InstallerPath, "/qn", "TARGETDIR=$InstallDir")
+  $process = Start-Process -FilePath "msiexec.exe" -ArgumentList $args -PassThru -WindowStyle Hidden
+} elseif ($ext -eq ".exe") {
+  # NSIS requires /D=... to be the final argument. Keep the target path simple
+  # and unquoted so NSIS accepts it.
+  if ($InstallDir -match "\s") {
+    throw "NSIS /D install path must not contain spaces: $InstallDir"
+  }
+  $args = @("/S", "/NS", "/D=$InstallDir")
+  $process = Start-Process -FilePath $InstallerPath -ArgumentList $args -PassThru -WindowStyle Hidden
+} else {
+  throw "Unsupported Windows installer extension: $ext"
+}
+
+if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+  Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+  throw "Installer did not exit within $TimeoutSeconds seconds: $InstallerPath"
+}
+
+if ($process.ExitCode -ne 0) {
+  throw "Installer exited with code $($process.ExitCode): $InstallerPath"
+}
+
+$appRoot = Resolve-AppRoot -Root $InstallDir
+Write-Host "Resolved installed app root: $appRoot"
+
+$required = @(
+  "Knapsack.exe",
+  "resources\node\node.exe",
+  "resources\node\node_modules\npm\bin\npm-cli.js",
+  "resources\clawdbot\package.json",
+  "resources\clawdbot\openclaw.mjs",
+  "resources\clawdbot\dist\entry.js",
+  "resources\clawdbot\dist\index.js"
+)
+
+foreach ($file in $required) {
+  Assert-File -AppRoot $appRoot -RelativePath $file
+}
+
+$clawdbotRoot = Join-Path $appRoot "resources\clawdbot"
+$tarPath = Join-Path $clawdbotRoot "node_modules.tar"
+$nodeModulesProbe = Join-Path $clawdbotRoot "node_modules\@earendil-works\pi-agent-core\dist\index.js"
+if ((Test-Path $tarPath) -or (Test-Path $nodeModulesProbe)) {
+  if (Test-Path $tarPath) {
+    Write-Host "verified resources\clawdbot\node_modules.tar"
+  }
+  if (Test-Path $nodeModulesProbe) {
+    Write-Host "verified extracted node_modules runtime probe"
+  }
+} else {
+  throw "Missing gateway runtime dependencies: expected node_modules.tar or extracted node_modules probe"
+}
+
+Write-Host "Windows installer artifact verification passed."
+
+$uninstaller = Join-Path $appRoot "uninstall.exe"
+if (Test-Path $uninstaller) {
+  $uninstall = Start-Process -FilePath $uninstaller -ArgumentList @("/S") -PassThru -WindowStyle Hidden
+  if (-not $uninstall.WaitForExit(60000)) {
+    Stop-Process -Id $uninstall.Id -Force -ErrorAction SilentlyContinue
+    Write-Warning "Silent uninstall did not exit within 60s; cleaned install directory manually."
+  }
+}
+
+if (Test-Path $InstallDir) {
+  Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- build both NSIS and MSI Windows installers in CI/release
- add a Windows installer verification script that installs/extracts artifacts into a temp directory
- fail CI if the installer hangs or if critical gateway files are missing after install
- include MSI artifacts in release uploads

## Why
The v2.3.2 Windows release opened the desktop app but did not start the gateway/browser. Local release QA found the installed app missing critical bundled gateway files including `resources/clawdbot/package.json`, `openclaw.mjs`, and `dist/entry.js`. The published NSIS setup wrapper also failed to exit within 120s. Existing CI verified the source resource tree before Tauri packaging, but did not verify the actual installer artifact after install.

## Local verification
- `git diff --check`
- `powershell -NoProfile -File src/scripts/verify-windows-installer.ps1 -InstallerPath does-not-exist.exe` fails cleanly on missing installer
- `powershell -NoProfile -File src/scripts/verify-windows-installer.ps1 -InstallerPath $env:TEMP\knapsack-release-v2.3.2-qa\Knapsack_2.3.2_x64-setup.exe -InstallDir $env:TEMP\ks-install-qa-bad-v232 -TimeoutSeconds 45` catches the bad v2.3.2 installer timeout