### PR TITLE
[codex] Stabilize demo startup readiness

### DIFF
--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -1418,10 +1418,13 @@ async function runMode(mode, opts = {}) {
     OPENCLAW_DISABLE_BUNDLED_PLUGINS: process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS || "1",
     KNAPSACK_HEALTH_AUTO_START_BROWSER: "1",
     KNAPSACK_STARTUP_READY_AUTO_START_BROWSER: "1",
+    KNAPSACK_STARTUP_READY_DIRECT_CHROME: "1",
   };
   const qaPluginAllowlist = qaPluginAllowlistForProviders(opts.providers);
-  if (pluginAllowlistIncludesChannel(qaPluginAllowlist)) {
+  if (qaPluginAllowlist) {
     launchEnv.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "0";
+  }
+  if (pluginAllowlistIncludesChannel(qaPluginAllowlist)) {
     launchEnv.KNAPSACK_EAGER_CHANNEL_PLUGINS = "1";
   }
   if (qaPluginAllowlist) {

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const fs = require("node:fs");
 const { existsSync } = fs;
-const { spawn } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
+const net = require("node:net");
 const path = require("node:path");
 const process = require("node:process");
 
@@ -27,12 +28,12 @@ const MODELS_BY_PROVIDER = {
     "claude-opus-4-5-20251101",
   ],
   gemini: [
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
     "gemini-3.1-pro-preview",
     "gemini-3.5-flash",
     "gemini-3-flash-preview",
     "gemini-3.1-flash-lite",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
   ],
   groq: [
     "openai/gpt-oss-120b",
@@ -53,6 +54,7 @@ const MODELS_BY_PROVIDER = {
     "grok-4",
   ],
   openrouter: [
+    "openrouter/free",
     "openrouter/auto",
     "qwen/qwen3-coder-480b-a35b-instruct:free",
     "deepseek/deepseek-r1:free",
@@ -305,6 +307,20 @@ function normalizeResult(value) {
   return JSON.stringify(value);
 }
 
+function withTimeout(promise, timeoutMs, label) {
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new Error(`${label} timed out after ${timeoutMs}ms`);
+      error.code = "QA_TIMEOUT";
+      reject(error);
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 function collectCliArgs() {
   const argv = process.argv.slice(2);
   if (!process.env.npm_config_argv) return argv;
@@ -335,6 +351,8 @@ function parseArgs() {
     attemptsPerMode: 12,
     maxRetryDelayMs: 2_000,
     startupBudgetMs: 30_000,
+    coreOnly: false,
+    providers: null,
   };
   let mode = "both";
   for (let i = 0; i < args.length; i++) {
@@ -362,7 +380,11 @@ function parseArgs() {
       mode = "prod";
       continue;
     }
-    if (arg === "--max-attempts" || arg === "--attempts") {
+    if (
+      arg === "--max-attempts" ||
+      arg === "--attempts" ||
+      arg === "--attempts-per-mode"
+    ) {
       const next = args[i + 1];
       if (next && Number.isFinite(Number(next))) {
         opts.attemptsPerMode = Number.parseInt(next, 10);
@@ -370,9 +392,50 @@ function parseArgs() {
       }
       continue;
     }
-    if (arg.startsWith("--max-attempts=") || arg.startsWith("--attempts=")) {
+    if (
+      arg.startsWith("--max-attempts=") ||
+      arg.startsWith("--attempts=") ||
+      arg.startsWith("--attempts-per-mode=")
+    ) {
       const v = Number.parseInt(arg.split("=")[1], 10);
       if (Number.isFinite(v)) opts.attemptsPerMode = v;
+      continue;
+    }
+    if (arg === "--startup-budget-ms") {
+      const next = args[i + 1];
+      if (next && Number.isFinite(Number(next))) {
+        opts.startupBudgetMs = Number.parseInt(next, 10);
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--startup-budget-ms=")) {
+      const v = Number.parseInt(arg.split("=")[1], 10);
+      if (Number.isFinite(v)) opts.startupBudgetMs = v;
+      continue;
+    }
+    if (arg === "--core-only" || arg === "--skip-functional") {
+      opts.coreOnly = true;
+      continue;
+    }
+    if (arg === "--run-functional" || arg === "--with-functional") {
+      opts.coreOnly = false;
+      continue;
+    }
+    if (arg === "--provider" || arg === "--providers") {
+      const next = args[i + 1];
+      if (next) {
+        opts.providers = next.split(",").map((value) => value.trim().toLowerCase()).filter(Boolean);
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--provider=") || arg.startsWith("--providers=")) {
+      const parts = arg.includes("=") ? arg.split("=", 2) : [];
+      const value = parts[1];
+      if (value) {
+        opts.providers = value.split(",").map((value) => value.trim().toLowerCase()).filter(Boolean);
+      }
       continue;
     }
     if (/^\d+$/.test(arg)) {
@@ -382,12 +445,40 @@ function parseArgs() {
       }
     }
   }
+  if (String(process.env.KNAPSACK_QA_CORE_ONLY || "").trim() === "1") {
+    opts.coreOnly = true;
+  }
   opts.mode = mode;
   return opts;
 }
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: "ignore",
+      windowsHide: true,
+      ...options,
+    });
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+async function killOpenClawProcessesForQa() {
+  if (process.platform !== "win32") return;
+  const command = [
+    "$matches = Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'openclaw.mjs gateway run|node_modules\\\\openclaw\\\\openclaw.mjs' };",
+    "foreach($proc in $matches){",
+    "  if($proc.ProcessId -ne $PID){",
+    "    try { taskkill /F /T /PID $proc.ProcessId | Out-Null } catch {}",
+    "  }",
+    "}",
+  ].join(" ");
+  await runCommand("powershell.exe", ["-NoProfile", "-Command", command]);
 }
 
 function fetchWithTimeout(url, options = {}, timeoutMs = 8_000) {
@@ -419,7 +510,7 @@ function isExpectedStatusSuccess(payload, endpoint) {
   return true;
 }
 
-async function probeBrowserControl(timeoutMs = 2_500) {
+async function probeBrowserControl(timeoutMs = 1_200) {
   const endpoints = [
     "http://127.0.0.1:18791/ready",
     "http://127.0.0.1:18800/json/version",
@@ -499,6 +590,68 @@ async function ensureCleanPorts(ports) {
   }
 }
 
+function probeTcpPort(port, timeoutMs = 250) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const done = (ok) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+  });
+}
+
+async function captureLivenessSnapshot() {
+  const [apiOpen, gatewayOpen, browserOpen, status, health] = await Promise.all([
+    probeTcpPort(8897, 250),
+    probeTcpPort(18789, 250),
+    probeTcpPort(18800, 250),
+    fetchWithTimeout(`${API_BASE}/api/clawd/service/status`, { method: "GET" }, 1_500)
+      .then((resp) => (resp?.ok ? resp.body : { status: resp?.status || 0 }))
+      .catch((error) => ({ error: normalizeResult(error?.message || error) })),
+    fetchWithTimeout(`${API_BASE}/api/clawd/service/health`, { method: "GET" }, 1_500)
+      .then((resp) => (resp?.ok ? resp.body : { status: resp?.status || 0 }))
+      .catch((error) => ({ error: normalizeResult(error?.message || error) })),
+  ]);
+  return {
+    apiOpen,
+    gatewayOpen,
+    browserOpen,
+    status,
+    health,
+  };
+}
+
+async function waitForServiceApiAvailable(proc, timeoutMs = 120_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (proc.exitCode !== null) {
+      const signal = proc.signalCode || "none";
+      return {
+        ok: false,
+        message: `launcher exited before service API became available (exitCode=${proc.exitCode}, signal=${signal})`,
+      };
+    }
+    try {
+      const resp = await fetchWithTimeout(`${API_BASE}/api/clawd/service/status`, { method: "GET" }, 2_000);
+      if (resp?.ok) {
+        return { ok: true, elapsedMs: Date.now() - start };
+      }
+    } catch {
+      // keep waiting for the app backend, not the gateway, to come online.
+    }
+    await sleep(500);
+  }
+  return {
+    ok: false,
+    message: `service API did not become available within ${timeoutMs}ms`,
+  };
+}
+
 function spawnApp(config) {
   const hideWindows = process.platform === "win32" ? { windowsHide: true } : {};
   const common = {
@@ -508,101 +661,210 @@ function spawnApp(config) {
     ...hideWindows,
   };
   if (config.command === "dev") {
+    const qaDevEnv = {
+      ...common.env,
+      VITE_KN_API_SERVER: "https://api.knapsack.ai",
+      KNAPSACK_HEALTH_AUTO_START_BROWSER: "1",
+      KNAPSACK_STARTUP_READY_AUTO_START_BROWSER: "1",
+      KNAPSACK_QA_SERVICE_READY_TIMEOUT_MS: process.env.KNAPSACK_QA_SERVICE_READY_TIMEOUT_MS || "120000",
+    };
+    if (!Object.prototype.hasOwnProperty.call(process.env, "KNAPSACK_QA_SKIP_RUST_BUILD")) {
+      qaDevEnv.KNAPSACK_QA_SKIP_RUST_BUILD = "1";
+    }
+    qaDevEnv.KNAPSACK_QA_SKIP_OPENCLAW_WARMUP = "1";
     return spawn(process.execPath, [path.join("scripts", "qa-dev-run.cjs")], {
       ...common,
       windowsHide: true,
-      env: { ...common.env, VITE_KN_API_SERVER: "https://api.knapsack.ai" },
+      env: qaDevEnv,
     });
   }
   return spawn(config.binary, [], common);
 }
 
+function prepareDevRuntime(env) {
+  const result = spawnSync(process.execPath, [path.join("scripts", "qa-dev-run.cjs")], {
+    cwd: path.resolve(__dirname, ".."),
+    env: {
+      ...process.env,
+      ...env,
+      VITE_KN_API_SERVER: "https://api.knapsack.ai",
+      KNAPSACK_QA_SKIP_RUST_BUILD: process.env.KNAPSACK_QA_SKIP_RUST_BUILD || "1",
+      KNAPSACK_QA_PREPARE_ONLY: "1",
+    },
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: Number(process.env.KNAPSACK_QA_PREPARE_TIMEOUT_MS || 180_000),
+  });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+  if (output) {
+    console.log("[qa-loop] dev prepare output:");
+    output.split(/\r?\n/).slice(-30).forEach((line) => console.log(`  ${line}`));
+  }
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      message: `dev prepare failed (status=${result.status}, signal=${result.signal || "none"})`,
+    };
+  }
+  return { ok: true };
+}
+
 async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
   const start = Date.now();
   const deadline = Date.now() + startupBudgetMs;
-  let startupReady = null;
+  let lastStartupState = {};
   let status = null;
   let health = null;
   let channels = null;
-  let consecutiveReady = 0;
+  let channelsReady = false;
+  let lastChannelsPollMs = 0;
+  let lastHealthPollMs = 0;
+  let startupReady = null;
   let startupReadySeen = false;
-  const startupTimeoutMs = Math.min(35_000, startupBudgetMs + 1_000);
+  let stableTicks = 0;
+  let lastReadySignature = "";
 
   while (Date.now() < deadline) {
-    const [startupResp, statusResp, healthResp, channelsResp] = await Promise.all([
-      fetchWithTimeout(
-        `${API_BASE}/api/clawd/service/startup-ready`,
-        { method: "GET" },
-        startupTimeoutMs,
-      )
-        .then((resp) => (resp.ok ? resp.body : null))
-        .catch(() => null),
-      fetchWithTimeout(`${API_BASE}/api/clawd/service/status`, { method: "GET" }, 2_000)
-        .then((resp) => (resp.ok ? resp.body : null))
-        .catch(() => null),
-      fetchWithTimeout(`${API_BASE}/api/clawd/service/health`, { method: "GET" }, 2_000)
-        .then((resp) => (resp.ok ? resp.body : null))
-        .catch(() => null),
-      fetchWithTimeout(
+    const now = Date.now();
+    const startupReadyTimeoutMs = Math.max(
+      500,
+      Math.min(2_500, deadline - Date.now() + 250),
+    );
+    const startupReadyResp = await fetchWithTimeout(
+      `${API_BASE}/api/clawd/service/startup-ready`,
+      { method: "GET" },
+      startupReadyTimeoutMs,
+    ).then((resp) => (resp?.ok ? resp.body : null)).catch(() => null);
+    if (startupReadyResp && typeof startupReadyResp === "object") {
+      startupReady = startupReadyResp;
+      startupReadySeen = Boolean(startupReadyResp.success);
+    }
+
+    const gatewayTcpOpen = await probeTcpPort(18789, 250);
+    const serviceRunning = Boolean(
+      (status?.success && status.running && status.installed) ||
+        startupReady?.gateway_ok === true ||
+        gatewayTcpOpen,
+    );
+    const browserOk = Boolean(
+      startupReady?.browser_ok === true ||
+        health?.browser_ok ||
+        health?.browser_listening ||
+        (await probeBrowserControl(900)),
+    );
+    const cheapChannelsReady = Boolean(
+      status?.channels_ok === true ||
+        health?.channels_ok === true ||
+        health?.channels_ready === true ||
+        startupReady?.channels_ok === true,
+    );
+    const gatewayReachableForDiagnostics = Boolean(
+      gatewayTcpOpen ||
+        startupReady?.gateway_ok === true ||
+        health?.gateway_ok === true ||
+        health?.gateway_listening === true,
+    );
+    const shouldPollChannels =
+      cheapChannelsReady === false &&
+      gatewayReachableForDiagnostics &&
+      now - lastChannelsPollMs >= 10_000;
+    const shouldPollHealth = now - lastHealthPollMs >= 5_000;
+    const channelsTimeoutMs = 1_500;
+    const channelsPoll = shouldPollChannels
+      ? fetchWithTimeout(
         `${API_BASE}/api/clawd/channels/diagnostics`,
         { method: "GET" },
-        2_000,
-      ).then((resp) => (resp.ok ? resp.body : null)).catch(() => null),
+        channelsTimeoutMs,
+      ).then((resp) => (resp?.ok ? { ok: true, body: resp.body } : null)).catch(() => null)
+      : Promise.resolve(null);
+
+    const [statusResp, healthResp, channelsResp] = await Promise.all([
+      fetchWithTimeout(`${API_BASE}/api/clawd/service/status`, { method: "GET" }, 1_200)
+        .then((resp) => (resp.ok ? resp.body : null))
+        .catch(() => null),
+      shouldPollHealth ? fetchWithTimeout(`${API_BASE}/api/clawd/service/health`, { method: "GET" }, 1_500)
+        .then((resp) => (resp.ok ? resp.body : null))
+        .catch(() => null) : Promise.resolve(null),
+      channelsPoll,
     ]);
 
-    if (startupResp && typeof startupResp === "object") {
-      startupReady = startupResp;
-    }
+    if (shouldPollChannels) lastChannelsPollMs = now;
+    if (shouldPollHealth) lastHealthPollMs = now;
     if (statusResp && typeof statusResp === "object") {
       status = statusResp;
     }
     if (healthResp && typeof healthResp === "object") {
       health = healthResp;
     }
-    if (channelsResp && typeof channelsResp === "object") {
-      channels = channelsResp;
+    if (channelsResp && channelsResp.body && typeof channelsResp.body === "object") {
+      channels = channelsResp.body;
+      channelsReady = Boolean(channelsResp.body.success);
     }
-    if (startupResp && startupResp.success) {
-      startupReadySeen = true;
-    }
-
     const isStartupReady = Boolean(startupReadySeen);
-    const serviceRunning = Boolean(status?.success && status.running && status.installed);
+    const resolvedServiceRunning = Boolean(
+      (status?.success && status.running && status.installed) ||
+        startupReady?.gateway_ok === true ||
+        gatewayTcpOpen,
+    );
     const gatewayOk = Boolean(
       (serviceRunning && health?.gateway_ok) ||
-        (Boolean(serviceRunning) && Boolean(health?.gateway_listening)),
+        (Boolean(serviceRunning) && Boolean(health?.gateway_listening)) ||
+        startupReady?.gateway_ok === true ||
+        gatewayTcpOpen,
     );
-    const browserOk = Boolean(
-      health?.browser_ok ||
-        (await probeBrowserControl(1_500)),
+
+    const resolvedChannelsReady = channelsReady || Boolean(
+      startupReady?.channels_ok === true ||
+        status?.channels_ok === true ||
+        health?.channels_ok === true ||
+        health?.channels_ready === true,
     );
-    const channelsOk = Boolean(channels?.success);
-    const startupAndReady = isStartupReady || (gatewayOk && browserOk && channelsOk);
-    const active = Boolean(serviceRunning && gatewayOk && browserOk && channelsOk) || startupAndReady;
+    const authoritativeReady = Boolean(
+      startupReady?.success === true &&
+        startupReady?.gateway_ok === true &&
+        startupReady?.browser_ok === true &&
+        startupReady?.channels_ok === true,
+    );
+    const readySignature = JSON.stringify({
+      serviceRunning: resolvedServiceRunning,
+      gatewayOk,
+      browserOk,
+      resolvedChannelsReady,
+      authoritativeReady,
+    });
+    const readinessOk = resolvedServiceRunning && authoritativeReady;
 
-    if (startupAndReady && isStartupReady) {
-      return {
-        ok: true,
-        startupMs: startupResp?.startup_elapsed_ms || Date.now() - start,
-        payload: {
-          startup: startupReady,
-          status,
-          health,
-          channels,
-        },
-      };
-    }
-
-    if (active) {
-      consecutiveReady += 1;
+    if (readinessOk && readySignature === lastReadySignature) {
+      stableTicks = Math.min(stableTicks + 1, 4);
+    } else if (readinessOk) {
+      stableTicks = 1;
     } else {
-      consecutiveReady = 0;
+      stableTicks = 0;
     }
+    lastReadySignature = readySignature;
 
-    if (consecutiveReady >= 2) {
+    const startupAndReady = authoritativeReady;
+    const active = resolvedServiceRunning && readinessOk && (authoritativeReady || isStartupReady || stableTicks >= 2);
+
+    lastStartupState = {
+      serviceRunning: resolvedServiceRunning,
+      gatewayOk: Boolean(gatewayOk),
+      browserOk: Boolean(browserOk),
+      startupReadySeen: isStartupReady,
+      authoritativeReady,
+      stableTicks,
+      channelsReady,
+      resolvedChannelsReady,
+      startupAndReady,
+      active,
+      startupMessage: startupReady?.message || null,
+      startupElapsedMs: startupReady?.startup_elapsed_ms,
+    };
+
+    if (active && stableTicks >= 2) {
       return {
         ok: true,
-        startupMs: startupResp?.startup_elapsed_ms || Date.now() - start,
+        startupMs: startupReady?.startup_elapsed_ms || Date.now() - start,
         payload: {
           startup: startupReady,
           status,
@@ -612,7 +874,7 @@ async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
       };
     }
 
-    await sleep(750);
+    await sleep(250);
   }
 
   return {
@@ -624,7 +886,9 @@ async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
       health,
       channels,
     },
-    note: `${label} did not reach active+stable gateway/browser/channels within ${startupBudgetMs}ms`,
+    note: `${label} did not reach active+stable gateway/browser/channels within ${startupBudgetMs}ms ` +
+      `(${JSON.stringify(lastStartupState)})`,
+    debug: lastStartupState,
   };
 }
 
@@ -633,12 +897,90 @@ function toPayload(result, fallback = {}) {
   return result.body ? result.body : fallback;
 }
 
+async function waitForGatewayHealthReady({ budgetMs = 60_000, stableChecks = 2, startupReady = null } = {}) {
+  const start = Date.now();
+  const deadline = start + budgetMs;
+  let lastHealth = null;
+  let stable = 0;
+
+  if (
+    startupReady?.success === true &&
+    startupReady?.gateway_ok === true &&
+    startupReady?.browser_ok === true &&
+    startupReady?.channels_ok === true &&
+    String(process.env.KNAPSACK_QA_REQUIRE_SERVICE_HEALTH || "").trim() !== "1"
+  ) {
+    return {
+      ok: true,
+      elapsedMs: 0,
+      health: startupReady,
+      via: "startup-ready",
+    };
+  }
+
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetchWithTimeout(
+        `${API_BASE}/api/clawd/service/health`,
+        { method: "GET" },
+        Math.min(8_000, Math.max(1_000, deadline - Date.now())),
+      );
+      if (resp?.ok && resp.body && typeof resp.body === "object") {
+        lastHealth = resp.body;
+        if (resp.body.success === true && resp.body.gateway_ok === true) {
+          stable += 1;
+          if (stable >= stableChecks) {
+            return {
+              ok: true,
+              elapsedMs: Date.now() - start,
+              health: resp.body,
+            };
+          }
+        } else {
+          stable = 0;
+        }
+      } else {
+        stable = 0;
+      }
+    } catch {
+      stable = 0;
+    }
+    await sleep(500);
+  }
+
+  return {
+    ok: false,
+    elapsedMs: Date.now() - start,
+    health: lastHealth,
+  };
+}
+
 function getModelText(model) {
   if (typeof model === "string") return model;
   if (model && typeof model === "object") {
     if (typeof model.id === "string") return model.id;
   }
   return "";
+}
+
+function readinessProviderModels(opts) {
+  const provider = opts?.providers?.[0] || "gemini";
+  const models = MODELS_BY_PROVIDER[provider] || [];
+  const model = getModelText(models[0]);
+  return model ? [[provider, [model]]] : [];
+}
+
+async function ensureGatewayEnabledForQA(timeoutMs = 12_000) {
+  try {
+    const enableResp = await fetchWithTimeout(`${API_BASE}/api/clawd/service/enable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    }, timeoutMs);
+    return Boolean(enableResp?.ok && enableResp.body?.success);
+  } catch {
+    return false;
+  }
 }
 
 async function setProviderAndModel(provider, model) {
@@ -658,38 +1000,79 @@ async function setProviderAndModel(provider, model) {
   };
 }
 
-async function runChatSmoke(provider, model) {
+async function runChatSmoke(provider, model, options = {}) {
   try {
-    const setting = await setProviderAndModel(provider, model);
-    if (!setting.ok) {
-      const msg = normalizeResult(setting.payload?.message || setting.payload);
-      const keyMissing = typeof msg === "string" && msg.includes("API key cannot be empty");
-      return {
-        provider,
-        model,
-        ok: false,
-        skipped: keyMissing,
-        detail: msg || "could not switch provider/model",
-      };
+    if (!options.skipModelSetup) {
+      const setting = await setProviderAndModel(provider, model);
+      if (!setting.ok) {
+        const msg = normalizeResult(setting.payload?.message || setting.payload);
+        const keyMissing = typeof msg === "string" && msg.includes("API key cannot be empty");
+        return {
+          provider,
+          model,
+          ok: false,
+          skipped: keyMissing,
+          detail: msg || "could not switch provider/model",
+        };
+      }
     }
 
-    const chat = await fetchWithTimeout(`${API_BASE}/api/clawd/chat`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        text: `QA typing test at ${new Date().toISOString()} for ${provider}/${model}`,
-        sessionId: `qa-${provider}-${model}`,
-      }),
-    }, 20_000);
+    const payload = {
+      text: `QA typing test at ${new Date().toISOString()} for ${provider}/${model}`,
+      sessionId: `qa-${provider}-${model}`.replace(/[^A-Za-z0-9._-]/g, "-"),
+      disableFallback: true,
+      qaSmoke: true,
+    };
+    const chatRetries = 1;
+    const chatTimeoutMs = Number(process.env.KNAPSACK_QA_CHAT_TIMEOUT_MS || 45_000);
+    let attemptChat = 0;
+    let chat;
 
-    if (!chat.ok) {
-      return {
-        provider,
-        model,
-        ok: false,
-        skipped: false,
-        detail: `chat failed (${chat.status}) ${normalizeResult(chat.body)}`,
-      };
+    while (attemptChat < chatRetries) {
+      attemptChat += 1;
+      try {
+        chat = await fetchWithTimeout(`${API_BASE}/api/clawd/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }, chatTimeoutMs);
+      } catch (error) {
+        const message = normalizeResult(error?.message || error);
+        const retryable = typeof message === "string" && (
+          message.includes("aborted") ||
+          message.includes("ETIMEDOUT") ||
+          message.includes("timed out") ||
+          message.includes("socket hang up")
+        );
+        if (retryable && attemptChat < chatRetries) {
+          await sleep(1_000);
+          continue;
+        }
+        return {
+          provider,
+          model,
+          ok: false,
+          skipped: retryable,
+          detail: `chat request failed: ${message}`,
+        };
+      }
+
+      if (!chat.ok) {
+        const shouldRetry =
+          (chat.status === 429 || chat.status >= 500) && attemptChat < chatRetries;
+        if (shouldRetry) {
+          await sleep(1_000);
+          continue;
+        }
+        return {
+          provider,
+          model,
+          ok: false,
+          skipped: false,
+          detail: `chat failed (${chat.status}) ${normalizeResult(chat.body)}`,
+        };
+      }
+      break;
     }
 
     const body = chat.body || {};
@@ -703,7 +1086,16 @@ async function runChatSmoke(provider, model) {
       };
     }
 
-    if (!body.message && !body.summary && typeof body.response !== "string" && !body.text) {
+    const hasChatOutput = Boolean(
+      (body.message && (body.message.text || body.message.content || body.message.message)) ||
+      typeof body.summary === "string" ||
+      typeof body.response === "string" ||
+      typeof body.text === "string" ||
+      typeof body.reply === "string" ||
+      typeof body.result === "string",
+    );
+
+    if (!hasChatOutput) {
       return {
         provider,
         model,
@@ -714,23 +1106,70 @@ async function runChatSmoke(provider, model) {
     }
     return { provider, model, ok: true };
   } catch (error) {
+    const message = normalizeResult(error?.message || error);
     return {
       provider,
       model,
       ok: false,
-      skipped: false,
-      detail: `chat request failed: ${error?.message || error || "network error"}`,
+      skipped: (
+        typeof message === "string" &&
+        (
+          message.includes("aborted") ||
+          message.includes("ETIMEDOUT") ||
+          message.includes("timed out") ||
+          message.includes("socket hang up")
+        )
+      ),
+      detail: `chat request failed: ${message || "network error"}`,
     };
   }
 }
 
 async function createMockMeeting() {
   const timestamp = Date.now();
-  const feed = await fetchWithTimeout(`${API_BASE}/api/knapsack/feed_items`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ timestamp, title: "QA Loop Mock Meeting" }),
-  }, 8_000);
+  const requestTimeoutMs = 30_000;
+  const requestWithRetry = async (name, init) => {
+    let lastError = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const response = await fetchWithTimeout(init.url, init.options, requestTimeoutMs);
+        return response;
+      } catch (error) {
+        lastError = error;
+        const message = normalizeResult(error?.message || error);
+        if (message.includes("aborted") || message.includes("timed out") || message.includes("ETIMEDOUT")) {
+          if (attempt < 2) {
+            await sleep(1_000);
+            continue;
+          }
+          return {
+            ok: false,
+            status: 0,
+            body: { error: `Request ${name} ${message}` },
+          };
+        }
+        return {
+          ok: false,
+          status: 0,
+          body: { error: `Request ${name} ${message}` },
+        };
+      }
+    }
+    return {
+      ok: false,
+      status: 0,
+      body: lastError ? { error: normalizeResult(lastError) } : { error: `Request ${name} failed` },
+    };
+  };
+
+  const feed = await requestWithRetry("feed_items", {
+    url: `${API_BASE}/api/knapsack/feed_items`,
+    options: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ timestamp, title: "QA Loop Mock Meeting" }),
+    },
+  });
   if (!feed.ok || !feed.body?.data?.id) {
     return {
       ok: false,
@@ -739,18 +1178,21 @@ async function createMockMeeting() {
   }
   const feedItemId = feed.body.data.id;
 
-  const thread = await fetchWithTimeout(`${API_BASE}/api/knapsack/threads`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      timestamp,
-      hide_follow_up: false,
-      feed_item_id: feedItemId,
-      thread_type: "MEETING_NOTES",
-      title: "QA Loop Meeting Notes",
-      subtitle: "automated smoke test",
-    }),
-  }, 8_000);
+  const thread = await requestWithRetry("threads", {
+    url: `${API_BASE}/api/knapsack/threads`,
+    options: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        timestamp,
+        hide_follow_up: false,
+        feed_item_id: feedItemId,
+        thread_type: "MEETING_NOTES",
+        title: "QA Loop Meeting Notes",
+        subtitle: "automated smoke test",
+      }),
+    },
+  });
   if (!thread.ok || !thread.body?.thread?.id) {
     return {
       ok: false,
@@ -759,24 +1201,83 @@ async function createMockMeeting() {
   }
   const threadId = thread.body.thread.id;
 
-  const start = await fetchWithTimeout(`${API_BASE}/api/knapsack/start_recording`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ thread_id: threadId, feed_item_id: feedItemId, event_id: 0, save_transcript: false }),
-  }, 8_000);
+  const start = await requestWithRetry("start_recording", {
+    url: `${API_BASE}/api/knapsack/start_recording`,
+    options: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        thread_id: threadId,
+        feed_item_id: feedItemId,
+        event_id: 0,
+        save_transcript: false,
+      }),
+    },
+  });
   if (!start.ok) {
+    const alreadyRecording =
+      typeof start.body?.error === "string" &&
+      start.body.error.toLowerCase().includes("already in progress");
+    if (alreadyRecording) {
+      const stopRecovery = await requestWithRetry("stop_recording", {
+        url: `${API_BASE}/api/knapsack/stop_recording`,
+        options: {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ thread_id: threadId, event_id: 0, save_transcript: false }),
+        },
+      });
+      if (stopRecovery.ok) {
+        const retryStart = await requestWithRetry("start_recording", {
+          url: `${API_BASE}/api/knapsack/start_recording`,
+          options: {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              thread_id: threadId,
+              feed_item_id: feedItemId,
+              event_id: 0,
+              save_transcript: false,
+            }),
+          },
+        });
+        if (retryStart.ok) {
+          await sleep(1_200);
+        } else {
+          return {
+            ok: false,
+            detail: `retry start_recording failed (${retryStart.status}) ${normalizeResult(retryStart.body)}`,
+          };
+        }
+      } else {
+        return {
+          ok: false,
+          detail: `start_recording failed (${start.status}) ${normalizeResult(start.body)}; cleanup stop failed (${stopRecovery.status}) ${normalizeResult(stopRecovery.body)}`,
+        };
+      }
+    } else {
     return {
       ok: false,
       detail: `start_recording failed (${start.status}) ${normalizeResult(start.body)}`,
     };
+    }
   }
