### PR TITLE
Fix Windows gateway startup contention

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -312,6 +312,7 @@ static BROWSER_LAST_HEALTHY_MS: AtomicU64 = AtomicU64::new(0);
 static GATEWAY_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 static BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 static PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+static BUNDLED_RUNTIME_SELF_LINK_WARMUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// First observed timestamp for the current gateway-unreachable period.
 static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
@@ -2631,6 +2632,27 @@ fn ensure_clawdbot_runtime_self_link(clawdbot_entry: &std::path::Path) {
   } else {
     ensure_openclaw_link_to(&extensions_nm, clawdbot_root);
   }
+}
+
+fn schedule_clawdbot_runtime_self_link_warmup(clawdbot_entry: PathBuf, reason: &'static str) {
+  if BUNDLED_RUNTIME_SELF_LINK_WARMUP_IN_PROGRESS.swap(true, Ordering::Relaxed) {
+    eprintln!(
+      "[clawd/service] bundled runtime self-link warmup already scheduled ({})",
+      reason
+    );
+    return;
+  }
+  std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_secs(20));
+    let started = std::time::Instant::now();
+    ensure_clawdbot_runtime_self_link(&clawdbot_entry);
+    BUNDLED_RUNTIME_SELF_LINK_WARMUP_IN_PROGRESS.store(false, Ordering::Relaxed);
+    eprintln!(
+      "[clawd/service] bundled runtime self-link warmup completed in {}ms ({})",
+      started.elapsed().as_millis(),
+      reason
+    );
+  });
 }
 
 fn should_mutate_bundled_clawdbot_runtime(path: &std::path::Path) -> bool {
@@ -6539,8 +6561,11 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
         "[clawd/service] startup-ready: Windows gateway lifecycle operation already in progress; waiting"
       );
     } else {
-      eprintln!("[clawd/service] startup-ready: starting Windows gateway");
-      auto_enable_if_needed(app_handle.get_ref()).await;
+      eprintln!("[clawd/service] startup-ready: scheduling Windows gateway start");
+      let ah = app_handle.get_ref().clone();
+      tokio::spawn(async move {
+        auto_enable_if_needed(&ah).await;
+      });
     }
   }
 
@@ -8627,6 +8652,7 @@ async fn prepare_gateway_config(
   app_handle: &tauri::AppHandle,
   cfg: &SharedClawdbotConfig,
 ) -> Result<ServiceSetup, String> {
+  let prepare_started = std::time::Instant::now();
   let tokens = load_or_create_tokens(app_handle)?;
 
   fn first_existing(paths: &[PathBuf]) -> Option<PathBuf> {
@@ -8701,10 +8727,15 @@ async fn prepare_gateway_config(
       return Err("Node.js not found. The bundled Node.js binary is missing and no system Node.js was found. Please reinstall Knapsack or install Node.js (https://nodejs.org).".to_string());
     }
   };
+  let node_ready_started = std::time::Instant::now();
   if let Err(e) = ensure_node_binary_ready(&node_path) {
     eprintln!("[clawd/service] ERROR: {}", e);
     return Err(format!("Node.js is not usable for the gateway. {}", e));
   }
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: node readiness check completed in {}ms",
+    node_ready_started.elapsed().as_millis()
+  );
 
   // ── Find clawdbot entry ────────────────────────────────────────────
   let clawdbot_entry = if cfg!(debug_assertions) {
@@ -8756,6 +8787,12 @@ async fn prepare_gateway_config(
     "[clawd/service] Using Clawdbot entry: {}",
     clawdbot_entry.display()
   );
+  #[cfg(target_os = "windows")]
+  schedule_clawdbot_runtime_self_link_warmup(
+    clawdbot_entry.clone(),
+    "prepare_gateway_config",
+  );
+  #[cfg(not(target_os = "windows"))]
   ensure_clawdbot_runtime_self_link(&clawdbot_entry);
 
   let clawdbot_home = app_clawdbot_home(app_handle);
@@ -9865,11 +9902,16 @@ async fn prepare_gateway_config(
     }
   }
 
