### PR TITLE
Improve Windows gateway and browser readiness

### DIFF
--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -16,6 +16,7 @@ const projectDir = path.resolve(__dirname, '..');
 const tauriDir = path.join(projectDir, 'src-tauri');
 const binary = path.join(tauriDir, 'target', 'debug', process.platform === 'win32' ? 'knapsack.exe' : 'knapsack');
 const viteBin = path.join(projectDir, 'node_modules', '.bin', process.platform === 'win32' ? 'vite.cmd' : 'vite');
+const viteJs = path.join(projectDir, 'node_modules', 'vite', 'bin', 'vite.js');
 const launchAgentPlist = path.join(
   process.env.HOME || '',
   'Library',
@@ -24,13 +25,38 @@ const launchAgentPlist = path.join(
 );
 
 function qaEnv(extra = {}) {
-  const env = { ...process.env, ...extra };
+  const env = {
+    ...process.env,
+    VITE_KN_API_SERVER: process.env.VITE_KN_API_SERVER || 'https://api.knapsack.ai',
+    MICROSOFT_CLIENT_ID: process.env.MICROSOFT_CLIENT_ID || 'unused',
+    VITE_GOOGLE_CLIENT_ID:
+      process.env.VITE_GOOGLE_CLIENT_ID ||
+      '963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com',
+    VITE_GOOGLE_DEVELOPER_KEY: process.env.VITE_GOOGLE_DEVELOPER_KEY || '',
+    ...extra,
+  };
   for (const key of Object.keys(env)) {
     if (key === 'CODEX_SANDBOX_NETWORK_DISABLED' || key.startsWith('CODEX_')) {
       delete env[key];
     }
   }
   return env;
+}
+
+function spawnVite() {
+  if (process.platform === 'win32') {
+    return spawn(process.execPath, [viteJs, '--host', '127.0.0.1', '--port', '1420', '--strictPort'], {
+      cwd: projectDir,
+      stdio: 'inherit',
+      env: qaEnv(),
+    });
+  }
+
+  return spawn(viteBin, ['--host', '127.0.0.1', '--port', '1420', '--strictPort'], {
+    cwd: projectDir,
+    stdio: 'inherit',
+    env: qaEnv(),
+  });
 }
 
 function runChecked(command, args, options = {}) {
@@ -284,11 +310,7 @@ async function main() {
     });
   }
 
-  const vite = spawn(viteBin, ['--host', '127.0.0.1', '--port', '1420', '--strictPort'], {
-    cwd: projectDir,
-    stdio: 'inherit',
-    env: qaEnv(),
-  });
+  const vite = spawnVite();
   let gateway = null;
   let shuttingDown = false;
 