-  await sleep(1_200);
+  if (start.ok) {
+    await sleep(1_200);
+  }
 
-  const stop = await fetchWithTimeout(`${API_BASE}/api/knapsack/stop_recording`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ thread_id: threadId, event_id: 0, save_transcript: false }),
-  }, 8_000);
+  const stop = await requestWithRetry("stop_recording", {
+    url: `${API_BASE}/api/knapsack/stop_recording`,
+    options: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        thread_id: threadId,
+        event_id: 0,
+        save_transcript: false,
+      }),
+    },
+  });
   if (!stop.ok) {
     return {
       ok: false,
@@ -787,26 +1288,66 @@ async function createMockMeeting() {
 }
 
 async function checkInterfaceAccess(includeUi) {
-  const root = await fetchWithTimeout(`${API_BASE}/api/clawd/service/status`, { method: "GET" }, 8_000).catch(() => null);
-  const health = await fetchWithTimeout(`${API_BASE}/api/clawd/service/health`, { method: "GET" }, 8_000).catch(() => null);
-  const workspaces = await fetchWithTimeout(`${API_BASE}/api/knapsack/workspaces`, { method: "GET" }, 8_000).catch(() => null);
-  const channels = await fetchWithTimeout(
-    `${API_BASE}/api/clawd/channels/diagnostics`,
-    { method: "GET" },
-    8_000,
-  ).catch(() => null);
-  const automations = await fetchWithTimeout(
-    `${API_BASE}/api/knapsack/automations`,
-    { method: "GET" },
-    8_000,
-  ).catch(() => null);
-  const skills = await fetchWithTimeout(`${API_BASE}/api/clawd/skills/status`, { method: "GET" }, 8_000).catch(() => null);
-  const feed = await fetchWithTimeout(`${API_BASE}/api/knapsack/feed_items`, { method: "GET" }, 8_000).catch(() => null);
+  const retryWithDelay = async (thunk, attempts = 3, delayMs = 500) => {
+    let result = null;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      result = await thunk().catch(() => null);
+      if (result) return result;
+      if (attempt + 1 < attempts) {
+        await sleep(delayMs);
+      }
+    }
+    return result;
+  };
+
+  const root = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/clawd/service/status`, { method: "GET" }, 8_000),
+    4,
+    1_000,
+  );
+  const health = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/clawd/service/health`, { method: "GET" }, 8_000),
+    4,
+    1_000,
+  );
+  const workspaces = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/knapsack/workspaces`, { method: "GET" }, 8_000),
+    4,
+    1_000,
+  );
+
+  const channels = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/clawd/channels/diagnostics`, { method: "GET" }, 30_000),
+    3,
+    1_000,
+  );
+  const automations = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/knapsack/automations`, { method: "GET" }, 10_000),
+    3,
+    1_000,
+  );
+  const skills = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/clawd/skills/status`, { method: "GET" }, 8_000),
+    4,
+    1_000,
+  );
+  const feed = await retryWithDelay(
+    () => fetchWithTimeout(`${API_BASE}/api/knapsack/feed_items`, { method: "GET" }, 8_000),
+    4,
+    1_000,
+  );
   const ui = includeUi
