### PR TITLE
Isolate QA direct gateway state from local OpenClaw installs

### DIFF
--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -33,6 +33,7 @@ const launchAgentPlist = path.join(
   "LaunchAgents",
   "ai.knap.knapsack.clawdbot.plist",
 );
+const qaStateDir = path.join(projectDir, ".qa-dev-openclaw-state");
 
 function qaEnv(extra = {}) {
   const env = {
@@ -476,6 +477,7 @@ async function main() {
   runChecked(process.execPath, [
     path.join(projectDir, "scripts", "ensure-clawdbot-deps.cjs"),
   ]);
+  fs.mkdirSync(qaStateDir, { recursive: true });
   bootoutLaunchAgent();
   killStaleGateways();
   killStaleOpenClawChrome();
@@ -539,7 +541,11 @@ async function main() {
 
   const appEnv =
     process.platform === "darwin"
-      ? qaEnv({ KNAPSACK_QA_DIRECT_GATEWAY: "1" })
+      ? qaEnv({
+          KNAPSACK_QA_DIRECT_GATEWAY: "1",
+          OPENCLAW_HOME: qaStateDir,
+          OPENCLAW_STATE_DIR: qaStateDir,
+        })
       : qaEnv();
     const app = spawn(binary, [], {
       cwd: tauriDir,

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -430,6 +430,11 @@ function startDirectGatewayFromPlist() {
     return null;
   }
 
+  const gatewayStateDir =
+    plist.EnvironmentVariables?.OPENCLAW_STATE_DIR ||
+    plist.EnvironmentVariables?.OPENCLAW_HOME ||
+    qaStateDir;
+
   console.log(
     "[qa-dev-run] Starting direct dev gateway from LaunchAgent plist",
   );
@@ -440,6 +445,7 @@ function startDirectGatewayFromPlist() {
     stdio: "inherit",
     env: qaEnv({
       ...(plist.EnvironmentVariables || {}),
+      OPENCLAW_CONFIG_PATH: path.join(gatewayStateDir, "openclaw.json"),
       OPENCLAW_QA_DIRECT_GATEWAY: "1",
     }),
     windowsHide: true,
@@ -545,6 +551,7 @@ async function main() {
           KNAPSACK_QA_DIRECT_GATEWAY: "1",
           OPENCLAW_HOME: qaStateDir,
           OPENCLAW_STATE_DIR: qaStateDir,
+          OPENCLAW_CONFIG_PATH: path.join(qaStateDir, "openclaw.json"),
         })
       : qaEnv();
     const app = spawn(binary, [], {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -9006,6 +9006,7 @@ async fn prepare_gateway_config(
   // ── Config file setup ──────────────────────────────────────────────
   // Ensure OpenClaw config exists with gateway.mode=local for first-run.
   let config_path = clawdbot_home.join("openclaw.json");
+  let config_path_str = config_path.to_string_lossy().to_string();
   let legacy_config_path = clawdbot_home.join("clawdbot.json");
   if legacy_config_path.exists() && !config_path.exists() {
     match fs::rename(&legacy_config_path, &config_path) {
@@ -10268,6 +10269,7 @@ async fn prepare_gateway_config(
     ("HOME".to_string(), user_home.clone()),
     ("OPENCLAW_HOME".to_string(), clawdbot_home_str.clone()),
     ("OPENCLAW_STATE_DIR".to_string(), clawdbot_home_str),
+    ("OPENCLAW_CONFIG_PATH".to_string(), config_path_str),
     (
       "OPENCLAW_GATEWAY_TOKEN".to_string(),
       tokens.gateway_token.clone(),

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -3479,6 +3479,13 @@ fn read_log_tail_lines_bounded(
 }
 
 fn app_clawdbot_home(app_handle: &tauri::AppHandle) -> PathBuf {
+  if qa_direct_gateway_mode() {
+    if let Some(override_dir) =
+      std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("OPENCLAW_HOME"))
+    {
+      return PathBuf::from(override_dir);
+    }
+  }
   app_handle
     .path_resolver()
     .app_data_dir()


### PR DESCRIPTION
## Summary
- give qa:dev its own Clawdbot/OpenClaw state directory instead of reusing the live app state
- let QA direct mode honor OPENCLAW_STATE_DIR/OPENCLAW_HOME when resolving clawdbot home
- prevent bundled dev gateways from tripping over config last touched by newer local OpenClaw installs

## Testing
- traced the current failure to qa:dev reusing ~/Library/Application Support/ai.knap.knapsack/clawdbot
- reran qa:dev locally; build started successfully, but final app boot verification was still in progress when I stopped
