### PR TITLE
Remove pre-bind browser warm start

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js
+++ b/src/src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js
@@ -1,14 +1,5 @@
 import { runGatewayCommand } from "./run-BG5Tcrgc.js";
 
-setTimeout(async () => {
-	try {
-		const { t: startBrowserControlServiceFromConfig } = await import("./control-service-QFP_AmWr.js");
-		await startBrowserControlServiceFromConfig();
-	} catch (err) {
-		console.warn(`[gateway] early browser-control warm start failed: ${String(err)}`);
-	}
-}, 7500);
-
 await runGatewayCommand({
 	allowUnconfigured: true,
 	bind: "loopback",


### PR DESCRIPTION
## Summary
- remove the gateway-entry browser warm-start timer added in the prior readiness pass
- the timer fired during `cli.config-snapshot` and made Windows gateway bind wait ~100s
- keep browser startup on the post-bind service/nudge path, which reaches direct browser-control HTTP within the 30s target

## QA
- Windows dev QA from merged main with this follow-up applied
- Spawn: 21:18:10, pid 48080
- Direct readiness: gateway listening by first health probe; `18791/?profile=openclaw` returned OK by probe +6s; health/startup-ready fully green by probe +11s
- Stability: health, startup-ready, `18791/?profile=openclaw`, and `18791/ready` stayed green through +38s, with settled direct browser-control probes around 15-36ms
- Main interface API smoke passed: feed_items, workspaces, calendar, recording_status, release_type, api-key-status, and iMessage/WhatsApp/Telegram/Slack statuses
- `node -c src-tauri/resources/clawdbot/dist/knapsack-gateway-entry.js`
- `npx tsc --noEmit`