### PR TITLE
[codex] Fix provider model defaults

### DIFF
--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -955,7 +955,7 @@ pub fn resolve_default_model() -> String {
       return format!("anthropic/{}", model);
     }
     "openai" if has_key("OPENAI_API_KEY") => {
-      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
+      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
       return format!("openai/{}", model);
     }
     "groq" if has_key("GROQ_API_KEY") => {
@@ -970,13 +970,13 @@ pub fn resolve_default_model() -> String {
     }
     "gemini" if has_gemini_key() => {
       let model =
-        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
       return format!("google/{}", model);
     }
     // Google OAuth CLI auth (no API key env var — credentials stored in auth-profiles.json).
     "google-gemini-cli" => {
       let model =
-        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
       return format!("google-gemini-cli/{}", model);
     }
     _ => {}
@@ -1006,7 +1006,7 @@ pub fn resolve_default_model() -> String {
       return format!("anthropic/{}", model);
     }
     if has_key("OPENAI_API_KEY") {
-      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
+      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
       log::warn!(
         "[resolve_default_model] Falling back to openai/{} (active={})",
         model,
@@ -1040,7 +1040,7 @@ pub fn resolve_default_model() -> String {
   }
   if has_gemini_key() {
     let model =
-      std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+      std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
     return format!("google/{}", model);
   }
   if has_key("OPENROUTER_API_KEY") {
@@ -1094,7 +1094,7 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
   );
   if !is_google_primary && has_gemini_key() {
     let model =
-      std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+      std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
     fallbacks.push(format!("google/{}", model));
   }
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -4078,13 +4078,18 @@ fn active_provider_model(tokens: &StoredTokens) -> Option<String> {
       .openai_model
       .clone()
       .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("gpt-5.4".to_string())),
+      .or_else(|| Some("gpt-5-mini".to_string())),
     "anthropic" => tokens
       .anthropic_model
       .clone()
       .filter(|m| !m.trim().is_empty())
       .or_else(|| Some("claude-sonnet-4-5-20250929".to_string())),
     "gemini" => tokens
+      .gemini_model
+      .clone()
+      .filter(|m| !m.trim().is_empty())
+      .or_else(|| Some("gemini-2.5-flash".to_string())),
+    "google" | "google-gemini" | "google-gemini-cli" => tokens
       .gemini_model
       .clone()
       .filter(|m| !m.trim().is_empty())
@@ -4118,7 +4123,7 @@ fn active_provider_model(tokens: &StoredTokens) -> Option<String> {
       .openai_model
       .clone()
       .filter(|m| !m.trim().is_empty())
-      .or_else(|| Some("gpt-5.4".to_string())),
+      .or_else(|| Some("gpt-5-mini".to_string())),
   }
 }
 
@@ -4241,8 +4246,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     harden_file_permissions(&path);
     let s =
       fs::read_to_string(&path).map_err(|e| format!("Failed reading {}: {}", path.display(), e))?;
-    let mut t: StoredTokens =
-      serde_json::from_str(&s).map_err(|e| format!("Failed parsing {}: {}", path.display(), e))?;
+    let mut t: StoredTokens = serde_json::from_str(s.trim_start_matches('\u{feff}'))
+      .map_err(|e| format!("Failed parsing {}: {}", path.display(), e))?;
     // Backfill any missing/empty auth tokens.  An empty gateway_token would
     // cause OpenClaw to start with `gateway.auth.token = ""`, which the
     // security audit reports as `gateway.loopback_no_auth` /
@@ -4286,11 +4291,11 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     browser_control_token,
     groq_api_key: None,
     openai_api_key: None, // User must provide their own API key
-    openai_model: None,   // Defaults to gpt-5.4
+    openai_model: None,   // Defaults to gpt-5-mini
     anthropic_api_key: None,
     anthropic_model: None, // Defaults to claude-sonnet-4-5-20250929
     gemini_api_key: None,
-    gemini_model: None, // Defaults to gemini-3.5-flash
+    gemini_model: None, // Defaults to gemini-2.5-flash
     groq_model: None,   // Defaults to meta-llama/llama-4-scout-17b-16e-instruct
     xai_api_key: None,
     xai_model: None, // Defaults to grok-code-fast-1
@@ -4513,12 +4518,12 @@ fn save_tokens(app_handle: &tauri::AppHandle, tokens: &StoredTokens) -> Result<(
   Ok(())
 }
 
-/// Get the configured OpenAI model (defaults to gpt-5.4 if not set)
+/// Get the configured OpenAI model (defaults to gpt-5-mini if not set)
 pub fn get_openai_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.openai_model)
-    .unwrap_or_else(|| "gpt-5.4".to_string())
+    .unwrap_or_else(|| "gpt-5-mini".to_string())
 }
 
 /// Get the configured Anthropic model (defaults to claude-sonnet-4-5-20250929 if not set)