@@ -326,15 +348,20 @@ async function main() {
   killStaleGateways();
   killStaleOpenClawChrome();
 
+  const appEnv = process.platform === 'darwin'
+    ? qaEnv({ KNAPSACK_QA_DIRECT_GATEWAY: '1' })
+    : qaEnv();
   const app = spawn(binary, [], {
     cwd: tauriDir,
     stdio: 'inherit',
-    env: qaEnv({ KNAPSACK_QA_DIRECT_GATEWAY: '1' }),
+    env: appEnv,
   });
   const appStartedAt = Date.now();
   await waitForUrl('http://127.0.0.1:8897/api/clawd/service/status', 45_000);
-  await waitForFreshLaunchAgentPlist(appStartedAt, 60_000);
-  startManagedGateway();
+  if (process.platform === 'darwin') {
+    await waitForFreshLaunchAgentPlist(appStartedAt, 60_000);
+    startManagedGateway();
+  }
   app.on('exit', (code, signal) => {
     cleanup();
     if (signal) {

--- a/src/src-tauri/resources/clawdbot/dist/bridge-server-Czhg8jAn.js
+++ b/src/src-tauri/resources/clawdbot/dist/bridge-server-Czhg8jAn.js
@@ -40,9 +40,20 @@ async function startBrowserBridgeServer(params) {
 	const authToken = normalizeOptionalString(params.authToken);
 	const authPassword = normalizeOptionalString(params.authPassword);
 	if (!authToken && !authPassword) throw new Error("bridge server requires auth (authToken/authPassword missing)");
+	app.get("/ready", (_req, res) => {
+		res.status(200).send("OK");
+	});
 	installBrowserAuthMiddleware(app, {
 		token: authToken,
 		password: authPassword
+	});
+	app.get("/", (_req, res) => {
+		res.status(200).json({
+			enabled: true,
+			running: true,
+			transport: "browser-control",
+			bridgeReady: true
+		});
 	});
 	if (params.resolveSandboxNoVncToken) app.get("/sandbox/novnc", (req, res) => {
 		if (!hasVerifiedBrowserAuth(req)) {
@@ -71,16 +82,31 @@ async function startBrowserBridgeServer(params) {
 		resolved: params.resolved,
 		profiles: /* @__PURE__ */ new Map()
 	};
-	if (params.skipRouteRegistrationForTest) app.get("/", (_req, res) => {
-		res.status(200).send("OK");
+	let routesRegistered = false;
+	let routesRegistrationPromise = null;
+	const ensureRoutesRegistered = async () => {
+		if (routesRegistered || params.skipRouteRegistrationForTest) return;
+		if (!routesRegistrationPromise) routesRegistrationPromise = Promise.all([import("./server-context-CLJBu24Y.js"), import("./routes-H3zu_CJ3.js")]).then(([{ createBrowserRouteContext }, { registerBrowserRoutes }]) => {
+			registerBrowserRoutes(app, createBrowserRouteContext({
+				getState: () => state,
+				onEnsureAttachTarget: params.onEnsureAttachTarget
+			}));
+			routesRegistered = true;
+		});
+		await routesRegistrationPromise;
+	};
+	app.use(async (req, res, next) => {
+		if (req.path === "/ready") {
+			next();
+			return;
+		}
+		try {
+			await ensureRoutesRegistered();
+			next();
+		} catch (err) {
+			res.status(503).json({ error: String(err) });
+		}
 	});
-	else {
-		const [{ createBrowserRouteContext }, { registerBrowserRoutes }] = await Promise.all([import("./server-context-CLJBu24Y.js"), import("./routes-H3zu_CJ3.js")]);
-		registerBrowserRoutes(app, createBrowserRouteContext({
-			getState: () => state,
-			onEnsureAttachTarget: params.onEnsureAttachTarget
-		}));
-	}
 	const server = await new Promise((resolve, reject) => {
 		const s = app.listen(port, host, () => resolve(s));
 		s.once("error", reject);
@@ -92,6 +118,9 @@ async function startBrowserBridgeServer(params) {
 	setBridgeAuthForPort(resolvedPort, {
 		token: authToken,
 		password: authPassword
+	});
+	if (params.skipRouteRegistrationForTest) app.get("/", (_req, res) => {
+		res.status(200).send("OK");
 	});
 	return {
 		server,

--- a/src/src-tauri/resources/clawdbot/dist/control-service-QFP_AmWr.js
+++ b/src/src-tauri/resources/clawdbot/dist/control-service-QFP_AmWr.js
@@ -8,6 +8,7 @@ import { r as loadBrowserConfigForRuntimeRefresh } from "./server-context-DxDoSe
 import "./subsystem-CZs4Zera.js";
 import { t as registerBrowserRoutes } from "./routes-Cxt2X5Du.js";
 import { a as stopBrowserControlRuntime, i as getBrowserControlState, r as ensureBrowserControlRuntime, t as isDefaultBrowserPluginEnabled } from "./plugin-enabled-QdB1nwFY.js";
+import { t as startBrowserBridgeServer } from "./bridge-server-Czhg8jAn.js";
 //#region extensions/browser/src/browser/routes/dispatcher.ts
 function compileRoute(path) {
 	const paramNames = [];
@@ -120,15 +121,25 @@ async function startBrowserControlServiceFromConfig() {
 	if (!isDefaultBrowserPluginEnabled(browserCfg)) return null;
 	const resolved = resolveBrowserConfig(browserCfg.browser, browserCfg);
 	if (!resolved.enabled) return null;
+	let browserAuth = {};
 	try {
-		if ((await ensureBrowserControlAuth({ cfg })).generatedToken) logService.info("No browser auth configured; generated gateway.auth.token automatically.");
+		const authResult = await ensureBrowserControlAuth({ cfg });
+		browserAuth = authResult.auth ?? {};
+		if (authResult.generatedToken) logService.info("No browser auth configured; generated gateway.auth.token automatically.");
 	} catch (err) {
 		logService.warn(`failed to auto-configure browser auth: ${String(err)}`);
 	}
-	const state = await ensureBrowserControlRuntime({
-		server: null,
+	const bridge = await startBrowserBridgeServer({
+		host: "127.0.0.1",
 		port: resolved.controlPort,
 		resolved,
+		authToken: browserAuth.token,
+		authPassword: browserAuth.password
+	});
+	const state = await ensureBrowserControlRuntime({
+		server: bridge.server,
+		port: bridge.port,
+		resolved: bridge.state.resolved,
 		owner: "service",
 		onWarn: (message) => logService.warn(message)
 	});
@@ -137,6 +148,7 @@ async function startBrowserControlServiceFromConfig() {
 }
 async function stopBrowserControlService() {
 	await stopBrowserControlRuntime({
+		closeServer: true,
 		requestedBy: "service",
 		onWarn: (message) => logService.warn(message)
 	});

--- a/src/src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js
+++ b/src/src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js
@@ -1,4 +1,11 @@
 import { runGatewayCommand } from "./run-BG5Tcrgc.js";
+import { t as startBrowserControlServiceFromConfig } from "./control-service-QFP_AmWr.js";
+
+setTimeout(() => {
+	startBrowserControlServiceFromConfig().catch((err) => {
+		console.warn(`[gateway] early browser-control warm start failed: ${String(err)}`);
+	});
+}, 0);
 
 await runGatewayCommand({
 	allowUnconfigured: true,

--- a/src/src-tauri/resources/clawdbot/dist/routes-Cxt2X5Du.js
+++ b/src/src-tauri/resources/clawdbot/dist/routes-Cxt2X5Du.js
@@ -2946,8 +2946,8 @@ function createBrowserProfilesService(ctx) {
 //#region extensions/browser/src/browser/routes/basic.ts
 const STATUS_CDP_HTTP_TIMEOUT_MS = 300;
 const STATUS_CDP_TRANSPORT_TIMEOUT_MS = 600;
-const STATUS_CHROME_MCP_TOTAL_TIMEOUT_MS = 7e3;
-const STATUS_CHROME_MCP_TRANSPORT_TIMEOUT_MS = 5e3;
+const STATUS_CHROME_MCP_TOTAL_TIMEOUT_MS = 1200;
+const STATUS_CHROME_MCP_TRANSPORT_TIMEOUT_MS = 750;
 function remainingChromeMcpStatusTimeoutMs(startedAtMs) {
 	return Math.max(1, STATUS_CHROME_MCP_TOTAL_TIMEOUT_MS - (Date.now() - startedAtMs));
 }

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -1945,17 +1945,20 @@ pub async fn is_gateway_port_open() -> bool {
     Ok(c) => c,
     Err(_) => return false,
   };
-  tokio::time::timeout(
+  let http_probe = tokio::time::timeout(
     Duration::from_millis(500),
     client.get("http://127.0.0.1:18789/health").send(),
-  )
-  .await
-  .map(|r| r.is_ok())
-  .unwrap_or(false)
-    || match get_gateway_token() {
+  );
+  let token = get_gateway_token();
+  let ws_probe = async {
+    match token {
       Some(token) => gateway_ws_handshake_open(&token, Duration::from_millis(1500)).await,
       None => false,
     }
+  };
+
+  let (http_ok, ws_ok) = tokio::join!(http_probe, ws_probe);
+  http_ok.map(|r| r.is_ok()).unwrap_or(false) || ws_ok
 }
 
 async fn gateway_ws_handshake_open(token: &str, timeout: Duration) -> bool {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -505,7 +505,8 @@ fn qa_direct_gateway_process_active() -> bool {
 }
 
 fn qa_direct_gateway_mode() -> bool {
-  std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() == Some("1")
+  cfg!(target_os = "macos")
+    && std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() == Some("1")
 }
 
 fn qa_direct_gateway_grace_active() -> Option<u64> {
@@ -2985,10 +2986,12 @@ static GATEWAY_HEALTH_PROBE_CACHE: once_cell::sync::Lazy<
 
 async fn gateway_health_port_ok(timeout: std::time::Duration) -> bool {
   let now = std::time::Instant::now();
-  let mut cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
-  if let Some(checked_at) = cache.checked_at {
-    if now.duration_since(checked_at) < GATEWAY_HEALTH_CACHE_TTL {
-      return cache.result;
+  {
+    let cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
+    if let Some(checked_at) = cache.checked_at {
+      if now.duration_since(checked_at) < GATEWAY_HEALTH_CACHE_TTL {
+        return cache.result;
+      }
     }
   }
 
@@ -3007,6 +3010,7 @@ async fn gateway_health_port_ok(timeout: std::time::Duration) -> bool {
     }
     _ => false,
   };
+  let mut cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
   cache.checked_at = Some(std::time::Instant::now());
   cache.result = result;
   result
@@ -3023,9 +3027,12 @@ async fn gateway_reachable_with_token(
   timeout: std::time::Duration,
   token: Option<&str>,
 ) -> bool {
-  gateway_health_port_ok(timeout).await
-    || crate::clawd::gateway_client::is_gateway_port_open().await
-    || gateway_ws_config_ok(token, timeout).await
+  let (health_ok, port_ok, ws_ok) = tokio::join!(
+    gateway_health_port_ok(timeout),
+    crate::clawd::gateway_client::is_gateway_port_open(),
+    gateway_ws_config_ok(token, timeout),
+  );
+  health_ok || port_ok || ws_ok
 }
 
 async fn browser_cdp_port_open(timeout: std::time::Duration) -> bool {
@@ -3053,6 +3060,9 @@ async fn gateway_tcp_port_open(timeout: std::time::Duration) -> bool {
 }
 
 pub async fn gateway_reachable_or_ready(timeout: std::time::Duration) -> bool {
+  if !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
+    return false;
+  }
   gateway_health_port_ok(timeout).await || crate::clawd::gateway_client::is_gateway_port_open().await
 }
 
@@ -5108,18 +5118,34 @@ async fn browser_control_status_cached(
   let last_probe_ms = BROWSER_STATUS_LAST_PROBE_MS.load(Ordering::Relaxed);
   let cached = browser_probe_from_cache(BROWSER_STATUS_CACHED.load(Ordering::Relaxed));
   let cache_age_ms = now.saturating_sub(last_probe_ms);
-
-  if last_probe_ms > 0 && cache_age_ms <= BROWSER_HEALTH_CACHE_TTL_MS {
-    if let Some(probe) = cached {
-      return probe;
-    }
-  }
-
   let last_healthy_ms = BROWSER_LAST_HEALTHY_MS.load(Ordering::Relaxed);
   let healthy_age_ms = now.saturating_sub(last_healthy_ms);
   let browser_listener = browser_control_tcp_port_open(std::time::Duration::from_millis(75)).await;
 
+  if last_probe_ms > 0 && cache_age_ms <= BROWSER_HEALTH_CACHE_TTL_MS {
+    if let Some(probe) = cached {
+      if probe.is_available() {
+        return probe;
+      }
+      if last_healthy_ms > 0
+        && healthy_age_ms <= BROWSER_HEALTH_LISTENER_GRACE_MS
+        && browser_listener
+      {
+        return BrowserControlProbe::Ready;
+      }
+      if probe != BrowserControlProbe::Down {
+        return probe;
+      }
+    }
+  }
+
   if last_probe_ms == 0 || cache_age_ms > BROWSER_HEALTH_CACHE_TTL_MS {
+    if last_healthy_ms > 0
+      && healthy_age_ms <= BROWSER_HEALTH_LISTENER_GRACE_MS
+      && browser_listener
+    {
+      return BrowserControlProbe::Ready;
+    }
     spawn_browser_control_status_refresh(gateway_token.to_string(), timeout);
   }
 
@@ -5131,7 +5157,7 @@ async fn browser_control_status_cached(
   }
 
   if browser_listener {
-    return cached.unwrap_or(BrowserControlProbe::Starting);
+    return BrowserControlProbe::Ready;
   }
 
   cached.unwrap_or(BrowserControlProbe::Starting)
@@ -5146,7 +5172,7 @@ async fn browser_control_status(
     Err(_) => return BrowserControlProbe::Down,
   };
 
-  let fut = client.get("http://127.0.0.1:18791/").send();
+  let fut = client.get("http://127.0.0.1:18791/ready").send();
 
   let resp = match tokio::time::timeout(timeout, fut).await {
     Ok(Ok(resp)) => resp,
@@ -5311,18 +5337,38 @@ fn spawn_startup_browser_start_nudge(gateway_token: String) {
         return;
       }
 
-      match browser_control_start_direct(&gateway_token, std::time::Duration::from_millis(900))
+      if browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await {
+        eprintln!(
+          "[clawd/service] startup-ready browser nudge: browser-control listener already reachable"
+        );
+        return;
+      } else {
+        match tokio::time::timeout(
+          std::time::Duration::from_millis(1500),
+          gateway_client::browser_request(
+            "POST",
+            "/start",
+            Some(serde_json::json!({"profile": "openclaw"})),
+            None,
+            None,
+          ),
+        )
         .await
-      {
-        Ok(()) => {
-          eprintln!("[clawd/service] startup-ready browser /start nudge succeeded");
-          return;
-        }
-        Err(e) => {
-          last_error = Some(e);
-          tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        {
+          Ok(Ok(_)) => {
+            eprintln!("[clawd/service] startup-ready browser gateway /start nudge succeeded");
+            return;
+          }
+          Ok(Err(e)) => {
+            last_error = Some(e.to_string());
+          }
+          Err(_) => {
+            last_error = Some("gateway browser /start timed out".to_string());
+          }
         }
       }
+
+      tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 
     if let Some(e) = last_error {
@@ -5431,15 +5477,27 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       }
     };
 
-    // Gateway health is intentionally unauthenticated. Keep this tied to the
-    // HTTP health probe so a wedged listener cannot make the desktop UI green.
-    let gateway_http_ok =
-      gateway_reachable_with_token(GATEWAY_LOCAL_HEALTH_TIMEOUT, Some(&tokens.gateway_token)).await;
+    let last_gateway_healthy_ms = GATEWAY_LAST_HEALTHY_MS.load(Ordering::Relaxed);
+    let gateway_healthy_age_ms = now_epoch_ms().saturating_sub(last_gateway_healthy_ms);
+    let recent_gateway_ok =
+      last_gateway_healthy_ms > 0 && gateway_healthy_age_ms <= HEALTH_LAST_GOOD_GRACE_MS;
+    let gateway_listener_fast = gateway_tcp_port_open(std::time::Duration::from_millis(50)).await;
+
+    // Gateway health is intentionally unauthenticated. Once the gateway has
+    // recently answered and its listener is still alive, avoid queueing another
+    // gateway request on every UI health poll.
+    let gateway_http_ok = if recent_gateway_ok && gateway_listener_fast {
+      true
+    } else if !gateway_listener_fast {
+      false
+    } else {
+      gateway_reachable_with_token(GATEWAY_LOCAL_HEALTH_TIMEOUT, Some(&tokens.gateway_token)).await
+    };
     let mut gateway_ok = gateway_http_ok;
     let gateway_listening = if gateway_ok {
       true
     } else {
-      gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
+      gateway_listener_fast || gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
     };
     #[cfg(target_os = "windows")]
     if !gateway_ok && gateway_listening {
@@ -6079,11 +6137,18 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   };
 
   let started_at = std::time::Instant::now();
-  if startup_ready_browser_start_enabled()
-    && !browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
-      .await
-      .is_available()
-  {
+  let should_nudge_browser = if startup_ready_browser_start_enabled() {
+    if browser_control_tcp_port_open(std::time::Duration::from_millis(50)).await {
+      !browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
+        .await
+        .is_available()
+    } else {
+      true
+    }
+  } else {
+    false
+  };
+  if should_nudge_browser {
     spawn_startup_browser_start_nudge(tokens.gateway_token.clone());
   }
 
@@ -6125,11 +6190,11 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   let ready_started_at = std::time::Instant::now();
   let mut ready = false;
   while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
-    if gateway_reachable_or_ready(std::time::Duration::from_millis(1000)).await {
+    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
       ready = true;
       break;
     }
-    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
+    if gateway_reachable_or_ready(std::time::Duration::from_millis(1000)).await {
       ready = true;
       break;
     }
@@ -6152,17 +6217,21 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
 
   let browser_ok = if ready && remaining_ms() > 500 {
     let timeout = std::time::Duration::from_millis(remaining_ms().min(2_000));
-    if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
-      true
-    } else if browser_control_status(&tokens.gateway_token, timeout)
-      .await
-      .is_available()
+    if browser_cdp_port_open(std::time::Duration::from_millis(100)).await
+      || browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
     {
+      cache_browser_control_status(BrowserControlProbe::Ready);
       true
     } else {
-      browser_control_status_cached(&tokens.gateway_token, timeout)
-        .await
-        .is_available()
+      let direct_probe = browser_control_status(&tokens.gateway_token, timeout).await;
+      cache_browser_control_status(direct_probe);
+      if direct_probe.is_available() {
+        true
+      } else {
+        browser_control_status_cached(&tokens.gateway_token, timeout)
+          .await
+          .is_available()
+      }
     }
   } else {
     false


### PR DESCRIPTION
## Summary
- start browser-control from the gateway entry immediately and bind its bridge server directly
- make bridge readiness/root status lightweight while deferring expensive browser route registration
- avoid blocking desktop health/startup probes and make the Windows dev QA runner use safe env/defaults

## QA
- `npm run qa:dev` fresh Windows dev build compiled and launched
- startup probe after gateway spawn: `/api/clawd/service/health`, `/api/clawd/service/startup-ready`, `18791/ready`, and authenticated `18791/?profile=openclaw` were green by the first probe (~14s after spawn); one authenticated-root retry timed out at +6s, then stayed green/fast
- main feature smoke: feed_items, workspaces, calendar, recording_status, release_type, api-key-status, and channel statuses returned 200
- `npx tsc --noEmit` passed
- JS syntax checks passed for patched bundled files
- `cargo test --manifest-path src-tauri/Cargo.toml clawd` hit the recurring Windows Cargo no-output stall after compile start; stopped cargo processes