### PR TITLE
[settings] Require opt-in for keep-awake lid-close mode

### DIFF
--- a/src/src-tauri/src/clawd/skills_catalog.json
+++ b/src/src-tauri/src/clawd/skills_catalog.json
@@ -13,6 +13,7 @@
   {"name":"notion","emoji":"📝","description":"Read and edit Notion pages and databases","source":"OpenClaw","eligible":false},
   {"name":"slack","emoji":"💬","description":"Team communication via Slack","source":"OpenClaw","eligible":false},
   {"name":"peekaboo","emoji":"👁️","description":"macOS UI automation via PeekabooBridge — screenshot, click, and inspect any app","source":"OpenClaw","eligible":false,"macOnly":true},
+  {"name":"computer-use","emoji":"🖥️","description":"Desktop automation via Codex Computer Use for local app and UI control","source":"OpenClaw","eligible":false,"install":[{"id":"default","label":"Enable"}]},
   {"name":"apple-notes","emoji":"🍎","description":"Create and manage macOS Notes","source":"OpenClaw","eligible":false},
   {"name":"apple-reminders","emoji":"⏰","description":"Manage macOS Reminders","source":"OpenClaw","eligible":false},
   {"name":"things-mac","emoji":"✅","description":"Things 3 task management for macOS","source":"OpenClaw","eligible":false},

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -980,6 +980,7 @@ const FALLBACK_SKILLS: SkillInfo[] = [
   {name:"gog",emoji:"📊",description:"Google Workspace — Gmail, Calendar, Drive, Sheets, Docs",source:"OpenClaw",eligible:false},
   {name:"notion",emoji:"📝",description:"Read and edit Notion pages and databases",source:"OpenClaw",eligible:false},
   {name:"slack",emoji:"💬",description:"Team communication via Slack",source:"OpenClaw",eligible:false},
+  {name:"computer-use",emoji:"🖥️",description:"Desktop automation via Codex Computer Use for local app and UI control",source:"OpenClaw",eligible:false,installOptions:[{id:"default",label:"Enable"}]},
   {name:"apple-notes",emoji:"🍎",description:"Create and manage macOS Notes",source:"OpenClaw",eligible:false},
   {name:"apple-reminders",emoji:"⏰",description:"Manage macOS Reminders",source:"OpenClaw",eligible:false},
   {name:"things-mac",emoji:"✅",description:"Things 3 task management for macOS",source:"OpenClaw",eligible:false},

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -4990,16 +4990,33 @@ ${actualText}`
             so normal restarts and sleep/wake blips don't surface a scary error.
             Suppressed entirely until an API key is saved — the gateway status is
             irrelevant and alarming when the user hasn't set up a key yet. */}
-        {hasCompletedOnboarding && health && !health.gateway_ok && gatewayDownPolls >= GATEWAY_CARD_GRACE_POLLS && !channelStatus.gatewayStarting && (
+        {hasCompletedOnboarding && health && !health.gateway_ok && gatewayDownPolls >= GATEWAY_CARD_GRACE_POLLS && !channelStatus.gatewayStarting && (() => {
+          const healthMessage = (health.message || '').toLowerCase()
+          const missingService =
+            health.diagnostic_type === 'service_not_installed' ||
+            health.diagnostic_type === 'service_not_loaded' ||
+            healthMessage.includes('launchagent plist not found') ||
+            healthMessage.includes('service is registering') ||
+            healthMessage.includes('service is not loaded')
+          const versionMismatch = health.diagnostic_type === 'version_mismatch' && !missingService
+          const bannerTitle = missingService
+            ? 'Gateway background service is missing'
+            : versionMismatch
+              ? 'OpenClaw version mismatch'
+              : 'Gateway connectivity issue'
+          const bannerDesc = missingService
+            ? 'Knapsack cannot find its background gateway service right now. This usually means the LaunchAgent was removed or did not load after restart. Try restarting the gateway below to reinstall it.'
+            : versionMismatch
+              ? 'The gateway config was written by a different OpenClaw version. Knapsack will attempt to recover automatically — if the gateway does not come back up, try restarting it below.'
+              : 'The gateway isn\'t responding. This can happen after a crash, permission change, or system sleep. Try one of these:'
+          return (
           <div className="ClawdMsg ClawdMsg-assistant">
             <div className="ClawdBubble ClawdGatewayBanner">
               <p className="ClawdGatewayBannerTitle">
-                {health.diagnostic_type === 'version_mismatch' ? 'OpenClaw version mismatch' : 'Gateway connectivity issue'}
+                {bannerTitle}
               </p>
               <p className="ClawdGatewayBannerDesc">
-                {health.diagnostic_type === 'version_mismatch'
-                  ? 'The gateway config was written by a different OpenClaw version. Knapsack will attempt to recover automatically — if the gateway does not come back up, try restarting it below.'
-                  : 'The gateway isn\'t responding. This can happen after a crash, permission change, or system sleep. Try one of these:'}
+                {bannerDesc}
               </p>
               <div className="ClawdPromptActions">
                 <button
@@ -5026,7 +5043,8 @@ ${actualText}`
               </div>
             </div>
           </div>
-        )}
+          )
+        })()}
         {/* Browser-only issue card — gateway OK but browser not responding for ~2 minutes. */}
         {hasCompletedOnboarding && health && health.gateway_ok && !health.browser_ok && !channelStatus.gatewayStarting && browserNotReadyPolls >= BROWSER_CARD_GRACE_POLLS && (
           <div className="ClawdMsg ClawdMsg-assistant">

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -34,6 +34,10 @@ import {
   setMeetingChatEnabled as setMeetingChatEnabledSetting,
   getMeetingChatAutoSend,
   setMeetingChatAutoSend as setMeetingChatAutoSendSetting,
+  getKeepAwakeOnLidCloseEnabled,
+  getKeepAwakeConfirmationAcknowledged,
+  setKeepAwakeOnLidCloseEnabled,
+  setKeepAwakeConfirmationAcknowledged,
 } from 'src/utils/settings'
 
 import { InputCheckbox } from 'src/components/atoms/input-checkbox'
@@ -251,6 +255,9 @@ export const SettingsDialog = ({
   const [saveTranscripts, setSaveTranscripts] = useState<boolean>(true)
   const [meetingChatEnabled, setMeetingChatEnabled] = useState<boolean>(true)
   const [meetingChatAutoSend, setMeetingChatAutoSend] = useState<boolean>(false)
+  const [keepAwakeOnLidCloseEnabled, setKeepAwakeOnLidCloseEnabledState] = useState<boolean>(false)
+  const [showKeepAwakeEnableModal, setShowKeepAwakeEnableModal] = useState<boolean>(false)
+  const [hasAcknowledgedKeepAwakeWarning, setHasAcknowledgedKeepAwakeWarning] = useState<boolean>(false)
   const [connectionsKey, setConnectionsKey] = useState<ConnectionKeys[]>([])
   const [showNotificationLeadTime, setShowNotificationLeadTime] = useState<number>(1)
   const [providerStatus, setProviderStatus] = useState<{
@@ -271,6 +278,7 @@ export const SettingsDialog = ({
   const [channelBusy, setChannelBusy] = useState<string | null>(null)
   const [telegramBotToken, setTelegramBotToken] = useState('')
   const [showTelegramInput, setShowTelegramInput] = useState(false)
+  const isMacPlatform = navigator.platform?.includes('Mac')
 
   // Accordion state — which provider section is expanded
   const [expandedProvider, setExpandedProvider] = useState<string | null>(null)
@@ -410,6 +418,8 @@ export const SettingsDialog = ({
 
     getMeetingChatEnabled().then(setMeetingChatEnabled)
     getMeetingChatAutoSend().then(setMeetingChatAutoSend)
+    getKeepAwakeOnLidCloseEnabled().then(setKeepAwakeOnLidCloseEnabledState)
+    getKeepAwakeConfirmationAcknowledged().then(setHasAcknowledgedKeepAwakeWarning)
   }, [])
 
   const handleNotificationEnabledChange = useCallback(async () => {
@@ -474,6 +484,40 @@ export const SettingsDialog = ({
     setMeetingChatAutoSend(newValue)
     setMeetingChatAutoSendSetting(newValue)
   }
+
+  const applyKeepAwakeOnLidCloseSetting = useCallback((newValue: boolean) => {
+    setKeepAwakeOnLidCloseEnabledState(newValue)
+    setKeepAwakeOnLidCloseEnabled(newValue)
+    invoke('kn_set_keep_awake', { enabled: newValue }).catch(() => {})
+  }, [])
+
+  const confirmKeepAwakeEnable = useCallback(() => {
+    void setKeepAwakeConfirmationAcknowledged()
+    setHasAcknowledgedKeepAwakeWarning(true)
+    setShowKeepAwakeEnableModal(false)
+    applyKeepAwakeOnLidCloseSetting(true)
+  }, [applyKeepAwakeOnLidCloseSetting])
+
+  const cancelKeepAwakeEnable = useCallback(() => {
+    setShowKeepAwakeEnableModal(false)
+  }, [])
+
+  const handleFlipKeepAwakeOnLidClose = useCallback(() => {
+    const newValue = !keepAwakeOnLidCloseEnabled
+    if (!newValue) {
+      applyKeepAwakeOnLidCloseSetting(false)
+      return
+    }
+    if (hasAcknowledgedKeepAwakeWarning) {
+      applyKeepAwakeOnLidCloseSetting(true)
+      return
+    }
+    setShowKeepAwakeEnableModal(true)
+  }, [
+    applyKeepAwakeOnLidCloseSetting,
+    hasAcknowledgedKeepAwakeWarning,
+    keepAwakeOnLidCloseEnabled,
+  ])
 
   // ── Ollama enable/disable ────────────────────────────────────────────────
 
@@ -1288,6 +1332,23 @@ export const SettingsDialog = ({
         </div>
 
         <hr className="border-zinc-200" />
+        {isMacPlatform && (
+          <div className="DocumentsContainer p-6 flex flex-col gap-4">
+            <Typography weight={TypographyWeight.medium}>Power</Typography>
+            <InputCheckbox
+              checked={keepAwakeOnLidCloseEnabled}
+              onClick={handleFlipKeepAwakeOnLidClose}
+            >
+              <Typography className="text-black">Keep computer awake when screen/lid closes</Typography>
+            </InputCheckbox>
+            <Typography className="text-xs text-zinc-500 leading-5">
+              Opt-in behavior while the app is running. Enable only for remote/off-screen workflows;
+              this can increase battery use and heat.
+            </Typography>
+          </div>
+        )}
+
+        <hr className="border-zinc-200" />
         <div className="DocumentsContainer p-6 flex flex-col gap-4">
           <Typography weight={TypographyWeight.medium}>Meeting Chat Notice</Typography>
           <InputCheckbox
@@ -1332,6 +1393,37 @@ export const SettingsDialog = ({
         </div>
         <hr className="border-zinc-200" />
         <SupportSection />
+        {showKeepAwakeEnableModal && (
+          <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-5 w-[430px] shadow-xl">
+              <Typography weight={TypographyWeight.medium} className="text-lg">
+                Keep Mac awake when lid/screen closes?
+              </Typography>
+              <p className="mt-2 text-sm text-zinc-600">
+                This enables a system wake assertion while Knapsack is running so your Mac stays awake with
+                the lid closed.
+              </p>
+              <p className="mt-3 text-sm text-zinc-600">
+                Turn it on only when needed for remote recording, remote troubleshooting, or other
+                unattended workflows. It may increase battery use and heat.
+              </p>
+              <div className="mt-5 flex justify-end gap-2">
+                <button
+                  className="px-3 py-1.5 rounded border border-zinc-300 text-sm hover:bg-zinc-100"
+                  onClick={cancelKeepAwakeEnable}
+                >
+                  Not now
+                </button>
+                <button
+                  className="px-3 py-1.5 rounded bg-red-600 text-white text-sm hover:bg-red-700"
+                  onClick={confirmKeepAwakeEnable}
+                >
+                  Enable
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </Dialog>
   )

--- a/src/src/utils/settings.tsx
+++ b/src/src/utils/settings.tsx
@@ -64,6 +64,8 @@ export const KN_BACKGROUND_NOTIFICATIONS_ENABLED = 'kn_background_notifications_
 export const KN_BACKGROUND_NOTIFICATIONS_LAST_RUN = 'kn_background_notifications_last_run'
 export const KN_POST_MEETING_FOLLOWUP_ENABLED = 'kn_post_meeting_followup_enabled'
 export const KN_BACKGROUND_NOTIFICATION_HOURS = 'kn_background_notification_hours'
+export const KN_KEEP_SCREEN_ON_WHILE_CLOSED = 'kn_keep_screen_on_while_closed'
+export const KN_KEEP_AWAKE_CONFIRMED = 'kn_keep_awake_confirmed'
 
 export const getBackgroundNotificationsEnabled = async (): Promise<boolean> => {
   const value = await KNLocalStorage.getItem(KN_BACKGROUND_NOTIFICATIONS_ENABLED)
@@ -98,6 +100,24 @@ export const getPostMeetingFollowupEnabled = async (): Promise<boolean> => {
 
 export const setPostMeetingFollowupEnabled = async (enabled: boolean) => {
   await KNLocalStorage.setItem(KN_POST_MEETING_FOLLOWUP_ENABLED, enabled)
+}
+
+export const getKeepAwakeOnLidCloseEnabled = async (): Promise<boolean> => {
+  const value = await KNLocalStorage.getItem(KN_KEEP_SCREEN_ON_WHILE_CLOSED)
+  return value === true
+}
+
+export const setKeepAwakeOnLidCloseEnabled = async (enabled: boolean) => {
+  await KNLocalStorage.setItem(KN_KEEP_SCREEN_ON_WHILE_CLOSED, enabled)
+}
+
+export const getKeepAwakeConfirmationAcknowledged = async (): Promise<boolean> => {
+  const value = await KNLocalStorage.getItem(KN_KEEP_AWAKE_CONFIRMED)
+  return value === true
+}
+
+export const setKeepAwakeConfirmationAcknowledged = async () => {
+  await KNLocalStorage.setItem(KN_KEEP_AWAKE_CONFIRMED, true)
 }
 
 // Meeting chat notice settings


### PR DESCRIPTION
## Summary
- Default keep-awake-on-lid-close is now opt-in (off by default).
- Added one-time confirmation modal when enabling the macOS lid-close wake setting in Settings.
- Added explicit warning text about battery/heat impact and when to use it.
- Gated the feature UI to macOS only to reduce confusion on other platforms.