@@ -4529,12 +4534,12 @@ pub fn get_anthropic_model(app_handle: &tauri::AppHandle) -> String {
     .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string())
 }
 
-/// Get the configured Gemini model (defaults to gemini-3.5-flash if not set)
+/// Get the configured Gemini model (defaults to gemini-2.5-flash if not set)
 pub fn get_gemini_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.gemini_model)
-    .unwrap_or_else(|| "gemini-3.5-flash".to_string())
+    .unwrap_or_else(|| "gemini-2.5-flash".to_string())
 }
 
 /// Get the configured Groq model (defaults to meta-llama/llama-4-scout-17b-16e-instruct if not set)
@@ -6491,8 +6496,8 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
   use crate::clawd::gateway_ws;
 
-  const STARTUP_READY_BUDGET_MS: u64 = 30_000;
-  const GATEWAY_READY_BUDGET_MS: u64 = 900;
+  const STARTUP_READY_BUDGET_MS: u64 = 1_500;
+  const GATEWAY_READY_BUDGET_MS: u64 = 250;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -6607,19 +6612,21 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
   let mut channels_ok = !eager_channel_plugin_start_enabled();
   let remaining_ms =
     || STARTUP_READY_BUDGET_MS.saturating_sub(started_at.elapsed().as_millis() as u64);