+  let channel_state_started = std::time::Instant::now();
   if sanitize_bundled_channel_plugin_install_state(&clawdbot_home) {
     eprintln!(
       "[clawd/service] Repaired stale bundled channel plugin install state before gateway launch"
     );
   }
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: channel install-state check completed in {}ms",
+    channel_state_started.elapsed().as_millis()
+  );
 
   // Keep the startup-critical root locked down immediately, but run the
   // recursive sweep off the launch path. Large state trees can contain
@@ -10294,6 +10336,11 @@ async fn prepare_gateway_config(
   eprintln!(
     "[clawd/service] Knapsack v{} on {} — starting service ({})",
     app_version, os_info, LAUNCH_AGENT_LABEL
+  );
+
+  eprintln!(
+    "[clawd/service] prepare_gateway_config completed in {}ms",
+    prepare_started.elapsed().as_millis()
   );
 
   Ok(ServiceSetup {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2375,6 +2375,72 @@ fn bundled_node_modules_has_declared_dependencies(
     .all(|dep| nm_path.join(dep).join("package.json").exists())
 }
 
+fn missing_declared_node_modules_dependencies(
+  dir: &std::path::Path,
+  nm_path: &std::path::Path,
+) -> Vec<String> {
+  let pkg_path = dir.join("package.json");
+  let Ok(raw) = fs::read_to_string(pkg_path) else {
+    return Vec::new();
+  };
+  let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&raw) else {
+    return Vec::new();
+  };
+  let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) else {
+    return Vec::new();
+  };
+
+  deps
+    .keys()
+    .filter(|dep| !nm_path.join(dep.as_str()).join("package.json").exists())
+    .cloned()
+    .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn fill_missing_node_modules_from_tar(
+  dir: &std::path::Path,
+  nm_path: &std::path::Path,
+  tar_name: &str,
+) {
+  let missing = missing_declared_node_modules_dependencies(dir, nm_path);
+  if missing.is_empty() {
+    return;
+  }
+
+  use std::os::windows::process::CommandExt;
+  const CREATE_NO_WINDOW: u32 = 0x08000000;
+  eprintln!(
+    "[clawd/service] Filling {} missing bundled node_modules packages from {} in {}",
+    missing.len(),
+    tar_name,
+    dir.display()
+  );
+  for dep in missing {
+    let archive_path = format!("node_modules/{}", dep.replace('\\', "/"));
+    let result = std::process::Command::new("tar")
+      .args(["-xkf", tar_name, &archive_path])
+      .current_dir(dir)
+      .creation_flags(CREATE_NO_WINDOW)
+      .status();
+    match result {
+      Ok(status) if status.success() => {}
+      Ok(status) => eprintln!(
+        "[clawd/service] WARNING: tar fill for {} exited {} in {}",
+        archive_path,
+        status,
+        dir.display()
+      ),
+      Err(err) => eprintln!(
+        "[clawd/service] WARNING: tar fill for {} failed in {}: {}",
+        archive_path,
+        dir.display(),
+        err
+      ),
+    }
+  }
+}
+
 fn bundled_node_modules_has_required_runtime_files(nm_path: &std::path::Path) -> bool {
   [
     "@earendil-works/pi-agent-core/package.json",
@@ -2417,10 +2483,19 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
 
   let nm_path = dir.join("node_modules");
   if cfg!(target_os = "windows") && !cfg!(debug_assertions) && nm_path.is_dir() {
-    eprintln!(
-      "[clawd/service] Windows release startup: using bundled node_modules without synchronous tar repair in {}",
-      dir.display()
-    );
+    #[cfg(target_os = "windows")]
+    fill_missing_node_modules_from_tar(dir, &nm_path, "node_modules.tar");
+    if bundled_node_modules_is_complete(dir, &nm_path) {
+      eprintln!(
+        "[clawd/service] Windows release startup: bundled node_modules ready after non-destructive tar fill in {}",
+        dir.display()
+      );
+    } else {
+      eprintln!(
+        "[clawd/service] WARNING: Windows release startup: bundled node_modules still incomplete after tar fill in {}",
+        dir.display()
+      );
+    }
     return;
   }
   let marker_path = nm_path.join(".knapsack-extracted-from-tar.json");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2416,6 +2416,13 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
   }
 
   let nm_path = dir.join("node_modules");
+  if cfg!(target_os = "windows") && !cfg!(debug_assertions) && nm_path.is_dir() {
+    eprintln!(
+      "[clawd/service] Windows release startup: using bundled node_modules without synchronous tar repair in {}",
+      dir.display()
+    );
+    return;
+  }
   let marker_path = nm_path.join(".knapsack-extracted-from-tar.json");
   let tar_meta = fs::metadata(&tar_path).ok();
   let tar_len = tar_meta.as_ref().map(|m| m.len()).unwrap_or(0);

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -8788,10 +8788,16 @@ async fn prepare_gateway_config(
     clawdbot_entry.display()
   );
   #[cfg(target_os = "windows")]
-  schedule_clawdbot_runtime_self_link_warmup(
-    clawdbot_entry.clone(),
-    "prepare_gateway_config",
-  );
+  if cfg!(debug_assertions) {
+    schedule_clawdbot_runtime_self_link_warmup(
+      clawdbot_entry.clone(),
+      "prepare_gateway_config",
+    );
+  } else {
+    eprintln!(
+      "[clawd/service] Skipping bundled runtime self-link mutation on Windows release startup"
+    );
+  }
   #[cfg(not(target_os = "windows"))]
   ensure_clawdbot_runtime_self_link(&clawdbot_entry);
 
@@ -8916,6 +8922,11 @@ async fn prepare_gateway_config(
       ),
     }
     harden_file_permissions(&config_path);
+  } else if cfg!(target_os = "windows") && !cfg!(debug_assertions) {
+    harden_file_permissions(&config_path);
+    eprintln!(
+      "[clawd/service] Windows release startup: using existing config without synchronous repair"
+    );
   } else {
     harden_file_permissions(&config_path);
     // Patch existing configs to ensure required fields are present.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -311,6 +311,7 @@ static BROWSER_LAST_HEALTHY_MS: AtomicU64 = AtomicU64::new(0);
 /// so the health endpoint doesn't spam `launchctl kickstart` on every poll.
 static GATEWAY_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 static BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+static PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// First observed timestamp for the current gateway-unreachable period.
 static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
@@ -1819,6 +1820,22 @@ fn remove_incomplete_plugin_runtime_deps_dirs(
     }
   }
   removed
+}
+
+fn schedule_plugin_runtime_deps_cleanup(clawdbot_home: PathBuf, current_version: String) {
+  if PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS
+    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+    .is_err()
+  {
+    return;
+  }
+
+  std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_secs(45));
+    remove_stale_plugin_runtime_deps_versions(&clawdbot_home, &current_version);
+    remove_incomplete_plugin_runtime_deps_dirs(&clawdbot_home, &current_version);
+    PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS.store(false, Ordering::Relaxed);
+  });
 }
 
 /// Wipe corrupt `.openclaw-npm-cache` directories inside plugin-runtime-deps