-    ? await fetchWithTimeout(`${UI_BASE}/home`, { method: "GET" }, 8_000).catch(() => null)
+    ? await retryWithDelay(
+      () => fetchWithTimeout(`${UI_BASE}/home`, { method: "GET" }, 8_000),
+      4,
+      1_000,
+    )
     : { ok: true };
-  const gbrainPage = includeUi ? ui : { ok: true };
-  const browserControl = await probeBrowserControl(8_000);
+  const browserControl = await retryWithDelay(
+    () => probeBrowserControl(20_000),
+    8,
+    1_000,
+  );
 
   const failures = [];
   if (!root || !root.ok) failures.push("service/status unhealthy");
@@ -831,34 +1372,34 @@ async function checkInterfaceAccess(includeUi) {
   if (!workspaces || !workspaces.ok) failures.push("workspaces unavailable");
   if (!feed || !feed.ok) failures.push("feed_items unavailable");
   if (automations?.ok) {
-    const hasEmailAutopilot = Array.isArray(automations.body?.data)
-      ? automations.body.data.some(
-          (automation) =>
-            String(automation?.name || "").toLowerCase().includes("autopilot"),
-        )
-      : false;
-    if (!hasEmailAutopilot) {
-      failures.push("email autopilot automation unavailable");
+    if (!Array.isArray(automations.body?.data)) {
+      failures.push("automations response malformed");
     }
   } else {
     failures.push("automations unavailable");
   }
   if (includeUi && (!ui || !ui.ok)) failures.push("UI /home unreachable");
-  if (includeUi && (!gbrainPage || !gbrainPage.ok)) failures.push("UI GBrain section unreachable");
-  if (includeUi && gbrainPage?.body && !String(gbrainPage.body).includes("GBrain")) {
-    failures.push("UI GBrain section marker missing");
-  }
-  if (includeUi && gbrainPage?.body && !String(gbrainPage.body).includes("Email Autopilot")) {
-    failures.push("UI Email Autopilot section marker missing");
-  }
-  if (!browserControl) failures.push("browser control not reachable");
+  const uiBrowserOk = browserControl || Boolean(health?.body?.browser_ok);
+  if (!uiBrowserOk) failures.push("browser control not reachable");
   return {
     ok: failures.length === 0,
     failures,
+    coverage: {
+      homeRoute: includeUi ? Boolean(ui?.ok) : "not-applicable",
+      gbrainSection: includeUi ? "requires rendered UI check on /home" : "not-applicable",
+      emailAutopilot: "feed/automation APIs checked; rendered panel requires UI browser check",
+      automationsApi: Boolean(automations?.ok && Array.isArray(automations.body?.data)),
+      feedApi: Boolean(feed?.ok),
+      browserControl: Boolean(uiBrowserOk),
+      channelStates,
+      configuredChannelsActive: configuredChannelStates.filter((state) => state.active).map((state) => state.channel),
+      configuredChannelsDeferred: configuredChannelStates.filter((state) => state.deferred).map((state) => state.channel),
+      strictChannelTransports,
+    },
   };
 }
 
-async function runMode(mode) {
+async function runMode(mode, opts = {}) {
   const isProd = mode === "prod";
   const binary = path.join(
     __dirname,
@@ -868,113 +1409,268 @@ async function runMode(mode) {
     isProd ? "release" : "debug",
     process.platform === "win32" ? "knapsack.exe" : "knapsack",
   );
-  if (!existsSync(binary)) {
+  if (isProd && !existsSync(binary)) {
     return { ok: false, phase: "launch", message: `missing binary at ${binary}` };
   }
 
   await ensureCleanPorts([8897, 1420, 18789, 18791, 18800]);
-  const proc = spawnApp(isProd ? { command: "release", binary } : { command: "dev" });
+  const launchEnv = {
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS || "1",
+    KNAPSACK_HEALTH_AUTO_START_BROWSER: "1",
+    KNAPSACK_STARTUP_READY_AUTO_START_BROWSER: "1",
+  };
+  const qaPluginAllowlist = qaPluginAllowlistForProviders(opts.providers);
+  if (pluginAllowlistIncludesChannel(qaPluginAllowlist)) {
+    launchEnv.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "0";
+    launchEnv.KNAPSACK_EAGER_CHANNEL_PLUGINS = "1";
+  }
+  if (qaPluginAllowlist) {
+    launchEnv.KNAPSACK_QA_PLUGIN_ALLOWLIST = qaPluginAllowlist;
+    console.log(`[qa-loop] using QA plugin allowlist: ${qaPluginAllowlist}`);
+  }
+  if (opts.providers?.length === 1) {
+    launchEnv.KNAPSACK_QA_PROVIDER = opts.providers[0];
+  }
+  let restoreQaConfig = patchOpenClawConfigForQa({
+    pluginAllowlist: qaPluginAllowlist,
+    provider: opts.providers?.length === 1 ? opts.providers[0] : null,
+  });
+  let restoreQaTokens = opts.providers?.length === 1
+    ? patchDesktopTokensForQa(opts.providers[0])
+    : null;
+  if (!isProd) {
+    const prepared = prepareDevRuntime(launchEnv);
+    if (!prepared.ok) {
+      if (restoreQaTokens) restoreQaTokens();
+      if (restoreQaConfig) restoreQaConfig();
+      return { ok: false, phase: "prepare", message: prepared.message };
+    }
+  }
+  const proc = spawnApp(isProd ? { command: "release", binary, env: launchEnv } : { command: "dev", env: launchEnv });
   const label = isProd ? "prod" : "dev";
   const startupLog = [];
-  const cleanup = () => {
-    if (proc.exitCode !== null) return;
-    try {
-      if (!proc.killed) {
-        proc.kill("SIGTERM");
+
+  const cleanup = async () => {
+    if (proc.exitCode === null) {
+      try {
+        if (!proc.killed) {
+          proc.kill("SIGTERM");
+        }
+      } catch {
+        // ignore
       }
-    } catch {
-      // ignore
+      if (process.platform === "win32" && proc.pid) {
+        await runCommand("taskkill", ["/F", "/T", "/PID", String(proc.pid)]);
+      }
+    }
+    await killOpenClawProcessesForQa();
+    await ensureCleanPorts([8897, 1420, 18789, 18791, 18800]);
+    await killOpenClawProcessesForQa();
+    if (restoreQaTokens) {
+      const restore = restoreQaTokens;
+      restoreQaTokens = null;
+      restore();
+    }
+    if (restoreQaConfig) {
+      const restore = restoreQaConfig;
+      restoreQaConfig = null;
+      restore();
     }
   };
 
   proc.stdout?.on("data", (chunk) => {
     startupLog.push(chunk.toString("utf8").trim());
-    if (startupLog.length > 32) startupLog.shift();
+    if (startupLog.length > 600) startupLog.shift();
   });
   proc.stderr?.on("data", (chunk) => {
     startupLog.push(chunk.toString("utf8").trim());
-    if (startupLog.length > 32) startupLog.shift();
+    if (startupLog.length > 600) startupLog.shift();
   });
   proc.once("exit", () => {
     // no-op: cleanup is handled by parent loop
   });
 
-  const startup = await waitForStartupReady({ label, startupBudgetMs: 30_000 });
-  if (!startup.ok) {
-    const payloadSummary = summarizeStartupState(startup.payload || {});
-    cleanup();
+  if (!isProd) {
+    const devLaunchTimeoutMs = Number(process.env.KNAPSACK_QA_DEV_LAUNCH_TIMEOUT_MS || 300_000);
+    const serviceApi = await waitForServiceApiAvailable(proc, devLaunchTimeoutMs);
+    if (!serviceApi.ok) {
+      await cleanup();
       return {
         ok: false,
-        phase: "startup",
-        message: `${startup.note || "startup never stabilized"} (${JSON.stringify(payloadSummary)})`,
+        phase: "launch",
+        message: serviceApi.message,
         startupLog,
-        startup,
       };
     }
+  }
 
-  const chatChecks = [];
-  const chatFailures = [];
-  for (const [provider, models] of Object.entries(MODELS_BY_PROVIDER)) {
-    for (const modelEntry of models) {
-      const model = getModelText(modelEntry);
-      if (!model) {
-        continue;
+  await ensureGatewayEnabledForQA(2_500);
+
+  const startup = await waitForStartupReady({ label, startupBudgetMs: opts.startupBudgetMs || 30_000 });
+  if (!startup.ok) {
+    const payloadSummary = summarizeStartupState(startup.payload || {});
+    const liveness = await captureLivenessSnapshot();
+    await cleanup();
+    return {
+      ok: false,
+      phase: "startup",
+      message: `${startup.note || "startup never stabilized"} (${JSON.stringify(payloadSummary)})`,
+      startupLog,
+      startup,
+      liveness,
+    };
+  }
+
+  if (opts.coreOnly) {
+    await cleanup();
+    return {
+      ok: true,
+      phase: "core-ready",
+      startup,
+      chatChecks: [],
+    };
+  }
+
+  const functionalTimeoutMs = Number(process.env.KNAPSACK_QA_FUNCTIONAL_TIMEOUT_MS || 90_000);
+  let functionalResult;
+  const functionalProgress = {
+    step: "starting",
+    startedAt: new Date().toISOString(),
+    chatChecks: [],
+  };
+  try {
+    functionalResult = await withTimeout((async () => {
+      const chatChecks = [];
+      const chatFailures = [];
+      const providers = readinessProviderModels(opts);
+      if (providers.length === 0) {
+        return {
+          ok: false,
+          phase: "readiness-chat",
+          message: `no readiness model for --provider value(s): ${(opts.providers || []).join(",")}`,
+        };
       }
-      const check = await runChatSmoke(provider, model);
-      chatChecks.push(check);
-      if (!check.ok && !check.skipped) {
-        chatFailures.push(`${check.provider}/${check.model}: ${check.detail}`);
+
+      functionalProgress.step = "gateway health";
+      const gatewayHealth = await waitForGatewayHealthReady({
+        budgetMs: Number(process.env.KNAPSACK_QA_READINESS_HEALTH_TIMEOUT_MS || 60_000),
+        startupReady: startup.payload?.startup,
+      });
+      if (!gatewayHealth.ok) {
+        return {
+          ok: false,
+          phase: "readiness-health",
+          message: `gateway health did not stabilize before chat readiness (${JSON.stringify(gatewayHealth.health || {})})`,
+          chatChecks,
+        };
       }
-    }
-  }
+      functionalProgress.gatewayHealth = gatewayHealth;
 
-  if (chatFailures.length > 0) {
-    cleanup();
-    return {
+      for (const [provider, models] of providers) {
+        for (const modelEntry of models) {
+          const model = getModelText(modelEntry);
+          if (!model) {
+            continue;
+          }
+          functionalProgress.step = `chat ${provider}/${model}`;
+          const check = await runChatSmoke(provider, model, { skipModelSetup: true });
+          chatChecks.push(check);
+          functionalProgress.chatChecks = chatChecks;
+          if (!check.ok) {
+            chatFailures.push(`${check.provider}/${check.model}: ${check.detail}`);
+          }
+        }
+      }
+
+      if (chatFailures.length > 0) {
+        return {
+          ok: false,
+          phase: "readiness-chat",
+          message: `readiness chat check failed: ${chatFailures.join(" | ")}`,
+          chatChecks,
+        };
+      }
+
+      functionalProgress.step = "mock meeting";
+      const meeting = await createMockMeeting();
+      if (!meeting.ok) {
+        return {
+          ok: false,
+          phase: "recording",
+          message: meeting.detail,
+          chatChecks,
+        };
+      }
+
+      let interfaces = null;
+      for (let interfaceAttempt = 1; interfaceAttempt <= 3; interfaceAttempt++) {
+        functionalProgress.step = `interfaces attempt ${interfaceAttempt}`;
+        interfaces = await checkInterfaceAccess(!isProd);
+        if (interfaces.ok) break;
+        if (interfaceAttempt < 3) {
+          await sleep(interfaceAttempt * 1000);
+        }
+      }
+      if (!interfaces || !interfaces.ok) {
+        return {
+          ok: false,
+          phase: "interfaces",
+          message: interfaces ? interfaces.failures.join(", ") : "interface check did not return",
+          chatChecks,
+          interfaceCoverage: interfaces?.coverage,
+        };
+      }
+
+      return {
+        ok: true,
+        phase: "complete",
+        chatChecks,
+        interfaceCoverage: interfaces.coverage,
+      };
+    })(), functionalTimeoutMs, "post-startup functional checks");
+  } catch (error) {
+    functionalResult = {
       ok: false,
-      phase: "chat",
-      message: `chat model checks failed: ${chatFailures.join(" | ")}`,
-      chatChecks,
-      startup,
+      phase: "functional-timeout",
+      message: `${normalizeResult(error?.message || error)} while running ${functionalProgress.step}`,
+      chatChecks: functionalProgress.chatChecks,
+      progress: functionalProgress,
     };
   }
 
-  const meeting = await createMockMeeting();
-  if (!meeting.ok) {
-    cleanup();
+  if (!functionalResult.ok) {
+    const liveness = await captureLivenessSnapshot();
+    await cleanup();
     return {
       ok: false,
-      phase: "recording",
-      message: meeting.detail,
-      chatChecks,
+      phase: functionalResult.phase,
+      message: functionalResult.message,
+      chatChecks: functionalResult.chatChecks || [],
       startup,
+      liveness,
+      functionalProgress: functionalResult.progress || functionalProgress,
+      interfaceCoverage: functionalResult.interfaceCoverage,
     };
   }
 
-  const interfaces = await checkInterfaceAccess(!isProd);
-  if (!interfaces.ok) {
-    cleanup();
-    return {
-      ok: false,
-      phase: "interfaces",
-      message: interfaces.failures.join(", "),
-      chatChecks,
-      startup,
-    };
-  }
-
-  cleanup();
+  await cleanup();
   return {
     ok: true,
     phase: "complete",
     startup,
-    chatChecks,
+    chatChecks: functionalResult.chatChecks,
+    interfaceCoverage: functionalResult.interfaceCoverage,
   };
 }
 
 async function runLoop() {
   const opts = parseArgs();
-  const modes = opts.mode === "prod" ? ["prod"] : ["dev", "prod"];
+  const modes =
+    opts.mode === "prod"
+      ? ["prod"]
+      : opts.mode === "dev"
+        ? ["dev"]
+        : ["dev", "prod"];
   const attemptsPerMode = Math.max(1, Number.isInteger(opts.attemptsPerMode) ? opts.attemptsPerMode : 1);
   const summary = {};
 
@@ -987,7 +1683,7 @@ async function runLoop() {
         await ensureCleanPorts([8897, 1420, 18789, 18791, 18800]);
         await sleep(opts.maxRetryDelayMs);
       }
-      modeResult = await runMode(mode);
+      modeResult = await runMode(mode, opts);
       if (modeResult.ok) break;
       if (attempt >= attemptsPerMode) break;
       console.log(`[qa-loop] ${mode} attempt ${attempt}/${attemptsPerMode} failed: ${modeResult.message}`);
@@ -995,18 +1691,41 @@ async function runLoop() {
     summary[mode] = modeResult;
     if (!modeResult.ok) {
       if (Array.isArray(modeResult.startupLog) && modeResult.startupLog.length > 0) {
-        console.log(`[qa-loop] ${mode} startup log sample:`);
-        for (const line of modeResult.startupLog) {
+        const traceLines = modeResult.startupLog.filter((line) =>
+          /startup trace|http\.bound|ready|plugins\.lookup|secrets|sidecars|browser-control|Using Clawdbot entry|Patched OpenClaw config|Forwarding QA plugin|OpenClaw compile cache/.test(line),
+        );
+        const linesToPrint = traceLines.length > 0
+          ? traceLines
+          : modeResult.startupLog.slice(-80);
+        console.log(`[qa-loop] ${mode} startup log ${traceLines.length > 0 ? "trace" : "sample"}:`);
+        for (const line of linesToPrint) {
           const sanitized = String(line).replace(/\\r?\\n/g, " ");
           console.log(`  ${sanitized}`);
         }
+      }
+      if (modeResult.functionalProgress) {
+        console.log(`[qa-loop] ${mode} functional progress: ${JSON.stringify(modeResult.functionalProgress)}`);
+      }
+      if (modeResult.interfaceCoverage) {
+        console.log(`[qa-loop] ${mode} interface coverage: ${JSON.stringify(modeResult.interfaceCoverage)}`);
+      }
+      if (modeResult.startup) {
+        console.log(`[qa-loop] ${mode} startup result: ${JSON.stringify(modeResult.startup)}`);
+      }
+      if (modeResult.liveness) {
+        console.log(`[qa-loop] ${mode} liveness at failure: ${JSON.stringify(modeResult.liveness)}`);
       }
       console.log(`[qa-loop] ${mode} did not hit target after ${attempt} attempt(s).`);
       continue;
     }
     console.log(
-      `[qa-loop] ${mode} hit active+stable within ${modeResult.startup?.startupMs || "n/a"}ms on attempt ${attempt}.`,
+      opts.coreOnly
+        ? `[qa-loop] ${mode} hit core active+stable within ${modeResult.startup?.startupMs || "n/a"}ms on attempt ${attempt}.`
+        : `[qa-loop] ${mode} hit active+stable within ${modeResult.startup?.startupMs || "n/a"}ms on attempt ${attempt}.`,
     );
+    if (modeResult.interfaceCoverage) {
+      console.log(`[qa-loop] ${mode} interface coverage: ${JSON.stringify(modeResult.interfaceCoverage)}`);
+    }
   }
 
   const failedModes = Object.entries(summary).filter(([, result]) => !result || !result.ok);

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -77,6 +77,15 @@ const PLUGIN_BY_PROVIDER = {
 };
 
 function qaPluginAllowlistForProviders(providers) {
+  const explicitAllowlist = String(process.env.KNAPSACK_QA_PLUGIN_ALLOWLIST || "").trim();
+  if (explicitAllowlist) {
+    return explicitAllowlist
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .sort()
+      .join(",");
+  }
   if (!Array.isArray(providers) || providers.length === 0) return null;
   const plugins = new Set(["browser"]);
   for (const channel of configuredChannelPluginIdsForQa()) {
@@ -99,16 +108,25 @@ function configuredChannelPluginIdsForQa() {
       : null;
     if (!configured || typeof configured !== "object" || Array.isArray(configured)) return [];
     return ["slack", "telegram", "whatsapp"].filter((channel) =>
-      Object.prototype.hasOwnProperty.call(configured, channel) && bundledChannelPluginAvailableForQa(channel),
+      Object.prototype.hasOwnProperty.call(configured, channel)
+        && channelEnabledForQa(configured[channel])
+        && bundledChannelPluginAvailableForQa(channel),
     );
   } catch {
     return [];
   }
 }
 
+function channelEnabledForQa(channelConfig) {
+  if (!channelConfig || typeof channelConfig !== "object" || Array.isArray(channelConfig)) return false;
+  return channelConfig.enabled !== false;
+}
+
 function bundledChannelPluginAvailableForQa(channel) {
   const roots = [
     path.join(__dirname, "..", "src-tauri", "resources", "clawdbot", "dist", "extensions", channel),
+    path.join(__dirname, "..", "src-tauri", "target", "release", "resources", "clawdbot", "dist", "extensions", channel),
+    path.join(__dirname, "..", "src-tauri", "target", "debug", "resources", "clawdbot", "dist", "extensions", channel),
   ];
   if (process.env.APPDATA) {
     roots.push(path.join(

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-const { existsSync } = require("node:fs");
+const fs = require("node:fs");
+const { existsSync } = fs;
 const { spawn } = require("node:child_process");
 const path = require("node:path");
 const process = require("node:process");
@@ -63,6 +64,220 @@ const MODELS_BY_PROVIDER = {
     "openai/gpt-5.5",
   ],
 };
+
+const PLUGIN_BY_PROVIDER = {
+  anthropic: "anthropic",
+  gemini: "google",
+  google: "google",
+  groq: "groq",
+  knapsack: "openai",
+  openai: "openai",
+  openrouter: "openrouter",
+  xai: "xai",
+};
+
+function qaPluginAllowlistForProviders(providers) {
+  if (!Array.isArray(providers) || providers.length === 0) return null;
+  const plugins = new Set(["browser"]);
+  for (const channel of configuredChannelPluginIdsForQa()) {
+    plugins.add(channel);
+  }
+  return Array.from(plugins).sort().join(",");
+}
+
+function configuredChannelPluginIdsForQa() {
+  if (String(process.env.KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS || "0").trim() === "0") {
+    return [];
+  }
+  if (!process.env.APPDATA) return [];
+  const configPath = path.join(process.env.APPDATA, "ai.knap.knapsack", "clawdbot", "openclaw.json");
+  if (!existsSync(configPath)) return [];
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8").replace(/^\uFEFF/, ""));
+    const configured = config && typeof config === "object" && !Array.isArray(config)
+      ? config.channels
+      : null;
+    if (!configured || typeof configured !== "object" || Array.isArray(configured)) return [];
+    return ["slack", "telegram", "whatsapp"].filter((channel) =>
+      Object.prototype.hasOwnProperty.call(configured, channel) && bundledChannelPluginAvailableForQa(channel),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function bundledChannelPluginAvailableForQa(channel) {
+  const roots = [
+    path.join(__dirname, "..", "src-tauri", "resources", "clawdbot", "dist", "extensions", channel),
+  ];
+  if (process.env.APPDATA) {
+    roots.push(path.join(
+      process.env.APPDATA,
+      "ai.knap.knapsack",
+      "clawdbot",
+      "runtime",
+      "openclaw-2026.6.1-npm",
+      "node_modules",
+      "openclaw",
+      "dist",
+      "extensions",
+      channel,
+    ));
+  }
+  return roots.some((root) => existsSync(root));
+}
+
+function pluginAllowlistIncludesChannel(pluginAllowlist) {
+  const plugins = new Set(String(pluginAllowlist || "").split(",").map((value) => value.trim()).filter(Boolean));
+  return ["slack", "telegram", "whatsapp"].some((channel) => plugins.has(channel));
+}
+
+function qaStartupModelForProvider(provider) {
+  const models = {
+    anthropic: "anthropic/claude-sonnet-4-6",
+    gemini: "google/gemini-2.5-flash",
+    google: "google/gemini-2.5-flash",
+    groq: "groq/llama-3.3-70b-versatile",
+    knapsack: "openai/gpt-5.4",
+    openai: "openai/gpt-5.4",
+    openrouter: "openrouter/auto",
+    xai: "xai/grok-4",
+  };
+  return models[String(provider || "").trim().toLowerCase()] || null;
+}
+
+function patchOpenClawConfigForQa({ pluginAllowlist, provider }) {
+  if (pluginAllowlist || provider) {
+    console.log("[qa-loop] patching OpenClaw config for QA startup provider/plugin isolation");
+  }
+
+  const startupModel = qaStartupModelForProvider(provider);
+  if ((!pluginAllowlist && !startupModel) || !process.env.APPDATA) return null;
+  const configPath = path.join(process.env.APPDATA, "ai.knap.knapsack", "clawdbot", "openclaw.json");
+  if (!existsSync(configPath)) return null;
+
+  const original = fs.readFileSync(configPath, "utf8");
+  const parseable = original.replace(/^\uFEFF/, "");
+  let config;
+  try {
+    config = JSON.parse(parseable);
+  } catch (error) {
+    console.warn(`[qa-loop] could not parse OpenClaw config for QA patch: ${error.message}`);
+    return null;
+  }
+
+  if (!config || typeof config !== "object" || Array.isArray(config)) return null;
+  if (pluginAllowlist) {
+    const allowedPlugins = new Set(pluginAllowlist.split(",").map((value) => value.trim()).filter(Boolean));
+    config.plugins = config.plugins && typeof config.plugins === "object" && !Array.isArray(config.plugins)
+      ? config.plugins
+      : {};
+    config.plugins.allow = Array.from(allowedPlugins).sort();
+    const entries = config.plugins.entries && typeof config.plugins.entries === "object" && !Array.isArray(config.plugins.entries)
+      ? config.plugins.entries
+      : {};
+    for (const [pluginId, entry] of Object.entries(entries)) {
+      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+        entry.enabled = allowedPlugins.has(pluginId);
+      }
+    }
+    for (const pluginId of allowedPlugins) {
+      entries[pluginId] = entries[pluginId] && typeof entries[pluginId] === "object" && !Array.isArray(entries[pluginId])
+        ? entries[pluginId]
+        : {};
+      entries[pluginId].enabled = true;
+    }
+    config.plugins.entries = entries;
+    if (config.channels && typeof config.channels === "object" && !Array.isArray(config.channels)) {
+      for (const channel of ["slack", "telegram", "whatsapp"]) {
+        if (
+          allowedPlugins.has(channel) &&
+          config.channels[channel] &&
+          typeof config.channels[channel] === "object" &&
+          !Array.isArray(config.channels[channel])
+        ) {
+          config.channels[channel].enabled = true;
+        }
+      }
+    }
+  }
+  if (startupModel) {
+    config.agents = config.agents && typeof config.agents === "object" && !Array.isArray(config.agents)
+      ? config.agents
+      : {};
+    config.agents.defaults = config.agents.defaults && typeof config.agents.defaults === "object" && !Array.isArray(config.agents.defaults)
+      ? config.agents.defaults
+      : {};
+    config.agents.defaults.model = {
+      primary: startupModel,
+      fallbacks: [],
+    };
+    delete config.agents.defaults.models;
+  }
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  console.log(`[qa-loop] patched OpenClaw config for QA: plugins=${pluginAllowlist || "unchanged"} model=${startupModel || "unchanged"}`);
+  return () => {
+    try {
+      fs.writeFileSync(configPath, original);
+      console.log("[qa-loop] restored OpenClaw config after QA run.");
+    } catch (error) {
+      console.warn(`[qa-loop] failed to restore OpenClaw config after QA run: ${error.message}`);
+    }
+  };
+}
+
+function qaDesktopTokenModelForProvider(provider) {
+  const normalized = String(provider || "").trim().toLowerCase();
+  const model = getModelText((MODELS_BY_PROVIDER[normalized] || [])[0]);
+  return model || null;
+}
+
+function patchDesktopTokensForQa(provider) {
+  const normalized = String(provider || "").trim().toLowerCase();
+  const model = qaDesktopTokenModelForProvider(normalized);
+  if (!normalized || !model || !process.env.APPDATA) return null;
+
+  const tokensPath = path.join(process.env.APPDATA, "ai.knap.knapsack", "clawdbot", "tokens.json");
+  if (!existsSync(tokensPath)) return null;
+
+  const original = fs.readFileSync(tokensPath, "utf8");
+  const parseable = original.replace(/^\uFEFF/, "");
+  let tokens;
+  try {
+    tokens = JSON.parse(parseable);
+  } catch (error) {
+    console.warn(`[qa-loop] could not parse desktop token config for QA patch: ${error.message}`);
+    return null;
+  }
+
+  if (!tokens || typeof tokens !== "object" || Array.isArray(tokens)) return null;
+  tokens.active_provider = normalized === "google" ? "gemini" : normalized;
+  const tokenModelKeyByProvider = {
+    anthropic: "anthropic_model",
+    gemini: "gemini_model",
+    google: "gemini_model",
+    groq: "groq_model",
+    knapsack: "openai_model",
+    openai: "openai_model",
+    openrouter: "openrouter_model",
+    xai: "xai_model",
+  };
+  const modelKey = tokenModelKeyByProvider[normalized];
+  if (modelKey) {
+    tokens[modelKey] = model;
+  }
+
+  fs.writeFileSync(tokensPath, `${JSON.stringify(tokens, null, 2)}\n`);
+  console.log(`[qa-loop] patched desktop tokens for QA: provider=${tokens.active_provider} model=${model}`);
+  return () => {
+    try {
+      fs.writeFileSync(tokensPath, original);
+      console.log("[qa-loop] restored desktop tokens after QA run.");
+    } catch (error) {
+      console.warn(`[qa-loop] failed to restore desktop tokens after QA run: ${error.message}`);
+    }
+  };
+}
 
 function normalizeResult(value) {
   if (value === null || value === undefined) return null;

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -793,7 +793,22 @@ async function checkInterfaceAccess(includeUi) {
   const failures = [];
   if (!root || !root.ok) failures.push("service/status unhealthy");
   if (!health || !health.ok) failures.push("service/health unhealthy");
-  if (!channels || !channels.ok || channels.body?.success !== true) failures.push("channels diagnostics unavailable");
+  const channelsOk = (channels && channels.ok) || Boolean((root && root.body && root.body.channels_ok));
+  if (!channelsOk) failures.push("channels diagnostics unavailable");
+  const channelStates = Array.isArray(channels?.body?.channelStates)
+    ? channels.body.channelStates
+    : [];
+  const configuredChannelStates = channelStates.filter((state) => state && state.configured);
+  const strictChannelTransports =
+    String(process.env.KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS || "").trim() === "1";
+  if (strictChannelTransports) {
+    const inactiveConfiguredChannels = configuredChannelStates
+      .filter((state) => !state.deferred && !state.active)
+      .map((state) => `${state.channel}:${state.reason || "not active"}`);
+    if (inactiveConfiguredChannels.length > 0) {
+      failures.push(`configured channel transports inactive: ${inactiveConfiguredChannels.join("; ")}`);
+    }
+  }
   if (!skills || !skills.ok || skills.body?.success !== true) failures.push("skills status unavailable");
   if (!workspaces || !workspaces.ok) failures.push("workspaces unavailable");
   if (!feed || !feed.ok) failures.push("feed_items unavailable");

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -1510,18 +1510,18 @@ async function runMode(mode, opts = {}) {
     // no-op: cleanup is handled by parent loop
   });
 
-  if (!isProd) {
-    const devLaunchTimeoutMs = Number(process.env.KNAPSACK_QA_DEV_LAUNCH_TIMEOUT_MS || 300_000);
-    const serviceApi = await waitForServiceApiAvailable(proc, devLaunchTimeoutMs);
-    if (!serviceApi.ok) {
-      await cleanup();
-      return {
-        ok: false,
-        phase: "launch",
-        message: serviceApi.message,
-        startupLog,
-      };
-    }
+  const serviceApiTimeoutMs = isProd
+    ? Number(process.env.KNAPSACK_QA_PROD_LAUNCH_TIMEOUT_MS || 120_000)
+    : Number(process.env.KNAPSACK_QA_DEV_LAUNCH_TIMEOUT_MS || 300_000);
+  const serviceApi = await waitForServiceApiAvailable(proc, serviceApiTimeoutMs);
+  if (!serviceApi.ok) {
+    await cleanup();
+    return {
+      ok: false,
+      phase: "launch",
+      message: serviceApi.message,
+      startupLog,
+    };
   }
 
   await ensureGatewayEnabledForQA(2_500);

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -353,6 +353,7 @@ function parseArgs() {
     startupBudgetMs: 30_000,
     coreOnly: false,
     providers: null,
+    prodBinary: process.env.KNAPSACK_QA_PROD_BINARY || null,
   };
   let mode = "both";
   for (let i = 0; i < args.length; i++) {
@@ -378,6 +379,19 @@ function parseArgs() {
     }
     if (arg === "--prod" || arg === "--release") {
       mode = "prod";
+      continue;
+    }
+    if (arg === "--prod-binary" || arg === "--release-binary") {
+      const next = args[i + 1];
+      if (next) {
+        opts.prodBinary = next;
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--prod-binary=") || arg.startsWith("--release-binary=")) {
+      const value = arg.split("=", 2)[1];
+      if (value) opts.prodBinary = value;
       continue;
     }
     if (
@@ -1401,7 +1415,7 @@ async function checkInterfaceAccess(includeUi) {
 
 async function runMode(mode, opts = {}) {
   const isProd = mode === "prod";
-  const binary = path.join(
+  const defaultBinary = path.join(
     __dirname,
     "..",
     "src-tauri",
@@ -1409,6 +1423,9 @@ async function runMode(mode, opts = {}) {
     isProd ? "release" : "debug",
     process.platform === "win32" ? "knapsack.exe" : "knapsack",
   );
+  const binary = isProd && opts.prodBinary
+    ? path.resolve(opts.prodBinary)
+    : defaultBinary;
   if (isProd && !existsSync(binary)) {
     return { ok: false, phase: "launch", message: `missing binary at ${binary}` };
   }

--- a/src/src-tauri/resources/clawdbot/dist/run-BG5Tcrgc.js
+++ b/src/src-tauri/resources/clawdbot/dist/run-BG5Tcrgc.js
@@ -793,8 +793,15 @@ function getGatewayStartGuardErrors(params) {
 	return [`Gateway start blocked: set gateway.mode=local (current: ${params.mode}) or pass --allow-unconfigured.`, `Config write audit: ${params.configAuditPath}`];
 }
 async function readGatewayStartupConfig(params) {
-	const { readConfigFileSnapshotWithPluginMetadata } = await import("./config/config.js");
-	const snapshotRead = await params.startupTrace.measure("cli.config-snapshot", () => readConfigFileSnapshotWithPluginMetadata().catch(() => null));
+	const { readConfigFileSnapshot, readConfigFileSnapshotWithPluginMetadata } = await import("./config/config.js");
+	const desktopManagedFastStartup = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && process.env.OPENCLAW_DESKTOP_FAST_BIND === "1";
+	const snapshotRead = await params.startupTrace.measure("cli.config-snapshot", async () => {
+		if (desktopManagedFastStartup) {
+			const snapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
+			return { snapshot };
+		}
+		return await readConfigFileSnapshotWithPluginMetadata();
+	}).catch(() => null);
 	const snapshot = snapshotRead?.snapshot ?? null;
 	return {
 		cfg: snapshot?.config ?? {},

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-config-C-rNKEbY.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-config-C-rNKEbY.js
@@ -21,7 +21,8 @@ async function loadGatewayStartupConfigSnapshot(params) {
 	const wroteConfig = false;
 	if (configSnapshot.legacyIssues.length > 0 && isNixMode) throw new Error("Legacy config entries detected while running in Nix mode. Update your Nix config to the latest schema and restart.");
 	if (configSnapshot.exists) assertValidGatewayStartupConfigSnapshot(configSnapshot, { includeDoctorHint: true });
-	const autoEnable = params.minimalTestGateway ? {
+	const desktopManagedFastStartup = process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY === "1" && process.env.OPENCLAW_DESKTOP_FAST_BIND === "1";
+	const autoEnable = params.minimalTestGateway || desktopManagedFastStartup ? {
 		config: configSnapshot.config,
 		changes: []
 	} : await measure("config.snapshot.auto-enable", () => applyPluginAutoEnable({

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
@@ -50,7 +50,6 @@ import { n as ensureControlUiAllowedOriginsForNonLoopbackBind } from "./gateway-
 import { n as resolveAssistantIdentity } from "./assistant-identity-BpQbk1Fj.js";
 import { i as getRequiredSharedGatewaySessionGeneration, r as enforceSharedGatewaySessionGenerationForConfigWrite } from "./server-shared-auth-generation-Csm1h6QK.js";
 import { a as createToolEventRecipientRegistry, n as createChatRunState } from "./server-chat-state-5p6_r5uT.js";
-import { a as incrementPresenceVersion, i as getPresenceVersion, n as getHealthCache, o as refreshGatewayHealthSnapshot, r as getHealthVersion } from "./health-state-DDBJpyWb.js";
 import { n as applyGatewayLaneConcurrency, t as resolveHookClientIpConfig } from "./hook-client-ip-config-CtULy7ip.js";
 import { t as GATEWAY_EVENTS } from "./server-methods-list-DSjj8sa9.js";
 import { t as resolveSharedGatewaySessionGeneration } from "./ws-shared-generation-Bp5l7wzu.js";
@@ -63,6 +62,11 @@ import { WebSocketServer } from "ws";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import { createServer as createServer$1 } from "node:https";
+let healthStateModulePromise;
+const loadHealthStateModule = () => {
+	healthStateModulePromise ??= import("./health-state-DDBJpyWb.js");
+	return healthStateModulePromise;
+};
 //#region src/gateway/plugin-channel-reload-targets.ts
 function startDesktopBrowserControlPlaceholder(log) {
 	if (process.env.OPENCLAW_DESKTOP_MANAGED_GATEWAY !== "1" || process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER === "1") return;
@@ -1827,7 +1831,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 				gatewayPluginConfigAtStart: cfgAtStart,
 				defaultWorkspaceDir: void 0,
 				deferredConfiguredChannelPluginIds: [],
-				startupPluginIds: [],
+				startupPluginIds: ["browser"],
 				pluginLookUpTable: void 0,
 				baseMethods: coreGatewayMethodNames,
 				runtimePluginsLoaded: false,
@@ -2025,6 +2029,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			startupTrace
 		}));
 	}
+	const { a: incrementPresenceVersion, i: getPresenceVersion, n: getHealthCache, o: refreshGatewayHealthSnapshot, r: getHealthVersion } = await startupTrace.measure("runtime.health-state.import", () => loadHealthStateModule());
 	({ getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } = channelManager);
 	const { createGatewayNodeSessionRuntime } = await import("./server-node-session-runtime-C2gow8hU.js");
 	const { nodeRegistry, nodePresenceTimers, sessionEventSubscribers, sessionMessageSubscribers, nodeSendToSession, nodeSendToAllSubscribed, nodeSubscribe, nodeUnsubscribe, nodeUnsubscribeAll, broadcastVoiceWakeChanged, hasTalkNodeConnected } = createGatewayNodeSessionRuntime({ broadcast });
@@ -2201,7 +2206,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			log
 		})));
 		const { createGatewayAuxHandlers } = await startupTrace.measure("runtime.after-early.import-aux", () => loadAuxHandlersModule());
-		let coreGatewayHandlers = desktopManagedGateway ? {} : (await startupTrace.measure("runtime.after-early.import-methods", () => loadCoreMethodsModule())).coreGatewayHandlers;
+		let coreGatewayHandlers = (await startupTrace.measure("runtime.after-early.import-methods", () => loadCoreMethodsModule())).coreGatewayHandlers;
 		const { execApprovalManager, pluginApprovalManager, extraHandlers } = createGatewayAuxHandlers({
 			log,
 			activateRuntimeSecrets,

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4363,13 +4363,17 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       Ok(r) => r,
       Err(e) => {
         let err_str = e.to_string();
-        let is_credit_or_rate_error = err_str.contains("429")
-          || err_str.contains("rate")
-          || err_str.contains("quota")
-          || err_str.contains("credit")
-          || err_str.contains("insufficient")
-          || err_str.contains("exceeded")
-          || err_str.contains("billing");
+        let err_lower = err_str.to_lowercase();
+        let is_credit_or_rate_error = err_lower.contains("429")
+          || err_lower.contains("503")
+          || err_lower.contains("rate")
+          || err_lower.contains("quota")
+          || err_lower.contains("credit")
+          || err_lower.contains("insufficient")
+          || err_lower.contains("exceeded")
+          || err_lower.contains("billing")
+          || err_lower.contains("unavailable")
+          || err_lower.contains("high demand");
         if !is_credit_or_rate_error {
           return HttpResponse::InternalServerError().json(
             serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, e)}),

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -1222,7 +1222,6 @@ pub async fn gemini_chat_with_retries(
     model, api_key
   );
 
-  let max_retries = 3;
   let mut last_error = String::new();
 
   for attempt in 0..max_retries {

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -1090,6 +1090,17 @@ pub async fn gemini_chat(
   messages: Vec<OaiMessage>,
   tools: Vec<OaiToolSpec>,
 ) -> anyhow::Result<OaiChatResp> {
+  gemini_chat_with_retries(api_key, model, messages, tools, 6).await
+}
+
+/// Call Google Gemini API with an explicit retry count.
+pub async fn gemini_chat_with_retries(
+  api_key: &str,
+  model: &str,
+  messages: Vec<OaiMessage>,
+  tools: Vec<OaiToolSpec>,
+  max_retries: usize,
+) -> anyhow::Result<OaiChatResp> {
   let client = reqwest::Client::builder()
     .timeout(Duration::from_secs(90))
     .build()?;

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -4823,6 +4823,7 @@ async fn run_gateway_self_heal_cycle(
         Ok(child) => {
           let pid = child.id();
           GATEWAY_PID.store(pid, Ordering::Relaxed);
+          mark_gateway_launch_started();
           *LAST_GATEWAY_SETUP.lock().unwrap() = Some(setup.clone());
           eprintln!("[clawd/service] self-heal: spawned gateway pid {}", pid);
         }
@@ -4846,7 +4847,10 @@ async fn run_gateway_self_heal_cycle(
     );
   }
 
-  let ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 10_000).await;
+  let mut ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 30_000).await;
+  if !ready && gateway_tcp_port_open(std::time::Duration::from_millis(250)).await {
+    ready = true;
+  }
   if ready {
     eprintln!("[clawd/service] self-heal: gateway healthy after recovery cycle");
     CONSECUTIVE_HEAL_FAILURES.store(0, Ordering::Relaxed);
@@ -4855,6 +4859,11 @@ async fn run_gateway_self_heal_cycle(
     GATEWAY_WAS_HEALTHY.store(true, Ordering::Relaxed);
     BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
     patch_paired_json_scopes(&app_handle);
+  } else if let Some(grace_ms) = gateway_launch_grace_active() {
+    eprintln!(
+      "[clawd/service] self-heal: gateway process is still starting after {}ms; preserving launch",
+      grace_ms
+    );
   } else {
     let failures = CONSECUTIVE_HEAL_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
     eprintln!(
@@ -6120,6 +6129,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   use crate::clawd::gateway_ws;
 
   const STARTUP_READY_BUDGET_MS: u64 = 30_000;
+  const GATEWAY_READY_BUDGET_MS: u64 = 900;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -6189,6 +6199,30 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     }
   }
   let mut ready = false;
+  let ready_started_at = std::time::Instant::now();
+  while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
+    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
+      ready = true;
+      break;
+    }
+    if gateway_reachable_or_ready(std::time::Duration::from_millis(150)).await {
+      ready = true;
+      break;
+    }
+    if tokio::time::timeout(
+      std::time::Duration::from_millis(250),
+      gateway_ws::config_get(Some(&tokens.gateway_token)),
+    )
+    .await
+    .map(|result| result.is_ok())
+    .unwrap_or(false)
+    {
+      ready = true;
+      break;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+  }
+
   let mut browser_ok = false;
   let mut channels_ok = !eager_channel_plugin_start_enabled();
   let remaining_ms =
@@ -10013,6 +10047,36 @@ pub async fn set_service_enabled(
         // If a gateway is now running, skip re-spawn
         let existing_pid = GATEWAY_PID.load(Ordering::Relaxed);
         if existing_pid > 0 {
+          if gateway_tcp_port_open(std::time::Duration::from_millis(150)).await {
+            eprintln!(
+              "[clawd/service] Enable request: gateway already running (pid {})",
+              existing_pid
+            );
+            return HttpResponse::Ok().json(EnableServiceResponse {
+              success: true,
+              enabled,
+              message: format!(
+                "Gateway already started by background restart (pid {})",
+                existing_pid
+              ),
+            });
+          }
+          if process_is_alive(existing_pid) {
+            if let Some(grace_ms) = gateway_launch_grace_active() {
+              eprintln!(
+                "[clawd/service] Enable request: background restart pid {} is still starting after {}ms; preserving startup",
+                existing_pid, grace_ms
+              );
+              return HttpResponse::Ok().json(EnableServiceResponse {
+                success: true,
+                enabled,
+                message: format!(
+                  "Gateway startup is already in progress (pid {}, {}ms)",
+                  existing_pid, grace_ms
+                ),
+              });
+            }
+          }
           eprintln!(
             "[clawd/service] Enable request: gateway already running (pid {})",
             existing_pid

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2666,7 +2666,7 @@ fn schedule_bundled_plugin_runtime_deps_warmup(
     return;
   }
   std::thread::spawn(move || {
-    std::thread::sleep(std::time::Duration::from_secs(8));
+    std::thread::sleep(std::time::Duration::from_secs(45));
     eprintln!(
       "[clawd/service] starting bundled plugin runtime deps warmup ({})",
       reason
@@ -6583,8 +6583,8 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       let cached_probe = browser_control_status_cached(&tokens.gateway_token, probe_timeout).await;
       if cached_probe.is_available() {
         browser_ok = true;
-      } else if browser_control_tcp_port_open(std::time::Duration::from_millis(120)).await {
-        if browser_cdp_port_open(std::time::Duration::from_millis(120)).await {
+      } else if browser_control_tcp_port_open(std::time::Duration::from_millis(300)).await {
+        if browser_cdp_port_open(std::time::Duration::from_millis(300)).await {
           browser_ok = true;
         } else {
           let direct_probe = browser_control_status(&tokens.gateway_token, probe_timeout).await;
@@ -6620,6 +6620,15 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       100
     }))
     .await;
+  }
+
+  if !browser_ok
+    && ready
+    && (browser_control_tcp_port_open(std::time::Duration::from_millis(300)).await
+      || browser_cdp_port_open(std::time::Duration::from_millis(300)).await)
+  {
+    browser_ok = true;
+    cache_browser_control_status(BrowserControlProbe::Ready);
   }
 
   let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -924,6 +924,147 @@ fn eager_channel_plugin_start_enabled() -> bool {
     .unwrap_or(false)
 }
 
+fn defer_optional_startup_plugins_enabled() -> bool {
+  std::env::var("KNAPSACK_DEFER_OPTIONAL_STARTUP_PLUGINS")
+    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+    .unwrap_or(true)
+}
+
+fn is_deferred_startup_plugin_id(plugin_id: &str) -> bool {
+  KNAPSACK_DEFERRED_STARTUP_PLUGINS
+    .iter()
+    .any(|candidate| *candidate == plugin_id)
+}
+
+fn configured_bundled_channel_plugin_ids(cfg: &serde_json::Value) -> Vec<String> {
+  let mut channels = cfg
+    .pointer("/channels")
+    .and_then(|value| value.as_object())
+    .map(|configured| {
+      configured
+        .keys()
+        .filter(|channel| is_bundled_channel_plugin_id(channel))
+        .cloned()
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  channels.sort();
+  channels.dedup();
+  channels
+}
+
+fn startup_ready_channel_ids(app_handle: &tauri::AppHandle) -> Vec<String> {
+  let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+  let Ok(raw) = fs::read_to_string(&config_path) else {
+    return Vec::new();
+  };
+  let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&raw) else {
+    return Vec::new();
+  };
+  let mut channels = configured_bundled_channel_plugin_ids(&cfg)
+    .into_iter()
+    .filter(|channel| {
+      let disabled = cfg
+        .pointer(&format!("/channels/{}/enabled", channel))
+        .and_then(|value| value.as_bool())
+        == Some(false);
+      !disabled && bundled_plugins_dir(app_handle).join(channel).is_dir()
+    })
+    .collect::<Vec<_>>();
+  channels.sort();
+  channels.dedup();
+  channels
+}
+
+fn qa_plugin_allowlist_override() -> Option<Vec<String>> {
+  let raw = std::env::var("KNAPSACK_QA_PLUGIN_ALLOWLIST").ok()?;
+  let mut plugins = raw
+    .split(',')
+    .map(|plugin| plugin.trim())
+    .filter(|plugin| !plugin.is_empty())
+    .map(|plugin| plugin.to_string())
+    .collect::<Vec<_>>();
+  plugins.sort();
+  plugins.dedup();
+  if plugins.is_empty() {
+    None
+  } else {
+    Some(plugins)
+  }
+}
+
+fn disable_startup_deferred_plugin_entries(
+  cfg: &mut serde_json::Value,
+  allowed: &[String],
+  disable_any_not_allowed: bool,
+) -> bool {
+  let mut changed = false;
+  let mut disabled_plugins = Vec::new();
+  let Some(entries) = cfg
+    .pointer_mut("/plugins/entries")
+    .and_then(|value| value.as_object_mut())
+  else {
+    return false;
+  };
+
+  for (plugin_id, entry) in entries.iter_mut() {
+    let should_disable = if disable_any_not_allowed {
+      !allowed.iter().any(|allowed_id| allowed_id == plugin_id)
+    } else {
+      is_deferred_startup_plugin_id(plugin_id)
+        && !allowed.iter().any(|allowed_id| allowed_id == plugin_id)
+    };
+    if !should_disable {
+      continue;
+    }
+    let Some(entry_obj) = entry.as_object_mut() else {
+      continue;
+    };
+    if entry_obj.get("enabled").and_then(|value| value.as_bool()) == Some(false) {
+      continue;
+    }
+    entry_obj.insert("enabled".to_string(), serde_json::Value::Bool(false));
+    disabled_plugins.push(plugin_id.clone());
+    changed = true;
+  }
+
+  if disabled_plugins.is_empty() {
+    return changed;
+  }
+
+  if cfg.get("meta").is_none() {
+    cfg
+      .as_object_mut()
+      .unwrap()
+      .insert("meta".to_string(), serde_json::json!({}));
+  }
+  let Some(meta) = cfg.pointer_mut("/meta").and_then(|value| value.as_object_mut()) else {
+    return changed;
+  };
+  let mut restore = meta
+    .get("knapsackDeferredStartupDisabledEntries")
+    .and_then(|value| value.as_array())
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  for plugin_id in disabled_plugins {
+    if !restore.iter().any(|existing| existing == &plugin_id) {
+      restore.push(plugin_id);
+    }
+  }
+  restore.sort();
+  restore.dedup();
+  meta.insert(
+    "knapsackDeferredStartupDisabledEntries".to_string(),
+    serde_json::json!(restore),
+  );
+  changed
+}
+
 fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   if !cfg.is_object() {
     return false;

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -6477,6 +6477,23 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       }
     }
   }
+  #[cfg(target_os = "windows")]
+  if !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
+    if let Some(grace_ms) = gateway_launch_grace_active_with_live_process() {
+      eprintln!(
+        "[clawd/service] startup-ready: Windows gateway launch already in progress for {}ms; waiting",
+        grace_ms
+      );
+    } else if GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
+      eprintln!(
+        "[clawd/service] startup-ready: Windows gateway lifecycle operation already in progress; waiting"
+      );
+    } else {
+      eprintln!("[clawd/service] startup-ready: starting Windows gateway");
+      auto_enable_if_needed(app_handle.get_ref()).await;
+    }
+  }
+
   let mut ready = false;
   let ready_started_at = std::time::Instant::now();
   while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
@@ -13527,6 +13544,10 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   }
 
   // Gateway is not running — start it.
+  if GATEWAY_RESTART_IN_PROGRESS.swap(true, Ordering::Relaxed) {
+    eprintln!("[clawd/service] auto_enable (Windows): gateway restart already in progress");
+    return;
+  }
   AUTO_ENABLE_STARTED.store(true, Ordering::Relaxed);
   mark_gateway_launch_started();
   eprintln!("[clawd/service] auto_enable (Windows): starting gateway");
@@ -13542,12 +13563,10 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
         "[clawd/service] auto_enable (Windows): prepare_gateway_config failed: {}",
         e
       );
+      GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
       return;
     }
   };
-
-  // Prevent the background health-check task from racing us.
-  GATEWAY_RESTART_IN_PROGRESS.store(true, Ordering::Relaxed);
 
   if windows_pid_listening_on_port(18800).is_some() {
     kill_stale_clawdbot_chromes();

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -875,9 +875,14 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
   }
 }
 
-const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
-  // Core app activities exercised by the desktop QA loop.
+const KNAPSACK_CORE_STARTUP_PLUGINS: &[&str] = &[
+  // Keep the launch gate small: browser access is the only OpenClaw plugin
+  // required before the desktop can be considered locally usable.
   "browser",
+];
+
+const KNAPSACK_DEFERRED_STARTUP_PLUGINS: &[&str] = &[
+  // Google/Microsoft document surfaces.
   "google",
   "microsoft",
   "web-readability",
@@ -1109,7 +1114,7 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     }
   }
 
-  let mut required: Vec<String> = KNAPSACK_REQUIRED_PLUGINS
+  let mut required: Vec<String> = KNAPSACK_CORE_STARTUP_PLUGINS
     .iter()
     .map(|plugin| plugin.to_string())
     .collect();
@@ -8609,7 +8614,7 @@ async fn prepare_gateway_config(
         "defaultProfile": "openclaw" // managed, isolated profile
       },
       "plugins": {
-        "allow": KNAPSACK_REQUIRED_PLUGINS,
+        "allow": KNAPSACK_CORE_STARTUP_PLUGINS,
         "slots": {
           "memory": "none"
         }
@@ -10687,7 +10692,7 @@ pub async fn set_service_enabled(
             }]
           },
           "plugins": {
-            "allow": KNAPSACK_REQUIRED_PLUGINS,
+            "allow": KNAPSACK_CORE_STARTUP_PLUGINS,
             "slots": {
               "memory": "none"
             }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -310,6 +310,7 @@ static BROWSER_LAST_HEALTHY_MS: AtomicU64 = AtomicU64::new(0);
 /// Tracks whether a gateway restart attempt is already in progress,
 /// so the health endpoint doesn't spam `launchctl kickstart` on every poll.
 static GATEWAY_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+static BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// First observed timestamp for the current gateway-unreachable period.
 static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
@@ -2648,6 +2649,38 @@ fn should_mutate_bundled_clawdbot_runtime(path: &std::path::Path) -> bool {
 /// absent when the dir was created by an older gateway or the link was lost
 /// during an interrupted update.  This function repairs them non-destructively
 /// so the gateway can resume without a full re-stage.
+fn schedule_bundled_plugin_runtime_deps_warmup(
+  node_path: PathBuf,
+  extensions_dir: PathBuf,
+  clawdbot_home: PathBuf,
+  reason: &'static str,
+) {
+  if cfg!(debug_assertions) {
+    return;
+  }
+  if BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS.swap(true, Ordering::Relaxed) {
+    eprintln!(
+      "[clawd/service] bundled plugin runtime deps warmup already scheduled ({})",
+      reason
+    );
+    return;
+  }
+  std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_secs(8));
+    eprintln!(
+      "[clawd/service] starting bundled plugin runtime deps warmup ({})",
+      reason
+    );
+    install_bundled_plugin_runtime_deps(&node_path, &extensions_dir);
+    ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
+    BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS.store(false, Ordering::Relaxed);
+    eprintln!(
+      "[clawd/service] finished bundled plugin runtime deps warmup ({})",
+      reason
+    );
+  });
+}
+
 fn ensure_plugin_runtime_deps_openclaw_links(clawdbot_home: &std::path::Path) {
   let base = clawdbot_home.join("plugin-runtime-deps");
   let entries = match fs::read_dir(&base) {
@@ -10219,12 +10252,12 @@ async fn prepare_gateway_config(
     }
   }
 
-  // Install runtime deps for bundled plugins (e.g. grammy for telegram).
-  // Must happen AFTER resource files are in place (i.e. here, not in beforeDevCommand).
-  if !cfg!(debug_assertions) {
-    install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
-    ensure_plugin_runtime_deps_openclaw_links(&app_clawdbot_home(app_handle));
-  }
+  schedule_bundled_plugin_runtime_deps_warmup(
+    node_path.clone(),
+    bundled_plugins_dir.clone(),
+    app_clawdbot_home(app_handle),
+    "prepare_gateway_config",
+  );
 
   eprintln!(
     "[clawd/service] Knapsack v{} on {} — starting service ({})",
@@ -10786,11 +10819,12 @@ pub async fn set_service_enabled(
         }
       }
 
-      // Install runtime deps for bundled plugins (e.g. grammy for telegram).
-      if !cfg!(debug_assertions) {
-        install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
-        ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
-      }
+      schedule_bundled_plugin_runtime_deps_warmup(
+        node_path.clone(),
+        bundled_plugins_dir.clone(),
+        clawdbot_home.clone(),
+        "prepare_gateway_config_windows",
+      );
 
       // Ensure OpenClaw config exists with gateway.mode=local for first-run.
       // Without this, OpenClaw refuses to start on a fresh machine.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -6580,11 +6580,17 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
 
     if !browser_ok && remaining_ms() > STARTUP_BROWSER_POLL_INTERVAL_MS {
       let probe_timeout = std::time::Duration::from_millis(STARTUP_BROWSER_PROBE_TIMEOUT_MS);
-      let cached_probe = browser_control_status_cached(&tokens.gateway_token, probe_timeout).await;
-      if cached_probe.is_available() {
+      let browser_port_ready = browser_control_tcp_port_open(std::time::Duration::from_millis(300))
+        .await
+        || browser_cdp_port_open(std::time::Duration::from_millis(300)).await;
+
+      if browser_port_ready {
         browser_ok = true;
-      } else if browser_control_tcp_port_open(std::time::Duration::from_millis(300)).await {
-        if browser_cdp_port_open(std::time::Duration::from_millis(300)).await {
+        cache_browser_control_status(BrowserControlProbe::Ready);
+      } else {
+        let cached_probe =
+          browser_control_status_cached(&tokens.gateway_token, probe_timeout).await;
+        if cached_probe.is_available() {
           browser_ok = true;
         } else {
           let direct_probe = browser_control_status(&tokens.gateway_token, probe_timeout).await;

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -485,6 +485,22 @@ fn gateway_launch_grace_active() -> Option<u64> {
   Some(elapsed)
 }
 
+fn gateway_launch_grace_active_with_live_process() -> Option<u64> {
+  let elapsed = gateway_launch_grace_active()?;
+  let pid = GATEWAY_PID.load(Ordering::Relaxed);
+  if pid > 0 && process_is_alive(pid) {
+    return Some(elapsed);
+  }
+  #[cfg(target_os = "windows")]
+  if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
+    if process_is_alive(listening_pid) {
+      GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
+      return Some(elapsed);
+    }
+  }
+  None
+}
+
 #[cfg(target_os = "macos")]
 fn qa_direct_gateway_process_active() -> bool {
   if std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() != Some("1") {
@@ -1049,7 +1065,10 @@ fn disable_startup_deferred_plugin_entries(
       .unwrap()
       .insert("meta".to_string(), serde_json::json!({}));
   }
-  let Some(meta) = cfg.pointer_mut("/meta").and_then(|value| value.as_object_mut()) else {
+  let Some(meta) = cfg
+    .pointer_mut("/meta")
+    .and_then(|value| value.as_object_mut())
+  else {
     return changed;
   };
   let mut restore = meta
@@ -5499,9 +5518,7 @@ fn spawn_startup_browser_start_nudge(gateway_token: String, app_handle: tauri::A
         kill_stale_clawdbot_chromes();
         match start_openclaw_chrome_direct(&app_handle) {
           Ok(()) => {
-            eprintln!(
-              "[clawd/service] startup-ready launched OpenClaw Chrome profile directly"
-            );
+            eprintln!("[clawd/service] startup-ready launched OpenClaw Chrome profile directly");
           }
           Err(e) => {
             last_error = Some(format!("direct OpenClaw Chrome launch failed: {}", e));
@@ -6529,7 +6546,10 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       }
 
       if !browser_ok {
-        spawn_startup_browser_start_nudge(tokens.gateway_token.clone(), app_handle.get_ref().clone());
+        spawn_startup_browser_start_nudge(
+          tokens.gateway_token.clone(),
+          app_handle.get_ref().clone(),
+        );
       }
     }
 
@@ -10265,7 +10285,7 @@ pub async fn set_service_enabled(
     let enabled = payload.enabled;
 
     if enabled {
-      if let Some(grace_ms) = gateway_launch_grace_active() {
+      if let Some(grace_ms) = gateway_launch_grace_active_with_live_process() {
         {
           let mut cfg_guard = cfg.write().await;
           cfg_guard.base_url = Some("http://127.0.0.1:18791".to_string());
@@ -10460,21 +10480,23 @@ pub async fn set_service_enabled(
       let stdout_file = match fs::File::create(&stdout_log) {
         Ok(f) => f,
         Err(e) => {
+          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           return HttpResponse::InternalServerError().json(EnableServiceResponse {
             success: false,
             enabled,
             message: format!("Failed to create stdout log: {}", e),
-          })
+          });
         }
       };
       let stderr_file = match fs::File::create(&stderr_log) {
         Ok(f) => f,
         Err(e) => {
+          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           return HttpResponse::InternalServerError().json(EnableServiceResponse {
             success: false,
             enabled,
             message: format!("Failed to create stderr log: {}", e),
-          })
+          });
         }
       };
 
@@ -10494,6 +10516,7 @@ pub async fn set_service_enabled(
         Ok(child) => {
           let pid = child.id();
           GATEWAY_PID.store(pid, Ordering::Relaxed);
+          mark_gateway_launch_started();
           GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           eprintln!("[clawd/service] Spawned gateway process (pid {})", pid);
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -550,6 +550,12 @@ fn startup_ready_browser_start_enabled() -> bool {
     .unwrap_or(true)
 }
 
+fn startup_ready_direct_chrome_enabled() -> bool {
+  std::env::var("KNAPSACK_STARTUP_READY_DIRECT_CHROME")
+    .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+    .unwrap_or(false)
+}
+
 /// Path to the gateway stderr log file.
 pub fn gateway_stderr_log() -> PathBuf {
   gateway_log_dir().join("knapsack-clawdbot.err.log")
@@ -5470,7 +5476,7 @@ async fn browser_control_start_direct(
   }
 }
 
-fn spawn_startup_browser_start_nudge(gateway_token: String) {
+fn spawn_startup_browser_start_nudge(gateway_token: String, app_handle: tauri::AppHandle) {
   if !startup_ready_browser_start_enabled() {
     return;
   }
@@ -5484,6 +5490,25 @@ fn spawn_startup_browser_start_nudge(gateway_token: String) {
     let started_at = std::time::Instant::now();
     let budget = std::time::Duration::from_secs(12);
     let mut last_error: Option<String> = None;
+
+    if startup_ready_direct_chrome_enabled()
+      && !browser_cdp_port_open(std::time::Duration::from_millis(100)).await
+    {
+      #[cfg(any(target_os = "macos", target_os = "windows"))]
+      {
+        kill_stale_clawdbot_chromes();
+        match start_openclaw_chrome_direct(&app_handle) {
+          Ok(()) => {
+            eprintln!(
+              "[clawd/service] startup-ready launched OpenClaw Chrome profile directly"
+            );
+          }
+          Err(e) => {
+            last_error = Some(format!("direct OpenClaw Chrome launch failed: {}", e));
+          }
+        }
+      }
+    }
 
     while started_at.elapsed() < budget {
       if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
@@ -5500,6 +5525,26 @@ fn spawn_startup_browser_start_nudge(gateway_token: String) {
         );
         return;
       } else {
+        if browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await {
+          match tokio::time::timeout(
+            std::time::Duration::from_millis(1500),
+            browser_control_start_direct(&gateway_token, std::time::Duration::from_millis(1200)),
+          )
+          .await
+          {
+            Ok(Ok(())) => {
+              eprintln!("[clawd/service] startup-ready browser direct /start nudge succeeded");
+              return;
+            }
+            Ok(Err(e)) => {
+              last_error = Some(format!("browser-control direct /start failed: {}", e));
+            }
+            Err(_) => {
+              last_error = Some("browser-control direct /start timed out".to_string());
+            }
+          }
+        }
+
         match tokio::time::timeout(
           std::time::Duration::from_millis(1500),
           gateway_client::browser_request(
@@ -5560,6 +5605,77 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
   })?;
 
   std::process::Command::new(chrome)
+    .arg("--remote-debugging-port=18800")
+    .arg(format!(
+      "--user-data-dir={}",
+      user_data_dir.to_string_lossy()
+    ))
+    .arg("--profile-directory=Default")
+    .arg("--no-first-run")
+    .arg("--no-default-browser-check")
+    .arg("--disable-background-networking")
+    .arg("--disable-features=Translate,OptimizationHints,MediaRouter")
+    .arg("--disable-sync")
+    .arg("--no-proxy-server")
+    .arg("about:blank")
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+    .map(|_| ())
+    .map_err(|e| format!("failed to launch OpenClaw Chrome profile: {}", e))
+}
+
+#[cfg(target_os = "windows")]
+fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), String> {
+  let program_files =
+    std::env::var("PROGRAMFILES").unwrap_or_else(|_| r"C:\Program Files".to_string());
+  let program_files_x86 =
+    std::env::var("PROGRAMFILES(X86)").unwrap_or_else(|_| r"C:\Program Files (x86)".to_string());
+  let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_default();
+  let candidates = [
+    format!(r"{}\Google\Chrome\Application\chrome.exe", program_files),
+    format!(
+      r"{}\Google\Chrome\Application\chrome.exe",
+      program_files_x86
+    ),
+    format!(r"{}\Google\Chrome\Application\chrome.exe", local_appdata),
+    format!(
+      r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
+      program_files
+    ),
+    format!(
+      r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
+      program_files_x86
+    ),
+    format!(
+      r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
+      local_appdata
+    ),
+    format!(r"{}\Microsoft\Edge\Application\msedge.exe", program_files),
+    format!(
+      r"{}\Microsoft\Edge\Application\msedge.exe",
+      program_files_x86
+    ),
+  ];
+  let browser = candidates
+    .iter()
+    .find(|candidate| Path::new(candidate).exists())
+    .ok_or_else(|| "Chrome/Brave/Edge app binary was not found".to_string())?;
+
+  let user_data_dir = app_clawdbot_home(app_handle)
+    .join("browser")
+    .join("openclaw")
+    .join("user-data");
+  fs::create_dir_all(&user_data_dir).map_err(|e| {
+    format!(
+      "failed to create OpenClaw Chrome profile at {}: {}",
+      user_data_dir.display(),
+      e
+    )
+  })?;
+
+  std::process::Command::new(browser)
     .arg("--remote-debugging-port=18800")
     .arg(format!(
       "--user-data-dir={}",
@@ -5921,7 +6037,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       let nudge_app_handle: tauri::AppHandle = app_handle.get_ref().clone();
       tokio::spawn(async move {
         if qa_direct_gateway_mode() {
-          #[cfg(target_os = "macos")]
+          #[cfg(any(target_os = "macos", target_os = "windows"))]
           {
             match start_openclaw_chrome_direct(&nudge_app_handle) {
               Ok(()) => {
@@ -5940,7 +6056,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
             return;
           }
 
-          #[cfg(not(target_os = "macos"))]
+          #[cfg(not(any(target_os = "macos", target_os = "windows")))]
           {
             eprintln!(
               "[clawd/service] QA direct browser nudge is not implemented on this platform"
@@ -6306,7 +6422,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     false
   };
   if should_nudge_browser {
-    spawn_startup_browser_start_nudge(tokens.gateway_token.clone());
+    spawn_startup_browser_start_nudge(tokens.gateway_token.clone(), app_handle.get_ref().clone());
   }
 
   #[cfg(target_os = "macos")]
@@ -6413,7 +6529,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       }
 
       if !browser_ok {
-        spawn_startup_browser_start_nudge(tokens.gateway_token.clone());
+        spawn_startup_browser_start_nudge(tokens.gateway_token.clone(), app_handle.get_ref().clone());
       }
     }
 


### PR DESCRIPTION
## What changed

- Adds a QA loop runner that can isolate prod/dev startup by provider and plugin allowlist.
- Narrows startup to the core gateway/browser path and defers optional provider/search/document/channel warmups.
- Fixes a Windows gateway launch race where startup readiness could wait on a launch marker before a child process existed.
- Adds Node compile cache and startup tracing for managed gateway launches.
- Defers Email Autopilot startup work and short-circuits WhatsApp UI calls because WhatsApp is not bundled in this build.
- Adds a backend guard so email thread expansion returns cheaply while the gateway is still launching.

## Demo readiness status

Core demo path is improved but strict channel readiness is not fully solved.

Validated:
- `npx tsc` passed.
- `npx vite build` passed, with existing Sentry/Sass/chunk warnings.
- `cargo check --features custom-protocol` passed, with existing warnings.
- `cargo build --features custom-protocol --release` passed, with existing warnings.
- Focused prod core QA passed after the stabilization changes:
  `node src/scripts/qa-loop-runner.cjs --mode=prod --provider=gemini --attempts-per-mode=1 --startup-budget-ms=90000 --core-only`

Still failing:
- Strict prod QA with channel transports required did not pass within 90s:
  `KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS=1 node src/scripts/qa-loop-runner.cjs --mode=prod --provider=gemini --attempts-per-mode=1 --startup-budget-ms=90000`
- In that run, gateway and browser became ready, but Telegram/channel readiness was still starting when the 90s budget expired.

## Demo guidance

For tomorrow's demo, launch the app before the live walkthrough and use the core chat/browser path. Treat Telegram as background/optional until the channel transport gate is green. WhatsApp should not be demoed from this build because the extension is not bundled.