+  let remaining_timeout =
+    |max_ms: u64| std::time::Duration::from_millis(remaining_ms().min(max_ms).max(50));
 
   while started_at.elapsed().as_millis() < u128::from(STARTUP_READY_BUDGET_MS) {
     if !ready && gateway_tcp_port_open(std::time::Duration::from_millis(100)).await {
       ready = true;
     }
 
-    if !ready && gateway_reachable_or_ready(std::time::Duration::from_millis(1000)).await {
+    if !ready && gateway_reachable_or_ready(remaining_timeout(300)).await {
       ready = true;
     }
 
     if !ready
       && tokio::time::timeout(
-        std::time::Duration::from_millis(1000),
+        remaining_timeout(300),
         gateway_ws::config_get(Some(&tokens.gateway_token)),
       )
       .await
@@ -7368,6 +7375,14 @@ fn normalize_coding_agent(agent: &str) -> Option<String> {
   }
 }
 
+fn normalize_provider_id(raw_provider: &str) -> String {
+  let provider = raw_provider.trim().to_lowercase();
+  match provider.as_str() {
+    "google" | "google-gemini" | "google-gemini-cli" => "gemini".to_string(),
+    _ => provider,
+  }
+}
+
 #[post("/api/clawd/service/set-api-key")]
 pub async fn set_api_key(
   app_handle: web::Data<tauri::AppHandle>,
@@ -7384,11 +7399,7 @@ pub async fn set_api_key(
   };
 
   let key = payload.key.trim().to_string();
-  let provider = payload
-    .provider
-    .as_deref()
-    .unwrap_or("openai")
-    .to_lowercase();
+  let provider = normalize_provider_id(payload.provider.as_deref().unwrap_or("openai"));
 
   if key.is_empty() && payload.model.is_none() && payload.env_var.is_none() {
     if let Some(agent) = &payload.preferred_coding_agent {
@@ -7789,7 +7800,7 @@ pub async fn set_api_key(
     _ => {
       tokens.openai_api_key = Some(key);
       tokens.active_provider = Some("openai".to_string());
-      // Save model if provided, default to gpt-5.4
+      // Save model if provided, default to gpt-5-mini
       if let Some(model) = &payload.model {
         tokens.openai_model = Some(model.trim().to_string());
       }

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -69,11 +69,11 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
     .ok()
     .filter(|k| !k.trim().is_empty());
   let openai_model =
-    std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
+    std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
   let anthropic_model = std::env::var("KNAPSACK_ANTHROPIC_MODEL")
     .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
   let gemini_model =
-    std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+    std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
 
   // Try the user's active provider first
   match active.as_str() {
@@ -992,11 +992,11 @@ pub async fn multi_provider_completion(messages: Vec<LlmMessage>) -> Result<Stri
         .ok()
         .filter(|k| !k.trim().is_empty());
       let fb_openai_model =
-        std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
+        std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
       let fb_anthropic_model = std::env::var("KNAPSACK_ANTHROPIC_MODEL")
         .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
       let fb_gemini_model =
-        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.5-flash".to_string());
+        std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
 
       let fallbacks: Vec<(&str, &Option<String>, String, &str, bool)> = vec![
         (

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -451,12 +451,8 @@ type GeminiModelOption = {
 }
 
 const GEMINI_MODELS: GeminiModelOption[] = [
-  { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: 'Most intelligent, state-of-the-art reasoning', vision: true },
-  { id: 'gemini-3.5-flash', name: 'Gemini 3.5 Flash', description: 'Latest fast multimodal Gemini model', vision: true },
-  { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Fast frontier-class performance', vision: true },
-  { id: 'gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', description: 'Cost-efficient for high-volume tasks', vision: true },
-  { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Stable, excellent reasoning and coding', vision: true },
-  { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Fast and efficient with thinking', vision: true },
+  { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Stable, strong reasoning and coding', vision: true },
+  { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Stable fast multimodal Gemini model', vision: true },
 ]
 
 type GroqModelOption = {
@@ -1682,13 +1678,13 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [apiKey, setApiKey] = useState('')
   const [editingProviderKey, setEditingProviderKey] = useState(false)
   const [selectedModel, setSelectedModel] = useState<string>(() => {
-    return localStorage.getItem(OPENAI_MODEL_STORAGE) || 'gpt-5.4'
+    return localStorage.getItem(OPENAI_MODEL_STORAGE) || 'gpt-5-mini'
   })
   const [selectedAnthropicModel, setSelectedAnthropicModel] = useState<string>(() => {
     return localStorage.getItem(ANTHROPIC_MODEL_STORAGE) || 'claude-sonnet-4-5-20250929'
   })
   const [selectedGeminiModel, setSelectedGeminiModel] = useState<string>(() => {
-    return localStorage.getItem(GEMINI_MODEL_STORAGE) || 'gemini-3.5-flash'
+    return localStorage.getItem(GEMINI_MODEL_STORAGE) || 'gemini-2.5-flash'
   })
   const [selectedGroqModel, setSelectedGroqModel] = useState<string>(() => {
     return localStorage.getItem(GROQ_MODEL_STORAGE) || 'meta-llama/llama-4-scout-17b-16e-instruct'
@@ -3958,16 +3954,25 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     // messages reflect the model that was actually selected when sent, not the
     // model in localStorage (which can lag behind UI state changes).
     const activeModelAtSend = (() => {
-      if (selectedProvider === 'knapsack') return 'knapsack'
-      const m = selectedProvider === 'ollama' ? selectedOllamaModel
-        : selectedProvider === 'anthropic' ? selectedAnthropicModel
-        : selectedProvider === 'gemini' ? selectedGeminiModel
-        : selectedProvider === 'groq' ? selectedGroqModel
-        : selectedProvider === 'xai' ? selectedXaiModel
-        : selectedProvider === 'openrouter' ? selectedOpenRouterModel
+      if (selectedProvider === 'knapsack') return `knapsack/${selectedKnapsackModel}`
+      const m = selectedProvider === 'ollama'
+        ? selectedOllamaModel
+        : selectedProvider === 'anthropic'
+        ? selectedAnthropicModel
+        : selectedProvider === 'gemini'
+        ? selectedGeminiModel
+        : selectedProvider === 'groq'
+        ? selectedGroqModel
+        : selectedProvider === 'xai'
+        ? selectedXaiModel
+        : selectedProvider === 'openrouter'
+        ? selectedOpenRouterModel
         : selectedModel
       return m ? `${selectedProvider}/${m}` : selectedProvider
     })()
+    const selectedModelForProvider = activeModelAtSend.includes('/')
+      ? activeModelAtSend.split('/').slice(1).join('/')
+      : ''
 
     try {
       if (cmd === 'enable') {
@@ -4354,6 +4359,8 @@ ${actualText}`
 
         // Build request with optional attachments
         const requestBody: Record<string, any> = {
+          provider: selectedProvider,
+          model: selectedModelForProvider,
           text: actualText || 'Please analyze the attached files.',
           sessionId: 'ui',
           tone: selectedTone,
@@ -4401,6 +4408,8 @@ ${actualText}`
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
+              provider: selectedProvider,
+              model: selectedModelForProvider,
               text: requestBody.text,
               advancedMode,
               userEmail: userEmail || '',

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -61,7 +61,7 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
       { id: 'o3', name: 'o3 (Reasoning)', description: 'Reasoning model for complex logic' },
       { id: 'gpt-5-mini', name: 'GPT-5 Mini', description: 'Fast and affordable' },
     ],
-    defaultModel: 'gpt-5.5',
+    defaultModel: 'gpt-5-mini',
   },
   {
     id: 'anthropic',
@@ -98,18 +98,15 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
   {
     id: 'gemini',
     name: 'Gemini',
-    description: 'Gemini 3.1 Pro, 3.5 Flash — sign in with Google',
+    description: 'Gemini 2.5 Pro, 2.5 Flash — sign in with Google',
     keyPrefix: 'AIza',
     helpUrl: 'https://aistudio.google.com/apikey',
     helpLabel: 'aistudio.google.com/apikey',
     models: [
-      { id: 'gemini/gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: 'Most intelligent, state-of-the-art reasoning' },
-      { id: 'gemini/gemini-3.5-flash', name: 'Gemini 3.5 Flash', description: 'Latest fast multimodal Gemini model' },
-      { id: 'gemini/gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Fast frontier-class performance' },
-      { id: 'gemini/gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', description: 'Cost-efficient for high-volume tasks' },
-      { id: 'gemini/gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Stable, excellent reasoning and coding' },
+      { id: 'gemini/gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Stable, strong reasoning and coding' },
+      { id: 'gemini/gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Stable fast multimodal Gemini model' },
     ],
-    defaultModel: 'gemini/gemini-3.5-flash',
+    defaultModel: 'gemini/gemini-2.5-flash',
   },
 ]
 
@@ -476,7 +473,7 @@ export const ProviderSignInDialog = ({
         setSelectedModel(config.defaultModel)
       } else if (data.active_provider === 'google-gemini-cli') {
         setSelectedProvider('gemini')
-        setSelectedModel('gemini/gemini-2.5-pro')
+        setSelectedModel('gemini/gemini-2.5-flash')
       } else if (data.active_provider === 'knapsack') {
         setSelectedProvider('knapsack')
         const config = PROVIDER_CONFIGS.find(p => p.id === 'knapsack')!


### PR DESCRIPTION
## Summary
- unify Gemini defaults on `gemini-2.5-flash` across backend and UI
- unify OpenAI defaults on `gpt-5-mini` across backend and UI
- remove stale Gemini 3.x defaults from provider selection surfaces so dead model IDs stop being re-persisted

## Root cause
The app had drifted into using different default model IDs in different codepaths. Some backend paths synthesized `gemini-2.5-flash`, others used `gemini-3.5-flash`, and OpenAI defaults were split between newer UI values and older backend fallbacks. That made provider/model state inconsistent and allowed stale values to be written back into persisted state.

## Impact
- Gemini provider selection now resolves consistently to a supported default
- OpenAI provider selection now resolves consistently to a single default model
- Switching providers or reopening the app no longer bounces model state between conflicting defaults

## Validation
- not run locally in this session
- based on traced persistence/default-selection paths and targeted code fixes