@@ -10382,13 +10399,21 @@ pub async fn set_service_enabled(
       // If a background restart is already in progress, wait for it to
       // finish rather than spawning a second gateway process.
       if GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
-        eprintln!(
-          "[clawd/service] Enable request: background restart already in progress, waiting..."
-        );
-        for _ in 0..20 {
-          std::thread::sleep(std::time::Duration::from_millis(500));
-          if !GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
-            break;
+        let restart_pid = GATEWAY_PID.load(Ordering::Relaxed);
+        if restart_pid == 0 && !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
+          eprintln!(
+            "[clawd/service] Enable request: stale background restart flag with no pid/listener; taking over startup"
+          );
+          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
+        } else {
+          eprintln!(
+            "[clawd/service] Enable request: background restart already in progress, waiting..."
+          );
+          for _ in 0..8 {
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            if !GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
+              break;
+            }
           }
         }
         // If a gateway is now running, skip re-spawn
@@ -10491,15 +10516,12 @@ pub async fn set_service_enabled(
 
       // Remove stale plugin runtime-deps locks so the new gateway doesn't wait
       // 5 minutes for a lock left by a previous crashed/killed process.
-      remove_stale_plugin_runtime_deps_locks(&app_clawdbot_home(&app_handle));
-      // Remove stale versioned plugin-runtime-deps dirs to prevent WhatsApp
-      // (and other plugins) from crashing the gateway with ENOENT during
-      // auth-store migration from old→new version staging directories.
-      {
-        let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
-        remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(&app_handle), &ver);
-        remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(&app_handle), &ver);
-      }
+      let clawdbot_home = app_clawdbot_home(&app_handle);
+      remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
+      // Defer versioned runtime-deps pruning until after the primary gateway
+      // launch. Optional channel warmup can tolerate this delay; startup cannot.
+      let bundle_ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
+      schedule_plugin_runtime_deps_cleanup(clawdbot_home, bundle_ver);
 
       // Doctor mutates the same runtime deps/config tree as gateway startup.
       // Keep it opt-in so it cannot race first-run dependency staging.
