### PR TITLE
Enable one-click install for computer-use skill

### DIFF
--- a/src/src-tauri/src/clawd/skills_catalog.json
+++ b/src/src-tauri/src/clawd/skills_catalog.json
@@ -13,6 +13,7 @@
   {"name":"notion","emoji":"📝","description":"Read and edit Notion pages and databases","source":"OpenClaw","eligible":false},
   {"name":"slack","emoji":"💬","description":"Team communication via Slack","source":"OpenClaw","eligible":false},
   {"name":"peekaboo","emoji":"👁️","description":"macOS UI automation via PeekabooBridge — screenshot, click, and inspect any app","source":"OpenClaw","eligible":false,"macOnly":true},
+  {"name":"computer-use","emoji":"🖥️","description":"Desktop automation via Codex Computer Use for local app and UI control","source":"OpenClaw","eligible":false,"install":[{"id":"default","label":"Enable"}]},
   {"name":"apple-notes","emoji":"🍎","description":"Create and manage macOS Notes","source":"OpenClaw","eligible":false},
   {"name":"apple-reminders","emoji":"⏰","description":"Manage macOS Reminders","source":"OpenClaw","eligible":false},
   {"name":"things-mac","emoji":"✅","description":"Things 3 task management for macOS","source":"OpenClaw","eligible":false},

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -980,6 +980,7 @@ const FALLBACK_SKILLS: SkillInfo[] = [
   {name:"gog",emoji:"📊",description:"Google Workspace — Gmail, Calendar, Drive, Sheets, Docs",source:"OpenClaw",eligible:false},
   {name:"notion",emoji:"📝",description:"Read and edit Notion pages and databases",source:"OpenClaw",eligible:false},
   {name:"slack",emoji:"💬",description:"Team communication via Slack",source:"OpenClaw",eligible:false},
+  {name:"computer-use",emoji:"🖥️",description:"Desktop automation via Codex Computer Use for local app and UI control",source:"OpenClaw",eligible:false,installOptions:[{id:"default",label:"Enable"}]},
   {name:"apple-notes",emoji:"🍎",description:"Create and manage macOS Notes",source:"OpenClaw",eligible:false},
   {name:"apple-reminders",emoji:"⏰",description:"Manage macOS Reminders",source:"OpenClaw",eligible:false},
   {name:"things-mac",emoji:"✅",description:"Things 3 task management for macOS",source:"OpenClaw",eligible:false},

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -4990,16 +4990,33 @@ ${actualText}`
             so normal restarts and sleep/wake blips don't surface a scary error.
             Suppressed entirely until an API key is saved — the gateway status is
             irrelevant and alarming when the user hasn't set up a key yet. */}
-        {hasCompletedOnboarding && health && !health.gateway_ok && gatewayDownPolls >= GATEWAY_CARD_GRACE_POLLS && !channelStatus.gatewayStarting && (
+        {hasCompletedOnboarding && health && !health.gateway_ok && gatewayDownPolls >= GATEWAY_CARD_GRACE_POLLS && !channelStatus.gatewayStarting && (() => {
+          const healthMessage = (health.message || '').toLowerCase()
+          const missingService =
+            health.diagnostic_type === 'service_not_installed' ||
+            health.diagnostic_type === 'service_not_loaded' ||
+            healthMessage.includes('launchagent plist not found') ||
+            healthMessage.includes('service is registering') ||
+            healthMessage.includes('service is not loaded')
+          const versionMismatch = health.diagnostic_type === 'version_mismatch' && !missingService
+          const bannerTitle = missingService
+            ? 'Gateway background service is missing'
+            : versionMismatch
+              ? 'OpenClaw version mismatch'
+              : 'Gateway connectivity issue'
+          const bannerDesc = missingService
+            ? 'Knapsack cannot find its background gateway service right now. This usually means the LaunchAgent was removed or did not load after restart. Try restarting the gateway below to reinstall it.'
+            : versionMismatch
+              ? 'The gateway config was written by a different OpenClaw version. Knapsack will attempt to recover automatically — if the gateway does not come back up, try restarting it below.'
+              : 'The gateway isn\'t responding. This can happen after a crash, permission change, or system sleep. Try one of these:'
+          return (
           <div className="ClawdMsg ClawdMsg-assistant">
             <div className="ClawdBubble ClawdGatewayBanner">
               <p className="ClawdGatewayBannerTitle">
-                {health.diagnostic_type === 'version_mismatch' ? 'OpenClaw version mismatch' : 'Gateway connectivity issue'}
+                {bannerTitle}
               </p>
               <p className="ClawdGatewayBannerDesc">
-                {health.diagnostic_type === 'version_mismatch'
-                  ? 'The gateway config was written by a different OpenClaw version. Knapsack will attempt to recover automatically — if the gateway does not come back up, try restarting it below.'
-                  : 'The gateway isn\'t responding. This can happen after a crash, permission change, or system sleep. Try one of these:'}
+                {bannerDesc}
               </p>
               <div className="ClawdPromptActions">
                 <button
@@ -5026,7 +5043,8 @@ ${actualText}`
               </div>
             </div>
           </div>
-        )}
+          )
+        })()}
         {/* Browser-only issue card — gateway OK but browser not responding for ~2 minutes. */}
         {hasCompletedOnboarding && health && health.gateway_ok && !health.browser_ok && !channelStatus.gatewayStarting && browserNotReadyPolls >= BROWSER_CARD_GRACE_POLLS && (
           <div className="ClawdMsg ClawdMsg-assistant">


### PR DESCRIPTION
## Summary
- Add install options to the static computer-use skill entry so it appears as a setup-required skill in the Clawd skills panel.
- Add a fallback one-click install action for computer-use in the UI catalog so installation is possible without live gateway data.

## Notes
- Uses existing install endpoint behavior () with .
- Applied to both the static catalog ( fallback) and chat panel fallback list for immediate visibility on Windows/macOS.