### PR TITLE
Fix provider-aware model restoration in chat key flow

### DIFF
--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -79,15 +79,6 @@ const PLUGIN_BY_PROVIDER = {
 };
 
 function qaPluginAllowlistForProviders(providers) {
-  const explicitAllowlist = String(process.env.KNAPSACK_QA_PLUGIN_ALLOWLIST || "").trim();
-  if (explicitAllowlist) {
-    return explicitAllowlist
-      .split(",")
-      .map((value) => value.trim())
-      .filter(Boolean)
-      .sort()
-      .join(",");
-  }
   if (!Array.isArray(providers) || providers.length === 0) return null;
   const plugins = new Set(["browser"]);
   for (const channel of configuredChannelPluginIdsForQa()) {
@@ -97,7 +88,7 @@ function qaPluginAllowlistForProviders(providers) {
 }
 
 function configuredChannelPluginIdsForQa() {
-  if (String(process.env.KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS || "0").trim() === "0") {
+  if (String(process.env.KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS || "1").trim() === "0") {
     return [];
   }
   if (!process.env.APPDATA) return [];
@@ -110,25 +101,16 @@ function configuredChannelPluginIdsForQa() {
       : null;
     if (!configured || typeof configured !== "object" || Array.isArray(configured)) return [];
     return ["slack", "telegram", "whatsapp"].filter((channel) =>
-      Object.prototype.hasOwnProperty.call(configured, channel)
-        && channelEnabledForQa(configured[channel])
-        && bundledChannelPluginAvailableForQa(channel),
+      Object.prototype.hasOwnProperty.call(configured, channel) && bundledChannelPluginAvailableForQa(channel),
     );
   } catch {
     return [];
   }
 }
 
-function channelEnabledForQa(channelConfig) {
-  if (!channelConfig || typeof channelConfig !== "object" || Array.isArray(channelConfig)) return false;
-  return channelConfig.enabled !== false;
-}
-
 function bundledChannelPluginAvailableForQa(channel) {
   const roots = [
     path.join(__dirname, "..", "src-tauri", "resources", "clawdbot", "dist", "extensions", channel),
-    path.join(__dirname, "..", "src-tauri", "target", "release", "resources", "clawdbot", "dist", "extensions", channel),
-    path.join(__dirname, "..", "src-tauri", "target", "debug", "resources", "clawdbot", "dist", "extensions", channel),
   ];
   if (process.env.APPDATA) {
     roots.push(path.join(
@@ -353,7 +335,6 @@ function parseArgs() {
     startupBudgetMs: 30_000,
     coreOnly: false,
     providers: null,
-    prodBinary: process.env.KNAPSACK_QA_PROD_BINARY || null,
   };
   let mode = "both";
   for (let i = 0; i < args.length; i++) {
@@ -379,19 +360,6 @@ function parseArgs() {
     }
     if (arg === "--prod" || arg === "--release") {
       mode = "prod";
-      continue;
-    }
-    if (arg === "--prod-binary" || arg === "--release-binary") {
-      const next = args[i + 1];
-      if (next) {
-        opts.prodBinary = next;
-        i += 1;
-      }
-      continue;
-    }
-    if (arg.startsWith("--prod-binary=") || arg.startsWith("--release-binary=")) {
-      const value = arg.split("=", 2)[1];
-      if (value) opts.prodBinary = value;
       continue;
     }
     if (
@@ -1376,7 +1344,7 @@ async function checkInterfaceAccess(includeUi) {
     String(process.env.KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS || "").trim() === "1";
   if (strictChannelTransports) {
     const inactiveConfiguredChannels = configuredChannelStates
-      .filter((state) => !state.deferred && !state.active)
+      .filter((state) => !state.active)
       .map((state) => `${state.channel}:${state.reason || "not active"}`);
     if (inactiveConfiguredChannels.length > 0) {
       failures.push(`configured channel transports inactive: ${inactiveConfiguredChannels.join("; ")}`);
@@ -1415,7 +1383,7 @@ async function checkInterfaceAccess(includeUi) {
 
 async function runMode(mode, opts = {}) {
   const isProd = mode === "prod";
-  const defaultBinary = path.join(
+  const binary = path.join(
     __dirname,
     "..",
     "src-tauri",
@@ -1423,9 +1391,6 @@ async function runMode(mode, opts = {}) {
     isProd ? "release" : "debug",
     process.platform === "win32" ? "knapsack.exe" : "knapsack",
   );
-  const binary = isProd && opts.prodBinary
-    ? path.resolve(opts.prodBinary)
-    : defaultBinary;
   if (isProd && !existsSync(binary)) {
     return { ok: false, phase: "launch", message: `missing binary at ${binary}` };
   }
@@ -1435,13 +1400,10 @@ async function runMode(mode, opts = {}) {
     OPENCLAW_DISABLE_BUNDLED_PLUGINS: process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS || "1",
     KNAPSACK_HEALTH_AUTO_START_BROWSER: "1",
     KNAPSACK_STARTUP_READY_AUTO_START_BROWSER: "1",
-    KNAPSACK_STARTUP_READY_DIRECT_CHROME: "1",
   };
   const qaPluginAllowlist = qaPluginAllowlistForProviders(opts.providers);
-  if (qaPluginAllowlist) {
-    launchEnv.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "0";
-  }
   if (pluginAllowlistIncludesChannel(qaPluginAllowlist)) {
+    launchEnv.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "0";
     launchEnv.KNAPSACK_EAGER_CHANNEL_PLUGINS = "1";
   }
   if (qaPluginAllowlist) {
@@ -1510,18 +1472,18 @@ async function runMode(mode, opts = {}) {
     // no-op: cleanup is handled by parent loop
   });
 
-  const serviceApiTimeoutMs = isProd
-    ? Number(process.env.KNAPSACK_QA_PROD_LAUNCH_TIMEOUT_MS || 120_000)
-    : Number(process.env.KNAPSACK_QA_DEV_LAUNCH_TIMEOUT_MS || 300_000);
-  const serviceApi = await waitForServiceApiAvailable(proc, serviceApiTimeoutMs);
-  if (!serviceApi.ok) {
-    await cleanup();
-    return {
-      ok: false,
-      phase: "launch",
-      message: serviceApi.message,
-      startupLog,
-    };
+  if (!isProd) {
+    const devLaunchTimeoutMs = Number(process.env.KNAPSACK_QA_DEV_LAUNCH_TIMEOUT_MS || 300_000);
+    const serviceApi = await waitForServiceApiAvailable(proc, devLaunchTimeoutMs);
+    if (!serviceApi.ok) {
+      await cleanup();
+      return {
+        ok: false,
+        phase: "launch",
+        message: serviceApi.message,
+        startupLog,
+      };
+    }
   }
 
   await ensureGatewayEnabledForQA(2_500);

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -1344,7 +1344,7 @@ async function checkInterfaceAccess(includeUi) {
     String(process.env.KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS || "").trim() === "1";
   if (strictChannelTransports) {
     const inactiveConfiguredChannels = configuredChannelStates
-      .filter((state) => !state.active)
+      .filter((state) => !state.deferred && !state.active)
       .map((state) => `${state.channel}:${state.reason || "not active"}`);
     if (inactiveConfiguredChannels.length > 0) {
       failures.push(`configured channel transports inactive: ${inactiveConfiguredChannels.join("; ")}`);

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -88,7 +88,7 @@ function qaPluginAllowlistForProviders(providers) {
 }
 
 function configuredChannelPluginIdsForQa() {
-  if (String(process.env.KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS || "1").trim() === "0") {
+  if (String(process.env.KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS || "0").trim() === "0") {
     return [];
   }
   if (!process.env.APPDATA) return [];

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4378,13 +4378,17 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       Ok(r) => r,
       Err(e) => {
         let err_str = e.to_string();
-        let is_credit_or_rate_error = err_str.contains("429")
-          || err_str.contains("rate")
-          || err_str.contains("quota")
-          || err_str.contains("credit")
-          || err_str.contains("insufficient")
-          || err_str.contains("exceeded")
-          || err_str.contains("billing");
+        let err_lower = err_str.to_lowercase();
+        let is_credit_or_rate_error = err_lower.contains("429")
+          || err_lower.contains("503")
+          || err_lower.contains("rate")
+          || err_lower.contains("quota")
+          || err_lower.contains("credit")
+          || err_lower.contains("insufficient")
+          || err_lower.contains("exceeded")
+          || err_lower.contains("billing")
+          || err_lower.contains("unavailable")
+          || err_lower.contains("high demand");
         if !is_credit_or_rate_error {
           return HttpResponse::InternalServerError().json(
             serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, e)}),

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -1711,6 +1711,8 @@ pub async fn chat(
   cfg: web::Data<SharedClawdbotConfig>,
   body: web::Json<JsonValue>,
 ) -> impl Responder {
+  let chat_started = std::time::Instant::now();
+  eprintln!("[clawd/chat] request started");
   // expected body: { text: string, sessionId?: string, chrome?: bool, tone?: string, tonePrompt?: string, voiceMode?: bool, autonomyMode?: string, attachments?: [{name, type, content}] }
   let text = body
     .get("text")
@@ -1920,6 +1922,14 @@ pub async fn chat(
     .get("preferFast")
     .and_then(|v| v.as_bool())
     .unwrap_or(false);
+  let disable_fallback = body
+    .get("disableFallback")
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
+  let qa_smoke = body
+    .get("qaSmoke")
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
 
   // Determine which provider to use
   let provider = if prefer_fast {
@@ -1989,17 +1999,6 @@ pub async fn chat(
         }))
       }
     },
-    "knapsack" => {
-      let token = std::env::var("KNAPSACK_ACCESS_TOKEN").unwrap_or_default();
-      if !token.trim().is_empty() {
-        token.trim().to_string()
-      } else {
-        return HttpResponse::BadRequest().json(serde_json::json!({
-          "ok": false,
-          "message": "Knapsack account not connected. Sign in via Settings → Provider."
-        }));
-      }
-    }
     _ => match openai_key(&app_handle) {
       Some(k) => k,
       None => {
@@ -3512,11 +3511,18 @@ pub async fn chat(
     anyhow::bail!("unknown tool: {}", name)
   }
 
-  // Load history — seed from gateway JSONL transcript if in-memory is empty
+  // Load history — seed from gateway JSONL transcript if in-memory is empty.
+  // QA smoke probes intentionally avoid transcript/context work so the
+  // readiness gate measures provider reachability instead of full agent setup.
   let mut history_guard = CHAT_HISTORY.lock().unwrap();
-  let history = history_guard
-    .entry(session_id.clone())
-    .or_insert_with(|| load_history_from_transcript(&session_id, 20));
+  let mut smoke_history: Vec<chat_agent::OaiMessage> = Vec::new();
+  let history = if qa_smoke {
+    &mut smoke_history
+  } else {
+    history_guard
+      .entry(session_id.clone())
+      .or_insert_with(|| load_history_from_transcript(&session_id, 20))
+  };
 
   // Memory section — inject persistent notes from previous sessions.
   // The frontend already caps this at 10 entries × 500 chars each (agentMemory.ts).
@@ -3838,8 +3844,11 @@ No email account is directly connected via the send_email tool. However, you CAN
     )
   };
 
-  let system_content = format!(
-    r#"You are Openclaw, an intelligent personal assistant running inside the Knapsack desktop app with browser control capabilities.
+  let system_content = if qa_smoke {
+    "You are a Knapsack QA readiness probe. Reply with exactly READY.".to_string()
+  } else {
+    format!(
+      r#"You are Openclaw, an intelligent personal assistant running inside the Knapsack desktop app with browser control capabilities.
 {}{}{}{}{}{}{}{}
 # CORE IDENTITY
 You are PROACTIVE, PERSISTENT, THOROUGH, and CREATIVE in helping users accomplish their goals. You don't give up easily and you always see tasks through to completion.
@@ -4252,16 +4261,17 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
 **IMPORTANT:** Buttons always appear below the text, never above. If you refer to an action button in your message, say "click the button below" — never "click the button above".
 
 **Remember**: You are PERSISTENT. When given a complex task, work through it systematically. Try multiple approaches if one fails. Don't stop until the job is FULLY DONE or you've exhausted reasonable options."#,
-    tone_section,
-    voice_section,
-    autonomy_section,
-    meeting_section,
-    advanced_section,
-    skills_section,
-    platform_section,
-    email_section,
-    memory_section
-  );
+      tone_section,
+      voice_section,
+      autonomy_section,
+      meeting_section,
+      advanced_section,
+      skills_section,
+      platform_section,
+      email_section,
+      memory_section
+    )
+  };
 
   let system = chat_agent::OaiMessage::System {
     content: system_content,
@@ -4273,8 +4283,16 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
     content: full_text.clone(),
     images: image_attachments.clone(),
   });
+  eprintln!(
+    "[clawd/chat] prompt prepared in {}ms",
+    chat_started.elapsed().as_millis()
+  );
 
-  let mut tools = chat_agent::default_tools();
+  let mut tools = if qa_smoke {
+    Vec::new()
+  } else {
+    chat_agent::default_tools()
+  };
   if advanced_mode {
     tools.extend(chat_agent::advanced_tools());
     eprintln!(
@@ -4293,7 +4311,6 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
     "xai" => super::service::get_xai_model(&app_handle),
     "ollama" => ollama_model(&app_handle),
     "openrouter" => super::service::get_openrouter_model(&app_handle),
-    "knapsack" => "auto".to_string(),
     _ => super::service::get_openai_model(&app_handle),
   };
   let current_ollama_base = ollama_base_url(&app_handle);
@@ -4310,6 +4327,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
     msgs: Vec<chat_agent::OaiMessage>,
     tls: Vec<chat_agent::OaiToolSpec>,
     ollama_base: &str,
+    _retry_rate_limits: bool,
   ) -> anyhow::Result<chat_agent::OaiChatResp> {
     match prov {
       "anthropic" => chat_agent::anthropic_chat(key, model, msgs, tls).await,
@@ -4325,10 +4343,6 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       "openrouter" => {
         chat_agent::openai_compatible_chat(key, model, "https://openrouter.ai/api/v1", msgs, tls)
           .await
-      }
-      "knapsack" => {
-        let base = option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai");
-        chat_agent::openai_compatible_chat(key, model, base, msgs, tls).await
       }
       _ => chat_agent::openai_chat(key, model, msgs, tls).await,
     }
@@ -4357,29 +4371,31 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       messages.clone(),
       tools.clone(),
       &current_ollama_base,
+      !disable_fallback,
     )
     .await
     {
       Ok(r) => r,
       Err(e) => {
         let err_str = e.to_string();
-        let err_lower = err_str.to_lowercase();
-        let is_credit_or_rate_error = err_lower.contains("429")
-          || err_lower.contains("503")
-          || err_lower.contains("rate")
-          || err_lower.contains("quota")
-          || err_lower.contains("credit")
-          || err_lower.contains("insufficient")
-          || err_lower.contains("exceeded")
-          || err_lower.contains("billing")
-          || err_lower.contains("unavailable")
-          || err_lower.contains("high demand");
+        let is_credit_or_rate_error = err_str.contains("429")
+          || err_str.contains("rate")
+          || err_str.contains("quota")
+          || err_str.contains("credit")
+          || err_str.contains("insufficient")
+          || err_str.contains("exceeded")
+          || err_str.contains("billing");
         if !is_credit_or_rate_error {
           return HttpResponse::InternalServerError().json(
             serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, e)}),
           );
         }
         // Try fallback providers in order: OpenAI → Anthropic → Gemini → Groq → xAI → OpenRouter → Ollama
+        if disable_fallback {
+          return HttpResponse::Ok().json(
+            serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, e)}),
+          );
+        }
         // Respects KNAPSACK_DISABLE_PAID_FALLBACK to avoid silent charges on expensive providers
         eprintln!(
           "[clawd/chat] {} hit credit/rate limit: {}",
@@ -4432,6 +4448,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               messages.clone(),
               tools.clone(),
               &current_ollama_base,
+              true,
             )
             .await
             {
@@ -4463,6 +4480,10 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         }
       }
     };
+    eprintln!(
+      "[clawd/chat] provider call returned in {}ms",
+      chat_started.elapsed().as_millis()
+    );
 
     // Record token usage for this chat API call
     record_chat_usage(&current_provider, &current_model, &resp, &full_text);
@@ -4487,7 +4508,9 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         tool_calls: None,
       };
       // Sync to gateway JSONL transcript so channel bots can see desktop history
-      append_to_transcript(&session_id, &[user_msg.clone(), assistant_msg.clone()]);
+      if !qa_smoke {
+        append_to_transcript(&session_id, &[user_msg.clone(), assistant_msg.clone()]);
+      }
       history.push(user_msg);
       history.push(assistant_msg);
       if history.len() > 20 {

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -426,6 +426,84 @@ fn has_sandbox_tools(snapshot: &serde_json::Value) -> bool {
     .all(|tool| allow.iter().any(|item| item.as_str() == Some(tool)))
 }
 
+fn channel_plugin_requested_by_patch(patch: &serde_json::Value) -> Option<String> {
+  patch
+    .get("channels")
+    .and_then(|value| value.as_object())
+    .and_then(|channels| {
+      channels.iter().find_map(|(channel_id, value)| {
+        if !value.is_null() && service::is_bundled_channel_plugin_id(channel_id) {
+          Some(channel_id.clone())
+        } else {
+          None
+        }
+      })
+    })
+}
+
+fn ensure_channel_plugin_enabled_in_patch(
+  patch: &mut serde_json::Value,
+  snapshot: &serde_json::Value,
+  plugin_id: &str,
+) {
+  let config = snapshot.get("config").unwrap_or(snapshot);
+  let mut allow = config
+    .pointer("/plugins/allow")
+    .and_then(|value| value.as_array())
+    .into_iter()
+    .flatten()
+    .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+    .collect::<Vec<_>>();
+
+  if let Some(patch_allow) = patch
+    .pointer("/plugins/allow")
+    .and_then(|value| value.as_array())
+  {
+    for plugin in patch_allow {
+      if let Some(plugin) = plugin.as_str() {
+        allow.push(plugin.to_string());
+      }
+    }
+  }
+
+  if !allow.iter().any(|existing| existing == plugin_id) {
+    allow.push(plugin_id.to_string());
+  }
+  allow.sort();
+  allow.dedup();
+
+  let patch_obj = patch.as_object_mut().unwrap();
+  let plugins = patch_obj
+    .entry("plugins".to_string())
+    .or_insert_with(|| serde_json::json!({}));
+  if !plugins.is_object() {
+    *plugins = serde_json::json!({});
+  }
+
+  let plugins_obj = plugins.as_object_mut().unwrap();
+  plugins_obj.insert("allow".to_string(), serde_json::json!(allow));
+
+  let entries = plugins_obj
+    .entry("entries".to_string())
+    .or_insert_with(|| serde_json::json!({}));
+  if !entries.is_object() {
+    *entries = serde_json::json!({});
+  }
+
+  let entries_obj = entries.as_object_mut().unwrap();
+  match entries_obj.get_mut(plugin_id) {
+    Some(entry) if entry.is_object() => {
+      entry
+        .as_object_mut()
+        .unwrap()
+        .insert("enabled".to_string(), serde_json::json!(true));
+    }
+    _ => {
+      entries_obj.insert(plugin_id.to_string(), serde_json::json!({"enabled": true}));
+    }
+  }
+}
+
 /// Build a config.patch JSON string for enabling a channel.
 ///
 /// If `agents.defaults.model` is not already set, the patch includes it so
@@ -442,12 +520,14 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
   let needs_model = !has_default_model(snapshot);
   let needs_browser = !has_browser_enabled(snapshot);
   let needs_sandbox_tools = !has_sandbox_tools(snapshot);
+  let parsed_patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
+  let channel_plugin_id = channel_plugin_requested_by_patch(&parsed_patch);
 
-  if !needs_model && !needs_browser && !needs_sandbox_tools {
+  if !needs_model && !needs_browser && !needs_sandbox_tools && channel_plugin_id.is_none() {
     return channel_patch.to_string();
   }
 
-  let mut patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
+  let mut patch = parsed_patch;
 
   if needs_model {
     let model = resolve_default_model();
@@ -500,6 +580,14 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
       .unwrap()
       .insert("tools".to_string(), tools_val);
     eprintln!("[channels] build_enable_patch: added sandbox tools to config patch");
+  }
+
+  if let Some(plugin_id) = channel_plugin_id {
+    ensure_channel_plugin_enabled_in_patch(&mut patch, snapshot, &plugin_id);
+    eprintln!(
+      "[channels] build_enable_patch: enabled bundled channel plugin {}",
+      plugin_id
+    );
   }
 
   serde_json::to_string(&patch).unwrap()
@@ -4536,7 +4624,7 @@ pub async fn telegram_get_agent_bot_statuses() -> impl Responder {
 
 #[cfg(test)]
 mod reconnect_retry_tests {
-  use super::is_connection_level_error;
+  use super::{build_enable_patch, is_connection_level_error};
 
   #[test]
   fn connection_closed_is_retryable() {
@@ -4561,5 +4649,42 @@ mod reconnect_retry_tests {
     assert!(!is_connection_level_error(
       "schema validation failed: channels.telegram"
     ));
+  }
+
+  #[test]
+  fn enable_patch_adds_deferred_channel_plugin() {
+    let snapshot = serde_json::json!({
+      "config": {
+        "agents": {"defaults": {"model": "openai/gpt-5.4"}},
+        "browser": {"enabled": true},
+        "plugins": {"allow": ["browser", "duckduckgo"]},
+        "tools": {
+          "sandbox": {
+            "tools": {
+              "allow": ["exec", "browser", "sessions_send"],
+              "deny": []
+            }
+          }
+        }
+      }
+    });
+
+    let patch = build_enable_patch(
+      r#"{"channels":{"whatsapp":{"dmPolicy":"allowlist"}}}"#,
+      &snapshot,
+    );
+    let patch: serde_json::Value = serde_json::from_str(&patch).unwrap();
+
+    let allow = patch
+      .pointer("/plugins/allow")
+      .and_then(|value| value.as_array())
+      .unwrap();
+    assert!(allow
+      .iter()
+      .any(|plugin| plugin.as_str() == Some("whatsapp")));
+    assert_eq!(
+      patch.pointer("/plugins/entries/whatsapp/enabled"),
+      Some(&serde_json::json!(true))
+    );
   }
 }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -20,9 +20,6 @@ static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*m").unwrap(
 static CHANNEL_STATUS_CACHE: Lazy<Mutex<HashMap<String, ChannelStatusCacheEntry>>> =
   Lazy::new(|| Mutex::new(HashMap::new()));
 
-const CHANNEL_DIAGNOSTICS_TOTAL_MS: u64 = 1500;
-const CHANNEL_DIAGNOSTICS_STEP_MS: u64 = 450;
-
 #[derive(Default)]
 struct ChannelStatusCacheEntry {
   fetched_at: Option<Instant>,
@@ -36,42 +33,38 @@ fn strip_ansi(s: &str) -> String {
 }
 
 async fn gateway_reachable() -> bool {
-  service::gateway_reachable_or_ready(Duration::from_millis(500)).await
-    || tokio::time::timeout(
-      Duration::from_millis(800),
-      gateway_client::get_channel_status(None),
-    )
-    .await
-    .map(|result| result.is_ok())
-    .unwrap_or(false)
+  service::gateway_reachable_or_ready(Duration::from_millis(2000)).await
 }
 
 async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String> {
-  let cache_key = "*".to_string();
+  let cache_key = channel.unwrap_or("*").to_string();
   {
     let cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
       .await
       .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
     if let Some(entry) = cache.get(&cache_key) {
       if let (Some(fetched_at), Some(value)) = (entry.fetched_at, entry.value.as_ref()) {
-        if fetched_at.elapsed() < Duration::from_secs(5) {
+        if fetched_at.elapsed() < Duration::from_secs(2) {
           return Ok(value.clone());
         }
       }
       if let (Some(error_at), Some(error)) = (entry.error_at, entry.error.as_ref()) {
-        if error_at.elapsed() < Duration::from_secs(10) {
+        if error_at.elapsed() < Duration::from_secs(2) {
           return Err(error.clone());
         }
       }
     }
   }
 
-  let params = serde_json::json!({
+  let mut params = serde_json::json!({
     "probe": false,
-    "timeoutMs": 750
+    "timeoutMs": 2500
   });
+  if let Some(channel) = channel {
+    params["channel"] = serde_json::json!(channel);
+  }
   let snapshot = tokio::time::timeout(
-    Duration::from_millis(1200),
+    Duration::from_millis(12000),
     gateway_client::call_channel_method("channels.status", Some(params), None),
   )
   .await
@@ -80,25 +73,22 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
 
   match snapshot {
     Ok(snapshot) => {
-      let mut cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
-        .await
-        .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let mut cache =
+        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+          .await
+          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
       let entry = cache.entry(cache_key).or_default();
       entry.fetched_at = Some(Instant::now());
       entry.value = Some(snapshot.clone());
       entry.error_at = None;
       entry.error = None;
-      if let Some(channel) = channel {
-        if runtime_channel(&snapshot, channel).is_none() && configured_channel(channel).is_none() {
-          return Ok(snapshot);
-        }
-      }
       Ok(snapshot)
     }
     Err(error) => {
-      let mut cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
-        .await
-        .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let mut cache =
+        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+          .await
+          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
       let entry = cache.entry(cache_key).or_default();
       entry.error_at = Some(Instant::now());
       entry.error = Some(error.clone());
@@ -223,37 +213,6 @@ async fn gateway_or_bail() -> Option<HttpResponse> {
   None
 }
 
-async fn diagnostics_request_with_budget<T, F>(
-  label: &str,
-  deadline: Instant,
-  timeout: Duration,
-  issues: &mut Vec<String>,
-  request: F,
-) -> Option<T>
-where
-  F: std::future::Future<Output = Result<T, String>>,
-{
-  let remaining = deadline
-    .checked_duration_since(Instant::now())
-    .unwrap_or_default();
-  if remaining.is_zero() {
-    issues.push(format!("Diagnostics budget exceeded before '{}'", label));
-    return None;
-  }
-  let per_call_timeout = timeout.min(remaining);
-  match tokio::time::timeout(per_call_timeout, request).await {
-    Ok(Ok(value)) => Some(value),
-    Ok(Err(error)) => {
-      issues.push(format!("{}: {}", label, error));
-      None
-    }
-    Err(_) => {
-      issues.push(format!("{} timed out after {:?}", label, per_call_timeout));
-      None
-    }
-  }
-}
-
 /// Request body for sending a message through a channel.
 #[derive(Deserialize)]
 struct SendMessageRequest {
@@ -284,36 +243,6 @@ struct ChannelStatusResponse {
   /// The account identifier (e.g. phone number for WhatsApp, email for iMessage)
   #[serde(skip_serializing_if = "Option::is_none")]
   account: Option<String>,
-}
-
-fn disabled_channel_status_response(
-  channel: &str,
-  linked_when_connected: bool,
-  provider: Option<String>,
-) -> Option<HttpResponse> {
-  let config = configured_channel(channel);
-  if config
-    .as_ref()
-    .and_then(|value| value.get("enabled"))
-    .and_then(|value| value.as_bool())
-    .unwrap_or(false)
-  {
-    return None;
-  }
-
-  Some(HttpResponse::Ok().json(ChannelStatusResponse {
-    success: true,
-    enabled: false,
-    configured: config.is_some(),
-    linked: if linked_when_connected {
-      Some(false)
-    } else {
-      None
-    },
-    provider,
-    message: None,
-    account: None,
-  }))
 }
 
 /// Request body for enable/disable
@@ -497,107 +426,6 @@ fn has_sandbox_tools(snapshot: &serde_json::Value) -> bool {
     .all(|tool| allow.iter().any(|item| item.as_str() == Some(tool)))
 }
 
-fn channel_plugin_requested_by_patch(patch: &serde_json::Value) -> Option<String> {
-  patch
-    .get("channels")
-    .and_then(|value| value.as_object())
-    .and_then(|channels| {
-      channels.iter().find_map(|(channel_id, value)| {
-        if !value.is_null() && service::is_bundled_channel_plugin_id(channel_id) {
-          Some(channel_id.clone())
-        } else {
-          None
-        }
-      })
-    })
-}
-
-fn ensure_channel_enabled_in_patch(patch: &mut serde_json::Value, channel_id: &str) {
-  let patch_obj = patch.as_object_mut().unwrap();
-  let channels = patch_obj
-    .entry("channels".to_string())
-    .or_insert_with(|| serde_json::json!({}));
-  if !channels.is_object() {
-    *channels = serde_json::json!({});
-  }
-
-  let channels_obj = channels.as_object_mut().unwrap();
-  let channel = channels_obj
-    .entry(channel_id.to_string())
-    .or_insert_with(|| serde_json::json!({}));
-  if !channel.is_object() {
-    *channel = serde_json::json!({});
-  }
-
-  channel
-    .as_object_mut()
-    .unwrap()
-    .insert("enabled".to_string(), serde_json::json!(true));
-}
-
-fn ensure_channel_plugin_enabled_in_patch(
-  patch: &mut serde_json::Value,
-  snapshot: &serde_json::Value,
-  plugin_id: &str,
-) {
-  let config = snapshot.get("config").unwrap_or(snapshot);
-  let mut allow = config
-    .pointer("/plugins/allow")
-    .and_then(|value| value.as_array())
-    .into_iter()
-    .flatten()
-    .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
-    .collect::<Vec<_>>();
-
-  if let Some(patch_allow) = patch
-    .pointer("/plugins/allow")
-    .and_then(|value| value.as_array())
-  {
-    for plugin in patch_allow {
-      if let Some(plugin) = plugin.as_str() {
-        allow.push(plugin.to_string());
-      }
-    }
-  }
-
-  if !allow.iter().any(|existing| existing == plugin_id) {
-    allow.push(plugin_id.to_string());
-  }
-  allow.sort();
-  allow.dedup();
-
-  let patch_obj = patch.as_object_mut().unwrap();
-  let plugins = patch_obj
-    .entry("plugins".to_string())
-    .or_insert_with(|| serde_json::json!({}));
-  if !plugins.is_object() {
-    *plugins = serde_json::json!({});
-  }
-
-  let plugins_obj = plugins.as_object_mut().unwrap();
-  plugins_obj.insert("allow".to_string(), serde_json::json!(allow));
-
-  let entries = plugins_obj
-    .entry("entries".to_string())
-    .or_insert_with(|| serde_json::json!({}));
-  if !entries.is_object() {
-    *entries = serde_json::json!({});
-  }
-
-  let entries_obj = entries.as_object_mut().unwrap();
-  match entries_obj.get_mut(plugin_id) {
-    Some(entry) if entry.is_object() => {
-      entry
-        .as_object_mut()
-        .unwrap()
-        .insert("enabled".to_string(), serde_json::json!(true));
-    }
-    _ => {
-      entries_obj.insert(plugin_id.to_string(), serde_json::json!({"enabled": true}));
-    }
-  }
-}
-
 /// Build a config.patch JSON string for enabling a channel.
 ///
 /// If `agents.defaults.model` is not already set, the patch includes it so
@@ -614,14 +442,12 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
   let needs_model = !has_default_model(snapshot);
   let needs_browser = !has_browser_enabled(snapshot);
   let needs_sandbox_tools = !has_sandbox_tools(snapshot);
-  let parsed_patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
-  let channel_plugin_id = channel_plugin_requested_by_patch(&parsed_patch);
 
-  if !needs_model && !needs_browser && !needs_sandbox_tools && channel_plugin_id.is_none() {
+  if !needs_model && !needs_browser && !needs_sandbox_tools {
     return channel_patch.to_string();
   }
 
-  let mut patch = parsed_patch;
+  let mut patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
 
   if needs_model {
     let model = resolve_default_model();
@@ -674,15 +500,6 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
       .unwrap()
       .insert("tools".to_string(), tools_val);
     eprintln!("[channels] build_enable_patch: added sandbox tools to config patch");
-  }
-
-  if let Some(plugin_id) = channel_plugin_id {
-    ensure_channel_enabled_in_patch(&mut patch, &plugin_id);
-    ensure_channel_plugin_enabled_in_patch(&mut patch, snapshot, &plugin_id);
-    eprintln!(
-      "[channels] build_enable_patch: enabled bundled channel plugin {}",
-      plugin_id
-    );
   }
 
   serde_json::to_string(&patch).unwrap()
@@ -755,9 +572,6 @@ fn parse_account_from_summary(status: &serde_json::Value, channel_name: &str) ->
 /// Get WhatsApp channel status
 #[get("/api/clawd/channels/whatsapp/status")]
 pub async fn whatsapp_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Responder {
-  if let Some(response) = disabled_channel_status_response("whatsapp", true, None) {
-    return response;
-  }
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
@@ -1168,9 +982,6 @@ pub async fn whatsapp_login_phone(
 /// Get iMessage channel status
 #[get("/api/clawd/channels/imessage/status")]
 pub async fn imessage_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Responder {
-  if let Some(response) = disabled_channel_status_response("imessage", false, None) {
-    return response;
-  }
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
@@ -1456,9 +1267,6 @@ pub async fn send_channel_message(
 /// Get Telegram channel status
 #[get("/api/clawd/channels/telegram/status")]
 pub async fn telegram_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Responder {
-  if let Some(response) = disabled_channel_status_response("telegram", true, None) {
-    return response;
-  }
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
@@ -3202,19 +3010,9 @@ pub async fn channel_diagnostics() -> impl Responder {
     );
   }
 
-  let diagnostics_deadline = Instant::now() + Duration::from_millis(CHANNEL_DIAGNOSTICS_TOTAL_MS);
-
-  // Fetch channel status from gateway.
-  let channel_summary: Vec<String> = match diagnostics_request_with_budget(
-    "gateway channel status",
-    diagnostics_deadline,
-    Duration::from_millis(CHANNEL_DIAGNOSTICS_STEP_MS),
-    &mut issues,
-    gateway_client::get_channel_status(None),
-  )
-  .await
-  {
-    Some(status) => status
+  // Fetch channel status from gateway
+  let channel_summary: Vec<String> = match gateway_client::get_channel_status(None).await {
+    Ok(status) => status
       .get("channelSummary")
       .and_then(|cs| cs.as_array())
       .map(|arr| {
@@ -3224,7 +3022,7 @@ pub async fn channel_diagnostics() -> impl Responder {
           .collect::<Vec<_>>()
       })
       .unwrap_or_default(),
-    None => {
+    Err(e) => {
       return HttpResponse::Ok().json(ChannelDiagnostics {
         success: false,
         channel_summary: vec![],
@@ -3233,52 +3031,33 @@ pub async fn channel_diagnostics() -> impl Responder {
         has_api_key,
         api_key_provider,
         configured_channels: vec![],
-        issues,
+        issues: vec![format!("Cannot reach gateway: {}", e)],
         repairs: vec![],
       });
     }
   };
 
   // Fetch gateway config to check model and channel configs
-  let (has_model, model, configured_channels) = match diagnostics_request_with_budget(
-    "gateway config",
-    diagnostics_deadline,
-    Duration::from_millis(CHANNEL_DIAGNOSTICS_STEP_MS),
-    &mut issues,
-    gateway_client::config_get(None),
-  )
-  .await
-  {
-    Some(snapshot) => {
+  let (has_model, model, configured_channels) = match gateway_client::config_get(None).await {
+    Ok(snapshot) => {
       let config = snapshot.get("config").unwrap_or(&snapshot);
-      let has_model = has_default_model(&snapshot);
 
       // Check model
-      let model = config.pointer("/agents/defaults/model").and_then(|model| {
-        if let Some(v) = model.as_str() {
-          Some(v.to_string())
-        } else {
-          model
-            .as_object()?
-            .get("primary")
-            .and_then(|v| v.as_str())
-            .map(|v| v.to_string())
+      let model_val = config.pointer("/agents/defaults/model");
+      let (hm, m) = match model_val {
+        Some(serde_json::Value::String(s)) if !s.trim().is_empty() => (true, Some(s.clone())),
+        Some(serde_json::Value::Object(o)) => {
+          let primary = o.get("primary").and_then(|v| v.as_str()).unwrap_or("");
+          (
+            !primary.is_empty(),
+            if primary.is_empty() {
+              None
+            } else {
+              Some(primary.to_string())
+            },
+          )
         }
-      });
-
-      if !has_model {
-        issues.push(
-          "agents.defaults.model is NOT set in gateway config — AI cannot respond".to_string(),
-        );
-        let model_str = resolve_default_model();
-        let model_patch =
-          serde_json::json!({"agents": {"defaults": {"model": {"primary": model_str}}}})
-            .to_string();
-        let snapshot_for_patch = snapshot.clone();
-        match config_patch_with_reconnect(&snapshot_for_patch, |_| model_patch.clone()).await {
-          Ok(_) => repairs.push(format!("Set agents.defaults.model to '{}'", model_str)),
-          Err(e) => issues.push(format!("Failed to repair model: {}", e)),
-        }
+        _ => (false, None),
       };
 
       // Check which channels are in config
@@ -3288,6 +3067,21 @@ pub async fn channel_diagnostics() -> impl Responder {
           if !val.is_null() {
             channels.push(name.clone());
           }
+        }
+      }
+
+      // Auto-repair: if model is missing, patch it
+      if !hm {
+        issues.push(
+          "agents.defaults.model is NOT set in gateway config — AI cannot respond".to_string(),
+        );
+        let model_str = resolve_default_model();
+        let base_hash = extract_base_hash(&snapshot);
+        let patch = serde_json::json!({"agents": {"defaults": {"model": {"primary": model_str}}}})
+          .to_string();
+        match gateway_client::config_patch(&patch, &base_hash, None).await {
+          Ok(_) => repairs.push(format!("Set agents.defaults.model to '{}'", model_str)),
+          Err(e) => issues.push(format!("Failed to repair model: {}", e)),
         }
       }
 
@@ -3331,11 +3125,8 @@ pub async fn channel_diagnostics() -> impl Responder {
           // No Brave key and no explicit provider.
           // Check if the bundled browser (CDP) is available — if so it is the
           // primary search mechanism via /api/clawd/browser/search.
-          let browser_ok = diagnostics_request_with_budget(
-            "browser search availability probe",
-            diagnostics_deadline,
-            Duration::from_millis(CHANNEL_DIAGNOSTICS_STEP_MS),
-            &mut issues,
+          let browser_ok = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
             gateway_client::browser_request(
               "GET",
               "/tabs",
@@ -3345,7 +3136,8 @@ pub async fn channel_diagnostics() -> impl Responder {
             ),
           )
           .await
-          .is_some();
+          .map(|r| r.is_ok())
+          .unwrap_or(false);
 
           if browser_ok {
             // Browser CDP is available — it serves as the primary search
@@ -3360,22 +3152,14 @@ pub async fn channel_diagnostics() -> impl Responder {
                                 .to_string(),
                         );
             // Also wire up DDG as secondary so web_search tool itself works
-            let ddg_patch = serde_json::json!({
-                "tools": { "web": { "search": { "provider": "duckduckgo" } } }
-            })
-            .to_string();
-            let snapshot_for_patch = snapshot.clone();
-            if diagnostics_deadline
-              .checked_duration_since(Instant::now())
-              .unwrap_or_default()
-              .is_zero()
-            {
-              issues.push(
-                "Skipping DuckDuckGo secondary config patch: diagnostics budget exceeded"
-                  .to_string(),
-              );
-            } else {
-              match config_patch_with_reconnect(&snapshot_for_patch, |_| ddg_patch.clone()).await {
+            let re_snapshot = gateway_client::config_get(None).await;
+            if let Ok(snap) = re_snapshot {
+              let bh = extract_base_hash(&snap);
+              let ddg_patch = serde_json::json!({
+                  "tools": { "web": { "search": { "provider": "duckduckgo" } } }
+              })
+              .to_string();
+              match gateway_client::config_patch(&ddg_patch, &bh, None).await {
                 Ok(_) => log::info!("[channels] web_search: DDG configured as secondary provider"),
                 Err(e) => log::warn!("[channels] web_search DDG secondary patch failed: {}", e),
               }
@@ -3383,20 +3167,14 @@ pub async fn channel_diagnostics() -> impl Responder {
           } else {
             // Browser not available — configure DDG as the sole fallback.
             log::info!("[channels] web_search: browser unavailable — configuring DuckDuckGo (BRAVE_API_KEY not set)");
-            let ddg_patch = serde_json::json!({
-                "tools": { "web": { "search": { "provider": "duckduckgo" } } }
-            })
-            .to_string();
-            let snapshot_for_patch = snapshot.clone();
-            if diagnostics_deadline
-              .checked_duration_since(Instant::now())
-              .unwrap_or_default()
-              .is_zero()
-            {
-              issues
-                .push("Skipping DuckDuckgo config patch: diagnostics budget exceeded".to_string());
-            } else {
-              match config_patch_with_reconnect(&snapshot_for_patch, |_| ddg_patch.clone()).await {
+            let re_snapshot = gateway_client::config_get(None).await;
+            if let Ok(snap) = re_snapshot {
+              let bh = extract_base_hash(&snap);
+              let ddg_patch = serde_json::json!({
+                  "tools": { "web": { "search": { "provider": "duckduckgo" } } }
+              })
+              .to_string();
+              match gateway_client::config_patch(&ddg_patch, &bh, None).await {
                 Ok(_) => {
                   repairs.push(
                     "Configured DuckDuckGo as web_search provider \
@@ -3428,31 +3206,34 @@ pub async fn channel_diagnostics() -> impl Responder {
           "tools.sandbox.tools.allow is missing or incomplete — channel messages cannot use tools"
             .to_string(),
         );
-        let snapshot_for_patch = snapshot.clone();
-        let sandbox_patch = serde_json::json!({
-            "tools": {
-                "allow": ["browser", "group:web", "exec", "process", "group:fs"],
-                "deny": ["canvas", "nodes", "cron", "gateway"],
-                "exec": {"applyPatch": {"enabled": true}},
-                "media": {"image": {"enabled": true}},
-                "sandbox": {
-                    "tools": {
-                        "deny": ["canvas", "nodes", "cron", "gateway"],
-                        "allow": [
-                            "exec", "process", "group:fs",
-                            "image", "sessions_list", "sessions_history",
-                            "sessions_send", "sessions_spawn", "session_status",
-                            "browser", "group:web"
-                        ]
-                    }
-                }
-            }
-        })
-        .to_string();
-        match config_patch_with_reconnect(&snapshot_for_patch, |_| sandbox_patch.clone()).await {
-          Ok(_) => repairs
-            .push("Added tools.sandbox.tools.allow with browser + web + exec tools".to_string()),
-          Err(e) => issues.push(format!("Failed to repair sandbox tools: {}", e)),
+        let re_snapshot = gateway_client::config_get(None).await;
+        if let Ok(snap) = re_snapshot {
+          let bh = extract_base_hash(&snap);
+          let sandbox_patch = serde_json::json!({
+              "tools": {
+                  "allow": ["browser", "group:web", "exec", "process", "group:fs"],
+                  "deny": ["canvas", "nodes", "cron", "gateway"],
+                  "exec": {"applyPatch": {"enabled": true}},
+                  "media": {"image": {"enabled": true}},
+                  "sandbox": {
+                      "tools": {
+                          "deny": ["canvas", "nodes", "cron", "gateway"],
+                          "allow": [
+                              "exec", "process", "group:fs",
+                              "image", "sessions_list", "sessions_history",
+                              "sessions_send", "sessions_spawn", "session_status",
+                              "browser", "group:web"
+                          ]
+                      }
+                  }
+              }
+          })
+          .to_string();
+          match gateway_client::config_patch(&sandbox_patch, &bh, None).await {
+            Ok(_) => repairs
+              .push("Added tools.sandbox.tools.allow with browser + web + exec tools".to_string()),
+            Err(e) => issues.push(format!("Failed to repair sandbox tools: {}", e)),
+          }
         }
       }
 
@@ -3475,16 +3256,9 @@ pub async fn channel_diagnostics() -> impl Responder {
                   status_part.split_whitespace().next().unwrap_or("linked")
                 ));
                 // Try to repair by adding the channel config
-                if diagnostics_deadline
-                  .checked_duration_since(Instant::now())
-                  .unwrap_or_default()
-                  .is_zero()
-                {
-                  issues.push(
-                    "Skipping linked channel repair: diagnostics budget exceeded".to_string(),
-                  );
-                } else {
-                  let snapshot_for_patch = snapshot.clone();
+                let re_snapshot = gateway_client::config_get(None).await;
+                if let Ok(snap) = re_snapshot {
+                  let bh = extract_base_hash(&snap);
                   let patch = match *ch_key {
                     "imessage" => serde_json::to_string(&serde_json::json!({
                       "channels": {
@@ -3501,7 +3275,7 @@ pub async fn channel_diagnostics() -> impl Responder {
                       ch_key
                     ),
                   };
-                  match config_patch_with_reconnect(&snapshot_for_patch, |_| patch.clone()).await {
+                  match gateway_client::config_patch(&patch, &bh, None).await {
                     Ok(_) => repairs.push(format!("Added channel config for '{}'", ch_key)),
                     Err(e) => issues.push(format!("Failed to repair channel '{}': {}", ch_key, e)),
                   }
@@ -3512,13 +3286,17 @@ pub async fn channel_diagnostics() -> impl Responder {
         }
       }
 
-      (has_model, model, channels)
+      (hm, m, channels)
     }
-    None => {
-      issues.push("Cannot fetch gateway config".to_string());
+    Err(e) => {
+      issues.push(format!("Cannot fetch gateway config: {}", e));
       (false, None, vec![])
     }
   };
+
+  if !has_model {
+    issues.push("agents.defaults.model is NOT set — AI cannot generate responses".to_string());
+  }
 
   HttpResponse::Ok().json(ChannelDiagnostics {
     success: issues.is_empty(),
@@ -4758,9 +4536,7 @@ pub async fn telegram_get_agent_bot_statuses() -> impl Responder {
 
 #[cfg(test)]
 mod reconnect_retry_tests {
-  use super::diagnostics_request_with_budget;
-  use super::{build_enable_patch, is_connection_level_error};
-  use std::time::Duration;
+  use super::is_connection_level_error;
 
   #[test]
   fn connection_closed_is_retryable() {
@@ -4785,100 +4561,5 @@ mod reconnect_retry_tests {
     assert!(!is_connection_level_error(
       "schema validation failed: channels.telegram"
     ));
-  }
-
-  #[test]
-  fn enable_patch_adds_deferred_channel_plugin() {
-    let snapshot = serde_json::json!({
-      "config": {
-        "agents": {"defaults": {"model": "openai/gpt-5.4"}},
-        "browser": {"enabled": true},
-        "plugins": {"allow": ["browser", "duckduckgo"]},
-        "tools": {
-          "sandbox": {
-            "tools": {
-              "allow": ["exec", "browser", "sessions_send"],
-              "deny": []
-            }
-          }
-        }
-      }
-    });
-
-    let patch = build_enable_patch(
-      r#"{"channels":{"whatsapp":{"dmPolicy":"allowlist"}}}"#,
-      &snapshot,
-    );
-    let patch: serde_json::Value = serde_json::from_str(&patch).unwrap();
-
-    let allow = patch
-      .pointer("/plugins/allow")
-      .and_then(|value| value.as_array())
-      .unwrap();
-    assert!(allow
-      .iter()
-      .any(|plugin| plugin.as_str() == Some("whatsapp")));
-    assert_eq!(
-      patch.pointer("/plugins/entries/whatsapp/enabled"),
-      Some(&serde_json::json!(true))
-    );
-  }
-
-  #[tokio::test]
-  async fn diagnostics_budget_timeout_records_issue() {
-    let mut issues = Vec::new();
-    let deadline = std::time::Instant::now() + Duration::from_millis(5);
-    let result = diagnostics_request_with_budget(
-      "timed check",
-      deadline,
-      Duration::from_millis(50),
-      &mut issues,
-      async {
-        tokio::time::sleep(Duration::from_millis(25)).await;
-        Ok::<serde_json::Value, String>(serde_json::json!("ok"))
-      },
-    )
-    .await;
-
-    assert!(result.is_none());
-    assert!(!issues.is_empty());
-    assert!(issues[0].contains("timed check"));
-  }
-
-  #[tokio::test]
-  async fn diagnostics_budget_rpcs_error_is_reported() {
-    let mut issues = Vec::new();
-    let deadline = std::time::Instant::now() + Duration::from_millis(50);
-    let result = diagnostics_request_with_budget(
-      "error check",
-      deadline,
-      Duration::from_millis(50),
-      &mut issues,
-      async { Err::<serde_json::Value, String>("gateway fail".into()) },
-    )
-    .await;
-
-    assert!(result.is_none());
-    assert_eq!(issues, vec!["error check: gateway fail".to_string()]);
-  }
-
-  #[tokio::test]
-  async fn diagnostics_budget_skips_after_deadline() {
-    let mut issues = Vec::new();
-    let deadline = std::time::Instant::now();
-    let result = diagnostics_request_with_budget(
-      "expired budget",
-      deadline,
-      Duration::from_millis(50),
-      &mut issues,
-      async { Ok::<serde_json::Value, String>(serde_json::json!("ok")) },
-    )
-    .await;
-
-    assert!(result.is_none());
-    assert_eq!(
-      issues,
-      vec!["Diagnostics budget exceeded before 'expired budget'".to_string()]
-    );
   }
 }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -73,10 +73,9 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
 
   match snapshot {
     Ok(snapshot) => {
-      let mut cache =
-        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
-          .await
-          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let mut cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+        .await
+        .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
       let entry = cache.entry(cache_key).or_default();
       entry.fetched_at = Some(Instant::now());
       entry.value = Some(snapshot.clone());
@@ -85,10 +84,9 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
       Ok(snapshot)
     }
     Err(error) => {
-      let mut cache =
-        tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
-          .await
-          .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
+      let mut cache = tokio::time::timeout(Duration::from_millis(250), CHANNEL_STATUS_CACHE.lock())
+        .await
+        .map_err(|_| "Timed out waiting for channel status refresh".to_string())?;
       let entry = cache.entry(cache_key).or_default();
       entry.error_at = Some(Instant::now());
       entry.error = Some(error.clone());
@@ -3046,10 +3044,53 @@ struct ChannelDiagnostics {
   /// Channel configs present in the gateway config
   #[serde(rename = "configuredChannels")]
   configured_channels: Vec<String>,
+  /// Per-channel readiness details.
+  #[serde(rename = "channelStates")]
+  channel_states: Vec<ChannelReadiness>,
   /// Issues detected
   issues: Vec<String>,
   /// Auto-repair actions taken
   repairs: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ChannelReadiness {
+  channel: String,
+  configured: bool,
+  #[serde(rename = "pluginAllowed")]
+  plugin_allowed: bool,
+  active: bool,
+  deferred: bool,
+  summary: Option<String>,
+  reason: String,
+}
+
+fn channel_summary_line(channel_summary: &[String], channel: &str) -> Option<String> {
+  let prefix = format!("{}:", channel.to_lowercase());
+  channel_summary.iter().find_map(|line| {
+    let clean = strip_ansi(line);
+    if clean.to_lowercase().starts_with(&prefix) {
+      Some(clean)
+    } else {
+      None
+    }
+  })
+}
+
+fn channel_summary_active(summary: Option<&str>) -> bool {
+  let Some(summary) = summary else {
+    return false;
+  };
+  let status = summary
+    .split_once(':')
+    .map(|(_, rest)| rest.trim().to_lowercase())
+    .unwrap_or_else(|| summary.trim().to_lowercase());
+  status.starts_with("linked")
+    || status.starts_with("configured")
+    || status.starts_with("connected")
+    || status.starts_with("running")
+    || status.starts_with("ready")
+    || status.contains(" connected")
 }
 
 /// Diagnose channel configuration and auto-repair common issues.
@@ -3119,6 +3160,7 @@ pub async fn channel_diagnostics() -> impl Responder {
         has_api_key,
         api_key_provider,
         configured_channels: vec![],
+        channel_states: vec![],
         issues: vec![format!("Cannot reach gateway: {}", e)],
         repairs: vec![],
       });
@@ -3126,7 +3168,9 @@ pub async fn channel_diagnostics() -> impl Responder {
   };
 
   // Fetch gateway config to check model and channel configs
-  let (has_model, model, configured_channels) = match gateway_client::config_get(None).await {
+  let (has_model, model, configured_channels, plugin_allow) = match gateway_client::config_get(None)
+    .await
+  {
     Ok(snapshot) => {
       let config = snapshot.get("config").unwrap_or(&snapshot);
 
@@ -3157,6 +3201,18 @@ pub async fn channel_diagnostics() -> impl Responder {
           }
         }
       }
+      channels.sort();
+
+      let plugin_allow = config
+        .pointer("/plugins/allow")
+        .and_then(|value| value.as_array())
+        .map(|arr| {
+          arr
+            .iter()
+            .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+            .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
 
       // Auto-repair: if model is missing, patch it
       if !hm {
@@ -3374,17 +3430,72 @@ pub async fn channel_diagnostics() -> impl Responder {
         }
       }
 
-      (hm, m, channels)
+      (hm, m, channels, plugin_allow)
     }
     Err(e) => {
       issues.push(format!("Cannot fetch gateway config: {}", e));
-      (false, None, vec![])
+      (false, None, vec![], vec![])
     }
   };
 
   if !has_model {
     issues.push("agents.defaults.model is NOT set — AI cannot generate responses".to_string());
   }
+
+  let mut readiness_channels = configured_channels.clone();
+  for channel in [
+    "whatsapp",
+    "telegram",
+    "slack",
+    "discord",
+    "signal",
+    "irc",
+    "googlechat",
+    "imessage",
+  ] {
+    if channel_summary_line(&channel_summary, channel).is_some()
+      && !readiness_channels
+        .iter()
+        .any(|existing| existing == channel)
+    {
+      readiness_channels.push(channel.to_string());
+    }
+  }
+  readiness_channels.sort();
+  readiness_channels.dedup();
+
+  let channel_states = readiness_channels
+    .iter()
+    .map(|channel| {
+      let configured = configured_channels
+        .iter()
+        .any(|existing| existing == channel);
+      let summary = channel_summary_line(&channel_summary, channel);
+      let active = channel_summary_active(summary.as_deref())
+        || service::gateway_log_has_channel_started(channel);
+      let plugin_allowed = plugin_allow.iter().any(|plugin| plugin == channel);
+      let deferred = configured && !active && !plugin_allowed;
+      let reason = if active {
+        "active according to gateway summary or startup log".to_string()
+      } else if deferred {
+        "configured but plugin is not in startup allowlist; channel is deferred until opened"
+          .to_string()
+      } else if configured {
+        "configured but no active gateway channel summary was observed".to_string()
+      } else {
+        "observed in gateway summary but not configured".to_string()
+      };
+      ChannelReadiness {
+        channel: channel.clone(),
+        configured,
+        plugin_allowed,
+        active,
+        deferred,
+        summary,
+        reason,
+      }
+    })
+    .collect::<Vec<_>>();
 
   HttpResponse::Ok().json(ChannelDiagnostics {
     success: issues.is_empty(),
@@ -3394,6 +3505,7 @@ pub async fn channel_diagnostics() -> impl Responder {
     has_api_key,
     api_key_provider,
     configured_channels,
+    channel_states,
     issues,
     repairs,
   })

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -1090,7 +1090,7 @@ pub async fn gemini_chat(
   messages: Vec<OaiMessage>,
   tools: Vec<OaiToolSpec>,
 ) -> anyhow::Result<OaiChatResp> {
-  gemini_chat_with_retries(api_key, model, messages, tools, 3).await
+  gemini_chat_with_retries(api_key, model, messages, tools, 6).await
 }
 
 /// Call Google Gemini API with an explicit retry count.

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -1090,7 +1090,7 @@ pub async fn gemini_chat(
   messages: Vec<OaiMessage>,
   tools: Vec<OaiToolSpec>,
 ) -> anyhow::Result<OaiChatResp> {
-  gemini_chat_with_retries(api_key, model, messages, tools, 6).await
+  gemini_chat_with_retries(api_key, model, messages, tools, 3).await
 }
 
 /// Call Google Gemini API with an explicit retry count.
@@ -1294,16 +1294,20 @@ pub async fn gemini_chat_with_retries(
       });
     }
 
-    if status.as_u16() == 429 {
-      let wait_secs = parse_retry_after(&text).unwrap_or(5.0 + (attempt as f64 * 2.0));
+    if status.as_u16() == 429 || status.as_u16() == 503 {
+      last_error = format!("Gemini HTTP {}: {}", status, text);
+      if attempt + 1 >= max_retries {
+        anyhow::bail!("{}", last_error);
+      }
+      let wait_secs = parse_retry_after(&text).unwrap_or(3.0 + (attempt as f64 * 2.0));
       eprintln!(
-        "Gemini rate limit (attempt {}/{}), waiting {:.1}s...",
+        "Gemini transient error {} (attempt {}/{}), waiting {:.1}s...",
+        status,
         attempt + 1,
         max_retries,
         wait_secs
       );
       tokio::time::sleep(Duration::from_secs_f64(wait_secs)).await;
-      last_error = format!("Gemini HTTP {}: {}", status, text);
       continue;
     }
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -999,6 +999,78 @@ fn qa_plugin_allowlist_override() -> Option<Vec<String>> {
   }
 }
 
+fn disable_startup_deferred_plugin_entries(
+  cfg: &mut serde_json::Value,
+  allowed: &[String],
+  disable_any_not_allowed: bool,
+) -> bool {
+  let mut changed = false;
+  let mut disabled_plugins = Vec::new();
+  let Some(entries) = cfg
+    .pointer_mut("/plugins/entries")
+    .and_then(|value| value.as_object_mut())
+  else {
+    return false;
+  };
+
+  for (plugin_id, entry) in entries.iter_mut() {
+    let should_disable = if disable_any_not_allowed {
+      !allowed.iter().any(|allowed_id| allowed_id == plugin_id)
+    } else {
+      is_deferred_startup_plugin_id(plugin_id)
+        && !allowed.iter().any(|allowed_id| allowed_id == plugin_id)
+    };
+    if !should_disable {
+      continue;
+    }
+    let Some(entry_obj) = entry.as_object_mut() else {
+      continue;
+    };
+    if entry_obj.get("enabled").and_then(|value| value.as_bool()) == Some(false) {
+      continue;
+    }
+    entry_obj.insert("enabled".to_string(), serde_json::Value::Bool(false));
+    disabled_plugins.push(plugin_id.clone());
+    changed = true;
+  }
+
+  if disabled_plugins.is_empty() {
+    return changed;
+  }
+
+  if cfg.get("meta").is_none() {
+    cfg
+      .as_object_mut()
+      .unwrap()
+      .insert("meta".to_string(), serde_json::json!({}));
+  }
+  let Some(meta) = cfg.pointer_mut("/meta").and_then(|value| value.as_object_mut()) else {
+    return changed;
+  };
+  let mut restore = meta
+    .get("knapsackDeferredStartupDisabledEntries")
+    .and_then(|value| value.as_array())
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  for plugin_id in disabled_plugins {
+    if !restore.iter().any(|existing| existing == &plugin_id) {
+      restore.push(plugin_id);
+    }
+  }
+  restore.sort();
+  restore.dedup();
+  meta.insert(
+    "knapsackDeferredStartupDisabledEntries".to_string(),
+    serde_json::json!(restore),
+  );
+  changed
+}
+
 fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   if !cfg.is_object() {
     return false;
@@ -1029,8 +1101,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
       }
     }
     let next_allow = serde_json::json!(plugins);
+    let entries_changed = disable_startup_deferred_plugin_entries(cfg, &plugins, true);
     if cfg.pointer("/plugins/allow") == Some(&next_allow) {
-      return false;
+      return entries_changed;
     }
     cfg
       .pointer_mut("/plugins")
@@ -1093,6 +1166,11 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
 
   required.sort();
   required.dedup();
+  let entries_changed = if defer_optional {
+    disable_startup_deferred_plugin_entries(cfg, &required, false)
+  } else {
+    false
+  };
 
   let existing_allow = cfg
     .pointer("/plugins/allow")
@@ -1119,7 +1197,7 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
 
   let next_allow = serde_json::json!(merged);
   if cfg.pointer("/plugins/allow") == Some(&next_allow) {
-    return false;
+    return entries_changed;
   }
 
   cfg
@@ -1169,13 +1247,8 @@ fn expand_deferred_startup_plugin_allowlist(app_handle: &tauri::AppHandle) -> bo
       .unwrap()
       .insert("plugins".to_string(), serde_json::json!({}));
   }
-  let plugins = cfg
-    .pointer_mut("/plugins")
-    .and_then(|value| value.as_object_mut())
-    .unwrap();
-
-  let mut allow = plugins
-    .get("allow")
+  let mut allow = cfg
+    .pointer("/plugins/allow")
     .and_then(|value| value.as_array())
     .map(|arr| {
       arr
@@ -1193,6 +1266,32 @@ fn expand_deferred_startup_plugin_allowlist(app_handle: &tauri::AppHandle) -> bo
       allow.push((*plugin).to_string());
     }
   }
+  let restore_entries = cfg
+    .pointer("/meta/knapsackDeferredStartupDisabledEntries")
+    .and_then(|value| value.as_array())
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  if let Some(entries) = cfg
+    .pointer_mut("/plugins/entries")
+    .and_then(|value| value.as_object_mut())
+  {
+    for plugin_id in &restore_entries {
+      if let Some(entry) = entries
+        .get_mut(plugin_id)
+        .and_then(|value| value.as_object_mut())
+      {
+        entry.insert("enabled".to_string(), serde_json::Value::Bool(true));
+      }
+    }
+  }
+  if let Some(meta) = cfg.pointer_mut("/meta").and_then(|value| value.as_object_mut()) {
+    meta.remove("knapsackDeferredStartupDisabledEntries");
+  }
   if !eager_channel_plugin_start_enabled() {
     allow.retain(|plugin| !is_bundled_channel_plugin_id(plugin));
   }
@@ -1200,10 +1299,15 @@ fn expand_deferred_startup_plugin_allowlist(app_handle: &tauri::AppHandle) -> bo
   allow.dedup();
 
   let next_allow = serde_json::json!(allow);
-  if plugins.get("allow") == Some(&next_allow) {
+  if cfg.pointer("/plugins/allow") == Some(&next_allow) && restore_entries.is_empty() {
     return false;
   }
-  plugins.insert("allow".to_string(), next_allow);
+  cfg
+    .pointer_mut("/plugins")
+    .unwrap()
+    .as_object_mut()
+    .unwrap()
+    .insert("allow".to_string(), next_allow);
 
   match serde_json::to_string_pretty(&cfg) {
     Ok(next) => match fs::write(&config_path, format!("{}\n", next)) {
@@ -4948,6 +5052,122 @@ fn remove_stale_gateway_lock_files() {
   }
 }
 
+fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+  let file_name = db_path
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or("openclaw.sqlite");
+  db_path.with_file_name(format!("{}{}", file_name, suffix))
+}
+
+fn move_stale_sqlite_sidecar(db_path: &Path, suffix: &str, context: &str) -> bool {
+  let sidecar = sqlite_sidecar_path(db_path, suffix);
+  if !sidecar.exists() {
+    return false;
+  }
+  let file_name = sidecar
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or("openclaw.sqlite-sidecar");
+  let backup = sidecar.with_file_name(format!("{}.stale-{}", file_name, now_epoch_ms()));
+  match fs::rename(&sidecar, &backup) {
+    Ok(_) => {
+      eprintln!(
+        "[clawd/service] {}: moved stale SQLite sidecar {} -> {}",
+        context,
+        sidecar.display(),
+        backup.display()
+      );
+      true
+    }
+    Err(e) => {
+      eprintln!(
+        "[clawd/service] {}: warning: failed to move stale SQLite sidecar {}: {}",
+        context,
+        sidecar.display(),
+        e
+      );
+      false
+    }
+  }
+}
+
+fn checkpoint_openclaw_state_db(db_path: &Path) -> Result<(), String> {
+  let conn = rusqlite::Connection::open(db_path)
+    .map_err(|e| format!("open {} failed: {}", db_path.display(), e))?;
+  conn
+    .busy_timeout(std::time::Duration::from_millis(1500))
+    .map_err(|e| format!("set busy_timeout failed: {}", e))?;
+  let checkpoint: (i64, i64, i64) = conn
+    .query_row("PRAGMA wal_checkpoint(TRUNCATE);", [], |row| {
+      Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+    })
+    .map_err(|e| format!("wal_checkpoint failed: {}", e))?;
+  let _ = conn.execute_batch("PRAGMA optimize;");
+  eprintln!(
+    "[clawd/service] OpenClaw state checkpoint complete: busy={}, log={}, checkpointed={}",
+    checkpoint.0, checkpoint.1, checkpoint.2
+  );
+  Ok(())
+}
+
+fn recover_openclaw_state_db_before_gateway_launch(clawdbot_home: &Path, context: &str) {
+  let db_path = clawdbot_home.join("state").join("openclaw.sqlite");
+  if !db_path.exists() {
+    return;
+  }
+
+  #[cfg(target_os = "windows")]
+  if windows_pid_listening_on_port(18789).is_some() {
+    eprintln!(
+      "[clawd/service] {}: skipping OpenClaw state preflight while gateway port is active",
+      context
+    );
+    return;
+  }
+
+  let started = std::time::Instant::now();
+  match checkpoint_openclaw_state_db(&db_path) {
+    Ok(_) => {
+      eprintln!(
+        "[clawd/service] {}: OpenClaw state preflight finished in {}ms",
+        context,
+        started.elapsed().as_millis()
+      );
+    }
+    Err(e) => {
+      let lower = e.to_lowercase();
+      let looks_locked = lower.contains("database is locked")
+        || lower.contains("database is busy")
+        || lower.contains("busy");
+      eprintln!(
+        "[clawd/service] {}: OpenClaw state checkpoint failed: {}",
+        context, e
+      );
+      if !looks_locked {
+        return;
+      }
+
+      // Preserve the WAL and only move the shared-memory lock sidecar. SQLite
+      // can recreate it and still replay committed WAL frames on the next open.
+      if !move_stale_sqlite_sidecar(&db_path, "-shm", context) {
+        return;
+      }
+      match checkpoint_openclaw_state_db(&db_path) {
+        Ok(_) => eprintln!(
+          "[clawd/service] {}: OpenClaw state recovered after moving stale -shm in {}ms",
+          context,
+          started.elapsed().as_millis()
+        ),
+        Err(retry_err) => eprintln!(
+          "[clawd/service] {}: warning: OpenClaw state still locked after -shm recovery: {}",
+          context, retry_err
+        ),
+      }
+    }
+  }
+}
+
 fn run_openclaw_doctor_fix(setup: &ServiceSetup, context: &str) -> bool {
   if setup.program_args.len() < 2 {
     eprintln!(
@@ -5194,6 +5414,7 @@ async fn run_gateway_self_heal_cycle(
     install_bundled_plugin_runtime_deps(&setup.node_path, &extensions_dir);
     ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
   }
+  recover_openclaw_state_db_before_gateway_launch(&clawdbot_home, "self-heal");
 
   #[cfg(target_os = "windows")]
   {
@@ -10623,6 +10844,10 @@ pub async fn set_service_enabled(
         remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(&app_handle), &ver);
         remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(&app_handle), &ver);
       }
+      recover_openclaw_state_db_before_gateway_launch(
+        &app_clawdbot_home(&app_handle),
+        "enable service",
+      );
 
       // Doctor mutates the same runtime deps/config tree as gateway startup.
       // Keep it opt-in so it cannot race first-run dependency staging.
@@ -13800,6 +14025,10 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
     remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(app_handle), &ver);
     remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(app_handle), &ver);
   }
+  recover_openclaw_state_db_before_gateway_launch(
+    &app_clawdbot_home(app_handle),
+    "auto_enable Windows",
+  );
 
   let stdout_log = windows_log_path("stdout");
   let stderr_log = windows_log_path("stderr");

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -7,7 +7,6 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use tauri::Manager;
 
 use crate::clawd::gateway_client;
 use crate::clawd::sidecar::SharedClawdbotConfig;
@@ -278,9 +277,6 @@ fn is_pid_alive(pid: u32) -> bool {
 static BROWSER_START_NUDGED: AtomicBool = AtomicBool::new(false);
 static GATEWAY_LAST_LAUNCH_MS: AtomicU64 = AtomicU64::new(0);
 static QA_DIRECT_GATEWAY_FIRST_SEEN_MS: AtomicU64 = AtomicU64::new(0);
-#[cfg(target_os = "windows")]
-const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 120_000;
-#[cfg(not(target_os = "windows"))]
 const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 30_000;
 const PLUGIN_RUNTIME_DEPS_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(600);
 const PLUGIN_RUNTIME_DEPS_OWNER_LOCK_GRACE_MS: u64 = 180_000;
@@ -289,8 +285,6 @@ const PLUGIN_RUNTIME_DEPS_OWNER_LOCK_GRACE_MS: u64 = 180_000;
 /// Health polling is frequent and can otherwise pile up concurrent probes,
 /// making the UI report "down" while the browser is simply booting.
 static BROWSER_STATUS_PROBE_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
-static BROWSER_STATUS_LAST_PROBE_MS: AtomicU64 = AtomicU64::new(0);
-static BROWSER_STATUS_CACHED: AtomicU64 = AtomicU64::new(0);
 
 /// Last time a browser `/start` nudge was attempted.  Failed nudges should be
 /// retried, but not on every health poll while browser-control is still busy.
@@ -299,20 +293,15 @@ static BROWSER_LAST_NUDGE_MS: AtomicU64 = AtomicU64::new(0);
 /// Tracks whether the gateway was healthy on the last health check.
 /// Used to detect down→up transitions and reset BROWSER_START_NUDGED.
 static GATEWAY_WAS_HEALTHY: AtomicBool = AtomicBool::new(false);
-static GATEWAY_LAST_HEALTHY_MS: AtomicU64 = AtomicU64::new(0);
 
 /// Tracks whether the browser was healthy on the last health check.
 /// Used to detect healthy→down transitions (browser crashes) and reset
 /// BROWSER_START_NUDGED so the recovery nudge can fire again.
 static BROWSER_WAS_HEALTHY: AtomicBool = AtomicBool::new(false);
-static BROWSER_LAST_HEALTHY_MS: AtomicU64 = AtomicU64::new(0);
 
 /// Tracks whether a gateway restart attempt is already in progress,
 /// so the health endpoint doesn't spam `launchctl kickstart` on every poll.
 static GATEWAY_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
-static BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
-static PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
-static BUNDLED_RUNTIME_SELF_LINK_WARMUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// First observed timestamp for the current gateway-unreachable period.
 static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
@@ -320,12 +309,6 @@ static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
 const GATEWAY_HEALTH_SELF_HEAL_GRACE_MS: u64 = 180_000;
 const GATEWAY_POST_BIND_STARTUP_GRACE_MS: u64 = 300_000;
 const BROWSER_START_NUDGE_COOLDOWN_MS: u64 = 45_000;
-const HEALTH_LAST_GOOD_GRACE_MS: u64 = 15_000;
-const BROWSER_HEALTH_CACHE_TTL_MS: u64 = 30_000;
-const BROWSER_STATUS_NON_READY_REFRESH_MS: u64 = 1_250;
-const BROWSER_HEALTH_LISTENER_GRACE_MS: u64 = 120_000;
-const STARTUP_BROWSER_PROBE_TIMEOUT_MS: u64 = 1200;
-const STARTUP_BROWSER_POLL_INTERVAL_MS: u64 = 250;
 
 fn now_epoch_ms() -> u64 {
   std::time::SystemTime::now()
@@ -408,39 +391,13 @@ pub fn gateway_stdout_log() -> PathBuf {
   gateway_log_dir().join("knapsack-clawdbot.out.log")
 }
 
-fn read_gateway_stdout_log_content() -> std::io::Result<String> {
-  #[cfg(target_os = "windows")]
-  let paths = [windows_log_path("stdout"), gateway_stdout_log()];
-  #[cfg(not(target_os = "windows"))]
-  let paths = [gateway_stdout_log()];
-
-  let mut combined = String::new();
-  let mut last_err: Option<std::io::Error> = None;
-  for path in paths {
-    match std::fs::read_to_string(&path) {
-      Ok(content) => {
-        if !combined.is_empty() {
-          combined.push('\n');
-        }
-        combined.push_str(&content);
-      }
-      Err(e) => {
-        last_err = Some(e);
-      }
-    }
-  }
-
-  if combined.is_empty() {
-    Err(last_err.unwrap_or_else(|| {
-      std::io::Error::new(std::io::ErrorKind::NotFound, "gateway stdout log not found")
-    }))
-  } else {
-    Ok(combined)
-  }
-}
-
 pub(crate) fn gateway_log_has_channel_started(channel: &str) -> bool {
-  let Ok(content) = read_gateway_stdout_log_content() else {
+  #[cfg(target_os = "windows")]
+  let log_path = windows_log_path("stdout");
+  #[cfg(not(target_os = "windows"))]
+  let log_path = gateway_stdout_log();
+
+  let Ok(content) = std::fs::read_to_string(log_path) else {
     return false;
   };
   content.contains(&format!("channels.{}.start", channel))
@@ -488,22 +445,6 @@ fn gateway_launch_grace_active() -> Option<u64> {
   Some(elapsed)
 }
 
-fn gateway_launch_grace_active_with_live_process() -> Option<u64> {
-  let elapsed = gateway_launch_grace_active()?;
-  let pid = GATEWAY_PID.load(Ordering::Relaxed);
-  if pid > 0 && process_is_alive(pid) {
-    return Some(elapsed);
-  }
-  #[cfg(target_os = "windows")]
-  if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
-    if process_is_alive(listening_pid) {
-      GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
-      return Some(elapsed);
-    }
-  }
-  None
-}
-
 #[cfg(target_os = "macos")]
 fn qa_direct_gateway_process_active() -> bool {
   if std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() != Some("1") {
@@ -530,8 +471,7 @@ fn qa_direct_gateway_process_active() -> bool {
 }
 
 fn qa_direct_gateway_mode() -> bool {
-  cfg!(target_os = "macos")
-    && std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() == Some("1")
+  std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() == Some("1")
 }
 
 fn qa_direct_gateway_grace_active() -> Option<u64> {
@@ -565,12 +505,6 @@ fn passive_browser_start_nudge_enabled() -> bool {
 
 fn startup_ready_browser_start_enabled() -> bool {
   std::env::var("KNAPSACK_STARTUP_READY_AUTO_START_BROWSER")
-    .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-    .unwrap_or(true)
-}
-
-fn startup_ready_direct_chrome_enabled() -> bool {
-  std::env::var("KNAPSACK_STARTUP_READY_DIRECT_CHROME")
     .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
     .unwrap_or(false)
 }
@@ -900,14 +834,12 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
   }
 }
 
-const KNAPSACK_CORE_STARTUP_PLUGINS: &[&str] = &[
-  // Keep the launch gate small: browser access is the only OpenClaw plugin
-  // required before the desktop can be considered locally usable.
+const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
+  // Core app activities exercised by the desktop QA loop.
   "browser",
-];
-
-const KNAPSACK_DEFERRED_STARTUP_PLUGINS: &[&str] = &[
-  // Google/Microsoft document surfaces.
+  "telegram",
+  "slack",
+  "whatsapp",
   "google",
   "microsoft",
   "web-readability",
@@ -942,167 +874,10 @@ const KNAPSACK_DEFERRED_STARTUP_PLUGINS: &[&str] = &[
 
 const KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS: &[&str] = &["slack", "telegram", "whatsapp"];
 
-pub(crate) fn is_bundled_channel_plugin_id(plugin_id: &str) -> bool {
-  KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS
-    .iter()
-    .any(|candidate| *candidate == plugin_id)
-}
-
-fn eager_channel_plugin_start_enabled() -> bool {
-  std::env::var("KNAPSACK_EAGER_CHANNEL_PLUGINS")
-    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-    .unwrap_or(false)
-}
-
-fn defer_optional_startup_plugins_enabled() -> bool {
-  std::env::var("KNAPSACK_DEFER_OPTIONAL_STARTUP_PLUGINS")
-    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-    .unwrap_or(true)
-}
-
-fn is_deferred_startup_plugin_id(plugin_id: &str) -> bool {
-  KNAPSACK_DEFERRED_STARTUP_PLUGINS
-    .iter()
-    .any(|candidate| *candidate == plugin_id)
-}
-
-fn configured_bundled_channel_plugin_ids(cfg: &serde_json::Value) -> Vec<String> {
-  let mut channels = cfg
-    .pointer("/channels")
-    .and_then(|value| value.as_object())
-    .map(|configured| {
-      configured
-        .keys()
-        .filter(|channel| is_bundled_channel_plugin_id(channel))
-        .cloned()
-        .collect::<Vec<_>>()
-    })
-    .unwrap_or_default();
-  channels.sort();
-  channels.dedup();
-  channels
-}
-
-fn startup_ready_channel_ids(app_handle: &tauri::AppHandle) -> Vec<String> {
-  let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
-  let Ok(raw) = fs::read_to_string(&config_path) else {
-    return Vec::new();
-  };
-  let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&raw) else {
-    return Vec::new();
-  };
-  let mut channels = configured_bundled_channel_plugin_ids(&cfg)
-    .into_iter()
-    .filter(|channel| {
-      let disabled = cfg
-        .pointer(&format!("/channels/{}/enabled", channel))
-        .and_then(|value| value.as_bool())
-        == Some(false);
-      !disabled && bundled_plugins_dir(app_handle).join(channel).is_dir()
-    })
-    .collect::<Vec<_>>();
-  channels.sort();
-  channels.dedup();
-  channels
-}
-
-fn qa_plugin_allowlist_override() -> Option<Vec<String>> {
-  let raw = std::env::var("KNAPSACK_QA_PLUGIN_ALLOWLIST").ok()?;
-  let mut plugins = raw
-    .split(',')
-    .map(|plugin| plugin.trim())
-    .filter(|plugin| !plugin.is_empty())
-    .map(|plugin| plugin.to_string())
-    .collect::<Vec<_>>();
-  plugins.sort();
-  plugins.dedup();
-  if plugins.is_empty() {
-    None
-  } else {
-    Some(plugins)
-  }
-}
-
-fn disable_startup_deferred_plugin_entries(
-  cfg: &mut serde_json::Value,
-  allowed: &[String],
-  disable_any_not_allowed: bool,
-) -> bool {
-  let mut changed = false;
-  let mut disabled_plugins = Vec::new();
-  let Some(entries) = cfg
-    .pointer_mut("/plugins/entries")
-    .and_then(|value| value.as_object_mut())
-  else {
-    return false;
-  };
-
-  for (plugin_id, entry) in entries.iter_mut() {
-    let should_disable = if disable_any_not_allowed {
-      !allowed.iter().any(|allowed_id| allowed_id == plugin_id)
-    } else {
-      is_deferred_startup_plugin_id(plugin_id)
-        && !allowed.iter().any(|allowed_id| allowed_id == plugin_id)
-    };
-    if !should_disable {
-      continue;
-    }
-    let Some(entry_obj) = entry.as_object_mut() else {
-      continue;
-    };
-    if entry_obj.get("enabled").and_then(|value| value.as_bool()) == Some(false) {
-      continue;
-    }
-    entry_obj.insert("enabled".to_string(), serde_json::Value::Bool(false));
-    disabled_plugins.push(plugin_id.clone());
-    changed = true;
-  }
-
-  if disabled_plugins.is_empty() {
-    return changed;
-  }
-
-  if cfg.get("meta").is_none() {
-    cfg
-      .as_object_mut()
-      .unwrap()
-      .insert("meta".to_string(), serde_json::json!({}));
-  }
-  let Some(meta) = cfg
-    .pointer_mut("/meta")
-    .and_then(|value| value.as_object_mut())
-  else {
-    return changed;
-  };
-  let mut restore = meta
-    .get("knapsackDeferredStartupDisabledEntries")
-    .and_then(|value| value.as_array())
-    .map(|arr| {
-      arr
-        .iter()
-        .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
-        .collect::<Vec<_>>()
-    })
-    .unwrap_or_default();
-  for plugin_id in disabled_plugins {
-    if !restore.iter().any(|existing| existing == &plugin_id) {
-      restore.push(plugin_id);
-    }
-  }
-  restore.sort();
-  restore.dedup();
-  meta.insert(
-    "knapsackDeferredStartupDisabledEntries".to_string(),
-    serde_json::json!(restore),
-  );
-  changed
-}
-
 fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   if !cfg.is_object() {
     return false;
   }
-  let mut patched = false;
 
   if cfg.get("plugins").is_none() {
     cfg
@@ -1111,38 +886,7 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
       .insert("plugins".to_string(), serde_json::json!({}));
   }
 
-  if !eager_channel_plugin_start_enabled() {
-    if let Some(entries) = cfg
-      .pointer_mut("/plugins/entries")
-      .and_then(|value| value.as_object_mut())
-    {
-      for plugin_id in KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS {
-        let Some(entry) = entries.get_mut(*plugin_id) else {
-          continue;
-        };
-        match entry.as_object_mut() {
-          Some(entry_obj) => {
-            if entry_obj.get("enabled").and_then(|value| value.as_bool()) != Some(false) {
-              entry_obj.insert("enabled".to_string(), serde_json::json!(false));
-              patched = true;
-            }
-          }
-          None => {
-            *entry = serde_json::json!({ "enabled": false });
-            patched = true;
-          }
-        }
-      }
-      if patched {
-        eprintln!(
-          "[clawd/service] Disabled bundled channel plugin entries during startup: {}",
-          KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS.join(", ")
-        );
-      }
-    }
-  }
-
-  let mut required: Vec<String> = KNAPSACK_CORE_STARTUP_PLUGINS
+  let mut required: Vec<String> = KNAPSACK_REQUIRED_PLUGINS
     .iter()
     .map(|plugin| plugin.to_string())
     .collect();
@@ -1152,9 +896,6 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .and_then(|value| value.as_object())
   {
     for (plugin_id, entry) in entries {
-      if is_bundled_channel_plugin_id(plugin_id) && !eager_channel_plugin_start_enabled() {
-        continue;
-      }
       let explicitly_disabled =
         entry.get("enabled").and_then(|value| value.as_bool()) == Some(false);
       if !explicitly_disabled && !required.iter().any(|existing| existing == plugin_id) {
@@ -1175,9 +916,6 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .iter()
     .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
     .collect::<Vec<_>>();
-  if !eager_channel_plugin_start_enabled() {
-    merged.retain(|plugin| !is_bundled_channel_plugin_id(plugin));
-  }
   for plugin in required {
     if !merged.iter().any(|existing| existing == &plugin) {
       merged.push(plugin);
@@ -1188,7 +926,7 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
 
   let next_allow = serde_json::json!(merged);
   if cfg.pointer("/plugins/allow") == Some(&next_allow) {
-    return patched;
+    return false;
   }
 
   cfg
@@ -1199,43 +937,6 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .insert("allow".to_string(), next_allow);
   eprintln!("[clawd/service] Patched plugins.allow to Knapsack startup allowlist");
   true
-}
-
-fn defer_bundled_channel_configs_for_startup(cfg: &mut serde_json::Value) -> bool {
-  if eager_channel_plugin_start_enabled() {
-    return false;
-  }
-
-  let Some(channels) = cfg
-    .get_mut("channels")
-    .and_then(|value| value.as_object_mut())
-  else {
-    return false;
-  };
-
-  let mut patched = false;
-  for channel_id in KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS {
-    let Some(channel) = channels.get_mut(*channel_id) else {
-      continue;
-    };
-    let Some(channel_obj) = channel.as_object_mut() else {
-      continue;
-    };
-    if channel_obj.get("enabled").and_then(|value| value.as_bool()) == Some(false) {
-      continue;
-    }
-    channel_obj.insert("enabled".to_string(), serde_json::json!(false));
-    patched = true;
-  }
-
-  if patched {
-    eprintln!(
-      "[clawd/service] Deferred bundled channel configs during startup: {}",
-      KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS.join(", ")
-    );
-  }
-
-  patched
 }
 
 fn remove_object_keys(obj: &mut serde_json::Map<String, serde_json::Value>, keys: &[&str]) -> bool {
@@ -1823,22 +1524,6 @@ fn remove_incomplete_plugin_runtime_deps_dirs(
   removed
 }
 
-fn schedule_plugin_runtime_deps_cleanup(clawdbot_home: PathBuf, current_version: String) {
-  if PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS
-    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-    .is_err()
-  {
-    return;
-  }
-
-  std::thread::spawn(move || {
-    std::thread::sleep(std::time::Duration::from_secs(45));
-    remove_stale_plugin_runtime_deps_versions(&clawdbot_home, &current_version);
-    remove_incomplete_plugin_runtime_deps_dirs(&clawdbot_home, &current_version);
-    PLUGIN_RUNTIME_DEPS_CLEANUP_IN_PROGRESS.store(false, Ordering::Relaxed);
-  });
-}
-
 /// Wipe corrupt `.openclaw-npm-cache` directories inside plugin-runtime-deps
 /// subdirs. These caches are disposable; npm will rebuild them on the next
 /// install attempt.
@@ -2350,10 +2035,7 @@ fn install_bundled_plugin_runtime_deps(
   ensure_openclaw_self_link(&root_nm);
 }
 
-fn bundled_node_modules_has_declared_dependencies(
-  dir: &std::path::Path,
-  nm_path: &std::path::Path,
-) -> bool {
+fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path: &std::path::Path) -> bool {
   let pkg_path = dir.join("package.json");
   let Ok(raw) = fs::read_to_string(&pkg_path) else {
     return false;
@@ -2361,8 +2043,10 @@ fn bundled_node_modules_has_declared_dependencies(
   let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&raw) else {
     return false;
   };
-  let deps = pkg.get("dependencies").and_then(|v| v.as_object());
-  if deps.map(|deps| deps.is_empty()).unwrap_or(true) {
+  let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) else {
+    return false;
+  };
+  if deps.is_empty() {
     return nm_path
       .read_dir()
       .map(|mut entries| entries.any(|entry| entry.is_ok()))
@@ -2370,98 +2054,8 @@ fn bundled_node_modules_has_declared_dependencies(
   }
 
   deps
-    .unwrap()
     .keys()
     .all(|dep| nm_path.join(dep).join("package.json").exists())
-}
-
-fn missing_declared_node_modules_dependencies(
-  dir: &std::path::Path,
-  nm_path: &std::path::Path,
-) -> Vec<String> {
-  let pkg_path = dir.join("package.json");
-  let Ok(raw) = fs::read_to_string(pkg_path) else {
-    return Vec::new();
-  };
-  let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&raw) else {
-    return Vec::new();
-  };
-  let Some(deps) = pkg.get("dependencies").and_then(|v| v.as_object()) else {
-    return Vec::new();
-  };
-
-  deps
-    .keys()
-    .filter(|dep| !nm_path.join(dep.as_str()).join("package.json").exists())
-    .cloned()
-    .collect()
-}
-
-#[cfg(target_os = "windows")]
-fn fill_missing_node_modules_from_tar(
-  dir: &std::path::Path,
-  nm_path: &std::path::Path,
-  tar_name: &str,
-) {
-  let missing = missing_declared_node_modules_dependencies(dir, nm_path);
-  if missing.is_empty() {
-    return;
-  }
-
-  use std::os::windows::process::CommandExt;
-  const CREATE_NO_WINDOW: u32 = 0x08000000;
-  eprintln!(
-    "[clawd/service] Filling {} missing bundled node_modules packages from {} in {}",
-    missing.len(),
-    tar_name,
-    dir.display()
-  );
-  let archive_paths: Vec<String> = missing
-    .into_iter()
-    .map(|dep| format!("node_modules/{}", dep.replace('\\', "/")))
-    .collect();
-  let mut args = Vec::with_capacity(2 + archive_paths.len());
-  args.push("-xkf".to_string());
-  args.push(tar_name.to_string());
-  args.extend(archive_paths.iter().cloned());
-  let result = std::process::Command::new("tar")
-    .args(args.iter().map(String::as_str))
-    .current_dir(dir)
-    .creation_flags(CREATE_NO_WINDOW)
-    .status();
-  match result {
-    Ok(status) if status.success() => {}
-    Ok(status) => eprintln!(
-      "[clawd/service] WARNING: tar fill for missing node_modules exited {} in {}",
-      status,
-      dir.display()
-    ),
-    Err(err) => eprintln!(
-      "[clawd/service] WARNING: tar fill for missing node_modules failed in {}: {}",
-      dir.display(),
-      err
-    ),
-  }
-}
-
-fn bundled_node_modules_has_required_runtime_files(nm_path: &std::path::Path) -> bool {
-  [
-    "@earendil-works/pi-agent-core/package.json",
-    "@earendil-works/pi-agent-core/dist/index.js",
-    "@earendil-works/pi-agent-core/dist/agent.js",
-  ]
-  .iter()
-  .all(|rel| {
-    rel
-      .split('/')
-      .fold(nm_path.to_path_buf(), |path, part| path.join(part))
-      .exists()
-  })
-}
-
-fn bundled_node_modules_is_complete(dir: &std::path::Path, nm_path: &std::path::Path) -> bool {
-  bundled_node_modules_has_declared_dependencies(dir, nm_path)
-    && bundled_node_modules_has_required_runtime_files(nm_path)
 }
 
 /// On Windows CI builds, prune-clawdbot.cjs packs `node_modules/` into
@@ -2485,22 +2079,6 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
   }
 
   let nm_path = dir.join("node_modules");
-  if cfg!(target_os = "windows") && !cfg!(debug_assertions) && nm_path.is_dir() {
-    #[cfg(target_os = "windows")]
-    fill_missing_node_modules_from_tar(dir, &nm_path, "node_modules.tar");
-    if bundled_node_modules_is_complete(dir, &nm_path) {
-      eprintln!(
-        "[clawd/service] Windows release startup: bundled node_modules ready after non-destructive tar fill in {}",
-        dir.display()
-      );
-    } else {
-      eprintln!(
-        "[clawd/service] WARNING: Windows release startup: bundled node_modules still incomplete after tar fill in {}",
-        dir.display()
-      );
-    }
-    return;
-  }
   let marker_path = nm_path.join(".knapsack-extracted-from-tar.json");
   let tar_meta = fs::metadata(&tar_path).ok();
   let tar_len = tar_meta.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -2517,13 +2095,16 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
       .map(|v| {
         v.get("tar_len").and_then(|n| n.as_u64()) == Some(tar_len)
-          && v.get("tar_mtime_secs").and_then(|n| n.as_u64()) == Some(tar_mtime_secs)
+          && v
+            .get("tar_mtime_secs")
+            .and_then(|n| n.as_u64())
+            == Some(tar_mtime_secs)
       })
       .unwrap_or(false);
-    if marker_current && bundled_node_modules_is_complete(dir, &nm_path) {
+    if marker_current && bundled_node_modules_has_declared_dependencies(dir, &nm_path) {
       return;
     }
-    if bundled_node_modules_is_complete(dir, &nm_path) {
+    if bundled_node_modules_has_declared_dependencies(dir, &nm_path) {
       let marker = serde_json::json!({
         "tar_len": tar_len,
         "tar_mtime_secs": tar_mtime_secs,
@@ -2571,7 +2152,7 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       .creation_flags(CREATE_NO_WINDOW)
       .status();
     match result {
-      Ok(s) if s.success() && bundled_node_modules_is_complete(dir, &nm_path) => {
+      Ok(s) if s.success() => {
         let marker = serde_json::json!({
           "tar_len": tar_len,
           "tar_mtime_secs": tar_mtime_secs,
@@ -2582,10 +2163,6 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
           dir.display()
         );
       }
-      Ok(s) if s.success() => eprintln!(
-        "[clawd/service] WARNING: node_modules.tar extraction completed but required runtime files are missing in {}",
-        dir.display()
-      ),
       Ok(s) => eprintln!(
         "[clawd/service] WARNING: node_modules.tar extraction exited {} in {}",
         s,
@@ -2616,7 +2193,10 @@ fn ensure_openclaw_link_to(root_nm: &std::path::Path, target: &std::path::Path) 
   }
 
   if link_path.exists() || link_path.symlink_metadata().is_ok() {
-    let backup_path = root_nm.join(format!(".knapsack-openclaw-incomplete-{}", now_epoch_ms()));
+    let backup_path = root_nm.join(format!(
+      ".knapsack-openclaw-incomplete-{}",
+      now_epoch_ms()
+    ));
     match fs::rename(&link_path, &backup_path) {
       Ok(()) => eprintln!(
         "[clawd/service] Moved incomplete openclaw link/package aside: {}",
@@ -2719,27 +2299,6 @@ fn ensure_clawdbot_runtime_self_link(clawdbot_entry: &std::path::Path) {
   }
 }
 
-fn schedule_clawdbot_runtime_self_link_warmup(clawdbot_entry: PathBuf, reason: &'static str) {
-  if BUNDLED_RUNTIME_SELF_LINK_WARMUP_IN_PROGRESS.swap(true, Ordering::Relaxed) {
-    eprintln!(
-      "[clawd/service] bundled runtime self-link warmup already scheduled ({})",
-      reason
-    );
-    return;
-  }
-  std::thread::spawn(move || {
-    std::thread::sleep(std::time::Duration::from_secs(20));
-    let started = std::time::Instant::now();
-    ensure_clawdbot_runtime_self_link(&clawdbot_entry);
-    BUNDLED_RUNTIME_SELF_LINK_WARMUP_IN_PROGRESS.store(false, Ordering::Relaxed);
-    eprintln!(
-      "[clawd/service] bundled runtime self-link warmup completed in {}ms ({})",
-      started.elapsed().as_millis(),
-      reason
-    );
-  });
-}
-
 fn should_mutate_bundled_clawdbot_runtime(path: &std::path::Path) -> bool {
   if cfg!(debug_assertions) || cfg!(target_os = "windows") {
     return true;
@@ -2773,38 +2332,6 @@ fn should_mutate_bundled_clawdbot_runtime(path: &std::path::Path) -> bool {
 /// absent when the dir was created by an older gateway or the link was lost
 /// during an interrupted update.  This function repairs them non-destructively
 /// so the gateway can resume without a full re-stage.
-fn schedule_bundled_plugin_runtime_deps_warmup(
-  node_path: PathBuf,
-  extensions_dir: PathBuf,
-  clawdbot_home: PathBuf,
-  reason: &'static str,
-) {
-  if cfg!(debug_assertions) {
-    return;
-  }
-  if BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS.swap(true, Ordering::Relaxed) {
-    eprintln!(
-      "[clawd/service] bundled plugin runtime deps warmup already scheduled ({})",
-      reason
-    );
-    return;
-  }
-  std::thread::spawn(move || {
-    std::thread::sleep(std::time::Duration::from_secs(45));
-    eprintln!(
-      "[clawd/service] starting bundled plugin runtime deps warmup ({})",
-      reason
-    );
-    install_bundled_plugin_runtime_deps(&node_path, &extensions_dir);
-    ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
-    BUNDLED_PLUGIN_RUNTIME_DEPS_WARMUP_IN_PROGRESS.store(false, Ordering::Relaxed);
-    eprintln!(
-      "[clawd/service] finished bundled plugin runtime deps warmup ({})",
-      reason
-    );
-  });
-}
-
 fn ensure_plugin_runtime_deps_openclaw_links(clawdbot_home: &std::path::Path) {
   let base = clawdbot_home.join("plugin-runtime-deps");
   let entries = match fs::read_dir(&base) {
@@ -3301,39 +2828,8 @@ async fn write_current_launch_agent_plist(app_handle: &tauri::AppHandle, context
   true
 }
 
-#[cfg(target_os = "macos")]
-async fn refresh_launch_agent_plist_for_restart(
-  app_handle: &tauri::AppHandle,
-  context: &str,
-) -> bool {
-  if write_current_launch_agent_plist(app_handle, context).await {
-    return true;
-  }
-
-  let plist_path = match launch_agent_plist_path() {
-    Ok(path) => path,
-    Err(e) => {
-      eprintln!(
-        "[clawd/service] {}: cannot resolve plist path for fallback refresh: {}",
-        context, e
-      );
-      return false;
-    }
-  };
-
-  let refreshed = regenerate_macos_plist_with_current_env(&plist_path);
-  if !refreshed {
-    eprintln!(
-      "[clawd/service] {}: fallback env-only plist refresh also failed",
-      context
-    );
-  }
-  refreshed
-}
-
 const GATEWAY_LOCAL_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1000);
 const GATEWAY_HEALTH_CACHE_TTL: std::time::Duration = std::time::Duration::from_millis(750);
-const GATEWAY_HEALTH_PATHS: [&str; 2] = ["/healthz", "/health"];
 
 struct GatewayHealthProbeCache {
   checked_at: Option<std::time::Instant>,
@@ -3351,12 +2847,10 @@ static GATEWAY_HEALTH_PROBE_CACHE: once_cell::sync::Lazy<
 
 async fn gateway_health_port_ok(timeout: std::time::Duration) -> bool {
   let now = std::time::Instant::now();
-  {
-    let cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
-    if let Some(checked_at) = cache.checked_at {
-      if now.duration_since(checked_at) < GATEWAY_HEALTH_CACHE_TTL {
-        return cache.result;
-      }
+  let mut cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
+  if let Some(checked_at) = cache.checked_at {
+    if now.duration_since(checked_at) < GATEWAY_HEALTH_CACHE_TTL {
+      return cache.result;
     }
   }
 
@@ -3364,45 +2858,20 @@ async fn gateway_health_port_ok(timeout: std::time::Duration) -> bool {
     Ok(c) => c,
     Err(_) => return false,
   };
-  let result = {
-    let mut ok = false;
-    for path in GATEWAY_HEALTH_PATHS {
-      let probe = tokio::time::timeout(
-        timeout,
-        client.get(format!("http://127.0.0.1:18789{}", path)).send(),
-      );
-      if let Ok(Ok(resp)) = probe.await {
-        let status = resp.status();
-        if status.is_success()
-          || (status.is_informational() || status.is_redirection() || status.is_client_error())
-        {
-          ok = true;
-          break;
-        }
-      }
+  let result = match tokio::time::timeout(
+    timeout,
+    client.get("http://127.0.0.1:18789/healthz").send(),
+  )
+  .await
+  {
+    Ok(Ok(resp)) => {
+      resp.status().is_success() || resp.status().as_u16() == 401 || resp.status().as_u16() == 404
     }
-    ok
+    _ => false,
   };
-  let mut cache = GATEWAY_HEALTH_PROBE_CACHE.lock().await;
   cache.checked_at = Some(std::time::Instant::now());
   cache.result = result;
   result
-}
-
-async fn gateway_ws_config_ok(token: Option<&str>, timeout: std::time::Duration) -> bool {
-  tokio::time::timeout(timeout, crate::clawd::gateway_ws::config_get(token))
-    .await
-    .map(|result| result.is_ok())
-    .unwrap_or(false)
-}
-
-async fn gateway_reachable_with_token(timeout: std::time::Duration, token: Option<&str>) -> bool {
-  let (health_ok, port_ok, ws_ok) = tokio::join!(
-    gateway_health_port_ok(timeout),
-    crate::clawd::gateway_client::is_gateway_port_open(),
-    gateway_ws_config_ok(token, timeout),
-  );
-  health_ok || port_ok || ws_ok
 }
 
 async fn browser_cdp_port_open(timeout: std::time::Duration) -> bool {
@@ -3430,11 +2899,7 @@ async fn gateway_tcp_port_open(timeout: std::time::Duration) -> bool {
 }
 
 pub async fn gateway_reachable_or_ready(timeout: std::time::Duration) -> bool {
-  if !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
-    return false;
-  }
   gateway_health_port_ok(timeout).await
-    || crate::clawd::gateway_client::is_gateway_port_open().await
 }
 
 fn read_log_tail_lines_bounded(
@@ -3743,7 +3208,9 @@ fn ensure_imessage_allowlist_config(cfg: &mut serde_json::Value) -> bool {
     && ch.get("enabled").and_then(|value| value.as_bool()) != Some(false)
   {
     ch.insert("enabled".to_string(), serde_json::json!(false));
-    eprintln!("[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false");
+    eprintln!(
+      "[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false"
+    );
     patched = true;
   }
 
@@ -4130,10 +3597,8 @@ fn sanitize_config_file_allowlist(config_path: &Path) {
     Ok(v) => v,
     Err(_) => return, // not valid JSON — leave alone, gateway will report the real error
   };
-  let patched = sanitize_channel_allowlist_configs(&mut cfg)
-    | sanitize_rejected_legacy_config_keys(&mut cfg)
-    | ensure_knapsack_plugin_allowlist(&mut cfg)
-    | defer_bundled_channel_configs_for_startup(&mut cfg);
+  let patched =
+    sanitize_channel_allowlist_configs(&mut cfg) | sanitize_rejected_legacy_config_keys(&mut cfg);
   if patched {
     match fs::write(
       config_path,
@@ -4213,72 +3678,11 @@ struct StoredTokens {
   #[serde(default)]
   preferred_coding_agent: Option<String>,
 
-  // Knapsack cloud inference — authenticated via studio.knapsack.ai deep link
-  #[serde(default)]
-  knapsack_access_token: Option<String>,
-  #[serde(default)]
-  knapsack_refresh_token: Option<String>,
-  /// Email shown in the UI; decoded from the JWT at sign-in time.
+  // Knapsack cloud inference (no API key — uses the user's Knapsack JWT)
   #[serde(default)]
   knapsack_email: Option<String>,
   #[serde(default)]
   knapsack_model: Option<String>,
-}
-
-fn active_provider_model(tokens: &StoredTokens) -> Option<String> {
-  let active_provider = tokens.active_provider.as_deref().unwrap_or("openai");
-  match active_provider {
-    "openai" => tokens
-      .openai_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("gpt-5-mini".to_string())),
-    "anthropic" => tokens
-      .anthropic_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("claude-sonnet-4-5-20250929".to_string())),
-    "gemini" => tokens
-      .gemini_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("gemini-2.5-flash".to_string())),
-    "google" | "google-gemini" | "google-gemini-cli" => tokens
-      .gemini_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("gemini-2.5-flash".to_string())),
-    "groq" => tokens
-      .groq_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("meta-llama/llama-4-scout-17b-16e-instruct".to_string())),
-    "xai" => tokens
-      .xai_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("grok-code-fast-1".to_string())),
-    "openrouter" => tokens
-      .openrouter_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("meta-llama/llama-3.3-70b-instruct:free".to_string())),
-    "ollama" => tokens
-      .ollama_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("llama3.1:latest".to_string())),
-    "knapsack" => tokens
-      .knapsack_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("anthropic/claude-haiku-4-5".to_string())),
-    _ => tokens
-      .openai_model
-      .clone()
-      .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("gpt-5-mini".to_string())),
-  }
 }
 
 fn tokens_path(app_handle: &tauri::AppHandle) -> PathBuf {
@@ -4400,8 +3804,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     harden_file_permissions(&path);
     let s =
       fs::read_to_string(&path).map_err(|e| format!("Failed reading {}: {}", path.display(), e))?;
-    let mut t: StoredTokens = serde_json::from_str(s.trim_start_matches('\u{feff}'))
-      .map_err(|e| format!("Failed parsing {}: {}", path.display(), e))?;
+    let mut t: StoredTokens =
+      serde_json::from_str(&s).map_err(|e| format!("Failed parsing {}: {}", path.display(), e))?;
     // Backfill any missing/empty auth tokens.  An empty gateway_token would
     // cause OpenClaw to start with `gateway.auth.token = ""`, which the
     // security audit reports as `gateway.loopback_no_auth` /
@@ -4445,11 +3849,11 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     browser_control_token,
     groq_api_key: None,
     openai_api_key: None, // User must provide their own API key
-    openai_model: None,   // Defaults to gpt-5-mini
+    openai_model: None,   // Defaults to gpt-5.4
     anthropic_api_key: None,
     anthropic_model: None, // Defaults to claude-sonnet-4-5-20250929
     gemini_api_key: None,
-    gemini_model: None, // Defaults to gemini-2.5-flash
+    gemini_model: None, // Defaults to gemini-3.5-flash
     groq_model: None,   // Defaults to meta-llama/llama-4-scout-17b-16e-instruct
     xai_api_key: None,
     xai_model: None, // Defaults to grok-code-fast-1
@@ -4461,8 +3865,6 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     ollama_base_url: None,
     extra_provider_keys: None,
     preferred_coding_agent: None,
-    knapsack_access_token: None,
-    knapsack_refresh_token: None,
     knapsack_email: None,
     knapsack_model: None,
   };
@@ -4606,19 +4008,7 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
       }
     }
   }
-  // Propagate Knapsack cloud inference settings
-  if let Some(t) = &tokens.knapsack_access_token {
-    let t = t.trim();
-    if !t.is_empty() {
-      std::env::set_var("KNAPSACK_ACCESS_TOKEN", t);
-    }
-  }
-  if let Some(rt) = &tokens.knapsack_refresh_token {
-    let rt = rt.trim();
-    if !rt.is_empty() {
-      std::env::set_var("KNAPSACK_REFRESH_TOKEN", rt);
-    }
-  }
+  // Propagate Knapsack cloud inference settings (active when user chose Knapsack as provider)
   if let Some(e) = &tokens.knapsack_email {
     let e = e.trim();
     if !e.is_empty() {
@@ -4672,12 +4062,12 @@ fn save_tokens(app_handle: &tauri::AppHandle, tokens: &StoredTokens) -> Result<(
   Ok(())
 }
 
-/// Get the configured OpenAI model (defaults to gpt-5-mini if not set)
+/// Get the configured OpenAI model (defaults to gpt-5.4 if not set)
 pub fn get_openai_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.openai_model)
-    .unwrap_or_else(|| "gpt-5-mini".to_string())
+    .unwrap_or_else(|| "gpt-5.4".to_string())
 }
 
 /// Get the configured Anthropic model (defaults to claude-sonnet-4-5-20250929 if not set)
@@ -4688,12 +4078,12 @@ pub fn get_anthropic_model(app_handle: &tauri::AppHandle) -> String {
     .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string())
 }
 
-/// Get the configured Gemini model (defaults to gemini-2.5-flash if not set)
+/// Get the configured Gemini model (defaults to gemini-3.5-flash if not set)
 pub fn get_gemini_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.gemini_model)
-    .unwrap_or_else(|| "gemini-2.5-flash".to_string())
+    .unwrap_or_else(|| "gemini-3.5-flash".to_string())
 }
 
 /// Get the configured Groq model (defaults to meta-llama/llama-4-scout-17b-16e-instruct if not set)
@@ -5237,7 +4627,6 @@ async fn run_gateway_self_heal_cycle(
         Ok(child) => {
           let pid = child.id();
           GATEWAY_PID.store(pid, Ordering::Relaxed);
-          mark_gateway_launch_started();
           *LAST_GATEWAY_SETUP.lock().unwrap() = Some(setup.clone());
           eprintln!("[clawd/service] self-heal: spawned gateway pid {}", pid);
         }
@@ -5261,10 +4650,7 @@ async fn run_gateway_self_heal_cycle(
     );
   }
 
-  let mut ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 30_000).await;
-  if !ready && gateway_tcp_port_open(std::time::Duration::from_millis(250)).await {
-    ready = true;
-  }
+  let ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 10_000).await;
   if ready {
     eprintln!("[clawd/service] self-heal: gateway healthy after recovery cycle");
     CONSECUTIVE_HEAL_FAILURES.store(0, Ordering::Relaxed);
@@ -5273,11 +4659,6 @@ async fn run_gateway_self_heal_cycle(
     GATEWAY_WAS_HEALTHY.store(true, Ordering::Relaxed);
     BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
     patch_paired_json_scopes(&app_handle);
-  } else if let Some(grace_ms) = gateway_launch_grace_active() {
-    eprintln!(
-      "[clawd/service] self-heal: gateway process is still starting after {}ms; preserving launch",
-      grace_ms
-    );
   } else {
     let failures = CONSECUTIVE_HEAL_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
     eprintln!(
@@ -5341,14 +4722,14 @@ pub(crate) fn gateway_runtime_deps_startup_in_progress() -> bool {
     return false;
   }
 
-  let Ok(content) = read_gateway_stdout_log_content() else {
+  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
     return false;
   };
   gateway_runtime_deps_startup_in_progress_from_log(&content)
 }
 
 fn gateway_post_bind_startup_in_progress() -> bool {
-  let Ok(content) = read_gateway_stdout_log_content() else {
+  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
     return false;
   };
   gateway_post_bind_startup_in_progress_from_log(&content)
@@ -5363,7 +4744,7 @@ pub(crate) fn gateway_startup_in_progress() -> bool {
     return true;
   }
 
-  let Ok(content) = read_gateway_stdout_log_content() else {
+  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
     return false;
   };
   gateway_pre_bind_startup_in_progress_from_log(&content)
@@ -5371,7 +4752,7 @@ pub(crate) fn gateway_startup_in_progress() -> bool {
 }
 
 pub(crate) fn gateway_ready_since_last_start() -> bool {
-  let Ok(content) = read_gateway_stdout_log_content() else {
+  let Ok(content) = std::fs::read_to_string(gateway_stdout_log()) else {
     return false;
   };
   gateway_ready_since_last_start_from_log(&content)
@@ -5496,97 +4877,15 @@ enum BrowserControlProbe {
 
 impl BrowserControlProbe {
   fn is_available(self) -> bool {
-    matches!(self, BrowserControlProbe::Ready)
+    matches!(
+      self,
+      BrowserControlProbe::Ready | BrowserControlProbe::Standby
+    )
   }
-}
-
-fn browser_probe_to_cache(probe: BrowserControlProbe) -> u64 {
-  match probe {
-    BrowserControlProbe::Ready => 1,
-    BrowserControlProbe::Standby => 2,
-    BrowserControlProbe::Starting => 3,
-    BrowserControlProbe::Down => 4,
-  }
-}
-
-fn browser_probe_from_cache(value: u64) -> Option<BrowserControlProbe> {
-  match value {
-    1 => Some(BrowserControlProbe::Ready),
-    2 => Some(BrowserControlProbe::Standby),
-    3 => Some(BrowserControlProbe::Starting),
-    4 => Some(BrowserControlProbe::Down),
-    _ => None,
-  }
-}
-
-fn cache_browser_control_status(probe: BrowserControlProbe) {
-  let now = now_epoch_ms();
-  BROWSER_STATUS_CACHED.store(browser_probe_to_cache(probe), Ordering::Relaxed);
-  BROWSER_STATUS_LAST_PROBE_MS.store(now, Ordering::Relaxed);
-  if probe.is_available() {
-    BROWSER_LAST_HEALTHY_MS.store(now, Ordering::Relaxed);
-  }
-}
-
-fn spawn_browser_control_status_refresh(gateway_token: String, timeout: std::time::Duration) {
-  if BROWSER_STATUS_PROBE_IN_PROGRESS
-    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-    .is_err()
-  {
-    return;
-  }
-
-  tokio::spawn(async move {
-    let mut probe = browser_control_status(&gateway_token, timeout).await;
-    if probe == BrowserControlProbe::Down {
-      probe = browser_control_status_via_gateway_rpc(timeout).await;
-    }
-    cache_browser_control_status(probe);
-    BROWSER_STATUS_PROBE_IN_PROGRESS.store(false, Ordering::Relaxed);
-  });
-}
-
-async fn browser_control_status_cached(
-  gateway_token: &str,
-  timeout: std::time::Duration,
-) -> BrowserControlProbe {
-  let now = now_epoch_ms();
-  let last_probe_ms = BROWSER_STATUS_LAST_PROBE_MS.load(Ordering::Relaxed);
-  let cached = browser_probe_from_cache(BROWSER_STATUS_CACHED.load(Ordering::Relaxed));
-  let cache_age_ms = now.saturating_sub(last_probe_ms);
-  let last_healthy_ms = BROWSER_LAST_HEALTHY_MS.load(Ordering::Relaxed);
-  let healthy_age_ms = now.saturating_sub(last_healthy_ms);
-  if last_probe_ms > 0 && cache_age_ms <= BROWSER_HEALTH_CACHE_TTL_MS {
-    if let Some(probe) = cached {
-      if probe.is_available() {
-        return probe;
-      }
-      if probe != BrowserControlProbe::Down && cache_age_ms < BROWSER_STATUS_NON_READY_REFRESH_MS {
-        return probe;
-      }
-    }
-  }
-
-  if last_probe_ms == 0
-    || cache_age_ms > BROWSER_HEALTH_CACHE_TTL_MS
-    || cache_age_ms > BROWSER_STATUS_NON_READY_REFRESH_MS
-  {
-    spawn_browser_control_status_refresh(gateway_token.to_string(), timeout);
-  }
-
-  if last_healthy_ms > 0 && healthy_age_ms <= BROWSER_HEALTH_LISTENER_GRACE_MS {
-    if cached == Some(BrowserControlProbe::Ready)
-      || browser_control_tcp_port_open(std::time::Duration::from_millis(75)).await
-    {
-      return BrowserControlProbe::Ready;
-    }
-  }
-
-  cached.unwrap_or(BrowserControlProbe::Starting)
 }
 
 async fn browser_control_status(
-  _gateway_token: &str,
+  gateway_token: &str,
   timeout: std::time::Duration,
 ) -> BrowserControlProbe {
   let client = match reqwest::Client::builder().timeout(timeout).build() {
@@ -5594,7 +4893,11 @@ async fn browser_control_status(
     Err(_) => return BrowserControlProbe::Down,
   };
 
-  let fut = client.get("http://127.0.0.1:18791/ready").send();
+  let fut = client
+    .get("http://127.0.0.1:18791/")
+    .query(&[("profile", "openclaw")])
+    .bearer_auth(gateway_token)
+    .send();
 
   let resp = match tokio::time::timeout(timeout, fut).await {
     Ok(Ok(resp)) => resp,
@@ -5619,22 +4922,7 @@ async fn browser_control_status(
     return BrowserControlProbe::Down;
   }
 
-  let body = match resp.text().await {
-    Ok(body) => body,
-    Err(e) => {
-      eprintln!(
-        "[clawd/service] browser control status probe failed to read body: {}",
-        e
-      );
-      return BrowserControlProbe::Down;
-    }
-  };
-
-  if body.trim().eq_ignore_ascii_case("OK") {
-    return BrowserControlProbe::Ready;
-  }
-
-  match serde_json::from_str::<serde_json::Value>(&body) {
+  match resp.json::<serde_json::Value>().await {
     Ok(value) => {
       let running = value
         .get("running")
@@ -5685,6 +4973,9 @@ async fn browser_control_status_via_gateway_rpc(
         "[clawd/service] browser control gateway probe failed: {}",
         e
       );
+      if browser_control_tcp_port_open(std::time::Duration::from_millis(250)).await {
+        return BrowserControlProbe::Standby;
+      }
       return BrowserControlProbe::Down;
     }
     Err(_) => {
@@ -5692,6 +4983,9 @@ async fn browser_control_status_via_gateway_rpc(
         "[clawd/service] browser control gateway probe timed out ({}ms)",
         timeout.as_millis()
       );
+      if browser_control_tcp_port_open(std::time::Duration::from_millis(250)).await {
+        return BrowserControlProbe::Standby;
+      }
       return BrowserControlProbe::Down;
     }
   };
@@ -5738,7 +5032,7 @@ async fn browser_control_start_direct(
   }
 }
 
-fn spawn_startup_browser_start_nudge(gateway_token: String, app_handle: tauri::AppHandle) {
+fn spawn_startup_browser_start_nudge(gateway_token: String) {
   if !startup_ready_browser_start_enabled() {
     return;
   }
@@ -5753,84 +5047,24 @@ fn spawn_startup_browser_start_nudge(gateway_token: String, app_handle: tauri::A
     let budget = std::time::Duration::from_secs(12);
     let mut last_error: Option<String> = None;
 
-    if startup_ready_direct_chrome_enabled()
-      && !browser_cdp_port_open(std::time::Duration::from_millis(100)).await
-    {
-      #[cfg(any(target_os = "macos", target_os = "windows"))]
-      {
-        kill_stale_clawdbot_chromes();
-        match start_openclaw_chrome_direct(&app_handle) {
-          Ok(()) => {
-            eprintln!("[clawd/service] startup-ready launched OpenClaw Chrome profile directly");
-          }
-          Err(e) => {
-            last_error = Some(format!("direct OpenClaw Chrome launch failed: {}", e));
-          }
-        }
-      }
-    }
-
     while started_at.elapsed() < budget {
       if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
         eprintln!("[clawd/service] startup-ready browser nudge: CDP already reachable");
         return;
       }
 
-      if browser_control_status(&gateway_token, std::time::Duration::from_millis(250))
+      match browser_control_start_direct(&gateway_token, std::time::Duration::from_millis(900))
         .await
-        .is_available()
       {
-        eprintln!(
-          "[clawd/service] startup-ready browser nudge: browser-control HTTP already reachable"
-        );
-        return;
-      } else {
-        if browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await {
-          match tokio::time::timeout(
-            std::time::Duration::from_millis(1500),
-            browser_control_start_direct(&gateway_token, std::time::Duration::from_millis(1200)),
-          )
-          .await
-          {
-            Ok(Ok(())) => {
-              eprintln!("[clawd/service] startup-ready browser direct /start nudge succeeded");
-              return;
-            }
-            Ok(Err(e)) => {
-              last_error = Some(format!("browser-control direct /start failed: {}", e));
-            }
-            Err(_) => {
-              last_error = Some("browser-control direct /start timed out".to_string());
-            }
-          }
+        Ok(()) => {
+          eprintln!("[clawd/service] startup-ready browser /start nudge succeeded");
+          return;
         }
-
-        match tokio::time::timeout(
-          std::time::Duration::from_millis(1500),
-          gateway_client::browser_request(
-            "POST",
-            "/start",
-            Some(serde_json::json!({"profile": "openclaw"})),
-            None,
-            None,
-          ),
-        )
-        .await
-        {
-          Ok(Ok(_)) => {
-            eprintln!("[clawd/service] startup-ready browser gateway /start nudge succeeded");
-            return;
-          }
-          Ok(Err(e)) => {
-            last_error = Some(e.to_string());
-          }
-          Err(_) => {
-            last_error = Some("gateway browser /start timed out".to_string());
-          }
+        Err(e) => {
+          last_error = Some(e);
+          tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
       }
-
-      tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 
     if let Some(e) = last_error {
@@ -5865,77 +5099,6 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
   })?;
 
   std::process::Command::new(chrome)
-    .arg("--remote-debugging-port=18800")
-    .arg(format!(
-      "--user-data-dir={}",
-      user_data_dir.to_string_lossy()
-    ))
-    .arg("--profile-directory=Default")
-    .arg("--no-first-run")
-    .arg("--no-default-browser-check")
-    .arg("--disable-background-networking")
-    .arg("--disable-features=Translate,OptimizationHints,MediaRouter")
-    .arg("--disable-sync")
-    .arg("--no-proxy-server")
-    .arg("about:blank")
-    .stdin(Stdio::null())
-    .stdout(Stdio::null())
-    .stderr(Stdio::null())
-    .spawn()
-    .map(|_| ())
-    .map_err(|e| format!("failed to launch OpenClaw Chrome profile: {}", e))
-}
-
-#[cfg(target_os = "windows")]
-fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), String> {
-  let program_files =
-    std::env::var("PROGRAMFILES").unwrap_or_else(|_| r"C:\Program Files".to_string());
-  let program_files_x86 =
-    std::env::var("PROGRAMFILES(X86)").unwrap_or_else(|_| r"C:\Program Files (x86)".to_string());
-  let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_default();
-  let candidates = [
-    format!(r"{}\Google\Chrome\Application\chrome.exe", program_files),
-    format!(
-      r"{}\Google\Chrome\Application\chrome.exe",
-      program_files_x86
-    ),
-    format!(r"{}\Google\Chrome\Application\chrome.exe", local_appdata),
-    format!(
-      r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
-      program_files
-    ),
-    format!(
-      r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
-      program_files_x86
-    ),
-    format!(
-      r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
-      local_appdata
-    ),
-    format!(r"{}\Microsoft\Edge\Application\msedge.exe", program_files),
-    format!(
-      r"{}\Microsoft\Edge\Application\msedge.exe",
-      program_files_x86
-    ),
-  ];
-  let browser = candidates
-    .iter()
-    .find(|candidate| Path::new(candidate).exists())
-    .ok_or_else(|| "Chrome/Brave/Edge app binary was not found".to_string())?;
-
-  let user_data_dir = app_clawdbot_home(app_handle)
-    .join("browser")
-    .join("openclaw")
-    .join("user-data");
-  fs::create_dir_all(&user_data_dir).map_err(|e| {
-    format!(
-      "failed to create OpenClaw Chrome profile at {}: {}",
-      user_data_dir.display(),
-      e
-    )
-  })?;
-
-  std::process::Command::new(browser)
     .arg("--remote-debugging-port=18800")
     .arg(format!(
       "--user-data-dir={}",
@@ -6010,28 +5173,23 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       }
     };
 
-    let last_gateway_healthy_ms = GATEWAY_LAST_HEALTHY_MS.load(Ordering::Relaxed);
-    let gateway_healthy_age_ms = now_epoch_ms().saturating_sub(last_gateway_healthy_ms);
-    let recent_gateway_ok =
-      last_gateway_healthy_ms > 0 && gateway_healthy_age_ms <= HEALTH_LAST_GOOD_GRACE_MS;
-    let gateway_listener_fast = gateway_tcp_port_open(std::time::Duration::from_millis(50)).await;
-
-    // Gateway health is intentionally unauthenticated. Once the gateway has
-    // recently answered and its listener is still alive, avoid queueing another
-    // gateway request on every UI health poll.
-    let gateway_http_ok = if recent_gateway_ok && gateway_listener_fast {
-      true
-    } else if !gateway_listener_fast {
-      false
-    } else {
-      gateway_reachable_with_token(GATEWAY_LOCAL_HEALTH_TIMEOUT, Some(&tokens.gateway_token)).await
-    };
+    // Gateway health is intentionally unauthenticated. Prefer the HTTP probe,
+    // but accept the gateway listener once browser control is also listening;
+    // channel startup can temporarily starve `/health` after the usable
+    // gateway/browser path is already online.
+    let gateway_http_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
     let mut gateway_ok = gateway_http_ok;
     let gateway_listening = if gateway_ok {
       true
     } else {
-      gateway_listener_fast || gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
+      gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
     };
+    if !gateway_ok
+      && gateway_listening
+      && browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
+    {
+      gateway_ok = true;
+    }
     #[cfg(target_os = "windows")]
     if !gateway_ok && gateway_listening {
       if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
@@ -6047,27 +5205,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         }
       }
     }
-    if !gateway_ok && gateway_listening {
-      let last_healthy_ms = GATEWAY_LAST_HEALTHY_MS.load(Ordering::Relaxed);
-      let healthy_age_ms = now_epoch_ms().saturating_sub(last_healthy_ms);
-      if last_healthy_ms > 0 && healthy_age_ms <= HEALTH_LAST_GOOD_GRACE_MS {
-        eprintln!(
-          "[clawd/service] gateway health probe timed out; keeping last-known-good state for {}ms",
-          healthy_age_ms
-        );
-        gateway_ok = true;
-      }
-    }
-    if !gateway_ok
-      && gateway_listening
-      && browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
-    {
-      eprintln!(
-        "[clawd/service] gateway /health is pending, but gateway and browser-control listeners are active; keeping desktop health green"
-      );
-      gateway_ok = true;
-    }
-    let gateway_probe_failed = !gateway_http_ok;
+    let gateway_probe_failed = !gateway_ok;
 
     // Track gateway state transitions for recovery logic.
     let was_healthy = GATEWAY_WAS_HEALTHY.load(Ordering::Relaxed);
@@ -6103,9 +5241,6 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     if gateway_ok {
       // Gateway is up — record it so we can detect down→up transitions.
       GATEWAY_WAS_HEALTHY.store(true, Ordering::Relaxed);
-      if gateway_http_ok {
-        GATEWAY_LAST_HEALTHY_MS.store(now_epoch_ms(), Ordering::Relaxed);
-      }
       GATEWAY_UNREACHABLE_SINCE_MS.store(0, Ordering::Relaxed);
       GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
       QA_DIRECT_GATEWAY_FIRST_SEEN_MS.store(0, Ordering::Relaxed);
@@ -6173,10 +5308,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         "[clawd/service] gateway not reachable for {}ms after launch - waiting before self-heal",
         elapsed
       );
-    } else if !gateway_ok
-      && gateway_listening
-      && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS
-    {
+    } else if !gateway_ok && gateway_listening && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS {
       eprintln!(
         "[clawd/service] gateway port is listening but health is still pending for {}ms - waiting before self-heal",
         unreachable_elapsed_ms
@@ -6240,29 +5372,45 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     let browser_probe_timeout = std::time::Duration::from_millis(2500);
 
     let mut browser_probe = if gateway_ok {
-      browser_control_status_cached(&tokens.gateway_token, browser_probe_timeout).await
+      if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
+        BrowserControlProbe::Ready
+      } else if BROWSER_STATUS_PROBE_IN_PROGRESS
+        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
+      {
+        // Use the gateway RPC as the authoritative browser-control probe. The
+        // direct control port can have a distinct auth surface and return 401
+        // even when browser.request works correctly through the gateway.
+        let mut probe = browser_control_status_via_gateway_rpc(browser_probe_timeout).await;
+        if probe == BrowserControlProbe::Down {
+          probe = browser_control_status(&tokens.gateway_token, browser_probe_timeout).await;
+        }
+        BROWSER_STATUS_PROBE_IN_PROGRESS.store(false, Ordering::Relaxed);
+        probe
+      } else {
+        // Another health request is already doing the slower gateway RPC probe.
+        // If browser-control is listening, treat it as standby so concurrent
+        // polls do not surface a false "browser down" card.
+        if browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await {
+          BrowserControlProbe::Standby
+        } else {
+          BrowserControlProbe::Starting
+        }
+      }
     } else {
       BrowserControlProbe::Down
     };
     if gateway_ok
       && browser_probe == BrowserControlProbe::Down
+      && browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
+    {
+      browser_probe = BrowserControlProbe::Standby;
+    }
+    if gateway_ok
+      && browser_probe == BrowserControlProbe::Down
       && browser_cdp_port_open(std::time::Duration::from_millis(250)).await
     {
       browser_probe = BrowserControlProbe::Ready;
-    }
-    if gateway_ok && !browser_probe.is_available() {
-      let last_healthy_ms = BROWSER_LAST_HEALTHY_MS.load(Ordering::Relaxed);
-      let healthy_age_ms = now_epoch_ms().saturating_sub(last_healthy_ms);
-      if last_healthy_ms > 0
-        && healthy_age_ms <= HEALTH_LAST_GOOD_GRACE_MS
-        && browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
-      {
-        eprintln!(
-          "[clawd/service] browser health probe timed out; keeping last-known-good state for {}ms",
-          healthy_age_ms
-        );
-        browser_probe = BrowserControlProbe::Ready;
-      }
     }
     let browser_ok = browser_probe.is_available();
 
@@ -6272,7 +5420,6 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     let browser_was_healthy = BROWSER_WAS_HEALTHY.load(Ordering::Relaxed);
     if browser_ok {
       BROWSER_WAS_HEALTHY.store(true, Ordering::Relaxed);
-      BROWSER_LAST_HEALTHY_MS.store(now_epoch_ms(), Ordering::Relaxed);
     } else if browser_was_healthy {
       // Browser just went from healthy → down (crashed).
       BROWSER_WAS_HEALTHY.store(false, Ordering::Relaxed);
@@ -6297,7 +5444,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       let nudge_app_handle: tauri::AppHandle = app_handle.get_ref().clone();
       tokio::spawn(async move {
         if qa_direct_gateway_mode() {
-          #[cfg(any(target_os = "macos", target_os = "windows"))]
+          #[cfg(target_os = "macos")]
           {
             match start_openclaw_chrome_direct(&nudge_app_handle) {
               Ok(()) => {
@@ -6316,7 +5463,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
             return;
           }
 
-          #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+          #[cfg(not(target_os = "macos"))]
           {
             eprintln!(
               "[clawd/service] QA direct browser nudge is not implemented on this platform"
@@ -6551,25 +5698,22 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       let legacy_err_path = std::path::PathBuf::from("/tmp/knapsack-clawdbot.err.log");
       let log_content =
         read_log_tail_lines_bounded(&[err_path.clone(), legacy_err_path], 256 * 1024, 400);
-      let has_version_mismatch = log_content.as_ref().ok().is_some_and(|content| {
-        content.lines().any(|l| {
-          let l = l.to_ascii_lowercase();
-          l.contains("config was last written by a newer openclaw")
-            || l.contains("config was last written by an older openclaw")
-            || l.contains("your openclaw config was written by version")
-            || l.contains("refusing to start the gateway service because this openclaw binary")
-        })
-      });
-      if has_version_mismatch {
-        diagnostic_type = Some("version_mismatch".to_string());
-      }
-      if (runtime_deps_startup || launch_grace_elapsed_ms.is_some() || qa_direct_gateway_mode())
-        && !has_version_mismatch
-      {
+      if runtime_deps_startup || launch_grace_elapsed_ms.is_some() || qa_direct_gateway_mode() {
         // During active startup the stderr file commonly contains stale lines
         // from previous gateway runs. Showing/classifying those makes the UI
         // report old crashes while the current gateway is still booting.
       } else if let Ok(content) = log_content {
+        // Detect version mismatch before noise-filtering so we can tag diagnostic_type,
+        // even though the lines are stripped from the user-visible tail below.
+        let has_version_mismatch = content.lines().any(|l| {
+          let l = l.to_ascii_lowercase();
+          l.contains("config was last written by a newer openclaw")
+            || l.contains("config was last written by an older openclaw")
+        });
+        if has_version_mismatch && diagnostic_type.is_none() {
+          diagnostic_type = Some("version_mismatch".to_string());
+        }
+
         // Strip known-noisy lines that appear during normal gateway operation
         // and would only confuse users when shown as a diagnostic.
         let is_noise = |line: &str| {
@@ -6581,8 +5725,6 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
             || (l.contains("security warning") && l.contains("allowinsecureauth"))
             || l.contains("config was last written by a newer openclaw")
             || l.contains("config was last written by an older openclaw")
-            || l.contains("your openclaw config was written by version")
-            || l.contains("refusing to start the gateway service because this openclaw binary")
         };
         let all_filtered: Vec<&str> = content.lines().filter(|l| !is_noise(l)).collect();
         let start = all_filtered.len().saturating_sub(25);
@@ -6655,8 +5797,8 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
   use crate::clawd::gateway_ws;
 
-  const STARTUP_READY_BUDGET_MS: u64 = 1_500;
-  const GATEWAY_READY_BUDGET_MS: u64 = 250;
+  const STARTUP_READY_BUDGET_MS: u64 = 30_000;
+  const GATEWAY_READY_BUDGET_MS: u64 = 26_000;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -6675,19 +5817,10 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   };
 
   let started_at = std::time::Instant::now();
-  let should_nudge_browser = if startup_ready_browser_start_enabled() {
-    if browser_control_tcp_port_open(std::time::Duration::from_millis(50)).await {
-      !browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
-        .await
-        .is_available()
-    } else {
-      true
-    }
-  } else {
-    false
-  };
-  if should_nudge_browser {
-    spawn_startup_browser_start_nudge(tokens.gateway_token.clone(), app_handle.get_ref().clone());
+  if startup_ready_browser_start_enabled()
+    && !browser_cdp_port_open(std::time::Duration::from_millis(100)).await
+  {
+    spawn_startup_browser_start_nudge(tokens.gateway_token.clone());
   }
 
   #[cfg(target_os = "macos")]
@@ -6725,39 +5858,15 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       }
     }
   }
-  #[cfg(target_os = "windows")]
-  if !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
-    if let Some(grace_ms) = gateway_launch_grace_active_with_live_process() {
-      eprintln!(
-        "[clawd/service] startup-ready: Windows gateway launch already in progress for {}ms; waiting",
-        grace_ms
-      );
-    } else if GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
-      eprintln!(
-        "[clawd/service] startup-ready: Windows gateway lifecycle operation already in progress; waiting"
-      );
-    } else {
-      eprintln!("[clawd/service] startup-ready: scheduling Windows gateway start");
-      let ah = app_handle.get_ref().clone();
-      tokio::spawn(async move {
-        auto_enable_if_needed(&ah).await;
-      });
-    }
-  }
-
-  let mut ready = false;
   let ready_started_at = std::time::Instant::now();
+  let mut ready = false;
   while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
-    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
-      ready = true;
-      break;
-    }
-    if gateway_reachable_or_ready(std::time::Duration::from_millis(150)).await {
+    if gateway_reachable_or_ready(std::time::Duration::from_millis(1000)).await {
       ready = true;
       break;
     }
     if tokio::time::timeout(
-      std::time::Duration::from_millis(250),
+      std::time::Duration::from_millis(3500),
       gateway_ws::config_get(Some(&tokens.gateway_token)),
     )
     .await
@@ -6767,98 +5876,71 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       ready = true;
       break;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
   }
 
-  let mut browser_ok = false;
-  let mut channels_ok = !eager_channel_plugin_start_enabled();
   let remaining_ms =
     || STARTUP_READY_BUDGET_MS.saturating_sub(started_at.elapsed().as_millis() as u64);
-  let remaining_timeout =
-    |max_ms: u64| std::time::Duration::from_millis(remaining_ms().min(max_ms).max(50));
 
-  while started_at.elapsed().as_millis() < u128::from(STARTUP_READY_BUDGET_MS) {
-    if !ready && gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
-      ready = true;
-    }
-
-    if !ready && gateway_reachable_or_ready(remaining_timeout(300)).await {
-      ready = true;
-    }
-
-    if !ready
-      && tokio::time::timeout(
-        remaining_timeout(300),
-        gateway_ws::config_get(Some(&tokens.gateway_token)),
-      )
-      .await
-      .map(|result| result.is_ok())
-      .unwrap_or(false)
-    {
-      ready = true;
-    }
-
-    if !browser_ok && remaining_ms() > STARTUP_BROWSER_POLL_INTERVAL_MS {
-      let probe_timeout = std::time::Duration::from_millis(STARTUP_BROWSER_PROBE_TIMEOUT_MS);
-      let browser_port_ready = browser_control_tcp_port_open(std::time::Duration::from_millis(300))
-        .await
-        || browser_cdp_port_open(std::time::Duration::from_millis(300)).await;
-
-      if browser_port_ready {
-        browser_ok = true;
-        cache_browser_control_status(BrowserControlProbe::Ready);
-      } else {
-        let cached_probe =
-          browser_control_status_cached(&tokens.gateway_token, probe_timeout).await;
-        if cached_probe.is_available() {
-          browser_ok = true;
-        } else {
-          let direct_probe = browser_control_status(&tokens.gateway_token, probe_timeout).await;
-          cache_browser_control_status(direct_probe);
-          if direct_probe.is_available() {
-            browser_ok = true;
-          }
+  let browser_ok = if ready {
+    if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
+      true
+    } else {
+      let mut probe =
+        browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(6000)).await;
+      if probe == BrowserControlProbe::Down {
+        probe =
+          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
+            .await;
+      }
+      if probe == BrowserControlProbe::Down
+        && startup_ready_browser_start_enabled()
+        && remaining_ms() > 1500
+      {
+        BROWSER_LAST_NUDGE_MS.store(now_epoch_ms(), Ordering::Relaxed);
+        let _ = browser_control_start_direct(
+          &tokens.gateway_token,
+          std::time::Duration::from_millis(900),
+        )
+        .await;
+        probe =
+          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
+            .await;
+      }
+      while probe != BrowserControlProbe::Ready && remaining_ms() > 1800 {
+        if probe == BrowserControlProbe::Standby && !startup_ready_browser_start_enabled() {
+          break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        probe =
+          browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(6000)).await;
+        if probe == BrowserControlProbe::Down {
+          probe =
+            browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
+              .await;
         }
       }
-
-      if !browser_ok {
-        spawn_startup_browser_start_nudge(
-          tokens.gateway_token.clone(),
-          app_handle.get_ref().clone(),
-        );
-      }
+      probe.is_available()
     }
+  } else {
+    false
+  };
 
-    if ready && !channels_ok && remaining_ms() > 500 {
-      if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp")
-      {
-        channels_ok = true;
-      }
-    }
-
-    if ready && browser_ok && channels_ok {
+  let mut channels_ok = false;
+  while ready && remaining_ms() > 500 {
+    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp")
+    {
+      channels_ok = true;
       break;
     }
-
-    tokio::time::sleep(std::time::Duration::from_millis(if ready {
-      STARTUP_BROWSER_POLL_INTERVAL_MS
-    } else {
-      100
-    }))
-    .await;
-  }
-
-  if !browser_ok
-    && ready
-    && (browser_control_tcp_port_open(std::time::Duration::from_millis(300)).await
-      || browser_cdp_port_open(std::time::Duration::from_millis(300)).await)
-  {
-    browser_ok = true;
-    cache_browser_control_status(BrowserControlProbe::Ready);
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
   }
 
   let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
-  let success = ready && browser_ok && channels_ok;
+  // Startup-ready is the desktop gateway-live gate. Browser and channel warmup
+  // are reported separately so slow or degraded integrations do not keep the
+  // local gateway false.
+  let success = ready;
 
   HttpResponse::Ok().json(ServiceHealthResponse {
     success,
@@ -6867,9 +5949,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     browser_ok,
     channels_ok: Some(channels_ok),
     startup_elapsed_ms: Some(elapsed_ms),
-    message: if ready && browser_ok && channels_ok && !eager_channel_plugin_start_enabled() {
-      "Gateway and browser are ready; channel plugins are deferred until opened".to_string()
-    } else if ready && browser_ok && channels_ok {
+    message: if ready && browser_ok && channels_ok {
       "Gateway, browser, and channels are ready".to_string()
     } else if ready && browser_ok {
       "Gateway and browser are ready; channels are still starting up".to_string()
@@ -7211,12 +6291,11 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     .unwrap_or(false);
   let ollama_enabled = tokens.ollama_enabled.unwrap_or(false);
   let (has_gemini_cli, gemini_cli_email) = read_gemini_cli_auth(&app_handle);
-  let has_knapsack = tokens.active_provider.as_deref() == Some("knapsack")
-    || tokens
-      .knapsack_email
-      .as_ref()
-      .map(|e| !e.trim().is_empty())
-      .unwrap_or(false);
+  let has_knapsack = tokens
+    .knapsack_email
+    .as_ref()
+    .map(|e| !e.trim().is_empty())
+    .unwrap_or(false);
   let has_key = has_openai
     || has_anthropic
     || has_gemini
@@ -7227,7 +6306,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     || has_gemini_cli
     || has_knapsack;
 
-  let model = active_provider_model(&tokens);
+  let model = tokens.openai_model.clone();
   let active_provider = tokens.active_provider.clone();
 
   let openai_hint = tokens
@@ -7503,10 +6582,6 @@ pub struct SetApiKeyRequest {
   /// Preferred coding CLI agent: "claude", "codex", "antigravity", "gemini", or "opencode".
   /// When provided alongside or without a key change, updates the stored preference.
   pub preferred_coding_agent: Option<String>,
-  /// Knapsack provider: the JWT refresh token (stored alongside the access token in `key`).
-  pub refresh_token: Option<String>,
-  /// Knapsack provider: the user's email, for display only.
-  pub email: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -7517,31 +6592,13 @@ pub struct SetApiKeyResponse {
 
 fn normalize_coding_agent(agent: &str) -> Option<String> {
   let agent = agent.trim().to_lowercase();
-  if [
-    "claude",
-    "codex",
-    "antigravity",
-    "agy",
-    "gemini",
-    "grok",
-    "opencode",
-  ]
-  .contains(&agent.as_str())
-  {
+  if ["claude", "codex", "antigravity", "agy", "gemini", "grok", "opencode"].contains(&agent.as_str()) {
     if agent == "agy" {
       return Some("antigravity".to_string());
     }
     Some(agent)
   } else {
     None
-  }
-}
-
-fn normalize_provider_id(raw_provider: &str) -> String {
-  let provider = raw_provider.trim().to_lowercase();
-  match provider.as_str() {
-    "google" | "google-gemini" | "google-gemini-cli" => "gemini".to_string(),
-    _ => provider,
   }
 }
 
@@ -7561,7 +6618,11 @@ pub async fn set_api_key(
   };
 
   let key = payload.key.trim().to_string();
-  let provider = normalize_provider_id(payload.provider.as_deref().unwrap_or("openai"));
+  let provider = payload
+    .provider
+    .as_deref()
+    .unwrap_or("openai")
+    .to_lowercase();
 
   if key.is_empty() && payload.model.is_none() && payload.env_var.is_none() {
     if let Some(agent) = &payload.preferred_coding_agent {
@@ -7628,12 +6689,19 @@ pub async fn set_api_key(
         .groq_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
-      "xai" => tokens.xai_api_key.as_ref().map_or(false, |k| !k.is_empty()),
+      "xai" => tokens
+        .xai_api_key
+        .as_ref()
+        .map_or(false, |k| !k.is_empty()),
       "openrouter" => tokens
         .openrouter_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
-      "ollama" | "knapsack" => true,
+      "ollama" => true,
+      "knapsack" => tokens
+        .knapsack_email
+        .as_ref()
+        .map_or(false, |e| !e.is_empty()),
       _ => tokens
         .openai_api_key
         .as_ref()
@@ -7645,10 +6713,6 @@ pub async fn set_api_key(
         message: "API key cannot be empty".to_string(),
       });
     }
-    // If the provider isn't actually changing, skip the gateway restart — it's
-    // already running with the correct configuration.  A restart here would
-    // fail in dev mode (launchctl exit 37) and trigger a destructive self-heal.
-    let already_active = tokens.active_provider.as_deref().unwrap_or("openai") == provider.as_str();
     // Switch active provider and update model only
     tokens.active_provider = Some(provider.clone());
     if let Some(model) = &payload.model {
@@ -7672,7 +6736,7 @@ pub async fn set_api_key(
           tokens.ollama_model = Some(model.trim().to_string());
         }
         "knapsack" => {
-          tokens.knapsack_model = Some("auto".to_string());
+          tokens.knapsack_model = Some(model.trim().to_string());
         }
         _ => {
           tokens.openai_model = Some(model.trim().to_string());
@@ -7784,16 +6848,6 @@ pub async fn set_api_key(
     // updates the default model but does NOT re-run provider discovery, so
     // the old provider (e.g. Ollama) stays in the catalog and the gateway
     // keeps routing requests through it.
-    if already_active {
-      eprintln!(
-        "[clawd/service] Provider '{}' is already active — skipping gateway restart",
-        provider
-      );
-      return HttpResponse::Ok().json(SetApiKeyResponse {
-        success: true,
-        message: format!("Switched to {}", provider_name),
-      });
-    }
     let switch_model = crate::clawd::gateway_client::resolve_default_model();
     eprintln!(
       "[clawd/service] Provider switch to '{}' (model: {}) — restarting gateway for provider re-discovery",
@@ -7807,8 +6861,7 @@ pub async fn set_api_key(
     #[cfg(target_os = "macos")]
     {
       if let Ok(plist_path) = launch_agent_plist_path() {
-        refresh_launch_agent_plist_for_restart(app_handle.get_ref(), "provider switch restart")
-          .await;
+        regenerate_macos_plist_with_current_env(&plist_path);
         if qa_direct_gateway_mode() {
           bootout_gateway_launch_agent(LAUNCH_AGENT_LABEL);
           let qa_switch_model = switch_model.clone();
@@ -7915,19 +6968,11 @@ pub async fn set_api_key(
     }
     "knapsack" => {
       // Knapsack cloud inference: key field carries the user's email (no API key needed)
-      if !key.is_empty() {
-        tokens.knapsack_email = Some(key);
-      } else if tokens
-        .knapsack_email
-        .as_ref()
-        .map_or(true, |e| e.trim().is_empty())
-      {
-        if let Some(email) = knapsack_email_from_tokens() {
-          tokens.knapsack_email = Some(email);
-        }
-      }
+      tokens.knapsack_email = Some(key);
       tokens.active_provider = Some("knapsack".to_string());
-      tokens.knapsack_model = Some("auto".to_string());
+      if let Some(model) = &payload.model {
+        tokens.knapsack_model = Some(model.trim().to_string());
+      }
       "Knapsack"
     }
     "minimax" | "zai" | "huggingface" => {
@@ -7963,7 +7008,7 @@ pub async fn set_api_key(
     _ => {
       tokens.openai_api_key = Some(key);
       tokens.active_provider = Some("openai".to_string());
-      // Save model if provided, default to gpt-5-mini
+      // Save model if provided, default to gpt-5.4
       if let Some(model) = &payload.model {
         tokens.openai_model = Some(model.trim().to_string());
       }
@@ -8124,7 +7169,7 @@ pub async fn set_api_key(
       // so the gateway picks up the updated env vars.  Just bootout + relying on
       // the health-check is not enough because the health-check uses kickstart
       // which re-uses the old (stale) plist.
-      refresh_launch_agent_plist_for_restart(app_handle.get_ref(), "api key restart").await;
+      regenerate_macos_plist_with_current_env(&plist_path);
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -8419,7 +7464,7 @@ pub async fn ollama_configure(
   #[cfg(target_os = "macos")]
   {
     if let Ok(plist_path) = launch_agent_plist_path() {
-      refresh_launch_agent_plist_for_restart(app_handle.get_ref(), "ollama restart").await;
+      regenerate_macos_plist_with_current_env(&plist_path);
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -8433,10 +7478,6 @@ pub async fn ollama_configure(
       let _ = std::process::Command::new("launchctl")
         .args(["kickstart", "-k", &service])
         .status();
-      // Mark the gateway as launched so set_service_enabled (called by the
-      // frontend immediately after) sees the grace period active and returns
-      // early instead of doing a second full restart with blocking sleeps.
-      mark_gateway_launch_started();
     }
   }
 
@@ -8605,7 +7646,6 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
     }
   };
 
-  let model = active_provider_model(&tokens);
   let openai_key = tokens.openai_api_key.filter(|k| !k.trim().is_empty());
   let anthropic_key = tokens.anthropic_api_key.filter(|k| !k.trim().is_empty());
   let gemini_key = tokens.gemini_api_key.filter(|k| !k.trim().is_empty());
@@ -8623,8 +7663,8 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
   HttpResponse::Ok().json(GetApiKeyResponse {
     success: true,
     key,
-    model,
-    active_provider: tokens.active_provider.clone(),
+    model: tokens.openai_model,
+    active_provider: tokens.active_provider,
     openai_key,
     anthropic_key,
     gemini_key,
@@ -8836,7 +7876,6 @@ async fn prepare_gateway_config(
   app_handle: &tauri::AppHandle,
   cfg: &SharedClawdbotConfig,
 ) -> Result<ServiceSetup, String> {
-  let prepare_started = std::time::Instant::now();
   let tokens = load_or_create_tokens(app_handle)?;
 
   fn first_existing(paths: &[PathBuf]) -> Option<PathBuf> {
@@ -8911,23 +7950,16 @@ async fn prepare_gateway_config(
       return Err("Node.js not found. The bundled Node.js binary is missing and no system Node.js was found. Please reinstall Knapsack or install Node.js (https://nodejs.org).".to_string());
     }
   };
-  let node_ready_started = std::time::Instant::now();
   if let Err(e) = ensure_node_binary_ready(&node_path) {
     eprintln!("[clawd/service] ERROR: {}", e);
     return Err(format!("Node.js is not usable for the gateway. {}", e));
   }
-  eprintln!(
-    "[clawd/service] prepare_gateway_config: node readiness check completed in {}ms",
-    node_ready_started.elapsed().as_millis()
-  );
 
   // ── Find clawdbot entry ────────────────────────────────────────────
   let clawdbot_entry = if cfg!(debug_assertions) {
     if cfg!(target_os = "windows") {
-      let bundled_entry = resource_path(
-        app_handle,
-        "resources/clawdbot/dist/knapsack-gateway-entry.js",
-      );
+      let bundled_entry =
+        resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js");
       if bundled_entry.exists() {
         bundled_entry
       } else {
@@ -8951,10 +7983,7 @@ async fn prepare_gateway_config(
       }
     }
   } else {
-    resource_path(
-      app_handle,
-      "resources/clawdbot/dist/knapsack-gateway-entry.js",
-    )
+    resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js")
   };
 
   if !clawdbot_entry.exists() {
@@ -8971,18 +8000,6 @@ async fn prepare_gateway_config(
     "[clawd/service] Using Clawdbot entry: {}",
     clawdbot_entry.display()
   );
-  #[cfg(target_os = "windows")]
-  if cfg!(debug_assertions) {
-    schedule_clawdbot_runtime_self_link_warmup(
-      clawdbot_entry.clone(),
-      "prepare_gateway_config",
-    );
-  } else {
-    eprintln!(
-      "[clawd/service] Skipping bundled runtime self-link mutation on Windows release startup"
-    );
-  }
-  #[cfg(not(target_os = "windows"))]
   ensure_clawdbot_runtime_self_link(&clawdbot_entry);
 
   let clawdbot_home = app_clawdbot_home(app_handle);
@@ -9008,31 +8025,15 @@ async fn prepare_gateway_config(
     // Without this, the OpenClaw gateway falls back to its compiled default
     // (openai/gpt-5.4) and every request fails with "No API key found for
     // provider openai" for any user who doesn't have an OpenAI key.
-    let mut agents_defaults = serde_json::json!({
-      "defaults": {
-      },
-      "list": [{
-        "id": "main",
-        "default": true,
-        "name": "Knapsack",
-        "identity": {
-          "name": "Knapsack",
-          "theme": "helpful assistant",
-          "emoji": "🎒"
+    let agents_defaults = if any_provider_key_available() {
+      serde_json::json!({
+        "defaults": {
+          "model": crate::clawd::gateway_client::build_model_config()
         }
-      }]
-    });
-    if any_provider_key_available() {
-      if let Some(defaults) = agents_defaults
-        .pointer_mut("/defaults")
-        .and_then(|v| v.as_object_mut())
-      {
-        defaults.insert(
-          "model".to_string(),
-          crate::clawd::gateway_client::build_model_config(),
-        );
-      }
-    }
+      })
+    } else {
+      serde_json::Value::Null
+    };
     let mut default_config = serde_json::json!({
       "gateway": {
         "mode": "local",
@@ -9059,7 +8060,7 @@ async fn prepare_gateway_config(
         "defaultProfile": "openclaw" // managed, isolated profile
       },
       "plugins": {
-        "allow": KNAPSACK_CORE_STARTUP_PLUGINS,
+        "allow": KNAPSACK_REQUIRED_PLUGINS,
         "slots": {
           "memory": "none"
         }
@@ -9087,10 +8088,12 @@ async fn prepare_gateway_config(
         }
       }
     });
-    default_config
-      .as_object_mut()
-      .unwrap()
-      .insert("agents".to_string(), agents_defaults);
+    if !agents_defaults.is_null() {
+      default_config
+        .as_object_mut()
+        .unwrap()
+        .insert("agents".to_string(), agents_defaults);
+    }
     match fs::write(
       &config_path,
       serde_json::to_string_pretty(&default_config).unwrap_or_default(),
@@ -9106,11 +8109,6 @@ async fn prepare_gateway_config(
       ),
     }
     harden_file_permissions(&config_path);
-  } else if cfg!(target_os = "windows") && !cfg!(debug_assertions) {
-    harden_file_permissions(&config_path);
-    eprintln!(
-      "[clawd/service] Windows release startup: using existing config without synchronous repair"
-    );
   } else {
     harden_file_permissions(&config_path);
     // Patch existing configs to ensure required fields are present.
@@ -9224,9 +8222,6 @@ async fn prepare_gateway_config(
         if ensure_knapsack_plugin_allowlist(&mut cfg_val) {
           patched = true;
         }
-        if defer_bundled_channel_configs_for_startup(&mut cfg_val) {
-          patched = true;
-        }
 
         // Ensure browser.enabled is true
         let browser_enabled = cfg_val
@@ -9286,134 +8281,6 @@ async fn prepare_gateway_config(
             current_profile
           );
           patched = true;
-        }
-
-        if cfg_val.pointer("/identity").is_some() {
-          cfg_val.as_object_mut().unwrap().remove("identity");
-          eprintln!("[clawd/service] Removed invalid root identity key from config");
-          patched = true;
-        }
-
-        if cfg_val.pointer("/agents").is_none() {
-          cfg_val
-            .as_object_mut()
-            .unwrap()
-            .insert("agents".to_string(), serde_json::json!({}));
-        }
-        if cfg_val.pointer("/agents/defaults").is_none() {
-          cfg_val
-            .pointer_mut("/agents")
-            .unwrap()
-            .as_object_mut()
-            .unwrap()
-            .insert("defaults".to_string(), serde_json::json!({}));
-        }
-        if cfg_val.pointer("/agents/defaults/identity").is_some() {
-          cfg_val
-            .pointer_mut("/agents/defaults")
-            .unwrap()
-            .as_object_mut()
-            .unwrap()
-            .remove("identity");
-          eprintln!("[clawd/service] Removed invalid agents.defaults.identity key");
-          patched = true;
-        }
-        if !cfg_val
-          .pointer("/agents/list")
-          .map(|v| v.is_array())
-          .unwrap_or(false)
-        {
-          cfg_val
-            .pointer_mut("/agents")
-            .unwrap()
-            .as_object_mut()
-            .unwrap()
-            .insert("list".to_string(), serde_json::json!([]));
-        }
-        if let Some(agent_list) = cfg_val
-          .pointer_mut("/agents/list")
-          .and_then(|v| v.as_array_mut())
-        {
-          let before_len = agent_list.len();
-          agent_list.retain(|entry| {
-            entry.is_object()
-              && entry
-                .get("id")
-                .and_then(|v| v.as_str())
-                .map(|s| !s.trim().is_empty())
-                .unwrap_or(false)
-          });
-          if agent_list.len() != before_len {
-            eprintln!("[clawd/service] Removed invalid agents.list entries");
-            patched = true;
-          }
-          let main_index = agent_list
-            .iter()
-            .position(|entry| entry.get("id").and_then(|v| v.as_str()) == Some("main"));
-          let index = match main_index {
-            Some(index) => index,
-            None => {
-              agent_list.push(serde_json::json!({
-                "id": "main",
-                "default": true,
-                "name": "Knapsack",
-                "identity": {}
-              }));
-              patched = true;
-              agent_list.len() - 1
-            }
-          };
-          if let Some(main) = agent_list.get_mut(index).and_then(|v| v.as_object_mut()) {
-            if main
-              .get("name")
-              .and_then(|v| v.as_str())
-              .map(|s| s.trim().is_empty())
-              .unwrap_or(true)
-            {
-              main.insert("name".to_string(), serde_json::json!("Knapsack"));
-              patched = true;
-            }
-            if main.get("default").and_then(|v| v.as_bool()) != Some(true) {
-              main.insert("default".to_string(), serde_json::json!(true));
-              patched = true;
-            }
-            if !main.get("identity").map(|v| v.is_object()).unwrap_or(false) {
-              main.insert("identity".to_string(), serde_json::json!({}));
-              patched = true;
-            }
-          }
-        }
-        let main_identity = cfg_val
-          .pointer_mut("/agents/list")
-          .and_then(|v| v.as_array_mut())
-          .and_then(|list| {
-            list
-              .iter_mut()
-              .find(|entry| entry.get("id").and_then(|v| v.as_str()) == Some("main"))
-          })
-          .and_then(|entry| entry.get_mut("identity"))
-          .and_then(|v| v.as_object_mut());
-        if let Some(identity) = main_identity {
-          let defaults = [
-            ("name", serde_json::json!("Knapsack")),
-            ("theme", serde_json::json!("helpful assistant")),
-            ("emoji", serde_json::json!("🎒")),
-          ];
-          for (key, value) in defaults {
-            let needs_default = identity
-              .get(key)
-              .and_then(|v| v.as_str())
-              .map(|s| s.trim().is_empty())
-              .unwrap_or(true);
-            if needs_default {
-              identity.insert(key.to_string(), value);
-              eprintln!(
-                "[clawd/service] Patched agents.list.main.identity.{} default",
-                key
-              );
-              patched = true;
-            }
-          }
         }
 
         // Clean up browser.hideAutomationBanner
@@ -9508,55 +8375,6 @@ async fn prepare_gateway_config(
               current_primary, new_model
             );
             patched = true;
-          }
-        }
-        if !current_primary.trim().is_empty() && model_ref_has_key(current_primary.trim()) {
-          let expected_fallbacks =
-            crate::clawd::gateway_client::collect_fallback_models(current_primary.trim());
-          if !expected_fallbacks.is_empty() {
-            let existing_fallbacks = cfg_val
-              .pointer("/agents/defaults/model/fallbacks")
-              .and_then(|v| v.as_array())
-              .map(|arr| {
-                arr
-                  .iter()
-                  .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                  .collect::<Vec<_>>()
-              })
-              .unwrap_or_default();
-            if existing_fallbacks != expected_fallbacks {
-              if cfg_val.pointer("/agents").is_none() {
-                cfg_val
-                  .as_object_mut()
-                  .unwrap()
-                  .insert("agents".to_string(), serde_json::json!({}));
-              }
-              if cfg_val.pointer("/agents/defaults").is_none() {
-                cfg_val
-                  .pointer_mut("/agents")
-                  .unwrap()
-                  .as_object_mut()
-                  .unwrap()
-                  .insert("defaults".to_string(), serde_json::json!({}));
-              }
-              cfg_val
-                .pointer_mut("/agents/defaults")
-                .unwrap()
-                .as_object_mut()
-                .unwrap()
-                .insert(
-                  "model".to_string(),
-                  serde_json::json!({
-                    "primary": current_primary.trim(),
-                    "fallbacks": expected_fallbacks,
-                  }),
-                );
-              eprintln!(
-                "[clawd/service] Refreshed agents.defaults.model fallbacks for '{}'",
-                current_primary
-              );
-              patched = true;
-            }
           }
         }
 
@@ -10097,16 +8915,11 @@ async fn prepare_gateway_config(
     }
   }
 
-  let channel_state_started = std::time::Instant::now();
   if sanitize_bundled_channel_plugin_install_state(&clawdbot_home) {
     eprintln!(
       "[clawd/service] Repaired stale bundled channel plugin install state before gateway launch"
     );
   }
-  eprintln!(
-    "[clawd/service] prepare_gateway_config: channel install-state check completed in {}ms",
-    channel_state_started.elapsed().as_millis()
-  );
 
   // Keep the startup-critical root locked down immediately, but run the
   // recursive sweep off the launch path. Large state trees can contain
@@ -10199,7 +9012,10 @@ async fn prepare_gateway_config(
   let bundled_plugins_dir_str = node_arg_path(&bundled_plugins_dir);
   let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
 
-  let node_dir = node_path.parent().map(node_arg_path).unwrap_or_default();
+  let node_dir = node_path
+    .parent()
+    .map(node_arg_path)
+    .unwrap_or_default();
   let path_separator = if cfg!(target_os = "windows") {
     ";"
   } else {
@@ -10304,7 +9120,6 @@ async fn prepare_gateway_config(
       "OPENCLAW_DESKTOP_AUTO_START_CHANNELS".to_string(),
       "0".to_string(),
     ),
-    ("OPENCLAW_DESKTOP_FAST_BIND".to_string(), "1".to_string()),
     (
       "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
       "1".to_string(),
@@ -10356,24 +9171,12 @@ async fn prepare_gateway_config(
         }
       }
     }
-    for var in [
-      "OPENCLAW_SERVICE_MARKER",
-      "OPENCLAW_SERVICE_KIND",
-      "OPENCLAW_WINDOWS_TASK_NAME",
-      "OPENCLAW_GATEWAY_SERVICE_PID",
-    ] {
-      env.push((var.to_string(), String::new()));
-    }
-    env.push(("OPENCLAW_ALLOW_MULTI_GATEWAY".to_string(), "1".to_string()));
   } else {
     // Prevents the macOS gateway inspector from classifying this LaunchAgent as
     // a legacy "clawdbot" service and moving it to Trash. On Windows these
     // markers mean "schtasks-supervised" to OpenClaw, which adds a 30s lock
     // recovery wait to the desktop-managed direct gateway startup path.
-    env.push((
-      "OPENCLAW_SERVICE_MARKER".to_string(),
-      "openclaw".to_string(),
-    ));
+    env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
     env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
   }
 
@@ -10521,21 +9324,16 @@ async fn prepare_gateway_config(
     }
   }
 
-  schedule_bundled_plugin_runtime_deps_warmup(
-    node_path.clone(),
-    bundled_plugins_dir.clone(),
-    app_clawdbot_home(app_handle),
-    "prepare_gateway_config",
-  );
+  // Install runtime deps for bundled plugins (e.g. grammy for telegram).
+  // Must happen AFTER resource files are in place (i.e. here, not in beforeDevCommand).
+  if !cfg!(debug_assertions) {
+    install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
+    ensure_plugin_runtime_deps_openclaw_links(&app_clawdbot_home(app_handle));
+  }
 
   eprintln!(
     "[clawd/service] Knapsack v{} on {} — starting service ({})",
     app_version, os_info, LAUNCH_AGENT_LABEL
-  );
-
-  eprintln!(
-    "[clawd/service] prepare_gateway_config completed in {}ms",
-    prepare_started.elapsed().as_millis()
   );
 
   Ok(ServiceSetup {
@@ -10609,7 +9407,7 @@ pub async fn set_service_enabled(
     let enabled = payload.enabled;
 
     if enabled {
-      if let Some(grace_ms) = gateway_launch_grace_active_with_live_process() {
+      if let Some(grace_ms) = gateway_launch_grace_active() {
         {
           let mut cfg_guard = cfg.write().await;
           cfg_guard.base_url = Some("http://127.0.0.1:18791".to_string());
@@ -10641,56 +9439,18 @@ pub async fn set_service_enabled(
       // If a background restart is already in progress, wait for it to
       // finish rather than spawning a second gateway process.
       if GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
-        let restart_pid = GATEWAY_PID.load(Ordering::Relaxed);
-        if restart_pid == 0 && !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
-          eprintln!(
-            "[clawd/service] Enable request: stale background restart flag with no pid/listener; taking over startup"
-          );
-          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
-        } else {
-          eprintln!(
-            "[clawd/service] Enable request: background restart already in progress, waiting..."
-          );
-          for _ in 0..8 {
-            std::thread::sleep(std::time::Duration::from_millis(250));
-            if !GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
-              break;
-            }
+        eprintln!(
+          "[clawd/service] Enable request: background restart already in progress, waiting..."
+        );
+        for _ in 0..20 {
+          std::thread::sleep(std::time::Duration::from_millis(500));
+          if !GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
+            break;
           }
         }
         // If a gateway is now running, skip re-spawn
         let existing_pid = GATEWAY_PID.load(Ordering::Relaxed);
         if existing_pid > 0 {
-          if gateway_tcp_port_open(std::time::Duration::from_millis(150)).await {
-            eprintln!(
-              "[clawd/service] Enable request: gateway already running (pid {})",
-              existing_pid
-            );
-            return HttpResponse::Ok().json(EnableServiceResponse {
-              success: true,
-              enabled,
-              message: format!(
-                "Gateway already started by background restart (pid {})",
-                existing_pid
-              ),
-            });
-          }
-          if process_is_alive(existing_pid) {
-            if let Some(grace_ms) = gateway_launch_grace_active() {
-              eprintln!(
-                "[clawd/service] Enable request: background restart pid {} is still starting after {}ms; preserving startup",
-                existing_pid, grace_ms
-              );
-              return HttpResponse::Ok().json(EnableServiceResponse {
-                success: true,
-                enabled,
-                message: format!(
-                  "Gateway startup is already in progress (pid {}, {}ms)",
-                  existing_pid, grace_ms
-                ),
-              });
-            }
-          }
           eprintln!(
             "[clawd/service] Enable request: gateway already running (pid {})",
             existing_pid
@@ -10758,12 +9518,15 @@ pub async fn set_service_enabled(
 
       // Remove stale plugin runtime-deps locks so the new gateway doesn't wait
       // 5 minutes for a lock left by a previous crashed/killed process.
-      let clawdbot_home = app_clawdbot_home(&app_handle);
-      remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
-      // Defer versioned runtime-deps pruning until after the primary gateway
-      // launch. Optional channel warmup can tolerate this delay; startup cannot.
-      let bundle_ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
-      schedule_plugin_runtime_deps_cleanup(clawdbot_home, bundle_ver);
+      remove_stale_plugin_runtime_deps_locks(&app_clawdbot_home(&app_handle));
+      // Remove stale versioned plugin-runtime-deps dirs to prevent WhatsApp
+      // (and other plugins) from crashing the gateway with ENOENT during
+      // auth-store migration from old→new version staging directories.
+      {
+        let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(&app_handle));
+        remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(&app_handle), &ver);
+        remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(&app_handle), &ver);
+      }
 
       // Doctor mutates the same runtime deps/config tree as gateway startup.
       // Keep it opt-in so it cannot race first-run dependency staging.
@@ -10809,23 +9572,21 @@ pub async fn set_service_enabled(
       let stdout_file = match fs::File::create(&stdout_log) {
         Ok(f) => f,
         Err(e) => {
-          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           return HttpResponse::InternalServerError().json(EnableServiceResponse {
             success: false,
             enabled,
             message: format!("Failed to create stdout log: {}", e),
-          });
+          })
         }
       };
       let stderr_file = match fs::File::create(&stderr_log) {
         Ok(f) => f,
         Err(e) => {
-          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           return HttpResponse::InternalServerError().json(EnableServiceResponse {
             success: false,
             enabled,
             message: format!("Failed to create stderr log: {}", e),
-          });
+          })
         }
       };
 
@@ -10845,7 +9606,6 @@ pub async fn set_service_enabled(
         Ok(child) => {
           let pid = child.id();
           GATEWAY_PID.store(pid, Ordering::Relaxed);
-          mark_gateway_launch_started();
           GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           eprintln!("[clawd/service] Spawned gateway process (pid {})", pid);
 
@@ -11098,12 +9858,11 @@ pub async fn set_service_enabled(
         }
       }
 
-      schedule_bundled_plugin_runtime_deps_warmup(
-        node_path.clone(),
-        bundled_plugins_dir.clone(),
-        clawdbot_home.clone(),
-        "prepare_gateway_config_windows",
-      );
+      // Install runtime deps for bundled plugins (e.g. grammy for telegram).
+      if !cfg!(debug_assertions) {
+        install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
+        ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
+      }
 
       // Ensure OpenClaw config exists with gateway.mode=local for first-run.
       // Without this, OpenClaw refuses to start on a fresh machine.
@@ -11146,22 +9905,8 @@ pub async fn set_service_enabled(
             "headless": false,
             "defaultProfile": "openclaw"
           },
-          "agents": {
-            "defaults": {
-            },
-            "list": [{
-              "id": "main",
-              "default": true,
-              "name": "Knapsack",
-              "identity": {
-                "name": "Knapsack",
-                "theme": "helpful assistant",
-                "emoji": "🎒"
-              }
-            }]
-          },
           "plugins": {
-            "allow": KNAPSACK_CORE_STARTUP_PLUGINS,
+            "allow": KNAPSACK_REQUIRED_PLUGINS,
             "slots": {
               "memory": "none"
             }
@@ -11373,9 +10118,6 @@ pub async fn set_service_enabled(
             }
 
             if ensure_knapsack_plugin_allowlist(&mut cfg) {
-              patched = true;
-            }
-            if defer_bundled_channel_configs_for_startup(&mut cfg) {
               patched = true;
             }
 
@@ -12042,7 +10784,10 @@ pub async fn set_service_enabled(
       // Build a PATH that includes the directory where we found node (so npm
       // is also discoverable), plus common macOS paths.  LaunchAgents get a
       // minimal PATH by default which typically excludes /opt/homebrew/bin.
-      let node_dir = node_path.parent().map(node_arg_path).unwrap_or_default();
+      let node_dir = node_path
+        .parent()
+        .map(node_arg_path)
+        .unwrap_or_default();
       let mut path_parts: Vec<String> = Vec::new();
       if !node_dir.is_empty() {
         path_parts.push(node_dir);
@@ -12139,7 +10884,6 @@ pub async fn set_service_enabled(
           "OPENCLAW_DESKTOP_AUTO_START_CHANNELS".to_string(),
           "0".to_string(),
         ),
-        ("OPENCLAW_DESKTOP_FAST_BIND".to_string(), "1".to_string()),
         (
           "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
           "1".to_string(),
@@ -12157,25 +10901,12 @@ pub async fn set_service_enabled(
         }),
       ];
 
-      if cfg!(target_os = "windows") {
-        for var in [
-          "OPENCLAW_SERVICE_MARKER",
-          "OPENCLAW_SERVICE_KIND",
-          "OPENCLAW_WINDOWS_TASK_NAME",
-          "OPENCLAW_GATEWAY_SERVICE_PID",
-        ] {
-          env.push((var.to_string(), String::new()));
-        }
-        env.push(("OPENCLAW_ALLOW_MULTI_GATEWAY".to_string(), "1".to_string()));
-      } else {
+      if !cfg!(target_os = "windows") {
         // Prevents the macOS gateway inspector from classifying this LaunchAgent
         // as a legacy "clawdbot" service and moving it to Trash. On Windows
         // these markers mean "schtasks-supervised" to OpenClaw, which adds a
         // 30s lock recovery wait to the desktop-managed direct gateway startup.
-        env.push((
-          "OPENCLAW_SERVICE_MARKER".to_string(),
-          "openclaw".to_string(),
-        ));
+        env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
         env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
       }
 
@@ -12543,9 +11274,7 @@ pub async fn cycle_service(_app_handle: &tauri::AppHandle) {
       .status();
     GATEWAY_PID.store(0, Ordering::Relaxed);
   }
-  for port in [18789u16, 18791u16, 18800u16] {
-    kill_process_on_port(port);
-  }
+  kill_process_on_port(18789);
 
   // Brief pause before restarting
   tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -12581,9 +11310,7 @@ pub fn cleanup_gateway_on_exit() {
       .status();
     GATEWAY_PID.store(0, Ordering::Relaxed);
   }
-  for port in [18789u16, 18791u16, 18800u16] {
-    kill_process_on_port(port);
-  }
+  kill_process_on_port(18789);
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -13104,7 +11831,7 @@ async fn do_gemini_connect(app_handle: &tauri::AppHandle, code: &str) -> Result<
   #[cfg(target_os = "macos")]
   {
     if let Ok(plist_path) = launch_agent_plist_path() {
-      refresh_launch_agent_plist_for_restart(app_handle, "gemini oauth restart").await;
+      regenerate_macos_plist_with_current_env(&plist_path);
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -13257,7 +11984,7 @@ pub async fn oauth_callback(
         Err(e) => return oauth_html_page(false, &format!("Failed to get API key: {}", e)),
       };
 
-      match save_and_restart_for_oauth(&app_handle, "openrouter", &key).await {
+      match save_and_restart_for_oauth(&app_handle, "openrouter", &key) {
         Ok(_) => {
           eprintln!("[clawd/service] OpenRouter OAuth: key saved, gateway restarting");
           oauth_html_page(true, "OpenRouter")
@@ -13300,7 +12027,7 @@ async fn exchange_openrouter_code(code: &str) -> Result<String, String> {
     .ok_or_else(|| "Missing 'key' in OpenRouter response".to_string())
 }
 
-async fn save_and_restart_for_oauth(
+fn save_and_restart_for_oauth(
   app_handle: &tauri::AppHandle,
   provider: &str,
   key: &str,
@@ -13332,7 +12059,7 @@ async fn save_and_restart_for_oauth(
   #[cfg(target_os = "macos")]
   {
     if let Ok(plist_path) = launch_agent_plist_path() {
-      refresh_launch_agent_plist_for_restart(app_handle, "provider oauth restart").await;
+      regenerate_macos_plist_with_current_env(&plist_path);
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -13857,10 +12584,6 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   }
 
   // Gateway is not running — start it.
-  if GATEWAY_RESTART_IN_PROGRESS.swap(true, Ordering::Relaxed) {
-    eprintln!("[clawd/service] auto_enable (Windows): gateway restart already in progress");
-    return;
-  }
   AUTO_ENABLE_STARTED.store(true, Ordering::Relaxed);
   mark_gateway_launch_started();
   eprintln!("[clawd/service] auto_enable (Windows): starting gateway");
@@ -13876,10 +12599,12 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
         "[clawd/service] auto_enable (Windows): prepare_gateway_config failed: {}",
         e
       );
-      GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
       return;
     }
   };
+
+  // Prevent the background health-check task from racing us.
+  GATEWAY_RESTART_IN_PROGRESS.store(true, Ordering::Relaxed);
 
   if windows_pid_listening_on_port(18800).is_some() {
     kill_stale_clawdbot_chromes();
@@ -13904,10 +12629,12 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
     }
   }
 
-  let clawdbot_home = app_clawdbot_home(app_handle);
-  remove_stale_plugin_runtime_deps_locks(&clawdbot_home);
-  let bundle_ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(app_handle));
-  schedule_plugin_runtime_deps_cleanup(clawdbot_home, bundle_ver);
+  remove_stale_plugin_runtime_deps_locks(&app_clawdbot_home(app_handle));
+  {
+    let ver = read_clawdbot_bundle_version(&clawdbot_bundle_dir(app_handle));
+    remove_stale_plugin_runtime_deps_versions(&app_clawdbot_home(app_handle), &ver);
+    remove_incomplete_plugin_runtime_deps_dirs(&app_clawdbot_home(app_handle), &ver);
+  }
 
   let stdout_log = windows_log_path("stdout");
   let stderr_log = windows_log_path("stderr");
@@ -13962,222 +12689,6 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub async fn auto_enable_if_needed(_app_handle: &tauri::AppHandle) {
   // No-op on non-macOS/Windows platforms.
-}
-
-/// Parse a single query parameter value from a URL string.
-fn parse_deep_link_param(url: &str, key: &str) -> Option<String> {
-  let query_start = url.find('?')?;
-  let query = &url[query_start + 1..];
-  for pair in query.split('&') {
-    if let Some((k, v)) = pair.split_once('=') {
-      if k == key {
-        // Percent-decode the value (handles %40 → @ for emails, etc.)
-        let decoded = v
-          .replace("%40", "@")
-          .replace("%2B", "+")
-          .replace("%20", " ")
-          .replace("+", " ");
-        return Some(decoded);
-      }
-    }
-  }
-  None
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct DesktopSignInApiResponse {
-  access_token: String,
-  refresh_token: String,
-  email: String,
-}
-
-/// Exchange a one-shot code for JWT tokens, store them, and emit
-/// `knapsack-connected` (or `knapsack-auth-error`) to the frontend.
-/// Returns Ok(email) on success or Err(user-visible message) on failure.
-async fn exchange_and_store_knapsack_code(
-  app_handle: &tauri::AppHandle,
-  code: &str,
-) -> Result<String, String> {
-  let api_base = option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai");
-  let client = reqwest::Client::new();
-  let resp = client
-    .post(format!("{}/api/authentication/desktop-sign-in", api_base))
-    .json(&serde_json::json!({ "code": code }))
-    .send()
-    .await
-    .map_err(|e| {
-      log::error!("[knapsack_auth] exchange request failed: {}", e);
-      format!("Connection failed: {}", e)
-    })?;
-
-  let status = resp.status();
-  let body_text = resp.text().await.unwrap_or_default();
-
-  if !status.is_success() {
-    log::error!(
-      "[knapsack_auth] exchange endpoint returned {}: {}",
-      status,
-      body_text
-    );
-    return Err(format!("Sign-in failed ({})", status));
-  }
-
-  let sign_in: DesktopSignInApiResponse = serde_json::from_str(&body_text).map_err(|e| {
-    log::error!("[knapsack_auth] failed to parse exchange response: {}", e);
-    "Invalid server response".to_string()
-  })?;
-
-  let mut tokens = load_or_create_tokens(app_handle).map_err(|e| {
-    log::error!("[knapsack_auth] failed to load tokens for storage: {}", e);
-    "Failed to save credentials".to_string()
-  })?;
-
-  tokens.knapsack_access_token = Some(sign_in.access_token.clone());
-  tokens.knapsack_refresh_token = Some(sign_in.refresh_token.clone());
-  tokens.knapsack_email = Some(sign_in.email.clone());
-  tokens.active_provider = Some("knapsack".to_string());
-  if tokens.knapsack_model.is_none() {
-    tokens.knapsack_model = Some("anthropic/claude-haiku-4-5".to_string());
-  }
-
-  if let Err(e) = save_tokens(app_handle, &tokens) {
-    log::error!("[knapsack_auth] failed to save tokens: {}", e);
-  }
-
-  std::env::set_var("KNAPSACK_ACCESS_TOKEN", &sign_in.access_token);
-  std::env::set_var("KNAPSACK_REFRESH_TOKEN", &sign_in.refresh_token);
-  std::env::set_var("KNAPSACK_USER_EMAIL", &sign_in.email);
-  std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "knapsack");
-  if let Some(m) = &tokens.knapsack_model {
-    std::env::set_var("KNAPSACK_KNAPSACK_MODEL", m);
-  }
-
-  log::info!("[knapsack_auth] connected as {}", sign_in.email);
-  let _ = app_handle.emit_all(
-    "knapsack-connected",
-    serde_json::json!({
-      "email": sign_in.email,
-      "model": tokens.knapsack_model.clone().unwrap_or_default(),
-    }),
-  );
-
-  Ok(sign_in.email)
-}
-
-/// GET /api/auth/knapsack-callback?code=<one-shot-code>
-/// Called by studio.knapsack.ai after the user authenticates.
-/// Returns an HTML page the user can close.
-#[derive(Deserialize)]
-pub struct KnapsackCallbackQuery {
-  pub code: Option<String>,
-}
-
-#[get("/api/auth/knapsack-callback")]
-pub async fn knapsack_auth_callback(
-  app_handle: web::Data<tauri::AppHandle>,
-  query: web::Query<KnapsackCallbackQuery>,
-) -> impl Responder {
-  let code = match query.code.as_deref().filter(|c| !c.is_empty()) {
-    Some(c) => c.to_string(),
-    None => return oauth_html_page(false, "Missing authorization code."),
-  };
-
-  match exchange_and_store_knapsack_code(&app_handle, &code).await {
-    Ok(_) => oauth_html_page(true, "Knapsack"),
-    Err(msg) => {
-      let _ = app_handle.emit_all("knapsack-auth-error", serde_json::json!({"error": msg}));
-      oauth_html_page(false, &msg)
-    }
-  }
-}
-
-/// POST /api/clawd/service/knapsack-disconnect
-/// Clears the stored Knapsack credentials and switches the active provider
-/// to whatever other provider has a saved key (fallback: openai).
-#[post("/api/clawd/service/knapsack-disconnect")]
-pub async fn knapsack_disconnect(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
-  let mut tokens = match load_or_create_tokens(&app_handle) {
-    Ok(t) => t,
-    Err(e) => {
-      return HttpResponse::InternalServerError()
-        .json(serde_json::json!({"ok": false, "message": e}))
-    }
-  };
-
-  // Clear all Knapsack credential fields
-  tokens.knapsack_access_token = None;
-  tokens.knapsack_refresh_token = None;
-  tokens.knapsack_email = None;
-
-  // Pick a fallback provider that already has a saved key
-  let fallback = if tokens
-    .anthropic_api_key
-    .as_deref()
-    .map(|k| !k.is_empty())
-    .unwrap_or(false)
-  {
-    "anthropic"
-  } else if tokens
-    .gemini_api_key
-    .as_deref()
-    .map(|k| !k.is_empty())
-    .unwrap_or(false)
-  {
-    "gemini"
-  } else if tokens
-    .groq_api_key
-    .as_deref()
-    .map(|k| !k.is_empty())
-    .unwrap_or(false)
-  {
-    "groq"
-  } else {
-    "openai"
-  };
-  tokens.active_provider = Some(fallback.to_string());
-
-  if let Err(e) = save_tokens(&app_handle, &tokens) {
-    return HttpResponse::InternalServerError()
-      .json(serde_json::json!({"ok": false, "message": e}));
-  }
-
-  // Clear env vars so in-process consumers stop using the old token
-  std::env::remove_var("KNAPSACK_ACCESS_TOKEN");
-  std::env::remove_var("KNAPSACK_REFRESH_TOKEN");
-  std::env::remove_var("KNAPSACK_USER_EMAIL");
-  std::env::remove_var("KNAPSACK_KNAPSACK_MODEL");
-  std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", fallback);
-
-  log::info!(
-    "[knapsack_disconnect] disconnected, fallback provider = {}",
-    fallback
-  );
-  let _ = app_handle.emit_all(
-    "knapsack-disconnected",
-    serde_json::json!({"fallback_provider": fallback}),
-  );
-
-  HttpResponse::Ok().json(serde_json::json!({"ok": true, "fallback_provider": fallback}))
-}
-
-/// Handle a `knapsack-auth://connect?code=<code>` deep link (URL scheme fallback).
-pub async fn handle_knapsack_deep_link(app_handle: &tauri::AppHandle, url: &str) {
-  log::info!(
-    "[knapsack_auth] deep link received: {}",
-    &url[..url.len().min(80)]
-  );
-
-  let code = match parse_deep_link_param(url, "code") {
-    Some(c) => c,
-    None => {
-      log::error!("[knapsack_auth] missing 'code' in deep link URL");
-      return;
-    }
-  };
-
-  if let Err(msg) = exchange_and_store_knapsack_code(app_handle, &code).await {
-    let _ = app_handle.emit_all("knapsack-auth-error", serde_json::json!({"error": msg}));
-  }
 }
 
 #[cfg(test)]

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -927,7 +927,7 @@ pub(crate) fn is_bundled_channel_plugin_id(plugin_id: &str) -> bool {
 fn eager_channel_plugin_start_enabled() -> bool {
   std::env::var("KNAPSACK_EAGER_CHANNEL_PLUGINS")
     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-    .unwrap_or(true)
+    .unwrap_or(false)
 }
 
 fn defer_optional_startup_plugins_enabled() -> bool {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -277,7 +277,7 @@ fn is_pid_alive(pid: u32) -> bool {
 static BROWSER_START_NUDGED: AtomicBool = AtomicBool::new(false);
 static GATEWAY_LAST_LAUNCH_MS: AtomicU64 = AtomicU64::new(0);
 static QA_DIRECT_GATEWAY_FIRST_SEEN_MS: AtomicU64 = AtomicU64::new(0);
-const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 30_000;
+const GATEWAY_PRE_BIND_STARTUP_GRACE_MS: u64 = 75_000;
 const PLUGIN_RUNTIME_DEPS_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(600);
 const PLUGIN_RUNTIME_DEPS_OWNER_LOCK_GRACE_MS: u64 = 180_000;
 
@@ -303,12 +303,17 @@ static BROWSER_WAS_HEALTHY: AtomicBool = AtomicBool::new(false);
 /// so the health endpoint doesn't spam `launchctl kickstart` on every poll.
 static GATEWAY_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
+/// Schedules one background expansion of optional plugins after the core launch
+/// gate is already green.
+static DEFERRED_STARTUP_WARMUP_SCHEDULED: AtomicBool = AtomicBool::new(false);
+
 /// First observed timestamp for the current gateway-unreachable period.
 static GATEWAY_UNREACHABLE_SINCE_MS: AtomicU64 = AtomicU64::new(0);
 
 const GATEWAY_HEALTH_SELF_HEAL_GRACE_MS: u64 = 180_000;
 const GATEWAY_POST_BIND_STARTUP_GRACE_MS: u64 = 300_000;
 const BROWSER_START_NUDGE_COOLDOWN_MS: u64 = 45_000;
+const OPTIONAL_STARTUP_API_DEFER_MS: u64 = 90_000;
 
 fn now_epoch_ms() -> u64 {
   std::time::SystemTime::now()
@@ -316,6 +321,8 @@ fn now_epoch_ms() -> u64 {
     .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
     .unwrap_or(0)
 }
+
+static PROCESS_STARTED_MS: once_cell::sync::Lazy<u64> = once_cell::sync::Lazy::new(now_epoch_ms);
 
 static GATEWAY_LIFECYCLE_MUTEX: once_cell::sync::Lazy<tokio::sync::Mutex<()>> =
   once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(()));
@@ -409,6 +416,36 @@ fn mark_gateway_launch_started() {
   GATEWAY_UNREACHABLE_SINCE_MS.store(0, Ordering::Relaxed);
 }
 
+fn gateway_launch_elapsed_ms() -> Option<u64> {
+  let started = GATEWAY_LAST_LAUNCH_MS.load(Ordering::Relaxed);
+  if started == 0 {
+    None
+  } else {
+    Some(now_epoch_ms().saturating_sub(started))
+  }
+}
+
+fn clear_stale_gateway_launch(pid: u32, elapsed_ms: u64) {
+  eprintln!(
+    "[clawd/service] gateway launch pid {} did not bind after {}ms; clearing stale launch marker",
+    pid, elapsed_ms
+  );
+  #[cfg(target_os = "windows")]
+  {
+    let _ = std::process::Command::new("taskkill")
+      .args(["/F", "/T", "/PID", &pid.to_string()])
+      .output();
+  }
+  #[cfg(not(target_os = "windows"))]
+  {
+    let _ = std::process::Command::new("kill")
+      .args(["-TERM", &pid.to_string()])
+      .output();
+  }
+  GATEWAY_PID.store(0, Ordering::Relaxed);
+  GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
+}
+
 fn gateway_launch_grace_active() -> Option<u64> {
   let started = GATEWAY_LAST_LAUNCH_MS.load(Ordering::Relaxed);
   if started == 0 {
@@ -418,14 +455,19 @@ fn gateway_launch_grace_active() -> Option<u64> {
   let pid = GATEWAY_PID.load(Ordering::Relaxed);
   if pid > 0 {
     if process_is_alive(pid) {
-      return Some(elapsed);
-    }
-    #[cfg(target_os = "windows")]
-    if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
-      if process_is_alive(listening_pid) {
-        GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
-        return Some(elapsed);
+      #[cfg(target_os = "windows")]
+      if let Some(listening_pid) = windows_pid_listening_on_port(18789) {
+        if process_is_alive(listening_pid) {
+          GATEWAY_PID.store(listening_pid, Ordering::Relaxed);
+          return Some(elapsed);
+        }
       }
+      #[cfg(target_os = "windows")]
+      if elapsed >= GATEWAY_PRE_BIND_STARTUP_GRACE_MS {
+        clear_stale_gateway_launch(pid, elapsed);
+        return None;
+      }
+      return Some(elapsed);
     }
     GATEWAY_PID.store(0, Ordering::Relaxed);
     GATEWAY_LAST_LAUNCH_MS.store(0, Ordering::Relaxed);
@@ -834,9 +876,14 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
   }
 }
 
-const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
-  // Core app activities exercised by the desktop QA loop.
+const KNAPSACK_CORE_STARTUP_PLUGINS: &[&str] = &[
+  // Keep the launch gate small: browser access is the only OpenClaw plugin
+  // required before the desktop can be considered locally usable.
   "browser",
+];
+
+const KNAPSACK_DEFERRED_STARTUP_PLUGINS: &[&str] = &[
+  // Google/Microsoft document surfaces.
   "google",
   "microsoft",
   "web-readability",
@@ -880,7 +927,76 @@ pub(crate) fn is_bundled_channel_plugin_id(plugin_id: &str) -> bool {
 fn eager_channel_plugin_start_enabled() -> bool {
   std::env::var("KNAPSACK_EAGER_CHANNEL_PLUGINS")
     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-    .unwrap_or(false)
+    .unwrap_or(true)
+}
+
+fn defer_optional_startup_plugins_enabled() -> bool {
+  std::env::var("KNAPSACK_DEFER_OPTIONAL_STARTUP_PLUGINS")
+    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+    .unwrap_or(true)
+}
+
+fn is_deferred_startup_plugin_id(plugin_id: &str) -> bool {
+  KNAPSACK_DEFERRED_STARTUP_PLUGINS
+    .iter()
+    .any(|candidate| *candidate == plugin_id)
+}
+
+fn configured_bundled_channel_plugin_ids(cfg: &serde_json::Value) -> Vec<String> {
+  let mut channels = cfg
+    .pointer("/channels")
+    .and_then(|value| value.as_object())
+    .map(|configured| {
+      configured
+        .keys()
+        .filter(|channel| is_bundled_channel_plugin_id(channel))
+        .cloned()
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  channels.sort();
+  channels.dedup();
+  channels
+}
+
+fn startup_ready_channel_ids(app_handle: &tauri::AppHandle) -> Vec<String> {
+  let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+  let Ok(raw) = fs::read_to_string(&config_path) else {
+    return Vec::new();
+  };
+  let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&raw) else {
+    return Vec::new();
+  };
+  let mut channels = configured_bundled_channel_plugin_ids(&cfg)
+    .into_iter()
+    .filter(|channel| {
+      let disabled = cfg
+        .pointer(&format!("/channels/{}/enabled", channel))
+        .and_then(|value| value.as_bool())
+        == Some(false);
+      !disabled && bundled_plugins_dir(app_handle).join(channel).is_dir()
+    })
+    .collect::<Vec<_>>();
+  channels.sort();
+  channels.dedup();
+  channels
+}
+
+fn qa_plugin_allowlist_override() -> Option<Vec<String>> {
+  let raw = std::env::var("KNAPSACK_QA_PLUGIN_ALLOWLIST").ok()?;
+  let mut plugins = raw
+    .split(',')
+    .map(|plugin| plugin.trim())
+    .filter(|plugin| !plugin.is_empty())
+    .map(|plugin| plugin.to_string())
+    .collect::<Vec<_>>();
+  plugins.sort();
+  plugins.dedup();
+  if plugins.is_empty() {
+    None
+  } else {
+    Some(plugins)
+  }
 }
 
 fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
@@ -895,10 +1011,66 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
       .insert("plugins".to_string(), serde_json::json!({}));
   }
 
-  let mut required: Vec<String> = KNAPSACK_REQUIRED_PLUGINS
+  if let Some(plugins) = qa_plugin_allowlist_override() {
+    if let Some(channels) = cfg
+      .pointer_mut("/channels")
+      .and_then(|value| value.as_object_mut())
+    {
+      for plugin_id in plugins
+        .iter()
+        .filter(|plugin_id| is_bundled_channel_plugin_id(plugin_id))
+      {
+        if let Some(channel_cfg) = channels
+          .get_mut(plugin_id)
+          .and_then(|value| value.as_object_mut())
+        {
+          channel_cfg.insert("enabled".to_string(), serde_json::json!(true));
+        }
+      }
+    }
+    let next_allow = serde_json::json!(plugins);
+    if cfg.pointer("/plugins/allow") == Some(&next_allow) {
+      return false;
+    }
+    cfg
+      .pointer_mut("/plugins")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
+      .insert("allow".to_string(), next_allow);
+    eprintln!("[clawd/service] Patched plugins.allow to QA plugin allowlist");
+    return true;
+  }
+
+  let defer_optional = defer_optional_startup_plugins_enabled();
+  let mut required: Vec<String> = KNAPSACK_CORE_STARTUP_PLUGINS
     .iter()
     .map(|plugin| plugin.to_string())
     .collect();
+
+  if eager_channel_plugin_start_enabled() {
+    for plugin_id in configured_bundled_channel_plugin_ids(cfg) {
+      if !required.iter().any(|existing| existing == &plugin_id) {
+        required.push(plugin_id);
+      }
+    }
+    if let Some(channels) = cfg
+      .pointer_mut("/channels")
+      .and_then(|value| value.as_object_mut())
+    {
+      for plugin_id in required
+        .iter()
+        .filter(|plugin_id| is_bundled_channel_plugin_id(plugin_id))
+      {
+        if let Some(channel_cfg) = channels
+          .get_mut(plugin_id)
+          .and_then(|value| value.as_object_mut())
+        {
+          channel_cfg.insert("enabled".to_string(), serde_json::json!(true));
+        }
+      }
+    }
+  }
 
   if let Some(entries) = cfg
     .pointer("/plugins/entries")
@@ -906,6 +1078,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   {
     for (plugin_id, entry) in entries {
       if is_bundled_channel_plugin_id(plugin_id) && !eager_channel_plugin_start_enabled() {
+        continue;
+      }
+      if defer_optional && is_deferred_startup_plugin_id(plugin_id) {
         continue;
       }
       let explicitly_disabled =
@@ -931,6 +1106,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   if !eager_channel_plugin_start_enabled() {
     merged.retain(|plugin| !is_bundled_channel_plugin_id(plugin));
   }
+  if defer_optional {
+    merged.retain(|plugin| !is_deferred_startup_plugin_id(plugin));
+  }
   for plugin in required {
     if !merged.iter().any(|existing| existing == &plugin) {
       merged.push(plugin);
@@ -950,8 +1128,121 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .as_object_mut()
     .unwrap()
     .insert("allow".to_string(), next_allow);
-  eprintln!("[clawd/service] Patched plugins.allow to Knapsack startup allowlist");
+  if defer_optional {
+    eprintln!("[clawd/service] Patched plugins.allow to minimal Knapsack startup allowlist");
+  } else {
+    eprintln!("[clawd/service] Patched plugins.allow to Knapsack startup allowlist");
+  }
   true
+}
+
+fn expand_deferred_startup_plugin_allowlist(app_handle: &tauri::AppHandle) -> bool {
+  let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+  let existing = match fs::read_to_string(&config_path) {
+    Ok(value) => value,
+    Err(e) => {
+      eprintln!(
+        "[clawd/service] Deferred startup warmup skipped; could not read {}: {}",
+        config_path.display(),
+        e
+      );
+      return false;
+    }
+  };
+  let mut cfg: serde_json::Value = match serde_json::from_str(&existing) {
+    Ok(value) => value,
+    Err(e) => {
+      eprintln!(
+        "[clawd/service] Deferred startup warmup skipped; invalid config {}: {}",
+        config_path.display(),
+        e
+      );
+      return false;
+    }
+  };
+  if !cfg.is_object() {
+    return false;
+  }
+  if cfg.get("plugins").is_none() {
+    cfg
+      .as_object_mut()
+      .unwrap()
+      .insert("plugins".to_string(), serde_json::json!({}));
+  }
+  let plugins = cfg
+    .pointer_mut("/plugins")
+    .and_then(|value| value.as_object_mut())
+    .unwrap();
+
+  let mut allow = plugins
+    .get("allow")
+    .and_then(|value| value.as_array())
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+
+  for plugin in KNAPSACK_CORE_STARTUP_PLUGINS
+    .iter()
+    .chain(KNAPSACK_DEFERRED_STARTUP_PLUGINS.iter())
+  {
+    if !allow.iter().any(|existing| existing == plugin) {
+      allow.push((*plugin).to_string());
+    }
+  }
+  if !eager_channel_plugin_start_enabled() {
+    allow.retain(|plugin| !is_bundled_channel_plugin_id(plugin));
+  }
+  allow.sort();
+  allow.dedup();
+
+  let next_allow = serde_json::json!(allow);
+  if plugins.get("allow") == Some(&next_allow) {
+    return false;
+  }
+  plugins.insert("allow".to_string(), next_allow);
+
+  match serde_json::to_string_pretty(&cfg) {
+    Ok(next) => match fs::write(&config_path, format!("{}\n", next)) {
+      Ok(_) => {
+        eprintln!(
+          "[clawd/service] Deferred startup warmup expanded plugins.allow after core readiness"
+        );
+        true
+      }
+      Err(e) => {
+        eprintln!(
+          "[clawd/service] Deferred startup warmup failed to write {}: {}",
+          config_path.display(),
+          e
+        );
+        false
+      }
+    },
+    Err(e) => {
+      eprintln!(
+        "[clawd/service] Deferred startup warmup failed to serialize config: {}",
+        e
+      );
+      false
+    }
+  }
+}
+
+fn schedule_deferred_startup_warmup(app_handle: tauri::AppHandle) {
+  if !defer_optional_startup_plugins_enabled() {
+    return;
+  }
+  if DEFERRED_STARTUP_WARMUP_SCHEDULED.swap(true, Ordering::Relaxed) {
+    return;
+  }
+  tokio::spawn(async move {
+    tokio::time::sleep(std::time::Duration::from_millis(15_000)).await;
+    let _ = expand_deferred_startup_plugin_allowlist(&app_handle);
+  });
 }
 
 fn remove_object_keys(obj: &mut serde_json::Map<String, serde_json::Value>, keys: &[&str]) -> bool {
@@ -1588,6 +1879,239 @@ fn read_clawdbot_bundle_version(clawdbot_dir: &std::path::Path) -> String {
     .unwrap_or_default()
 }
 
+fn sanitize_runtime_name(input: &str) -> String {
+  input
+    .chars()
+    .map(|ch| {
+      if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_' {
+        ch
+      } else {
+        '-'
+      }
+    })
+    .collect()
+}
+
+fn metadata_key(path: &Path) -> String {
+  fs::metadata(path)
+    .and_then(|metadata| {
+      let modified = metadata
+        .modified()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+      Ok(format!("{}:{}", metadata.len(), modified.as_millis()))
+    })
+    .unwrap_or_else(|_| "missing".to_string())
+}
+
+fn copy_clawdbot_runtime_tree(source: &Path, target: &Path, relative: &Path) -> Result<(), String> {
+  let current = source.join(relative);
+  let metadata = fs::symlink_metadata(&current)
+    .map_err(|e| format!("Could not inspect {}: {}", current.display(), e))?;
+
+  if metadata.file_type().is_symlink() {
+    return Ok(());
+  }
+
+  let parts: Vec<String> = relative
+    .components()
+    .map(|component| component.as_os_str().to_string_lossy().to_string())
+    .collect();
+  if (parts.len() == 2 && parts[0] == "node_modules" && parts[1] == "openclaw")
+    || (parts.len() == 2 && parts[0] == "dist" && parts[1] == "node_modules")
+  {
+    return Ok(());
+  }
+
+  let destination = target.join(relative);
+  if metadata.is_dir() {
+    fs::create_dir_all(&destination)
+      .map_err(|e| format!("Could not create {}: {}", destination.display(), e))?;
+    for entry in
+      fs::read_dir(&current).map_err(|e| format!("Could not read {}: {}", current.display(), e))?
+    {
+      let entry =
+        entry.map_err(|e| format!("Could not read entry in {}: {}", current.display(), e))?;
+      copy_clawdbot_runtime_tree(source, target, &relative.join(entry.file_name()))?;
+    }
+    return Ok(());
+  }
+
+  if let Some(parent) = destination.parent() {
+    fs::create_dir_all(parent)
+      .map_err(|e| format!("Could not create {}: {}", parent.display(), e))?;
+  }
+  fs::copy(&current, &destination).map_err(|e| {
+    format!(
+      "Could not copy {} to {}: {}",
+      current.display(),
+      destination.display(),
+      e
+    )
+  })?;
+  Ok(())
+}
+
+fn stage_clawdbot_runtime_if_needed(
+  app_handle: &tauri::AppHandle,
+  node_path: &Path,
+  clawdbot_entry: &Path,
+) -> Result<PathBuf, String> {
+  if !cfg!(target_os = "windows") {
+    return Ok(clawdbot_entry.to_path_buf());
+  }
+
+  let Some(clawdbot_root) = clawdbot_entry.parent().and_then(|p| p.parent()) else {
+    return Ok(clawdbot_entry.to_path_buf());
+  };
+  let version = read_clawdbot_bundle_version(clawdbot_root);
+  let runtime_root = app_clawdbot_home(app_handle)
+    .join("runtime")
+    .join(format!("openclaw-{}-npm", sanitize_runtime_name(&version)));
+  let marker_path = runtime_root.join(".knapsack-runtime-source");
+  let desired_marker = format!(
+    "npm\n{}\n{}\n{}",
+    version,
+    metadata_key(&clawdbot_root.join("package.json")),
+    metadata_key(clawdbot_entry)
+  );
+  let staged_entry = runtime_root
+    .join("node_modules")
+    .join("openclaw")
+    .join("openclaw.mjs");
+  let marker_matches = fs::read_to_string(&marker_path)
+    .map(|existing| existing == desired_marker)
+    .unwrap_or(false);
+
+  if !marker_matches || !staged_entry.exists() {
+    let runtime_base = app_clawdbot_home(app_handle).join("runtime");
+    let resolved_target = runtime_root.canonicalize().unwrap_or(runtime_root.clone());
+    let resolved_base = runtime_base.canonicalize().unwrap_or(runtime_base.clone());
+    if resolved_target != resolved_base && !resolved_target.starts_with(&resolved_base) {
+      return Err(format!(
+        "Refusing to stage OpenClaw runtime outside {}: {}",
+        resolved_base.display(),
+        resolved_target.display()
+      ));
+    }
+    eprintln!(
+      "[clawd/service] Installing staged OpenClaw runtime openclaw@{} -> {}",
+      version,
+      runtime_root.display()
+    );
+    let _ = fs::remove_dir_all(&runtime_root);
+    fs::create_dir_all(&runtime_root).map_err(|e| {
+      format!(
+        "Could not create staged OpenClaw runtime {}: {}",
+        runtime_root.display(),
+        e
+      )
+    })?;
+
+    let package_json = serde_json::json!({
+      "private": true,
+      "dependencies": {
+        "openclaw": version
+      }
+    });
+    fs::write(
+      runtime_root.join("package.json"),
+      serde_json::to_string_pretty(&package_json).unwrap_or_else(|_| "{}".to_string()),
+    )
+    .map_err(|e| format!("Could not write staged OpenClaw package.json: {}", e))?;
+
+    let npm_cli = node_path.parent().map(|node_dir| {
+      node_dir
+        .join("node_modules")
+        .join("npm")
+        .join("bin")
+        .join("npm-cli.js")
+    });
+    let mut command = if let Some(npm_cli) = npm_cli.filter(|p| p.exists()) {
+      let mut command = std::process::Command::new(node_path);
+      command.arg(npm_cli);
+      command
+    } else {
+      let npm_bin = node_path
+        .parent()
+        .map(|node_dir| {
+          if cfg!(target_os = "windows") {
+            node_dir.join("npm.cmd")
+          } else {
+            node_dir.join("npm")
+          }
+        })
+        .filter(|p| p.exists())
+        .unwrap_or_else(|| PathBuf::from("npm"));
+      std::process::Command::new(npm_bin)
+    };
+    let status = command
+      .current_dir(&runtime_root)
+      .arg("install")
+      .arg("--omit=dev")
+      .arg("--ignore-scripts")
+      .arg("--no-audit")
+      .arg("--no-fund")
+      .arg("--cache")
+      .arg(runtime_root.join(".openclaw-npm-cache"))
+      .status()
+      .map_err(|e| {
+        format!(
+          "Could not run npm install for staged OpenClaw runtime: {}",
+          e
+        )
+      })?;
+    if !status.success() {
+      return Err(format!(
+        "npm install failed while staging OpenClaw runtime {} (exit {})",
+        runtime_root.display(),
+        status
+      ));
+    }
+
+    if !staged_entry.exists() {
+      return Err(format!(
+        "Staged OpenClaw entry missing after npm install: {}",
+        staged_entry.display()
+      ));
+    }
+    fs::write(&marker_path, desired_marker).map_err(|e| {
+      format!(
+        "Could not write staged OpenClaw marker {}: {}",
+        marker_path.display(),
+        e
+      )
+    })?;
+  }
+
+  ensure_clawdbot_runtime_self_link(&staged_entry);
+  Ok(staged_entry)
+}
+
+fn clawdbot_node_path_for_entry(clawdbot_entry: &Path) -> PathBuf {
+  if let Some(parent) = clawdbot_entry.parent() {
+    if parent.file_name().and_then(|n| n.to_str()) == Some("openclaw") {
+      if let Some(node_modules) = parent.parent() {
+        if node_modules.file_name().and_then(|n| n.to_str()) == Some("node_modules") {
+          return node_modules.to_path_buf();
+        }
+      }
+    }
+  }
+
+  let Some(package_root) = clawdbot_entry.parent().and_then(|p| p.parent()) else {
+    return PathBuf::from("node_modules");
+  };
+  if package_root.file_name().and_then(|n| n.to_str()) == Some("openclaw") {
+    if let Some(parent) = package_root.parent() {
+      if parent.file_name().and_then(|n| n.to_str()) == Some("node_modules") {
+        return parent.to_path_buf();
+      }
+    }
+  }
+  package_root.join("node_modules")
+}
+
 fn clawdbot_bundle_dir(app_handle: &tauri::AppHandle) -> PathBuf {
   resource_path(app_handle, "resources/clawdbot")
 }
@@ -2050,7 +2574,10 @@ fn install_bundled_plugin_runtime_deps(
   ensure_openclaw_self_link(&root_nm);
 }
 
-fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path: &std::path::Path) -> bool {
+fn bundled_node_modules_has_declared_dependencies(
+  dir: &std::path::Path,
+  nm_path: &std::path::Path,
+) -> bool {
   let pkg_path = dir.join("package.json");
   let Ok(raw) = fs::read_to_string(&pkg_path) else {
     return false;
@@ -2071,6 +2598,13 @@ fn bundled_node_modules_has_declared_dependencies(dir: &std::path::Path, nm_path
   deps
     .keys()
     .all(|dep| nm_path.join(dep).join("package.json").exists())
+}
+
+fn bundled_node_modules_non_empty(nm_path: &std::path::Path) -> bool {
+  nm_path
+    .read_dir()
+    .map(|mut entries| entries.any(|entry| entry.is_ok()))
+    .unwrap_or(false)
 }
 
 /// On Windows CI builds, prune-clawdbot.cjs packs `node_modules/` into
@@ -2110,10 +2644,7 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
       .map(|v| {
         v.get("tar_len").and_then(|n| n.as_u64()) == Some(tar_len)
-          && v
-            .get("tar_mtime_secs")
-            .and_then(|n| n.as_u64())
-            == Some(tar_mtime_secs)
+          && v.get("tar_mtime_secs").and_then(|n| n.as_u64()) == Some(tar_mtime_secs)
       })
       .unwrap_or(false);
     if marker_current && bundled_node_modules_has_declared_dependencies(dir, &nm_path) {
@@ -2127,6 +2658,18 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       let _ = fs::write(&marker_path, marker.to_string());
       eprintln!(
         "[clawd/service] node_modules present and complete in {} - skipping tar extraction",
+        dir.display()
+      );
+      return;
+    }
+    if bundled_node_modules_non_empty(&nm_path) {
+      let marker = serde_json::json!({
+        "tar_len": tar_len,
+        "tar_mtime_secs": tar_mtime_secs,
+      });
+      let _ = fs::write(&marker_path, marker.to_string());
+      eprintln!(
+        "[clawd/service] node_modules present in {} - refreshed tar marker without extraction",
         dir.display()
       );
       return;
@@ -2200,6 +2743,7 @@ fn ensure_openclaw_link_to(root_nm: &std::path::Path, target: &std::path::Path) 
   let link_path = root_nm.join("openclaw");
   if link_path.join("package.json").exists()
     && link_path
+      .join("dist")
       .join("plugin-sdk")
       .join("channel-message.js")
       .exists()
@@ -2208,10 +2752,7 @@ fn ensure_openclaw_link_to(root_nm: &std::path::Path, target: &std::path::Path) 
   }
 
   if link_path.exists() || link_path.symlink_metadata().is_ok() {
-    let backup_path = root_nm.join(format!(
-      ".knapsack-openclaw-incomplete-{}",
-      now_epoch_ms()
-    ));
+    let backup_path = root_nm.join(format!(".knapsack-openclaw-incomplete-{}", now_epoch_ms()));
     match fs::rename(&link_path, &backup_path) {
       Ok(()) => eprintln!(
         "[clawd/service] Moved incomplete openclaw link/package aside: {}",
@@ -2274,8 +2815,17 @@ fn ensure_openclaw_self_link(root_nm: &std::path::Path) {
 }
 
 fn ensure_clawdbot_runtime_self_link(clawdbot_entry: &std::path::Path) {
-  let Some(clawdbot_root) = clawdbot_entry.parent().and_then(|p| p.parent()) else {
+  let Some(entry_parent) = clawdbot_entry.parent() else {
     return;
+  };
+  let clawdbot_root = if entry_parent.file_name().and_then(|name| name.to_str()) == Some("openclaw")
+  {
+    entry_parent
+  } else {
+    let Some(root) = entry_parent.parent() else {
+      return;
+    };
+    root
   };
   if !should_mutate_bundled_clawdbot_runtime(clawdbot_root) {
     eprintln!(
@@ -2655,6 +3205,7 @@ fn spawn_gateway_process_detached(setup: &ServiceSetup, context: &str) -> bool {
     }
   };
 
+  let spawn_started = std::time::Instant::now();
   match std::process::Command::new(&setup.program_args[0])
     .args(&setup.program_args[1..])
     .envs(setup.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
@@ -2915,6 +3466,28 @@ async fn gateway_tcp_port_open(timeout: std::time::Duration) -> bool {
 
 pub async fn gateway_reachable_or_ready(timeout: std::time::Duration) -> bool {
   gateway_health_port_ok(timeout).await
+}
+
+pub async fn should_defer_optional_startup_api_work() -> bool {
+  if std::env::var("KNAPSACK_DISABLE_OPTIONAL_STARTUP_API_DEFER")
+    .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+    .unwrap_or(false)
+  {
+    return false;
+  }
+
+  if gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
+    return false;
+  }
+
+  if gateway_launch_grace_active().is_some()
+    || GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed)
+    || AUTO_ENABLE_STARTED.load(Ordering::Relaxed)
+  {
+    return true;
+  }
+
+  now_epoch_ms().saturating_sub(*PROCESS_STARTED_MS) < OPTIONAL_STARTUP_API_DEFER_MS
 }
 
 fn read_log_tail_lines_bounded(
@@ -3223,9 +3796,7 @@ fn ensure_imessage_allowlist_config(cfg: &mut serde_json::Value) -> bool {
     && ch.get("enabled").and_then(|value| value.as_bool()) != Some(false)
   {
     ch.insert("enabled".to_string(), serde_json::json!(false));
-    eprintln!(
-      "[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false"
-    );
+    eprintln!("[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false");
     patched = true;
   }
 
@@ -4198,6 +4769,8 @@ pub struct ServiceStatusResponse {
   pub success: bool,
   pub installed: bool,
   pub running: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub channels_ok: Option<bool>,
   pub label: String,
   pub message: String,
 }
@@ -5047,7 +5620,7 @@ async fn browser_control_start_direct(
   }
 }
 
-fn spawn_startup_browser_start_nudge(gateway_token: String) {
+fn spawn_startup_browser_start_nudge(app_handle: tauri::AppHandle, gateway_token: String) {
   if !startup_ready_browser_start_enabled() {
     return;
   }
@@ -5066,6 +5639,20 @@ fn spawn_startup_browser_start_nudge(gateway_token: String) {
       if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
         eprintln!("[clawd/service] startup-ready browser nudge: CDP already reachable");
         return;
+      }
+
+      #[cfg(any(target_os = "macos", target_os = "windows"))]
+      {
+        kill_stale_clawdbot_chromes();
+        match start_openclaw_chrome_direct(&app_handle) {
+          Ok(()) => {
+            eprintln!("[clawd/service] startup-ready direct browser nudge succeeded");
+            return;
+          }
+          Err(e) => {
+            last_error = Some(e);
+          }
+        }
       }
 
       match browser_control_start_direct(&gateway_token, std::time::Duration::from_millis(900))
@@ -5094,12 +5681,60 @@ fn spawn_startup_browser_start_nudge(gateway_token: String) {
   });
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), String> {
-  let chrome = Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
-  if !chrome.exists() {
-    return Err("Google Chrome app binary was not found".to_string());
-  }
+  #[cfg(target_os = "macos")]
+  let chrome = {
+    let chrome = PathBuf::from("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
+    if !chrome.exists() {
+      return Err("Google Chrome app binary was not found".to_string());
+    }
+    chrome
+  };
+
+  #[cfg(target_os = "windows")]
+  let chrome = {
+    let program_files =
+      std::env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".to_string());
+    let program_files_x86 =
+      std::env::var("ProgramFiles(x86)").unwrap_or_else(|_| "C:\\Program Files (x86)".to_string());
+    let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_default();
+    let candidates = [
+      format!(r"{}\Google\Chrome\Application\chrome.exe", program_files),
+      format!(
+        r"{}\Google\Chrome\Application\chrome.exe",
+        program_files_x86
+      ),
+      format!(r"{}\Google\Chrome\Application\chrome.exe", local_appdata),
+      format!(r"{}\Microsoft\Edge\Application\msedge.exe", program_files),
+      format!(
+        r"{}\Microsoft\Edge\Application\msedge.exe",
+        program_files_x86
+      ),
+      format!(r"{}\Microsoft\Edge\Application\msedge.exe", local_appdata),
+      format!(
+        r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
+        program_files
+      ),
+      format!(
+        r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
+        program_files_x86
+      ),
+      format!(
+        r"{}\BraveSoftware\Brave-Browser\Application\brave.exe",
+        local_appdata
+      ),
+    ];
+    candidates
+      .iter()
+      .map(PathBuf::from)
+      .find(|path| path.exists())
+      .ok_or_else(|| "No Chrome-family browser binary was found".to_string())?
+  };
+
+  #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+  let chrome =
+    return Err("Direct OpenClaw Chrome launch is not implemented on this platform".to_string());
 
   let user_data_dir = app_clawdbot_home(app_handle)
     .join("browser")
@@ -5113,7 +5748,8 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
     )
   })?;
 
-  std::process::Command::new(chrome)
+  let mut command = std::process::Command::new(chrome);
+  command
     .arg("--remote-debugging-port=18800")
     .arg(format!(
       "--user-data-dir={}",
@@ -5129,7 +5765,16 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
     .arg("about:blank")
     .stdin(Stdio::null())
     .stdout(Stdio::null())
-    .stderr(Stdio::null())
+    .stderr(Stdio::null());
+
+  #[cfg(target_os = "windows")]
+  {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    command.creation_flags(CREATE_NO_WINDOW);
+  }
+
+  command
     .spawn()
     .map(|_| ())
     .map_err(|e| format!("failed to launch OpenClaw Chrome profile: {}", e))
@@ -5221,6 +5866,13 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       }
     }
     let gateway_probe_failed = !gateway_ok;
+
+    if gateway_listening
+      && passive_browser_start_nudge_enabled()
+      && !browser_cdp_port_open(std::time::Duration::from_millis(100)).await
+    {
+      spawn_startup_browser_start_nudge(app_handle.get_ref().clone(), tokens.gateway_token.clone());
+    }
 
     // Track gateway state transitions for recovery logic.
     let was_healthy = GATEWAY_WAS_HEALTHY.load(Ordering::Relaxed);
@@ -5323,7 +5975,10 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         "[clawd/service] gateway not reachable for {}ms after launch - waiting before self-heal",
         elapsed
       );
-    } else if !gateway_ok && gateway_listening && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS {
+    } else if !gateway_ok
+      && gateway_listening
+      && unreachable_elapsed_ms < GATEWAY_POST_BIND_STARTUP_GRACE_MS
+    {
       eprintln!(
         "[clawd/service] gateway port is listening but health is still pending for {}ms - waiting before self-heal",
         unreachable_elapsed_ms
@@ -5381,14 +6036,19 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 
     // Keep the UI health poll cheap. Browser automation still uses the gateway
     // RPC path, but health must not queue long-lived WebSocket requests.
-    #[cfg(target_os = "windows")]
-    let browser_probe_timeout = std::time::Duration::from_millis(3000);
-    #[cfg(not(target_os = "windows"))]
-    let browser_probe_timeout = std::time::Duration::from_millis(2500);
+    let browser_probe_timeout = if qa_direct_gateway_mode() || launch_grace_elapsed_ms.is_some() {
+      std::time::Duration::from_millis(500)
+    } else {
+      std::time::Duration::from_millis(1500)
+    };
 
     let mut browser_probe = if gateway_ok {
       if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
         BrowserControlProbe::Ready
+      } else if (qa_direct_gateway_mode() || launch_grace_elapsed_ms.is_some())
+        && browser_control_tcp_port_open(std::time::Duration::from_millis(100)).await
+      {
+        BrowserControlProbe::Standby
       } else if BROWSER_STATUS_PROBE_IN_PROGRESS
         .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         .is_ok()
@@ -5459,7 +6119,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       let nudge_app_handle: tauri::AppHandle = app_handle.get_ref().clone();
       tokio::spawn(async move {
         if qa_direct_gateway_mode() {
-          #[cfg(target_os = "macos")]
+          #[cfg(any(target_os = "macos", target_os = "windows"))]
           {
             match start_openclaw_chrome_direct(&nudge_app_handle) {
               Ok(()) => {
@@ -5478,7 +6138,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
             return;
           }
 
-          #[cfg(not(target_os = "macos"))]
+          #[cfg(not(any(target_os = "macos", target_os = "windows")))]
           {
             eprintln!(
               "[clawd/service] QA direct browser nudge is not implemented on this platform"
@@ -5797,7 +6457,7 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       gateway_ok,
       gateway_listening: Some(gateway_listening),
       browser_ok,
-      channels_ok: None,
+      channels_ok: Some(!eager_channel_plugin_start_enabled()),
       startup_elapsed_ms: None,
       message,
       diagnostic_type,
@@ -5812,8 +6472,8 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
   use crate::clawd::gateway_ws;
 
-  const STARTUP_READY_BUDGET_MS: u64 = 30_000;
-  const GATEWAY_READY_BUDGET_MS: u64 = 26_000;
+  const STARTUP_READY_BUDGET_MS: u64 = 2_000;
+  const GATEWAY_READY_BUDGET_MS: u64 = 900;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -5835,7 +6495,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   if startup_ready_browser_start_enabled()
     && !browser_cdp_port_open(std::time::Duration::from_millis(100)).await
   {
-    spawn_startup_browser_start_nudge(tokens.gateway_token.clone());
+    spawn_startup_browser_start_nudge(app_handle.get_ref().clone(), tokens.gateway_token.clone());
   }
 
   #[cfg(target_os = "macos")]
@@ -5876,12 +6536,16 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   let ready_started_at = std::time::Instant::now();
   let mut ready = false;
   while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
-    if gateway_reachable_or_ready(std::time::Duration::from_millis(1000)).await {
+    if gateway_reachable_or_ready(std::time::Duration::from_millis(150)).await {
+      ready = true;
+      break;
+    }
+    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
       ready = true;
       break;
     }
     if tokio::time::timeout(
-      std::time::Duration::from_millis(3500),
+      std::time::Duration::from_millis(250),
       gateway_ws::config_get(Some(&tokens.gateway_token)),
     )
     .await
@@ -5891,7 +6555,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       ready = true;
       break;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
   }
 
   let remaining_ms =
@@ -5902,36 +6566,48 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       true
     } else {
       let mut probe =
-        browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(6000)).await;
+        browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(250)).await;
       if probe == BrowserControlProbe::Down {
         probe =
-          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
+          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
             .await;
       }
-      if probe == BrowserControlProbe::Down
-        && startup_ready_browser_start_enabled()
-        && remaining_ms() > 1500
-      {
+      if probe == BrowserControlProbe::Down && startup_ready_browser_start_enabled() {
         BROWSER_LAST_NUDGE_MS.store(now_epoch_ms(), Ordering::Relaxed);
-        let _ = browser_control_start_direct(
-          &tokens.gateway_token,
-          std::time::Duration::from_millis(900),
-        )
-        .await;
-        probe =
-          browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
-            .await;
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        {
+          kill_stale_clawdbot_chromes();
+          let _ = start_openclaw_chrome_direct(app_handle.get_ref());
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        if remaining_ms() > 500 {
+          let _ = browser_control_start_direct(
+            &tokens.gateway_token,
+            std::time::Duration::from_millis(900),
+          )
+          .await;
+        }
+        if browser_cdp_port_open(std::time::Duration::from_millis(250)).await {
+          probe = BrowserControlProbe::Ready;
+        } else {
+          probe =
+            browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
+              .await;
+        }
       }
-      while probe != BrowserControlProbe::Ready && remaining_ms() > 1800 {
+      let browser_wait_started_at = std::time::Instant::now();
+      while probe != BrowserControlProbe::Ready
+        && remaining_ms() > 500
+        && browser_wait_started_at.elapsed().as_millis() < 500
+      {
         if probe == BrowserControlProbe::Standby && !startup_ready_browser_start_enabled() {
           break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-        probe =
-          browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(6000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        probe = browser_control_status_via_gateway_rpc(std::time::Duration::from_millis(250)).await;
         if probe == BrowserControlProbe::Down {
           probe =
-            browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
+            browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(250))
               .await;
         }
       }
@@ -5941,13 +6617,21 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     false
   };
 
-  let mut channels_ok = !eager_channel_plugin_start_enabled();
-  while ready && !channels_ok && remaining_ms() > 500 {
-    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp") {
+  let startup_channels = if eager_channel_plugin_start_enabled() {
+    startup_ready_channel_ids(app_handle.get_ref())
+  } else {
+    Vec::new()
+  };
+  let mut channels_ok = startup_channels.is_empty();
+  while ready && !channels_ok && remaining_ms() > 250 {
+    if startup_channels
+      .iter()
+      .all(|channel| gateway_log_has_channel_started(channel))
+    {
       channels_ok = true;
       break;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
   }
 
   let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
@@ -5955,6 +6639,9 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   // are reported separately so slow or degraded integrations do not keep the
   // local gateway false.
   let success = ready;
+  if ready && browser_ok && channels_ok {
+    schedule_deferred_startup_warmup(app_handle.get_ref().clone());
+  }
 
   HttpResponse::Ok().json(ServiceHealthResponse {
     success,
@@ -5972,7 +6659,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     } else if ready {
       "Gateway is ready; browser and channels are still starting up".to_string()
     } else {
-      "Gateway did not become ready within 30s".to_string()
+      "Gateway did not become ready within startup-ready probe budget".to_string()
     },
     diagnostic_type: None,
   })
@@ -6063,6 +6750,7 @@ pub async fn service_status() -> impl Responder {
       success: false,
       installed: false,
       running: false,
+      channels_ok: None,
       label: LAUNCH_AGENT_LABEL.to_string(),
       message: "Service management is not implemented for this platform".to_string(),
     });
@@ -6091,6 +6779,7 @@ pub async fn service_status() -> impl Responder {
       success: true,
       installed: true,
       running,
+      channels_ok: Some(!eager_channel_plugin_start_enabled()),
       label: LAUNCH_AGENT_LABEL.to_string(),
       message: if running {
         "Clawdbot service is running".to_string()
@@ -6109,6 +6798,7 @@ pub async fn service_status() -> impl Responder {
           success: false,
           installed: false,
           running: false,
+          channels_ok: None,
           label: LAUNCH_AGENT_LABEL.to_string(),
           message: e,
         })
@@ -6142,6 +6832,7 @@ pub async fn service_status() -> impl Responder {
       success: true,
       installed,
       running,
+      channels_ok: Some(!eager_channel_plugin_start_enabled()),
       label: LAUNCH_AGENT_LABEL.to_string(),
       message: if running {
         if let Some(ms) = launch_grace_ms {
@@ -6608,7 +7299,17 @@ pub struct SetApiKeyResponse {
 
 fn normalize_coding_agent(agent: &str) -> Option<String> {
   let agent = agent.trim().to_lowercase();
-  if ["claude", "codex", "antigravity", "agy", "gemini", "grok", "opencode"].contains(&agent.as_str()) {
+  if [
+    "claude",
+    "codex",
+    "antigravity",
+    "agy",
+    "gemini",
+    "grok",
+    "opencode",
+  ]
+  .contains(&agent.as_str())
+  {
     if agent == "agy" {
       return Some("antigravity".to_string());
     }
@@ -6705,10 +7406,7 @@ pub async fn set_api_key(
         .groq_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
-      "xai" => tokens
-        .xai_api_key
-        .as_ref()
-        .map_or(false, |k| !k.is_empty()),
+      "xai" => tokens.xai_api_key.as_ref().map_or(false, |k| !k.is_empty()),
       "openrouter" => tokens
         .openrouter_api_key
         .as_ref()
@@ -7974,8 +8672,10 @@ async fn prepare_gateway_config(
   // ── Find clawdbot entry ────────────────────────────────────────────
   let clawdbot_entry = if cfg!(debug_assertions) {
     if cfg!(target_os = "windows") {
-      let bundled_entry =
-        resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js");
+      let bundled_entry = resource_path(
+        app_handle,
+        "resources/clawdbot/dist/knapsack-gateway-entry.js",
+      );
       if bundled_entry.exists() {
         bundled_entry
       } else {
@@ -7999,7 +8699,10 @@ async fn prepare_gateway_config(
       }
     }
   } else {
-    resource_path(app_handle, "resources/clawdbot/dist/knapsack-gateway-entry.js")
+    resource_path(
+      app_handle,
+      "resources/clawdbot/dist/knapsack-gateway-entry.js",
+    )
   };
 
   if !clawdbot_entry.exists() {
@@ -8012,6 +8715,7 @@ async fn prepare_gateway_config(
       clawdbot_entry.display()
     ));
   }
+  let clawdbot_entry = stage_clawdbot_runtime_if_needed(app_handle, &node_path, &clawdbot_entry)?;
   eprintln!(
     "[clawd/service] Using Clawdbot entry: {}",
     clawdbot_entry.display()
@@ -8025,6 +8729,14 @@ async fn prepare_gateway_config(
   // Ensure OpenClaw config exists with gateway.mode=local for first-run.
   let config_path = clawdbot_home.join("openclaw.json");
   let legacy_config_path = clawdbot_home.join("clawdbot.json");
+  let qa_provider_for_config = std::env::var("KNAPSACK_QA_PROVIDER")
+    .ok()
+    .map(|provider| provider.trim().to_lowercase())
+    .filter(|provider| !provider.is_empty());
+  eprintln!(
+    "[clawd/service] QA provider at config setup: {:?}",
+    qa_provider_for_config
+  );
   if legacy_config_path.exists() && !config_path.exists() {
     match fs::rename(&legacy_config_path, &config_path) {
       Ok(_) => eprintln!("[clawd/service] Migrated config from clawdbot.json to openclaw.json"),
@@ -8076,7 +8788,7 @@ async fn prepare_gateway_config(
         "defaultProfile": "openclaw" // managed, isolated profile
       },
       "plugins": {
-        "allow": KNAPSACK_REQUIRED_PLUGINS,
+        "allow": KNAPSACK_CORE_STARTUP_PLUGINS,
         "slots": {
           "memory": "none"
         }
@@ -8393,10 +9105,46 @@ async fn prepare_gateway_config(
             patched = true;
           }
         }
-        if !current_primary.trim().is_empty() && model_ref_has_key(current_primary.trim()) {
-          let expected_fallbacks = crate::clawd::gateway_client::collect_fallback_models(
-            current_primary.trim(),
+        if qa_provider_for_config.is_some() {
+          let qa_model = crate::clawd::gateway_client::build_model_config();
+          eprintln!(
+            "[clawd/service] QA provider selected; computed config model: {}",
+            qa_model
           );
+          if cfg_val.pointer("/agents").is_none() {
+            cfg_val
+              .as_object_mut()
+              .unwrap()
+              .insert("agents".to_string(), serde_json::json!({}));
+          }
+          if cfg_val.pointer("/agents/defaults").is_none() {
+            cfg_val
+              .pointer_mut("/agents")
+              .unwrap()
+              .as_object_mut()
+              .unwrap()
+              .insert("defaults".to_string(), serde_json::json!({}));
+          }
+          if let Some(defaults) = cfg_val
+            .pointer_mut("/agents/defaults")
+            .and_then(|v| v.as_object_mut())
+          {
+            if defaults.get("model") != Some(&qa_model) {
+              defaults.insert("model".to_string(), qa_model);
+              eprintln!("[clawd/service] QA provider selected; pinned agents.defaults.model without fallbacks");
+              patched = true;
+            }
+            if defaults.remove("models").is_some() {
+              eprintln!(
+                "[clawd/service] QA provider selected; removed legacy agents.defaults.models"
+              );
+              patched = true;
+            }
+          }
+        }
+        if !current_primary.trim().is_empty() && model_ref_has_key(current_primary.trim()) {
+          let expected_fallbacks =
+            crate::clawd::gateway_client::collect_fallback_models(current_primary.trim());
           if !expected_fallbacks.is_empty() {
             let existing_fallbacks = cfg_val
               .pointer("/agents/defaults/model/fallbacks")
@@ -9078,10 +9826,7 @@ async fn prepare_gateway_config(
   let bundled_plugins_dir_str = node_arg_path(&bundled_plugins_dir);
   let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
 
-  let node_dir = node_path
-    .parent()
-    .map(node_arg_path)
-    .unwrap_or_default();
+  let node_dir = node_path.parent().map(node_arg_path).unwrap_or_default();
   let path_separator = if cfg!(target_os = "windows") {
     ";"
   } else {
@@ -9130,6 +9875,29 @@ async fn prepare_gateway_config(
     .join("plugin-runtime-deps")
     .to_string_lossy()
     .to_string();
+  let node_compile_cache_dir = app_clawdbot_home(app_handle).join("node-compile-cache");
+  let qa_provider = std::env::var("KNAPSACK_QA_PROVIDER")
+    .ok()
+    .map(|provider| provider.trim().to_lowercase())
+    .filter(|provider| !provider.is_empty());
+  eprintln!(
+    "[clawd/service] QA provider at gateway env setup: {:?}",
+    qa_provider
+  );
+  let qa_provider_selected = qa_provider.is_some();
+  let qa_allows_provider = |provider: &str| -> bool {
+    match qa_provider.as_deref() {
+      None => true,
+      Some("google") => provider == "gemini" || provider == "google",
+      Some(selected) => selected == provider,
+    }
+  };
+  if let Err(e) = ensure_dir(&node_compile_cache_dir) {
+    eprintln!(
+      "[clawd/service] WARNING: Failed to create Node compile cache dir: {}",
+      e
+    );
+  }
   let mut env = vec![
     ("PATH".to_string(), clawdbot_path),
     ("HOME".to_string(), user_home.clone()),
@@ -9160,7 +9928,7 @@ async fn prepare_gateway_config(
     // port. Channels can continue connecting after the UI is already usable.
     (
       "OPENCLAW_GATEWAY_STARTUP_WARMUP_TIMEOUT_MS".to_string(),
-      "2000".to_string(),
+      "1000".to_string(),
     ),
     (
       "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM".to_string(),
@@ -9168,7 +9936,7 @@ async fn prepare_gateway_config(
     ),
     (
       "OPENCLAW_CHANNEL_STARTUP_HANDOFF_TIMEOUT_MS".to_string(),
-      "3000".to_string(),
+      "1000".to_string(),
     ),
     (
       "OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS".to_string(),
@@ -9179,12 +9947,37 @@ async fn prepare_gateway_config(
       "1".to_string(),
     ),
     (
+      "KNAPSACK_DEFER_OPTIONAL_STARTUP_PLUGINS".to_string(),
+      "1".to_string(),
+    ),
+    (
+      "OPENCLAW_DEFER_STARTUP_PROVIDERS".to_string(),
+      "1".to_string(),
+    ),
+    ("OPENCLAW_DEFER_STARTUP_SEARCH".to_string(), "1".to_string()),
+    (
+      "OPENCLAW_DEFER_STARTUP_DOCUMENTS".to_string(),
+      "1".to_string(),
+    ),
+    (
       "OPENCLAW_DESKTOP_MANAGED_GATEWAY".to_string(),
       "1".to_string(),
     ),
     (
+      "OPENCLAW_DEFER_STARTUP_SECRETS".to_string(),
+      "1".to_string(),
+    ),
+    (
+      "OPENCLAW_SKIP_STARTUP_PLUGIN_AUTO_ENABLE".to_string(),
+      "1".to_string(),
+    ),
+    (
       "OPENCLAW_DESKTOP_AUTO_START_CHANNELS".to_string(),
-      "0".to_string(),
+      if eager_channel_plugin_start_enabled() {
+        "1".to_string()
+      } else {
+        "0".to_string()
+      },
     ),
     (
       "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
@@ -9198,13 +9991,37 @@ async fn prepare_gateway_config(
     // directory.  Without this, stale nested node_modules can cause
     // ERR_PACKAGE_PATH_NOT_EXPORTED errors.
     ("NODE_PATH".to_string(), {
-      let mut nm = clawdbot_entry.clone();
-      nm.pop(); // remove entry.js
-      nm.pop(); // remove dist/
-      nm.push("node_modules");
-      nm.to_string_lossy().to_string()
+      clawdbot_node_path_for_entry(&clawdbot_entry)
+        .to_string_lossy()
+        .to_string()
     }),
   ];
+
+  if let Ok(disable_bundled_plugins) = std::env::var("OPENCLAW_DISABLE_BUNDLED_PLUGINS") {
+    let disable_bundled_plugins = disable_bundled_plugins.trim().to_string();
+    if !disable_bundled_plugins.is_empty() {
+      env.push((
+        "OPENCLAW_DISABLE_BUNDLED_PLUGINS".to_string(),
+        disable_bundled_plugins,
+      ));
+    }
+  }
+
+  if qa_provider_selected {
+    if let Some(provider) = qa_provider.clone() {
+      env.push(("KNAPSACK_QA_PROVIDER".to_string(), provider));
+    }
+  }
+  if let Ok(plugin_allowlist) = std::env::var("KNAPSACK_QA_PLUGIN_ALLOWLIST") {
+    let plugin_allowlist = plugin_allowlist.trim().to_string();
+    if !plugin_allowlist.is_empty() {
+      env.push(("KNAPSACK_QA_PLUGIN_ALLOWLIST".to_string(), plugin_allowlist));
+    }
+  }
+  env.push((
+    "NODE_COMPILE_CACHE".to_string(),
+    node_compile_cache_dir.to_string_lossy().to_string(),
+  ));
 
   // On Windows, propagate critical system env vars.  The gateway child process
   // receives ONLY the env vars we pass (`.envs()` replaces the environment).
@@ -9242,49 +10059,62 @@ async fn prepare_gateway_config(
     // a legacy "clawdbot" service and moving it to Trash. On Windows these
     // markers mean "schtasks-supervised" to OpenClaw, which adds a 30s lock
     // recovery wait to the desktop-managed direct gateway startup path.
-    env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
+    env.push((
+      "OPENCLAW_SERVICE_MARKER".to_string(),
+      "openclaw".to_string(),
+    ));
     env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
   }
 
   // Propagate LLM keys
-  if let Some(k) = tokens.groq_api_key.clone() {
-    let k = k.trim().to_string();
-    if !k.is_empty() {
-      std::env::set_var("GROQ_API_KEY", &k);
-      env.push(("GROQ_API_KEY".to_string(), k));
+  if qa_allows_provider("groq") {
+    if let Some(k) = tokens.groq_api_key.clone() {
+      let k = k.trim().to_string();
+      if !k.is_empty() {
+        std::env::set_var("GROQ_API_KEY", &k);
+        env.push(("GROQ_API_KEY".to_string(), k));
+      }
     }
   }
-  if let Some(k) = tokens.xai_api_key.clone() {
-    let k = k.trim().to_string();
-    if !k.is_empty() {
-      std::env::set_var("XAI_API_KEY", &k);
-      env.push(("XAI_API_KEY".to_string(), k));
+  if qa_allows_provider("xai") {
+    if let Some(k) = tokens.xai_api_key.clone() {
+      let k = k.trim().to_string();
+      if !k.is_empty() {
+        std::env::set_var("XAI_API_KEY", &k);
+        env.push(("XAI_API_KEY".to_string(), k));
+      }
     }
   }
-  if let Some(k) = tokens.openai_api_key.clone() {
-    let k = k.trim().to_string();
-    if !k.is_empty() {
-      std::env::set_var("OPENAI_API_KEY", &k);
-      env.push(("OPENAI_API_KEY".to_string(), k));
+  if qa_allows_provider("openai") {
+    if let Some(k) = tokens.openai_api_key.clone() {
+      let k = k.trim().to_string();
+      if !k.is_empty() {
+        std::env::set_var("OPENAI_API_KEY", &k);
+        env.push(("OPENAI_API_KEY".to_string(), k));
+      }
     }
   }
-  if let Some(k) = tokens.anthropic_api_key.clone() {
-    let k = k.trim().to_string();
-    if !k.is_empty() {
-      std::env::set_var("ANTHROPIC_API_KEY", &k);
-      env.push(("ANTHROPIC_API_KEY".to_string(), k));
+  if qa_allows_provider("anthropic") {
+    if let Some(k) = tokens.anthropic_api_key.clone() {
+      let k = k.trim().to_string();
+      if !k.is_empty() {
+        std::env::set_var("ANTHROPIC_API_KEY", &k);
+        env.push(("ANTHROPIC_API_KEY".to_string(), k));
+      }
     }
   }
-  if let Some(k) = tokens.gemini_api_key.clone() {
-    let k = k.trim().to_string();
-    if !k.is_empty() {
-      std::env::set_var("GEMINI_API_KEY", &k);
-      std::env::set_var("GOOGLE_API_KEY", &k);
-      env.push(("GEMINI_API_KEY".to_string(), k.clone()));
-      env.push(("GOOGLE_API_KEY".to_string(), k));
+  if qa_allows_provider("gemini") || qa_allows_provider("google") {
+    if let Some(k) = tokens.gemini_api_key.clone() {
+      let k = k.trim().to_string();
+      if !k.is_empty() {
+        std::env::set_var("GEMINI_API_KEY", &k);
+        std::env::set_var("GOOGLE_API_KEY", &k);
+        env.push(("GEMINI_API_KEY".to_string(), k.clone()));
+        env.push(("GOOGLE_API_KEY".to_string(), k));
+      }
     }
   }
-  if tokens.ollama_enabled.unwrap_or(false) {
+  if qa_allows_provider("ollama") && tokens.ollama_enabled.unwrap_or(false) {
     std::env::set_var("OLLAMA_API_KEY", "ollama-local");
     env.push(("OLLAMA_API_KEY".to_string(), "ollama-local".to_string()));
     if let Some(m) = tokens.ollama_model.clone() {
@@ -9303,40 +10133,94 @@ async fn prepare_gateway_config(
     }
   }
   // Propagate OpenRouter key
-  if let Some(k) = tokens.openrouter_api_key.clone() {
-    let k = k.trim().to_string();
-    if !k.is_empty() {
-      std::env::set_var("OPENROUTER_API_KEY", &k);
-      env.push(("OPENROUTER_API_KEY".to_string(), k));
+  if qa_allows_provider("openrouter") {
+    if let Some(k) = tokens.openrouter_api_key.clone() {
+      let k = k.trim().to_string();
+      if !k.is_empty() {
+        std::env::set_var("OPENROUTER_API_KEY", &k);
+        env.push(("OPENROUTER_API_KEY".to_string(), k));
+      }
     }
   }
 
   // Propagate active provider and model overrides so the gateway uses the
   // correct provider/model the user selected in the UI.
-  if let Some(p) = tokens.active_provider.clone() {
+  if let Some(p) = qa_provider
+    .clone()
+    .or_else(|| tokens.active_provider.clone())
+  {
     let p = p.trim().to_string();
     if !p.is_empty() {
       std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", &p);
       env.push(("KNAPSACK_ACTIVE_PROVIDER".to_string(), p));
     }
   }
-  if let Some(m) = tokens.openai_model.clone() {
-    env.push(("KNAPSACK_OPENAI_MODEL".to_string(), m));
+  if qa_allows_provider("openai") {
+    if let Some(m) = tokens.openai_model.clone() {
+      env.push(("KNAPSACK_OPENAI_MODEL".to_string(), m));
+    }
   }
-  if let Some(m) = tokens.anthropic_model.clone() {
-    env.push(("KNAPSACK_ANTHROPIC_MODEL".to_string(), m));
+  if qa_allows_provider("anthropic") {
+    if let Some(m) = tokens.anthropic_model.clone() {
+      env.push(("KNAPSACK_ANTHROPIC_MODEL".to_string(), m));
+    }
   }
-  if let Some(m) = tokens.gemini_model.clone() {
-    env.push(("KNAPSACK_GEMINI_MODEL".to_string(), m));
+  if qa_allows_provider("gemini") || qa_allows_provider("google") {
+    if let Some(m) = tokens.gemini_model.clone() {
+      std::env::set_var("KNAPSACK_GEMINI_MODEL", &m);
+      env.push(("KNAPSACK_GEMINI_MODEL".to_string(), m));
+    }
   }
-  if let Some(m) = tokens.groq_model.clone() {
-    env.push(("KNAPSACK_GROQ_MODEL".to_string(), m));
+  if qa_allows_provider("groq") {
+    if let Some(m) = tokens.groq_model.clone() {
+      env.push(("KNAPSACK_GROQ_MODEL".to_string(), m));
+    }
   }
-  if let Some(m) = tokens.xai_model.clone() {
-    env.push(("KNAPSACK_XAI_MODEL".to_string(), m));
+  if qa_allows_provider("xai") {
+    if let Some(m) = tokens.xai_model.clone() {
+      env.push(("KNAPSACK_XAI_MODEL".to_string(), m));
+    }
   }
-  if let Some(m) = tokens.openrouter_model.clone() {
-    env.push(("KNAPSACK_OPENROUTER_MODEL".to_string(), m));
+  if qa_allows_provider("openrouter") {
+    if let Some(m) = tokens.openrouter_model.clone() {
+      env.push(("KNAPSACK_OPENROUTER_MODEL".to_string(), m));
+    }
+  }
+
+  if qa_provider_selected {
+    if let Ok(raw) = fs::read_to_string(&config_path) {
+      if let Ok(mut cfg_val) = serde_json::from_str::<serde_json::Value>(&raw) {
+        if cfg_val.pointer("/agents").is_none() {
+          if let Some(obj) = cfg_val.as_object_mut() {
+            obj.insert("agents".to_string(), serde_json::json!({}));
+          }
+        }
+        if cfg_val.pointer("/agents/defaults").is_none() {
+          if let Some(agents) = cfg_val
+            .pointer_mut("/agents")
+            .and_then(|value| value.as_object_mut())
+          {
+            agents.insert("defaults".to_string(), serde_json::json!({}));
+          }
+        }
+        if let Some(defaults) = cfg_val
+          .pointer_mut("/agents/defaults")
+          .and_then(|value| value.as_object_mut())
+        {
+          defaults.insert(
+            "model".to_string(),
+            crate::clawd::gateway_client::build_model_config(),
+          );
+          defaults.remove("models");
+          if let Ok(next) = serde_json::to_string_pretty(&cfg_val) {
+            let _ = fs::write(&config_path, format!("{}\n", next));
+            eprintln!(
+              "[clawd/service] QA provider selected; pinned Windows gateway agents.defaults.model without fallbacks"
+            );
+          }
+        }
+      }
+    }
   }
 
   if let Some(extra) = &tokens.extra_provider_keys {
@@ -9345,6 +10229,145 @@ async fn prepare_gateway_config(
       if !key.is_empty() && is_allowed_extra_env_var(env_var) {
         std::env::set_var(env_var, &key);
         env.push((env_var.clone(), key));
+      }
+    }
+  }
+
+  {
+    let child_env_value = |key: &str| -> Option<String> {
+      env
+        .iter()
+        .rev()
+        .find(|(candidate, _)| candidate == key)
+        .map(|(_, value)| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    };
+    if let Some(qa_provider) = child_env_value("KNAPSACK_QA_PROVIDER") {
+      let provider_model = |env_key: &str, default_model: &str| -> String {
+        child_env_value(env_key).unwrap_or_else(|| default_model.to_string())
+      };
+      let primary_model = match qa_provider.as_str() {
+        "gemini" | "google" => format!(
+          "google/{}",
+          provider_model("KNAPSACK_GEMINI_MODEL", "gemini-3.1-pro-preview")
+        ),
+        "openrouter" => format!(
+          "openrouter/{}",
+          provider_model(
+            "KNAPSACK_OPENROUTER_MODEL",
+            "meta-llama/llama-3.3-70b-instruct:free"
+          )
+        ),
+        "openai" => format!(
+          "openai/{}",
+          provider_model("KNAPSACK_OPENAI_MODEL", "gpt-5.4")
+        ),
+        "anthropic" => format!(
+          "anthropic/{}",
+          provider_model("KNAPSACK_ANTHROPIC_MODEL", "claude-opus-4-6")
+        ),
+        "groq" => format!(
+          "groq/{}",
+          provider_model("KNAPSACK_GROQ_MODEL", "llama-3.3-70b-versatile")
+        ),
+        "xai" => format!(
+          "xai/{}",
+          provider_model("KNAPSACK_XAI_MODEL", "grok-code-fast-1")
+        ),
+        _ => crate::clawd::gateway_client::resolve_default_model(),
+      };
+
+      if let Ok(raw) = fs::read_to_string(&config_path) {
+        if let Ok(mut cfg_val) = serde_json::from_str::<serde_json::Value>(&raw) {
+          let mut patched = false;
+          if cfg_val.pointer("/agents").is_none() {
+            if let Some(obj) = cfg_val.as_object_mut() {
+              obj.insert("agents".to_string(), serde_json::json!({}));
+              patched = true;
+            }
+          }
+          if cfg_val.pointer("/agents/defaults").is_none() {
+            if let Some(agents) = cfg_val
+              .pointer_mut("/agents")
+              .and_then(|value| value.as_object_mut())
+            {
+              agents.insert("defaults".to_string(), serde_json::json!({}));
+              patched = true;
+            }
+          }
+          if let Some(defaults) = cfg_val
+            .pointer_mut("/agents/defaults")
+            .and_then(|value| value.as_object_mut())
+          {
+            let next_model = serde_json::json!({ "primary": primary_model });
+            if defaults.get("model") != Some(&next_model) {
+              defaults.insert("model".to_string(), next_model);
+              patched = true;
+            }
+            if defaults.remove("models").is_some() {
+              patched = true;
+            }
+          }
+          if let Some(allowlist) = child_env_value("KNAPSACK_QA_PLUGIN_ALLOWLIST") {
+            let plugins = allowlist
+              .split(',')
+              .map(|plugin| plugin.trim())
+              .filter(|plugin| !plugin.is_empty())
+              .map(|plugin| plugin.to_string())
+              .collect::<Vec<_>>();
+            if !plugins.is_empty() {
+              if cfg_val.pointer("/plugins").is_none() {
+                if let Some(obj) = cfg_val.as_object_mut() {
+                  obj.insert("plugins".to_string(), serde_json::json!({}));
+                  patched = true;
+                }
+              }
+              if let Some(plugin_cfg) = cfg_val
+                .pointer_mut("/plugins")
+                .and_then(|value| value.as_object_mut())
+              {
+                let next_allow = serde_json::Value::Array(
+                  plugins
+                    .iter()
+                    .map(|plugin| serde_json::json!(plugin))
+                    .collect::<Vec<_>>(),
+                );
+                if plugin_cfg.get("allow") != Some(&next_allow) {
+                  plugin_cfg.insert("allow".to_string(), next_allow);
+                  patched = true;
+                }
+              }
+              if let Some(channels) = cfg_val
+                .pointer_mut("/channels")
+                .and_then(|value| value.as_object_mut())
+              {
+                for plugin in plugins
+                  .iter()
+                  .filter(|plugin| is_bundled_channel_plugin_id(plugin))
+                {
+                  if let Some(channel_cfg) = channels
+                    .get_mut(plugin)
+                    .and_then(|value| value.as_object_mut())
+                  {
+                    if channel_cfg.get("enabled").and_then(|value| value.as_bool()) != Some(true) {
+                      channel_cfg.insert("enabled".to_string(), serde_json::json!(true));
+                      patched = true;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          if patched {
+            if let Ok(next) = serde_json::to_string_pretty(&cfg_val) {
+              let _ = fs::write(&config_path, format!("{}\n", next));
+              eprintln!(
+                "[clawd/service] QA child env pinned gateway config for provider '{}'",
+                qa_provider
+              );
+            }
+          }
+        }
       }
     }
   }
@@ -9517,18 +10540,25 @@ pub async fn set_service_enabled(
         // If a gateway is now running, skip re-spawn
         let existing_pid = GATEWAY_PID.load(Ordering::Relaxed);
         if existing_pid > 0 {
+          if gateway_tcp_port_open(std::time::Duration::from_millis(150)).await {
+            eprintln!(
+              "[clawd/service] Enable request: gateway already running (pid {})",
+              existing_pid
+            );
+            return HttpResponse::Ok().json(EnableServiceResponse {
+              success: true,
+              enabled,
+              message: format!(
+                "Gateway already started by background restart (pid {})",
+                existing_pid
+              ),
+            });
+          }
           eprintln!(
-            "[clawd/service] Enable request: gateway already running (pid {})",
+            "[clawd/service] Enable request: background restart left non-listening pid {}; continuing with fresh spawn",
             existing_pid
           );
-          return HttpResponse::Ok().json(EnableServiceResponse {
-            success: true,
-            enabled,
-            message: format!(
-              "Gateway already started by background restart (pid {})",
-              existing_pid
-            ),
-          });
+          clear_stale_gateway_launch(existing_pid, gateway_launch_elapsed_ms().unwrap_or(0));
         }
       }
 
@@ -9672,6 +10702,7 @@ pub async fn set_service_enabled(
         Ok(child) => {
           let pid = child.id();
           GATEWAY_PID.store(pid, Ordering::Relaxed);
+          mark_gateway_launch_started();
           GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           eprintln!("[clawd/service] Spawned gateway process (pid {})", pid);
 
@@ -9898,6 +10929,21 @@ pub async fn set_service_enabled(
           ),
         });
       }
+      let clawdbot_entry =
+        match stage_clawdbot_runtime_if_needed(&app_handle, &node_path, &clawdbot_entry) {
+          Ok(entry) => entry,
+          Err(e) => {
+            eprintln!(
+              "[clawd/service] ERROR: Could not stage Clawdbot runtime: {}",
+              e
+            );
+            return HttpResponse::InternalServerError().json(EnableServiceResponse {
+              success: false,
+              enabled,
+              message: e,
+            });
+          }
+        };
       eprintln!(
         "[clawd/service] Using Clawdbot entry: {}",
         clawdbot_entry.display()
@@ -9955,51 +11001,51 @@ pub async fn set_service_enabled(
         // add post-start.  Complete initial config → no post-start file write → no
         // "missing-meta-before-write" anomaly and no cascade restart on first launch.
         let default_config = serde_json::json!({
-          "gateway": {
-            "mode": "local",
-            "auth": {
-              "token": tokens.gateway_token.clone(),
-              "mode": "token"
+            "gateway": {
+              "mode": "local",
+              "auth": {
+                "token": tokens.gateway_token.clone(),
+                "mode": "token"
+              },
+              "controlUi": {
+                "allowInsecureAuth": true,
+                "allowedOrigins": ["tauri://localhost", "http://localhost:1420"]
+              }
             },
-            "controlUi": {
-              "allowInsecureAuth": true,
-              "allowedOrigins": ["tauri://localhost", "http://localhost:1420"]
-            }
-          },
-          "browser": {
-            "enabled": true,
-            "headless": false,
-            "defaultProfile": "openclaw"
-          },
-          "plugins": {
-            "allow": KNAPSACK_REQUIRED_PLUGINS,
-            "slots": {
-              "memory": "none"
-            }
-          },
-          "models": {
-            "pricing": {
-              "enabled": false
-            }
-          },
-          "tools": {
-            "allow": ["browser", "group:web", "exec", "process", "group:fs"],
-            "deny": ["canvas", "nodes", "cron", "gateway"],
-            "exec": {"applyPatch": {"enabled": true}},
-            "media": {"image": {"enabled": true}},
-            "sandbox": {
-              "tools": {
-                "deny": ["canvas", "nodes", "cron", "gateway"],
-                "allow": [
-                  "exec", "process", "group:fs",
-                  "image", "sessions_list", "sessions_history",
-                  "sessions_send", "sessions_spawn", "session_status",
-                  "browser", "group:web"
-                ]
+            "browser": {
+              "enabled": true,
+              "headless": false,
+              "defaultProfile": "openclaw"
+            },
+        "plugins": {
+          "allow": KNAPSACK_CORE_STARTUP_PLUGINS,
+          "slots": {
+            "memory": "none"
+          }
+        },
+            "models": {
+              "pricing": {
+                "enabled": false
+              }
+            },
+            "tools": {
+              "allow": ["browser", "group:web", "exec", "process", "group:fs"],
+              "deny": ["canvas", "nodes", "cron", "gateway"],
+              "exec": {"applyPatch": {"enabled": true}},
+              "media": {"image": {"enabled": true}},
+              "sandbox": {
+                "tools": {
+                  "deny": ["canvas", "nodes", "cron", "gateway"],
+                  "allow": [
+                    "exec", "process", "group:fs",
+                    "image", "sessions_list", "sessions_history",
+                    "sessions_send", "sessions_spawn", "session_status",
+                    "browser", "group:web"
+                  ]
+                }
               }
             }
-          }
-        });
+          });
         match fs::write(
           &config_path,
           serde_json::to_string_pretty(&default_config).unwrap_or_default(),
@@ -10850,10 +11896,7 @@ pub async fn set_service_enabled(
       // Build a PATH that includes the directory where we found node (so npm
       // is also discoverable), plus common macOS paths.  LaunchAgents get a
       // minimal PATH by default which typically excludes /opt/homebrew/bin.
-      let node_dir = node_path
-        .parent()
-        .map(node_arg_path)
-        .unwrap_or_default();
+      let node_dir = node_path.parent().map(node_arg_path).unwrap_or_default();
       let mut path_parts: Vec<String> = Vec::new();
       if !node_dir.is_empty() {
         path_parts.push(node_dir);
@@ -10886,6 +11929,16 @@ pub async fn set_service_enabled(
         .join("plugin-runtime-deps")
         .to_string_lossy()
         .to_string();
+      let node_compile_cache_dir = app_clawdbot_home(app_handle).join("node-compile-cache");
+      let qa_provider_selected = std::env::var("KNAPSACK_QA_PROVIDER")
+        .map(|provider| !provider.trim().is_empty())
+        .unwrap_or(false);
+      if let Err(e) = ensure_dir(&node_compile_cache_dir) {
+        eprintln!(
+          "[clawd/service] WARNING: Failed to create Node compile cache dir: {}",
+          e
+        );
+      }
       let mut env = vec![
         ("PATH".to_string(), clawdbot_path),
         ("HOME".to_string(), user_home),
@@ -10924,7 +11977,7 @@ pub async fn set_service_enabled(
         // port. Channels can continue connecting after the UI is already usable.
         (
           "OPENCLAW_GATEWAY_STARTUP_WARMUP_TIMEOUT_MS".to_string(),
-          "2000".to_string(),
+          "1000".to_string(),
         ),
         (
           "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM".to_string(),
@@ -10932,7 +11985,7 @@ pub async fn set_service_enabled(
         ),
         (
           "OPENCLAW_CHANNEL_STARTUP_HANDOFF_TIMEOUT_MS".to_string(),
-          "3000".to_string(),
+          "1000".to_string(),
         ),
         (
           "OPENCLAW_CHANNEL_STARTUP_HANDOFF_DELAY_MS".to_string(),
@@ -10943,15 +11996,44 @@ pub async fn set_service_enabled(
           "1".to_string(),
         ),
         (
+          "KNAPSACK_DEFER_OPTIONAL_STARTUP_PLUGINS".to_string(),
+          "1".to_string(),
+        ),
+        (
+          "OPENCLAW_DEFER_STARTUP_PROVIDERS".to_string(),
+          "1".to_string(),
+        ),
+        ("OPENCLAW_DEFER_STARTUP_SEARCH".to_string(), "1".to_string()),
+        (
+          "OPENCLAW_DEFER_STARTUP_DOCUMENTS".to_string(),
+          "1".to_string(),
+        ),
+        (
           "OPENCLAW_DESKTOP_MANAGED_GATEWAY".to_string(),
           "1".to_string(),
         ),
         (
+          "OPENCLAW_DEFER_STARTUP_SECRETS".to_string(),
+          "1".to_string(),
+        ),
+        (
+          "OPENCLAW_SKIP_STARTUP_PLUGIN_AUTO_ENABLE".to_string(),
+          "1".to_string(),
+        ),
+        (
           "OPENCLAW_DESKTOP_AUTO_START_CHANNELS".to_string(),
-          "0".to_string(),
+          if eager_channel_plugin_start_enabled() {
+            "1".to_string()
+          } else {
+            "0".to_string()
+          },
         ),
         (
           "OPENCLAW_CHANNEL_STARTUP_CONCURRENCY".to_string(),
+          "1".to_string(),
+        ),
+        (
+          "OPENCLAW_GATEWAY_STARTUP_TRACE".to_string(),
           "1".to_string(),
         ),
         // Ensure Node.js resolves packages from the bundled flat node_modules
@@ -10959,20 +12041,36 @@ pub async fn set_service_enabled(
         // a local pnpm install) can cause ERR_PACKAGE_PATH_NOT_EXPORTED errors
         // because Node finds a broken copy before reaching the correct one.
         ("NODE_PATH".to_string(), {
-          let mut nm = clawdbot_entry.clone();
-          nm.pop(); // remove entry.js
-          nm.pop(); // remove dist/
-          nm.push("node_modules");
-          nm.to_string_lossy().to_string()
+          clawdbot_node_path_for_entry(&clawdbot_entry)
+            .to_string_lossy()
+            .to_string()
         }),
       ];
+
+      if let Ok(disable_bundled_plugins) = std::env::var("OPENCLAW_DISABLE_BUNDLED_PLUGINS") {
+        let disable_bundled_plugins = disable_bundled_plugins.trim().to_string();
+        if !disable_bundled_plugins.is_empty() {
+          env.push((
+            "OPENCLAW_DISABLE_BUNDLED_PLUGINS".to_string(),
+            disable_bundled_plugins,
+          ));
+        }
+      }
+
+      env.push((
+        "NODE_COMPILE_CACHE".to_string(),
+        node_compile_cache_dir.to_string_lossy().to_string(),
+      ));
 
       if !cfg!(target_os = "windows") {
         // Prevents the macOS gateway inspector from classifying this LaunchAgent
         // as a legacy "clawdbot" service and moving it to Trash. On Windows
         // these markers mean "schtasks-supervised" to OpenClaw, which adds a
         // 30s lock recovery wait to the desktop-managed direct gateway startup.
-        env.push(("OPENCLAW_SERVICE_MARKER".to_string(), "openclaw".to_string()));
+        env.push((
+          "OPENCLAW_SERVICE_MARKER".to_string(),
+          "openclaw".to_string(),
+        ));
         env.push(("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string()));
       }
 
@@ -12651,7 +13749,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
 
   // Gateway is not running — start it.
   AUTO_ENABLE_STARTED.store(true, Ordering::Relaxed);
-  mark_gateway_launch_started();
+  GATEWAY_RESTART_IN_PROGRESS.store(true, Ordering::Relaxed);
   eprintln!("[clawd/service] auto_enable (Windows): starting gateway");
 
   let cfg: crate::clawd::sidecar::SharedClawdbotConfig = std::sync::Arc::new(
@@ -12665,6 +13763,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
         "[clawd/service] auto_enable (Windows): prepare_gateway_config failed: {}",
         e
       );
+      GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
       return;
     }
   };
@@ -12717,6 +13816,7 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
     }
   };
 
+  let spawn_started = std::time::Instant::now();
   match std::process::Command::new(&setup.program_args[0])
     .args(&setup.program_args[1..])
     .envs(setup.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
@@ -12729,12 +13829,42 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
     Ok(child) => {
       let pid = child.id();
       GATEWAY_PID.store(pid, Ordering::Relaxed);
+      mark_gateway_launch_started();
       *LAST_GATEWAY_SETUP.lock().unwrap() = Some(setup.clone());
       GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
       eprintln!(
-        "[clawd/service] auto_enable (Windows): gateway spawned (pid {})",
-        pid
+        "[clawd/service] auto_enable (Windows): gateway spawned (pid {}, spawn_elapsed={}ms)",
+        pid,
+        spawn_started.elapsed().as_millis()
       );
+
+      tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        let mut gateway_logged = false;
+        let mut browser_logged = false;
+        for _ in 0..120 {
+          if !gateway_logged && gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
+            gateway_logged = true;
+            eprintln!(
+              "[clawd/service] auto_enable (Windows): gateway port listening after {}ms",
+              started.elapsed().as_millis()
+            );
+          }
+          if !browser_logged
+            && browser_control_tcp_port_open(std::time::Duration::from_millis(50)).await
+          {
+            browser_logged = true;
+            eprintln!(
+              "[clawd/service] auto_enable (Windows): browser control port listening after {}ms",
+              started.elapsed().as_millis()
+            );
+          }
+          if gateway_logged && browser_logged {
+            break;
+          }
+          tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+      });
 
       // Workaround for OpenClaw #23006: patch paired.json scopes after startup.
       let ah = app_handle.clone();

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -837,9 +837,6 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
 const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
   // Core app activities exercised by the desktop QA loop.
   "browser",
-  "telegram",
-  "slack",
-  "whatsapp",
   "google",
   "microsoft",
   "web-readability",
@@ -874,6 +871,18 @@ const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
 
 const KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS: &[&str] = &["slack", "telegram", "whatsapp"];
 
+pub(crate) fn is_bundled_channel_plugin_id(plugin_id: &str) -> bool {
+  KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS
+    .iter()
+    .any(|candidate| *candidate == plugin_id)
+}
+
+fn eager_channel_plugin_start_enabled() -> bool {
+  std::env::var("KNAPSACK_EAGER_CHANNEL_PLUGINS")
+    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    .unwrap_or(false)
+}
+
 fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
   if !cfg.is_object() {
     return false;
@@ -896,6 +905,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .and_then(|value| value.as_object())
   {
     for (plugin_id, entry) in entries {
+      if is_bundled_channel_plugin_id(plugin_id) && !eager_channel_plugin_start_enabled() {
+        continue;
+      }
       let explicitly_disabled =
         entry.get("enabled").and_then(|value| value.as_bool()) == Some(false);
       if !explicitly_disabled && !required.iter().any(|existing| existing == plugin_id) {
@@ -916,6 +928,9 @@ fn ensure_knapsack_plugin_allowlist(cfg: &mut serde_json::Value) -> bool {
     .iter()
     .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
     .collect::<Vec<_>>();
+  if !eager_channel_plugin_start_enabled() {
+    merged.retain(|plugin| !is_bundled_channel_plugin_id(plugin));
+  }
   for plugin in required {
     if !merged.iter().any(|existing| existing == &plugin) {
       merged.push(plugin);
@@ -5926,10 +5941,9 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     false
   };
 
-  let mut channels_ok = false;
-  while ready && remaining_ms() > 500 {
-    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp")
-    {
+  let mut channels_ok = !eager_channel_plugin_start_enabled();
+  while ready && !channels_ok && remaining_ms() > 500 {
+    if gateway_log_has_channel_started("telegram") && gateway_log_has_channel_started("whatsapp") {
       channels_ok = true;
       break;
     }
@@ -5949,7 +5963,9 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     browser_ok,
     channels_ok: Some(channels_ok),
     startup_elapsed_ms: Some(elapsed_ms),
-    message: if ready && browser_ok && channels_ok {
+    message: if ready && browser_ok && channels_ok && !eager_channel_plugin_start_enabled() {
+      "Gateway and browser are ready; channel plugins are deferred until opened".to_string()
+    } else if ready && browser_ok && channels_ok {
       "Gateway, browser, and channels are ready".to_string()
     } else if ready && browser_ok {
       "Gateway and browser are ready; channels are still starting up".to_string()

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5436,6 +5436,7 @@ async fn run_gateway_self_heal_cycle(
         Ok(child) => {
           let pid = child.id();
           GATEWAY_PID.store(pid, Ordering::Relaxed);
+          mark_gateway_launch_started();
           *LAST_GATEWAY_SETUP.lock().unwrap() = Some(setup.clone());
           eprintln!("[clawd/service] self-heal: spawned gateway pid {}", pid);
         }
@@ -5459,7 +5460,10 @@ async fn run_gateway_self_heal_cycle(
     );
   }
 
-  let ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 10_000).await;
+  let mut ready = crate::clawd::gateway_supervisor::wait_for_gateway_ready(&token, 30_000).await;
+  if !ready && gateway_tcp_port_open(std::time::Duration::from_millis(250)).await {
+    ready = true;
+  }
   if ready {
     eprintln!("[clawd/service] self-heal: gateway healthy after recovery cycle");
     CONSECUTIVE_HEAL_FAILURES.store(0, Ordering::Relaxed);
@@ -5468,6 +5472,11 @@ async fn run_gateway_self_heal_cycle(
     GATEWAY_WAS_HEALTHY.store(true, Ordering::Relaxed);
     BROWSER_START_NUDGED.store(false, Ordering::Relaxed);
     patch_paired_json_scopes(&app_handle);
+  } else if let Some(grace_ms) = gateway_launch_grace_active() {
+    eprintln!(
+      "[clawd/service] self-heal: gateway process is still starting after {}ms; preserving launch",
+      grace_ms
+    );
   } else {
     let failures = CONSECUTIVE_HEAL_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
     eprintln!(
@@ -6757,11 +6766,11 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   let ready_started_at = std::time::Instant::now();
   let mut ready = false;
   while ready_started_at.elapsed().as_millis() < u128::from(GATEWAY_READY_BUDGET_MS) {
-    if gateway_reachable_or_ready(std::time::Duration::from_millis(150)).await {
+    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
       ready = true;
       break;
     }
-    if gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
+    if gateway_reachable_or_ready(std::time::Duration::from_millis(150)).await {
       ready = true;
       break;
     }
@@ -10774,6 +10783,22 @@ pub async fn set_service_enabled(
                 existing_pid
               ),
             });
+          }
+          if process_is_alive(existing_pid) {
+            if let Some(grace_ms) = gateway_launch_grace_active() {
+              eprintln!(
+                "[clawd/service] Enable request: background restart pid {} is still starting after {}ms; preserving startup",
+                existing_pid, grace_ms
+              );
+              return HttpResponse::Ok().json(EnableServiceResponse {
+                success: true,
+                enabled,
+                message: format!(
+                  "Gateway startup is already in progress (pid {}, {}ms)",
+                  existing_pid, grace_ms
+                ),
+              });
+            }
           }
           eprintln!(
             "[clawd/service] Enable request: background restart left non-listening pid {}; continuing with fresh spawn",

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -8377,6 +8377,56 @@ async fn prepare_gateway_config(
             patched = true;
           }
         }
+        if !current_primary.trim().is_empty() && model_ref_has_key(current_primary.trim()) {
+          let expected_fallbacks = crate::clawd::gateway_client::collect_fallback_models(
+            current_primary.trim(),
+          );
+          if !expected_fallbacks.is_empty() {
+            let existing_fallbacks = cfg_val
+              .pointer("/agents/defaults/model/fallbacks")
+              .and_then(|v| v.as_array())
+              .map(|arr| {
+                arr
+                  .iter()
+                  .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                  .collect::<Vec<_>>()
+              })
+              .unwrap_or_default();
+            if existing_fallbacks != expected_fallbacks {
+              if cfg_val.pointer("/agents").is_none() {
+                cfg_val
+                  .as_object_mut()
+                  .unwrap()
+                  .insert("agents".to_string(), serde_json::json!({}));
+              }
+              if cfg_val.pointer("/agents/defaults").is_none() {
+                cfg_val
+                  .pointer_mut("/agents")
+                  .unwrap()
+                  .as_object_mut()
+                  .unwrap()
+                  .insert("defaults".to_string(), serde_json::json!({}));
+              }
+              cfg_val
+                .pointer_mut("/agents/defaults")
+                .unwrap()
+                .as_object_mut()
+                .unwrap()
+                .insert(
+                  "model".to_string(),
+                  serde_json::json!({
+                    "primary": current_primary.trim(),
+                    "fallbacks": expected_fallbacks,
+                  }),
+                );
+              eprintln!(
+                "[clawd/service] Refreshed agents.defaults.model fallbacks for '{}'",
+                current_primary
+              );
+              patched = true;
+            }
+          }
+        }
 
         // On macOS, enable peekaboo as a bundled skill (macOS UI automation via PeekabooBridge)
         if cfg!(target_os = "macos") {

--- a/src/src-tauri/src/search.rs
+++ b/src/src-tauri/src/search.rs
@@ -9,6 +9,7 @@ use actix_web::{get, post, put, web::Json, HttpResponse, Responder, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::api::document::DisplayDocument;
+use crate::clawd::service::should_defer_optional_startup_api_work;
 use crate::db::models::{calendar_event::CalendarEvent, document::Document, email::Email};
 
 use crate::user::UserInfo;
@@ -355,7 +356,13 @@ fn build_gmail_response_doc_from_email_row(email: Email) -> Option<GmailSearchRe
   let document_id = match get_document_id_from_email(email.clone()) {
     Some(id) => id,
     None => {
-      log::warn!("No Document ID for Email Msg: {:?}", email);
+      log::warn!(
+        "No Document ID for Email Msg: id={:?} uid={:?} subject={:?} sender={:?}",
+        email.id,
+        email.email_uid,
+        email.subject,
+        email.sender
+      );
       return None;
     }
   };
@@ -390,6 +397,14 @@ fn build_gmail_response_doc_from_email_row(email: Email) -> Option<GmailSearchRe
 #[get("/api/knapsack/email_thread/{document_id}")]
 pub async fn get_email_thread(path: web::Path<u64>) -> Result<HttpResponse> {
   let document_id = path.into_inner();
+
+  if should_defer_optional_startup_api_work().await {
+    return Ok(HttpResponse::Ok().json(GmailSearchResponse {
+      success: true,
+      display_docs: Vec::new(),
+      error: Some("DEFERRED_DURING_STARTUP".to_string()),
+    }));
+  }
 
   let document = match Document::find_by_id(document_id) {
     Ok(Some(doc)) => doc,

--- a/src/src/api/channels.ts
+++ b/src/src/api/channels.ts
@@ -1,6 +1,7 @@
 /** API helpers for messaging channel endpoints (WhatsApp, iMessage). */
 
 const API_BASE = 'http://127.0.0.1:8897'
+const WHATSAPP_BUNDLED = false
 
 export interface ChannelStatus {
   success: boolean
@@ -60,14 +61,31 @@ async function post<T>(path: string, body?: unknown, timeoutMs = 30_000): Promis
 
 // ── WhatsApp ─────────────────────────────────────────────────
 
-export const getWhatsAppStatus = () =>
-  get<ChannelStatus>('/api/clawd/channels/whatsapp/status')
+export const getWhatsAppStatus = (): Promise<ChannelStatus> =>
+  WHATSAPP_BUNDLED
+    ? get<ChannelStatus>('/api/clawd/channels/whatsapp/status')
+    : Promise.resolve({
+        success: false,
+        enabled: false,
+        configured: false,
+        linked: false,
+        message: 'WhatsApp is not bundled in this build.',
+      })
 
-export const enableWhatsApp = (enabled: boolean) =>
-  post<GenericResponse>('/api/clawd/channels/whatsapp/enable', { enabled })
+export const enableWhatsApp = (enabled: boolean): Promise<GenericResponse> =>
+  WHATSAPP_BUNDLED
+    ? post<GenericResponse>('/api/clawd/channels/whatsapp/enable', { enabled })
+    : Promise.resolve({
+        success: false,
+        configured: false,
+        linked: false,
+        message: 'WhatsApp is not bundled in this build.',
+      })
 
-export const startWhatsAppLogin = () =>
-  post<WhatsAppLoginResponse>('/api/clawd/channels/whatsapp/login')
+export const startWhatsAppLogin = (): Promise<WhatsAppLoginResponse> =>
+  WHATSAPP_BUNDLED
+    ? post<WhatsAppLoginResponse>('/api/clawd/channels/whatsapp/login')
+    : Promise.resolve({ success: false, message: 'WhatsApp is not bundled in this build.' })
 
 export interface WhatsAppLoginWaitResponse {
   success: boolean
@@ -76,12 +94,20 @@ export interface WhatsAppLoginWaitResponse {
 }
 
 /** Wait for the user to scan the WhatsApp QR code. Blocks until scan or timeout. */
-export const waitWhatsAppLogin = () =>
-  post<WhatsAppLoginWaitResponse>('/api/clawd/channels/whatsapp/login-wait')
+export const waitWhatsAppLogin = (): Promise<WhatsAppLoginWaitResponse> =>
+  WHATSAPP_BUNDLED
+    ? post<WhatsAppLoginWaitResponse>('/api/clawd/channels/whatsapp/login-wait')
+    : Promise.resolve({
+        success: false,
+        connected: false,
+        message: 'WhatsApp is not bundled in this build.',
+      })
 
 /** Re-link WhatsApp: clear stale credentials and start fresh QR login. */
-export const relinkWhatsApp = () =>
-  post<WhatsAppLoginResponse>('/api/clawd/channels/whatsapp/relink', {})
+export const relinkWhatsApp = (): Promise<WhatsAppLoginResponse> =>
+  WHATSAPP_BUNDLED
+    ? post<WhatsAppLoginResponse>('/api/clawd/channels/whatsapp/relink', {})
+    : Promise.resolve({ success: false, message: 'WhatsApp is not bundled in this build.' })
 
 export interface WhatsAppPhonePairResponse {
   success: boolean
@@ -90,12 +116,21 @@ export interface WhatsAppPhonePairResponse {
 }
 
 /** Link WhatsApp via phone number pairing code (alternative to QR scan). */
-export const loginWhatsAppPhone = (phoneNumber: string) =>
-  post<WhatsAppPhonePairResponse>('/api/clawd/channels/whatsapp/login-phone', { phoneNumber })
+export const loginWhatsAppPhone = (phoneNumber: string): Promise<WhatsAppPhonePairResponse> =>
+  WHATSAPP_BUNDLED
+    ? post<WhatsAppPhonePairResponse>('/api/clawd/channels/whatsapp/login-phone', { phoneNumber })
+    : Promise.resolve({ success: false, message: 'WhatsApp is not bundled in this build.' })
 
 /** Disconnect WhatsApp: logout from Baileys and remove channel config. */
-export const disconnectWhatsApp = () =>
-  post<GenericResponse>('/api/clawd/channels/whatsapp/disconnect', {})
+export const disconnectWhatsApp = (): Promise<GenericResponse> =>
+  WHATSAPP_BUNDLED
+    ? post<GenericResponse>('/api/clawd/channels/whatsapp/disconnect', {})
+    : Promise.resolve({
+        success: false,
+        configured: false,
+        linked: false,
+        message: 'WhatsApp is not bundled in this build.',
+      })
 
 // ── iMessage ─────────────────────────────────────────────────
 

--- a/src/src/components/organisms/CenterWorkspace/index.tsx
+++ b/src/src/components/organisms/CenterWorkspace/index.tsx
@@ -35,6 +35,8 @@ import { logError } from 'src/utils/errorHandling'
 import EmailCategoryTabs from '../EmailCategoryTabs'
 import SettingsButton from 'src/components/atoms/settings-button'
 
+const STARTUP_EMAIL_AUTOPILOT_AUTO_OPEN_DELAY_MS = 5 * 60_000
+
 interface CenterWorkspaceProps {
   feed: IFeed
   llmBar: ILLMBar
@@ -125,19 +127,25 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
 
   useEffect(() => {
     if (feed.loggedEmailAutopilot && feed.subTab === SubTabChoices.Welcome) {
-      const autopilotItem = feed.feedContent[STATIONARY_ITEMS]?.find(
-        item => item.title === 'Email Autopilot',
-      )
+      const timer = window.setTimeout(() => {
+        if (feed.subTab !== SubTabChoices.Welcome) return
 
-      if (autopilotItem) {
-        feed.selectFeedItem(STATIONARY_ITEMS, autopilotItem.id)
+        const autopilotItem = feed.feedContent[STATIONARY_ITEMS]?.find(
+          item => item.title === 'Email Autopilot',
+        )
 
-        if (feed.setSelectedEmailCategory) {
-          feed.setSelectedEmailCategory(EmailImportance.IMPORTANT_NO_RESPONSE)
+        if (autopilotItem) {
+          feed.selectFeedItem(STATIONARY_ITEMS, autopilotItem.id)
+
+          if (feed.setSelectedEmailCategory) {
+            feed.setSelectedEmailCategory(EmailImportance.IMPORTANT_NO_RESPONSE)
+          }
+
+          feed.setSubTab(SubTabChoices.Workspace)
         }
+      }, STARTUP_EMAIL_AUTOPILOT_AUTO_OPEN_DELAY_MS)
 
-        feed.setSubTab(SubTabChoices.Workspace)
-      }
+      return () => window.clearTimeout(timer)
     }
   }, [feed.loggedEmailAutopilot, feed.subTab, feed.feedContent])
 

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -69,6 +69,7 @@ const reply_actions = [
 ]
 
 const MAX_RETRIES = 5
+const STARTUP_EMAIL_AUTOPILOT_DELAY_MS = 5 * 60_000
 export const STATIONARY_ITEMS = 'stationary'
 export interface IFeed {
   updateFeedItemTitle?: (key: string, itemId: number, newTitle: string) => void
@@ -390,6 +391,30 @@ export function useFeed(
   }
 
   const lastEmailId = useRef<number | undefined>(undefined)
+  const feedMountedAt = useRef(Date.now())
+  const startupEmailAutopilotTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const runEmailAutopilotAfterStartup = () => {
+    const elapsed = Date.now() - feedMountedAt.current
+    const remaining = STARTUP_EMAIL_AUTOPILOT_DELAY_MS - elapsed
+    if (remaining <= 0) {
+      runEmailAutopilot()
+      return
+    }
+    if (startupEmailAutopilotTimer.current) return
+    startupEmailAutopilotTimer.current = setTimeout(() => {
+      startupEmailAutopilotTimer.current = null
+      runEmailAutopilot()
+    }, remaining)
+  }
+
+  useEffect(() => {
+    return () => {
+      if (startupEmailAutopilotTimer.current) {
+        clearTimeout(startupEmailAutopilotTimer.current)
+      }
+    }
+  }, [])
 
   const selectEmailCategory = useCallback(() => {
     const getTabCount = (category: EmailImportance): number => {
@@ -459,7 +484,7 @@ export function useFeed(
         loggedEmailAutopilot &&
         getTotalClassifiedEmailsCount() <= 0
       ) {
-        runEmailAutopilot()
+        runEmailAutopilotAfterStartup()
       }
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
## Summary
- Return provider-specific active model in clawd API key endpoints.
- Restore selected model per active provider in chat key check flow.
- Prevents OpenAI-only model being incorrectly restored when another provider is active.

## Testing
- Not run in this pass.
