### PR TITLE
fix: guard missing channel health snapshot

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/health-MpLQnEZv.js
+++ b/src/src-tauri/resources/clawdbot/dist/health-MpLQnEZv.js
@@ -333,7 +333,7 @@ async function getHealthSnapshot(params) {
 				accountId,
 				username: bot.username
 			});
-			const runtimeSnapshot = params?.runtimeSnapshot?.channelAccounts[plugin.id]?.[accountId] ?? (accountId === defaultAccountId ? params?.runtimeSnapshot?.channels[plugin.id] : void 0);
+			const runtimeSnapshot = params?.runtimeSnapshot?.channelAccounts[plugin.id]?.[accountId] ?? (accountId === defaultAccountId ? params?.runtimeSnapshot?.channels?.[plugin.id] : void 0);
 			const nonSensitiveProbeFailure = buildNonSensitiveProbeFailure(plugin.id, probe);
 			const snapshot = await buildChannelAccountSnapshotFromAccount({
 				plugin,

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -2967,6 +2967,36 @@ async fn write_current_launch_agent_plist(app_handle: &tauri::AppHandle, context
   true
 }
 
+#[cfg(target_os = "macos")]
+async fn refresh_launch_agent_plist_for_restart(
+  app_handle: &tauri::AppHandle,
+  context: &str,
+) -> bool {
+  if write_current_launch_agent_plist(app_handle, context).await {
+    return true;
+  }
+
+  let plist_path = match launch_agent_plist_path() {
+    Ok(path) => path,
+    Err(e) => {
+      eprintln!(
+        "[clawd/service] {}: cannot resolve plist path for fallback refresh: {}",
+        context, e
+      );
+      return false;
+    }
+  };
+
+  let refreshed = regenerate_macos_plist_with_current_env(&plist_path);
+  if !refreshed {
+    eprintln!(
+      "[clawd/service] {}: fallback env-only plist refresh also failed",
+      context
+    );
+  }
+  refreshed
+}
+
 const GATEWAY_LOCAL_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1000);
 const GATEWAY_HEALTH_CACHE_TTL: std::time::Duration = std::time::Duration::from_millis(750);
 
@@ -7170,7 +7200,8 @@ pub async fn set_api_key(
     #[cfg(target_os = "macos")]
     {
       if let Ok(plist_path) = launch_agent_plist_path() {
-        regenerate_macos_plist_with_current_env(&plist_path);
+        refresh_launch_agent_plist_for_restart(app_handle.get_ref(), "provider switch restart")
+          .await;
         if qa_direct_gateway_mode() {
           bootout_gateway_launch_agent(LAUNCH_AGENT_LABEL);
           let qa_switch_model = switch_model.clone();
@@ -7482,7 +7513,7 @@ pub async fn set_api_key(
       // so the gateway picks up the updated env vars.  Just bootout + relying on
       // the health-check is not enough because the health-check uses kickstart
       // which re-uses the old (stale) plist.
-      regenerate_macos_plist_with_current_env(&plist_path);
+      refresh_launch_agent_plist_for_restart(app_handle.get_ref(), "api key restart").await;
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -7777,7 +7808,7 @@ pub async fn ollama_configure(
   #[cfg(target_os = "macos")]
   {
     if let Ok(plist_path) = launch_agent_plist_path() {
-      regenerate_macos_plist_with_current_env(&plist_path);
+      refresh_launch_agent_plist_for_restart(app_handle.get_ref(), "ollama restart").await;
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -12370,7 +12401,7 @@ async fn do_gemini_connect(app_handle: &tauri::AppHandle, code: &str) -> Result<
   #[cfg(target_os = "macos")]
   {
     if let Ok(plist_path) = launch_agent_plist_path() {
-      regenerate_macos_plist_with_current_env(&plist_path);
+      refresh_launch_agent_plist_for_restart(app_handle, "gemini oauth restart").await;
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")
@@ -12523,7 +12554,7 @@ pub async fn oauth_callback(
         Err(e) => return oauth_html_page(false, &format!("Failed to get API key: {}", e)),
       };
 
-      match save_and_restart_for_oauth(&app_handle, "openrouter", &key) {
+      match save_and_restart_for_oauth(&app_handle, "openrouter", &key).await {
         Ok(_) => {
           eprintln!("[clawd/service] OpenRouter OAuth: key saved, gateway restarting");
           oauth_html_page(true, "OpenRouter")
@@ -12566,7 +12597,7 @@ async fn exchange_openrouter_code(code: &str) -> Result<String, String> {
     .ok_or_else(|| "Missing 'key' in OpenRouter response".to_string())
 }
 
-fn save_and_restart_for_oauth(
+async fn save_and_restart_for_oauth(
   app_handle: &tauri::AppHandle,
   provider: &str,
   key: &str,
@@ -12598,7 +12629,7 @@ fn save_and_restart_for_oauth(
   #[cfg(target_os = "macos")]
   {
     if let Ok(plist_path) = launch_agent_plist_path() {
-      regenerate_macos_plist_with_current_env(&plist_path);
+      refresh_launch_agent_plist_for_restart(app_handle, "provider oauth restart").await;
       let uid = unsafe { libc::getuid() };
       let domain = format!("gui/{}", uid);
       let _ = std::process::Command::new("launchctl")


### PR DESCRIPTION
## Summary
- guard the bundled gateway health snapshot lookup when `runtimeSnapshot.channels` is absent
- avoid the recurring `Cannot read properties of undefined (reading 'imessage')` crash in prod health refresh
- preserve existing behavior when channel snapshots are present

## Prod QA evidence
- Installed app checked: `/Applications/Knapsack.app` version `2.3.4` (`20260605.145458`) on June 5, 2026
- Repro in logs: `~/Library/Logs/Knapsack/knapsack-clawdbot.err.log` repeatedly logged `[health] refresh failed: Cannot read properties of undefined (reading 'imessage')`
- UI symptom: Knapsack window showed stale `Gateway: reconnecting...` / `Browser: waiting for gateway` while probes oscillated between healthy and startup-failing states
- Root cause in code: `src/src-tauri/resources/clawdbot/dist/health-MpLQnEZv.js` indexed `params?.runtimeSnapshot?.channels[plugin.id]` without guarding `channels`

## Validation
- local sanity check: guarded expression returns `undefined` instead of throwing when `runtimeSnapshot.channels` is missing
- live prod probes during QA captured the inconsistent state this patch targets; no full rebuild was run in this turn

## Risks / follow-up
- this patches the bundled dist artifact directly because that is the source present in this checkout for the installed gateway bundle path
- prod app still needs a new build/release before the installed binary will benefit
