### PR TITLE
Improve meeting follow-up email tone and brevity

### DIFF
--- a/src/src/components/organisms/CenterWorkspace/index.tsx
+++ b/src/src/components/organisms/CenterWorkspace/index.tsx
@@ -32,7 +32,6 @@ import { RecordingContextProps } from '../MeetingNotesMode/RecordingContext'
 import Mic from '/assets/images/icons/mic-white.svg'
 import { EmailAutopilot } from 'src/components/molecules/EmailAutopilot'
 import { logError } from 'src/utils/errorHandling'
-import { markdownToEmailHtml } from 'src/utils/emails'
 import EmailCategoryTabs from '../EmailCategoryTabs'
 import SettingsButton from 'src/components/atoms/settings-button'
 
@@ -304,7 +303,6 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
       const hasMeetingNotesThread = item.threads.some(
         thread => thread.threadType === ThreadType.MEETING_NOTES
       )
-
       const showPermissionsOverlay = ((hasMeetingNotesThread &&
                                  (!micPermission || !screenPermission)) ||
                                  forceShowPermissions) && !permissionsDismissed;
@@ -360,15 +358,18 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
                       userEmail={userEmail}
                       userName={userName}
-                      onEmailClick={(notesMarkdown, meeting) => {
+                      onEmailClick={(_notesMarkdown, meeting) => {
                         const participants = meeting?.participants ?? []
                         const toEmails = participants
                           .filter(p => p.email && p.email !== userEmail)
                           .map(p => p.email)
                           .join(', ')
-                        const subject = meeting?.title ? `Follow up: ${meeting.title}` : 'Meeting Follow Up'
-                        const notesHtml = markdownToEmailHtml(notesMarkdown)
-                        const body = `<p>Hi,</p><p>Thank you for our meeting${meeting?.title ? ` — ${meeting.title}` : ''}. Here's a summary of what we discussed:</p>${notesHtml}<p>Please let me know if you have any questions!</p><p>Best,<br>${userName || ''}</p>`
+                        const subject = meeting?.title
+                          ? `Great to chat — ${meeting.title}`
+                          : 'Great to chat'
+                        const body = `<p>Hi,</p><p>Great connecting today${meeting?.title ? ` about <strong>${meeting.title}</strong>` : ''}. Thanks again for the conversation — it was a productive meeting.</p><p>What we agreed on:
+<br>- Next steps are captured in my notes.
+<br>- I’ll follow up if anything else pops up.</p><p>If you want a tighter version for this thread, I can help with that too.</p><p>Talk soon,<br>${userName || ''}</p>`
                         feed.setComposedEmailDraft({ to: toEmails, subject, body })
                       }}
                     />

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -54,7 +54,6 @@ import MCPMarketplace from 'src/components/organisms/MCPMarketplace'
 import GBrain from 'src/components/organisms/GBrain'
 import GBrainView from 'src/components/organisms/GBrainView'
 import { Workspace } from 'src/api/workspaces'
-import { markdownToEmailHtml } from 'src/utils/emails'
 
 export interface ToastrState {
   message?: ReactElement
@@ -670,15 +669,18 @@ function Home({
                     setCurrentTab(TabChoices.Library)
                     setSelectedWorkspace(ws)
                   }}
-                  onEmailClick={(notesMarkdown, meeting) => {
+                  onEmailClick={(_notesMarkdown, meeting) => {
                     const participants = meeting?.participants ?? []
                     const toEmails = participants
                       .filter(p => p.email && p.email !== userEmail)
                       .map(p => p.email)
                       .join(', ')
-                    const subject = meeting?.title ? `Follow up: ${meeting.title}` : 'Meeting Follow Up'
-                    const notesHtml = markdownToEmailHtml(notesMarkdown)
-                    const body = `<p>Hi,</p><p>Thank you for our meeting${meeting?.title ? ` — ${meeting.title}` : ''}. Here's a summary of what we discussed:</p>${notesHtml}<p>Please let me know if you have any questions!</p><p>Best,<br>${userName || ''}</p>`
+                    const subject = meeting?.title
+                      ? `Great to chat — ${meeting.title}`
+                      : 'Great to chat'
+                    const body = `<p>Hi,</p><p>Great connecting today${meeting?.title ? ` about <strong>${meeting.title}</strong>` : ''}. Thanks again for the conversation — it was a productive meeting.</p><p>What we agreed on:
+<br>- Next steps are captured in my notes.
+<br>- I’ll follow up if anything else pops up.</p><p>If you want a tighter version for this thread, I can help with that too.</p><p>Talk soon,<br>${userName || ''}</p>`
                     feed.setComposedEmailDraft({ to: toEmails, subject, body })
                   }}
                 />

--- a/src/src/prompts.ts
+++ b/src/src/prompts.ts
@@ -515,7 +515,7 @@ Your response MUST be a JSON object with this exact format:
 {
   "notificationTitle": "<8 words max, plain text only, no markdown - the headline for the notification>",
   "notificationBody": "<20 words max, plain text only, no markdown - brief summary of what to do next, address the user as 'you'>",
-  "fullAnalysis": "<Your comprehensive follow-up plan in Markdown. Include specific action items as checkboxes, draft email snippets where appropriate, and concrete next steps. Reference specific things discussed in the meeting. IMPORTANT: End with a single suggested next action as a markdown link in the format [Descriptive Action Label](knapsack://prompt/detailed instruction for the action). For example: [Draft Follow-up Email to Team](knapsack://prompt/Draft a follow-up email summarizing the key decisions and action items from the meeting, addressed to all attendees). The action should be the most impactful follow-up task.>",
+  "fullAnalysis": "<Your comprehensive follow-up plan in Markdown. Keep the tone warm, practical, and conversational. Include specific action items as checkboxes, draft email snippets where appropriate, and concrete next steps. Reference specific things discussed in the meeting. For follow-up email snippets, use a friendly and clear style (subject line + 2-4 short paragraphs) as a natural meeting summary follow-up, not a template-like memo. Do not include full transcripts, raw meeting notes, or long markdown blocks—keep snippets concise and email-ready. IMPORTANT: End with a single suggested next action as a markdown link in the format [Descriptive Action Label](knapsack://prompt/detailed instruction for the action). For example: [Draft Follow-up Email to Team](knapsack://prompt/Draft a follow-up email summarizing the key decisions and action items from the meeting, addressed to all attendees). The action should be the most impactful follow-up task.>",
   "suggestedActionShort": "<exactly 2 words - verb + noun summarizing the suggested action, e.g. Draft Email, Send Summary, Create Tasks>",
   "suggestedActionPrompt": "<the full detailed instruction for the suggested action, matching what's in the knapsack://prompt/ link>",
   "actionItemCount": <number of action items identified>,
@@ -525,7 +525,7 @@ Your response MUST be a JSON object with this exact format:
 Rules:
 - Be specific - reference actual topics, names, and decisions from the meeting
 - Action items should have clear owners and deadlines when mentioned
-- If email follow-ups are needed, draft brief outlines of what they should say
+- If email follow-ups are needed, draft concise outlines in a conversational tone, using natural language and a warm, human sounding voice. Avoid reproducing full notes in email drafts.
 - ALWAYS end fullAnalysis with exactly one suggested next action link in [Label](knapsack://prompt/...) format
 - The knapsack://prompt/ content MUST be plain English (e.g., "Draft a reply to Sarah about the budget"). NEVER put tool calls, function calls, HTML tags, or code inside the prompt link.
 - Do NOT write the suggested action text as plain text before the link — only include it once, as the link itself. No duplication.


### PR DESCRIPTION
## Summary
- Make automatic meeting follow-up email snippets conversational and less formal.
- Remove markdown meeting-note dump from manual follow-up email drafts.
- Update follow-up prompt guidance to avoid full transcripts/raw notes in email snippets.

## Notes
This keeps the current JSON payload format for follow-up generation while improving copy.