@@ -13640,12 +13662,10 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
     }
   }
 
-  remove_stale_plugin_runtime_deps_locks(&app_clawdbot_home(app_handle));
-  {
-    let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(app_handle));
-    remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(app_handle), &ver);
-    remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(app_handle), &ver);
-  }
+  let clawdbot_home = app_clawdbot_home(app_handle);
+  remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
+  let bundle_ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(app_handle));
+  schedule_plugin_runtime_deps_cleanup(clawdbot_home, bundle_ver);
 
   let stdout_log = windows_log_path("stdout");
   let stderr_log = windows_log_path("stderr");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2416,28 +2416,31 @@ fn fill_missing_node_modules_from_tar(
     tar_name,
     dir.display()
   );
-  for dep in missing {
-    let archive_path = format!("node_modules/{}", dep.replace('\\', "/"));
-    let result = std::process::Command::new("tar")
-      .args(["-xkf", tar_name, &archive_path])
-      .current_dir(dir)
-      .creation_flags(CREATE_NO_WINDOW)
-      .status();
-    match result {
-      Ok(status) if status.success() => {}
-      Ok(status) => eprintln!(
-        "[clawd/service] WARNING: tar fill for {} exited {} in {}",
-        archive_path,
-        status,
-        dir.display()
-      ),
-      Err(err) => eprintln!(
-        "[clawd/service] WARNING: tar fill for {} failed in {}: {}",
-        archive_path,
-        dir.display(),
-        err
-      ),
-    }
+  let archive_paths: Vec<String> = missing
+    .into_iter()
+    .map(|dep| format!("node_modules/{}", dep.replace('\\', "/")))
+    .collect();
+  let mut args = Vec::with_capacity(2 + archive_paths.len());
+  args.push("-xkf".to_string());
+  args.push(tar_name.to_string());
+  args.extend(archive_paths.iter().cloned());
+  let result = std::process::Command::new("tar")
+    .args(args.iter().map(String::as_str))
+    .current_dir(dir)
+    .creation_flags(CREATE_NO_WINDOW)
+    .status();
+  match result {
+    Ok(status) if status.success() => {}
+    Ok(status) => eprintln!(
+      "[clawd/service] WARNING: tar fill for missing node_modules exited {} in {}",
+      status,
+      dir.display()
+    ),
+    Err(err) => eprintln!(
+      "[clawd/service] WARNING: tar fill for missing node_modules failed in {}: {}",
+      dir.display(),
+      err
+    ),
   }
 }
 


### PR DESCRIPTION
## Summary
- treats a no-PID/no-listener Windows restart flag as stale so enable can take over immediately instead of burning startup budget
- defers versioned plugin-runtime-deps pruning until after the primary gateway launch path
- keeps lock cleanup before spawn so stale runtime locks still cannot block startup

## Evidence
- v2.3.4 release published successfully: https://github.com/knap-ai/knapsack_desktop/releases/tag/v2.3.4
- release-built Windows QA with Gemini failed the 30s gate because browser was up but gateway had no pid/listener and `/startup-ready` spent the budget waiting on lifecycle state
- `cargo check` passed with required compile-time env placeholders (`VITE_KN_API_SERVER`, `VITE_GOOGLE_CLIENT_ID`)

## Notes
This is a follow-up to the release, not included in v2.3.4. It targets the readiness miss observed on the published Windows artifact.