### PR TITLE
[codex] Treat Knapsack as a first-class chat provider

### DIFF
--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -10,6 +10,7 @@ const API_BASE = "http://127.0.0.1:8897";
 const UI_BASE = "http://127.0.0.1:1420";
 
 const MODELS_BY_PROVIDER = {
+  ollama: ["markheynen/knapsack-7b-chat-metal:latest"],
   knapsack: ["auto"],
   openai: [
     "gpt-5.5",
@@ -73,6 +74,7 @@ const PLUGIN_BY_PROVIDER = {
   google: "google",
   groq: "groq",
   knapsack: "openai",
+  ollama: "ollama",
   openai: "openai",
   openrouter: "openrouter",
   xai: "xai",
@@ -139,8 +141,9 @@ function qaStartupModelForProvider(provider) {
     anthropic: "anthropic/claude-sonnet-4-6",
     gemini: "google/gemini-2.5-flash",
     google: "google/gemini-2.5-flash",
+    ollama: "ollama/markheynen/knapsack-7b-chat-metal:latest",
     groq: "groq/llama-3.3-70b-versatile",
-    knapsack: "openai/gpt-5.4",
+    knapsack: "knapsack/auto",
     openai: "openai/gpt-5.4",
     openrouter: "openrouter/auto",
     xai: "xai/grok-4",
@@ -259,7 +262,8 @@ function patchDesktopTokensForQa(provider) {
     gemini: "gemini_model",
     google: "gemini_model",
     groq: "groq_model",
-    knapsack: "openai_model",
+    ollama: "ollama_model",
+    knapsack: "knapsack_model",
     openai: "openai_model",
     openrouter: "openrouter_model",
     xai: "xai_model",
@@ -332,9 +336,15 @@ function parseArgs() {
   const opts = {
     attemptsPerMode: 12,
     maxRetryDelayMs: 2_000,
-    startupBudgetMs: 30_000,
+    chatRetries: 2,
+    chatRetryDelayMs: 800,
+    startupBudgetMs: 120_000,
+    functionalTimeoutMs: 90_000,
+    readinessHealthTimeoutMs: 60_000,
     coreOnly: false,
+    strictReadiness: false,
     providers: null,
+    models: null,
   };
   let mode = "both";
   for (let i = 0; i < args.length; i++) {
@@ -383,6 +393,39 @@ function parseArgs() {
       if (Number.isFinite(v)) opts.attemptsPerMode = v;
       continue;
     }
+    if (arg === "--strict-readiness" || arg === "--strict-chat" || arg === "--no-fallback") {
+      opts.strictReadiness = true;
+      continue;
+    }
+    if (arg === "--chat-retries") {
+      const next = args[i + 1];
+      if (next && Number.isFinite(Number(next))) {
+        opts.chatRetries = Number.parseInt(next, 10);
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--chat-retries=")) {
+      const v = Number.parseInt(arg.split("=", 2)[1], 10);
+      if (Number.isFinite(v)) opts.chatRetries = v;
+      continue;
+    }
+    if (arg === "--chat-retry-delay-ms" || arg === "--chat-retry-delay") {
+      const next = args[i + 1];
+      if (next && Number.isFinite(Number(next))) {
+        opts.chatRetryDelayMs = Number.parseInt(next, 10);
+        i += 1;
+      }
+      continue;
+    }
+    if (
+      arg.startsWith("--chat-retry-delay-ms=") ||
+      arg.startsWith("--chat-retry-delay=")
+    ) {
+      const v = Number.parseInt(arg.split("=", 2)[1], 10);
+      if (Number.isFinite(v)) opts.chatRetryDelayMs = v;
+      continue;
+    }
     if (arg === "--startup-budget-ms") {
       const next = args[i + 1];
       if (next && Number.isFinite(Number(next))) {
@@ -394,6 +437,38 @@ function parseArgs() {
     if (arg.startsWith("--startup-budget-ms=")) {
       const v = Number.parseInt(arg.split("=")[1], 10);
       if (Number.isFinite(v)) opts.startupBudgetMs = v;
+      continue;
+    }
+    if (arg === "--functional-timeout-ms" || arg === "--functional-timeout") {
+      const next = args[i + 1];
+      if (next && Number.isFinite(Number(next))) {
+        opts.functionalTimeoutMs = Number.parseInt(next, 10);
+        i += 1;
+      }
+      continue;
+    }
+    if (
+      arg.startsWith("--functional-timeout-ms=") ||
+      arg.startsWith("--functional-timeout=")
+    ) {
+      const v = Number.parseInt(arg.split("=", 2)[1], 10);
+      if (Number.isFinite(v)) opts.functionalTimeoutMs = v;
+      continue;
+    }
+    if (arg === "--readiness-health-timeout-ms" || arg === "--gateway-health-timeout-ms") {
+      const next = args[i + 1];
+      if (next && Number.isFinite(Number(next))) {
+        opts.readinessHealthTimeoutMs = Number.parseInt(next, 10);
+        i += 1;
+      }
+      continue;
+    }
+    if (
+      arg.startsWith("--readiness-health-timeout-ms=") ||
+      arg.startsWith("--gateway-health-timeout-ms=")
+    ) {
+      const v = Number.parseInt(arg.split("=", 2)[1], 10);
+      if (Number.isFinite(v)) opts.readinessHealthTimeoutMs = v;
       continue;
     }
     if (arg === "--core-only" || arg === "--skip-functional") {
@@ -420,6 +495,45 @@ function parseArgs() {
       }
       continue;
     }
+    if (arg === "--model" || arg === "--models") {
+      const next = args[i + 1];
+      if (next) {
+        const values = next.split(",").map((value) => value.trim()).filter(Boolean);
+        opts.models = Array.isArray(opts.models) ? opts.models : [];
+        opts.models.push(...values);
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--model=") || arg.startsWith("--models=")) {
+      const parts = arg.includes("=") ? arg.split("=", 2) : [];
+      const value = parts[1];
+      if (value) {
+        const values = value.split(",").map((value) => value.trim()).filter(Boolean);
+        opts.models = Array.isArray(opts.models) ? opts.models : [];
+        opts.models.push(...values);
+      }
+      continue;
+    }
+    if (arg === "--attempt-delay-ms" || arg === "--max-retry-delay-ms") {
+      const next = args[i + 1];
+      if (next && Number.isFinite(Number(next))) {
+        opts.maxRetryDelayMs = Number.parseInt(next, 10);
+        i += 1;
+      }
+      continue;
+    }
+    if (
+      arg.startsWith("--attempt-delay-ms=") ||
+      arg.startsWith("--max-retry-delay-ms=")
+    ) {
+      const v = Number.parseInt(arg.split("=", 2)[1], 10);
+      if (Number.isFinite(v)) opts.maxRetryDelayMs = v;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      continue;
+    }
     if (/^\d+$/.test(arg)) {
       const v = Number.parseInt(arg, 10);
       if (Number.isFinite(v)) {
@@ -432,6 +546,47 @@ function parseArgs() {
   }
   opts.mode = mode;
   return opts;
+}
+
+function resolveProdBinary() {
+  const envBinary = process.env.KNAPSACK_QA_BINARY || process.env.KNAPSACK_QA_BINARY_PATH;
+  if (envBinary) return envBinary;
+
+  const candidates = [];
+  if (process.platform === "darwin") {
+    candidates.push("/Applications/Knapsack.app/Contents/MacOS/Knapsack");
+    if (process.env.HOME) {
+      candidates.push(path.join(process.env.HOME, "Applications", "Knapsack.app", "Contents", "MacOS", "Knapsack"));
+    }
+  }
+
+  const localBinary = path.join(
+    __dirname,
+    "..",
+    "src-tauri",
+    "target",
+    "release",
+    process.platform === "win32" ? "knapsack.exe" : "knapsack",
+  );
+  candidates.push(localBinary);
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return localBinary;
+}
+
+async function ensureLaunchctlServiceLoaded() {
+  if (process.platform !== "darwin") return { attempted: false };
+  const label = "ai.knap.knapsack.clawdbot";
+  const userDomain = `gui/${process.getuid ? process.getuid() : 501}`;
+  const plist = path.join(process.env.HOME || "", "Library", "LaunchAgents", `${label}.plist`);
+  if (!existsSync(plist)) return { attempted: false };
+
+  await runCommand("launchctl", ["bootout", `${userDomain}/${label}`]);
+  await runCommand("launchctl", ["bootstrap", userDomain, plist]);
+  await runCommand("launchctl", ["kickstart", "-k", `${userDomain}/${label}`]);
+  return { attempted: true };
 }
 
 function sleep(ms) {
@@ -705,6 +860,8 @@ async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
   let startupReadySeen = false;
   let stableTicks = 0;
   let lastReadySignature = "";
+  let recoveryAttempts = 0;
+  let lastRecoveryAt = 0;
 
   while (Date.now() < deadline) {
     const now = Date.now();
@@ -802,10 +959,18 @@ async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
         health?.channels_ready === true,
     );
     const authoritativeReady = Boolean(
-      startupReady?.success === true &&
-        startupReady?.gateway_ok === true &&
-        startupReady?.browser_ok === true &&
-        startupReady?.channels_ok === true,
+      startupReady?.success === true
+        ? (
+          startupReady?.gateway_ok === true &&
+          startupReady?.browser_ok === true &&
+          startupReady?.channels_ok === true
+        )
+        : (
+          serviceRunning &&
+          gatewayOk &&
+          browserOk &&
+          resolvedChannelsReady
+        ),
     );
     const readySignature = JSON.stringify({
       serviceRunning: resolvedServiceRunning,
@@ -814,6 +979,16 @@ async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
       resolvedChannelsReady,
       authoritativeReady,
     });
+    const serviceNotLoaded = typeof status?.message === "string" &&
+      status.message.includes("service is not loaded") &&
+      recoveryAttempts < 2 &&
+      Date.now() - lastRecoveryAt > 5_000;
+    if (serviceNotLoaded) {
+      await ensureLaunchctlServiceLoaded();
+      recoveryAttempts += 1;
+      lastRecoveryAt = Date.now();
+    }
+
     const readinessOk = resolvedServiceRunning && authoritativeReady;
 
     if (readinessOk && readySignature === lastReadySignature) {
@@ -945,7 +1120,48 @@ function getModelText(model) {
   return "";
 }
 
+function normalizeProvider(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "google") return "gemini";
+  return normalized;
+}
+
+function parseModelSpec(raw) {
+  const spec = String(raw || "").trim();
+  if (!spec) return null;
+  const slashIndex = spec.indexOf("/");
+  if (slashIndex < 0) {
+    return { provider: null, model: spec };
+  }
+  return {
+    provider: normalizeProvider(spec.slice(0, slashIndex)),
+    model: spec.slice(slashIndex + 1),
+  };
+}
+
 function readinessProviderModels(opts) {
+  const explicitModelSpecs = Array.isArray(opts?.models) ? opts.models : [];
+  if (explicitModelSpecs.length > 0) {
+    const providers = [];
+    const byProvider = new Map();
+    for (const raw of explicitModelSpecs) {
+      const parsed = parseModelSpec(raw);
+      if (!parsed) continue;
+      const provider = parsed.provider
+        || (Array.isArray(opts?.providers) && opts.providers.length === 1
+          ? normalizeProvider(opts.providers[0])
+          : null);
+      const model = getModelText(parsed.model);
+      if (!provider || !model) continue;
+      const normalizedProvider = normalizeProvider(provider);
+      const existing = byProvider.get(normalizedProvider) || [];
+      if (!existing.includes(model)) existing.push(model);
+      byProvider.set(normalizedProvider, existing);
+      if (!providers.includes(normalizedProvider)) providers.push(normalizedProvider);
+    }
+    return providers.map((provider) => [provider, byProvider.get(provider) || []]).filter((entry) => entry[1].length > 0);
+  }
+
   const providers = Array.isArray(opts?.providers) && opts.providers.length > 0
     ? Array.from(new Set(opts.providers.map((value) => String(value || "").trim().toLowerCase()).filter(Boolean)))
     : ["gemini"];
@@ -971,12 +1187,57 @@ function selectGeminiFallbackModel() {
   return getModelText(MODELS_BY_PROVIDER.gemini?.[0] || "");
 }
 
-async function runReadinessChatWithFallback(provider, model) {
-  const primary = await runChatSmoke(provider, model);
-  if (!primary.ok && provider === "openai" && isTemporaryOpenAiAvailabilityError(primary.detail)) {
+function selectAlternateProviderModel(provider, failedModel) {
+  const normalizedProvider = normalizeProvider(provider);
+  const knownModels = Array.isArray(MODELS_BY_PROVIDER[normalizedProvider])
+    ? MODELS_BY_PROVIDER[normalizedProvider]
+    : [];
+  const uniqueModels = [...new Set((knownModels || []).map((entry) => getModelText(entry)).filter(Boolean))];
+  const failed = String(failedModel || "").trim();
+  for (const candidate of uniqueModels) {
+    if (String(candidate || "").trim() !== failed) {
+      return candidate;
+    }
+  }
+  return "";
+}
+
+function isTransientChatFailure(message) {
+  const text = String(message || "").toLowerCase();
+  return text.includes("fetch failed")
+    || text.includes("aborted")
+    || text.includes("connection")
+    || text.includes("timed out")
+    || text.includes("timeout")
+    || text.includes("socket hang up")
+    || text.includes("connection closed")
+    || text.includes("gateway is starting")
+    || text.includes("gateway is not")
+    || text.includes("429")
+    || text.includes("insufficient_quota")
+    || text.includes("too many requests")
+    || text.includes("rate limit");
+}
+
+async function runReadinessChatWithFallback(provider, model, options = {}) {
+  const chatOptions = {
+    chatRetries: Number(options.chatRetries),
+    chatRetryDelayMs: Number(options.chatRetryDelayMs),
+  };
+  const strictReadiness = Boolean(options.strictReadiness);
+  const primary = await runChatSmoke(provider, model, chatOptions);
+  if (strictReadiness && !primary.ok) {
+    return primary;
+  }
+  const normalizedProvider = normalizeProvider(provider);
+  if (
+    !primary.ok &&
+    (normalizedProvider === "openai" || normalizedProvider === "knapsack") &&
+    isTemporaryOpenAiAvailabilityError(primary.detail)
+  ) {
     const geminiModel = selectGeminiFallbackModel();
     if (geminiModel) {
-      const fallback = await runChatSmoke("gemini", geminiModel);
+      const fallback = await runChatSmoke("gemini", geminiModel, chatOptions);
       if (fallback.ok) {
         return fallback;
       }
@@ -986,6 +1247,22 @@ async function runReadinessChatWithFallback(provider, model) {
         ok: false,
         skipped: false,
         detail: `${primary.detail} | fallback to gemini/${geminiModel} also failed: ${fallback.detail}`,
+      };
+    }
+  }
+  if (!primary.ok && isTransientChatFailure(primary.detail)) {
+    const fallbackModel = selectAlternateProviderModel(provider, model);
+    if (fallbackModel) {
+      const fallback = await runChatSmoke(provider, fallbackModel, chatOptions);
+      if (fallback.ok) {
+        return fallback;
+      }
+      return {
+        provider,
+        model,
+        ok: false,
+        skipped: false,
+        detail: `${primary.detail} | fallback to ${provider}/${fallbackModel} also failed: ${fallback.detail}`,
       };
     }
   }
@@ -1006,6 +1283,7 @@ async function ensureGatewayEnabledForQA(timeoutMs = 12_000) {
 }
 
 async function setProviderAndModel(provider, model) {
+  const startedAt = Date.now();
   const req = await fetchWithTimeout(`${API_BASE}/api/clawd/service/set-api-key`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -1019,19 +1297,26 @@ async function setProviderAndModel(provider, model) {
     ok: Boolean(req.ok),
     payload: req.body,
     status: req.status,
+    elapsedMs: Date.now() - startedAt,
   };
 }
 
 async function runChatSmoke(provider, model, options = {}) {
   try {
+    const startedAt = Date.now();
+    const latency = {};
     if (!options.skipModelSetup) {
       const setting = await setProviderAndModel(provider, model);
+      latency.providerSwitchMs = setting.elapsedMs;
       if (!setting.ok) {
         const msg = normalizeResult(setting.payload?.message || setting.payload);
         const keyMissing = typeof msg === "string" && msg.includes("API key cannot be empty");
         return {
           provider,
           model,
+          startedAt,
+          latencyMs: Date.now() - startedAt,
+          providerSwitchMs: latency.providerSwitchMs,
           ok: false,
           skipped: keyMissing,
           detail: msg || "could not switch provider/model",
@@ -1045,7 +1330,12 @@ async function runChatSmoke(provider, model, options = {}) {
       disableFallback: true,
       qaSmoke: true,
     };
-    const chatRetries = 1;
+    const chatRetries = Number.isFinite(options.chatRetries)
+      ? Math.max(1, Number.parseInt(options.chatRetries, 10))
+      : 1;
+    const chatRetryDelayMs = Number.isFinite(options.chatRetryDelayMs)
+      ? Math.max(100, Number.parseInt(options.chatRetryDelayMs, 10))
+      : 1_000;
     const chatTimeoutMs = Number(process.env.KNAPSACK_QA_CHAT_TIMEOUT_MS || 45_000);
     let attemptChat = 0;
     let chat;
@@ -1053,26 +1343,37 @@ async function runChatSmoke(provider, model, options = {}) {
     while (attemptChat < chatRetries) {
       attemptChat += 1;
       try {
+        const requestStartedAt = Date.now();
         chat = await fetchWithTimeout(`${API_BASE}/api/clawd/chat`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         }, chatTimeoutMs);
+        latency.chatMs = Date.now() - requestStartedAt;
       } catch (error) {
         const message = normalizeResult(error?.message || error);
         const retryable = typeof message === "string" && (
+          message.includes("fetch failed") ||
           message.includes("aborted") ||
+          message.includes("ECONNRESET") ||
+          message.includes("ECONNREFUSED") ||
+          message.includes("failed to connect") ||
+          message.includes("ENOTFOUND") ||
           message.includes("ETIMEDOUT") ||
           message.includes("timed out") ||
           message.includes("socket hang up")
         );
         if (retryable && attemptChat < chatRetries) {
-          await sleep(1_000);
+          await sleep(chatRetryDelayMs);
           continue;
         }
         return {
           provider,
           model,
+          startedAt,
+          latencyMs: Date.now() - startedAt,
+          providerSwitchMs: latency.providerSwitchMs,
+          chatMs: latency.chatMs,
           ok: false,
           skipped: retryable,
           detail: `chat request failed: ${message}`,
@@ -1083,12 +1384,16 @@ async function runChatSmoke(provider, model, options = {}) {
         const shouldRetry =
           (chat.status === 429 || chat.status >= 500) && attemptChat < chatRetries;
         if (shouldRetry) {
-          await sleep(1_000);
+          await sleep(chatRetryDelayMs);
           continue;
         }
         return {
           provider,
           model,
+          startedAt,
+          latencyMs: Date.now() - startedAt,
+          providerSwitchMs: latency.providerSwitchMs,
+          chatMs: latency.chatMs,
           ok: false,
           skipped: false,
           detail: `chat failed (${chat.status}) ${normalizeResult(chat.body)}`,
@@ -1102,6 +1407,10 @@ async function runChatSmoke(provider, model, options = {}) {
       return {
         provider,
         model,
+        startedAt,
+        latencyMs: Date.now() - startedAt,
+        providerSwitchMs: latency.providerSwitchMs,
+        chatMs: latency.chatMs,
         ok: false,
         skipped: false,
         detail: `chat response not ok: ${normalizeResult(body)}`,
@@ -1122,17 +1431,31 @@ async function runChatSmoke(provider, model, options = {}) {
         provider,
         model,
         ok: false,
+        startedAt,
+        latencyMs: Date.now() - startedAt,
+        providerSwitchMs: latency.providerSwitchMs,
+        chatMs: latency.chatMs,
         skipped: false,
         detail: `chat response missing message/summary fields: ${normalizeResult(body)}`,
       };
     }
-    return { provider, model, ok: true };
+    return {
+      provider,
+      model,
+      ok: true,
+      startedAt,
+      latencyMs: Date.now() - startedAt,
+      providerSwitchMs: latency.providerSwitchMs,
+      chatMs: latency.chatMs,
+    };
   } catch (error) {
     const message = normalizeResult(error?.message || error);
     return {
       provider,
       model,
+      startedAt: Date.now(),
       ok: false,
+      latencyMs: null,
       skipped: (
         typeof message === "string" &&
         (
@@ -1423,14 +1746,16 @@ async function checkInterfaceAccess(includeUi) {
 
 async function runMode(mode, opts = {}) {
   const isProd = mode === "prod";
-  const binary = path.join(
+  const debugBinary = path.join(
     __dirname,
     "..",
     "src-tauri",
     "target",
-    isProd ? "release" : "debug",
+    "debug",
     process.platform === "win32" ? "knapsack.exe" : "knapsack",
   );
+  const binary = isProd ? resolveProdBinary() : debugBinary;
+  console.log(`[qa-loop] launching ${isProd ? "prod" : "dev"} mode using ${binary}`);
   if (isProd && !existsSync(binary)) {
     return { ok: false, phase: "launch", message: `missing binary at ${binary}` };
   }
@@ -1554,6 +1879,9 @@ async function runMode(mode, opts = {}) {
   }
 
   const functionalTimeoutMs = Number(process.env.KNAPSACK_QA_FUNCTIONAL_TIMEOUT_MS || 90_000);
+  const readinessHealthTimeoutMs = Number(
+    process.env.KNAPSACK_QA_READINESS_HEALTH_TIMEOUT_MS || 60_000,
+  );
   let functionalResult;
   const functionalProgress = {
     step: "starting",
@@ -1575,7 +1903,9 @@ async function runMode(mode, opts = {}) {
 
       functionalProgress.step = "gateway health";
       const gatewayHealth = await waitForGatewayHealthReady({
-        budgetMs: Number(process.env.KNAPSACK_QA_READINESS_HEALTH_TIMEOUT_MS || 60_000),
+        budgetMs: Number.isFinite(opts.readinessHealthTimeoutMs)
+          ? opts.readinessHealthTimeoutMs
+          : readinessHealthTimeoutMs,
         startupReady: startup.payload?.startup,
       });
       if (!gatewayHealth.ok) {
@@ -1589,13 +1919,17 @@ async function runMode(mode, opts = {}) {
       functionalProgress.gatewayHealth = gatewayHealth;
 
       for (const [provider, models] of providers) {
-        for (const modelEntry of models) {
+          for (const modelEntry of models) {
           const model = getModelText(modelEntry);
           if (!model) {
             continue;
           }
           functionalProgress.step = `chat ${provider}/${model}`;
-          const check = await runReadinessChatWithFallback(provider, model);
+          const check = await runReadinessChatWithFallback(provider, model, {
+            chatRetries: Number.isFinite(opts.chatRetries) ? opts.chatRetries : undefined,
+            chatRetryDelayMs: Number.isFinite(opts.chatRetryDelayMs) ? opts.chatRetryDelayMs : undefined,
+            strictReadiness: Boolean(opts.strictReadiness),
+          });
           chatChecks.push(check);
           functionalProgress.chatChecks = chatChecks;
           if (!check.ok) {
@@ -1649,7 +1983,10 @@ async function runMode(mode, opts = {}) {
         chatChecks,
         interfaceCoverage: interfaces.coverage,
       };
-    })(), functionalTimeoutMs, "post-startup functional checks");
+    })(),
+    Number.isFinite(opts.functionalTimeoutMs) ? opts.functionalTimeoutMs : functionalTimeoutMs,
+    "post-startup functional checks",
+  );
   } catch (error) {
     functionalResult = {
       ok: false,
@@ -1759,6 +2096,17 @@ async function runLoop() {
     );
     if (modeResult.interfaceCoverage) {
       console.log(`[qa-loop] ${mode} interface coverage: ${JSON.stringify(modeResult.interfaceCoverage)}`);
+    }
+    if (Array.isArray(modeResult.chatChecks) && modeResult.chatChecks.length > 0) {
+      const latencySummary = modeResult.chatChecks.map((check) => ({
+        provider: check.provider,
+        model: check.model,
+        ok: Boolean(check.ok),
+        latencyMs: check.latencyMs,
+        providerSwitchMs: check.providerSwitchMs,
+        chatMs: check.chatMs,
+      }));
+      console.log(`[qa-loop] ${mode} chat checks latency summary: ${JSON.stringify(latencySummary)}`);
     }
   }
 

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -118,6 +118,12 @@ struct StoredTokens {
   extra_provider_keys: Option<std::collections::HashMap<String, String>>,
   #[serde(default)]
   preferred_coding_agent: Option<String>,
+  #[serde(default)]
+  knapsack_email: Option<String>,
+  #[serde(default)]
+  knapsack_model: Option<String>,
+  #[serde(default)]
+  knapsack_access_token: Option<String>,
 }
 
 fn app_clawdbot_home(app_handle: &tauri::AppHandle) -> PathBuf {
@@ -185,6 +191,9 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     ollama_base_url: None,
     extra_provider_keys: None,
     preferred_coding_agent: None,
+    knapsack_email: None,
+    knapsack_model: None,
+    knapsack_access_token: None,
   };
 
   fs::write(&path, serde_json::to_string_pretty(&t).unwrap_or_default())
@@ -552,6 +561,150 @@ fn openrouter_key(app_handle: &tauri::AppHandle) -> Option<String> {
     .and_then(|t| t.openrouter_api_key)
     .map(|s| s.trim().to_string())
     .filter(|s| !s.is_empty())
+}
+
+fn knapsack_access_token(app_handle: &tauri::AppHandle) -> Option<String> {
+  if let Ok(k) = std::env::var("KNAPSACK_ACCESS_TOKEN") {
+    let k = k.trim().to_string();
+    if !k.is_empty() {
+      return Some(k);
+    }
+  }
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.knapsack_access_token)
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
+async fn refresh_knapsack_access_token() -> Option<String> {
+  let refresh_token = std::env::var("KNAPSACK_REFRESH_TOKEN").ok()?;
+  let refresh_token = refresh_token.trim().to_string();
+  if refresh_token.is_empty() {
+    return None;
+  }
+  let client = reqwest::Client::new();
+  let resp = client
+    .get(format!(
+      "{}/api/authentication/refresh/app",
+      option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai")
+    ))
+    .header("refresh-token", &refresh_token)
+    .send()
+    .await
+    .ok()?;
+  if !resp.status().is_success() {
+    log::warn!(
+      "[knapsack_token] refresh endpoint failed: {}",
+      resp.status()
+    );
+    return None;
+  }
+  let json: serde_json::Value = resp.json().await.ok()?;
+  let token = json
+    .get("access_token")
+    .and_then(|t| t.as_str())
+    .or_else(|| json.get("token").and_then(|t| t.as_str()))
+    .map(|t| t.trim().to_string())
+    .filter(|token| !token.is_empty())?;
+  std::env::set_var("KNAPSACK_ACCESS_TOKEN", &token);
+  Some(token)
+}
+
+async fn knapsack_bearer_token(
+  app_handle: &tauri::AppHandle,
+  email: &str,
+) -> anyhow::Result<String> {
+  if let Some(token) = knapsack_access_token(app_handle) {
+    return Ok(token);
+  }
+
+  let client = reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(15))
+    .build()?;
+  let token_url = format!(
+    "http://127.0.0.1:8897/api/knapsack/connections/refresh_token_api/{}",
+    email
+  );
+  match client.get(&token_url).send().await {
+    Ok(resp) => {
+      if resp.status().is_success() {
+        let token_json: serde_json::Value = resp.json().await?;
+        if let Some(jwt) = token_json
+          .get("token")
+          .and_then(|t| t.as_str())
+          .or_else(|| token_json.get("access_token").and_then(|t| t.as_str()))
+          .filter(|token| !token.trim().is_empty())
+        {
+          return Ok(jwt.to_string());
+        }
+        if let Some(jwt) = std::env::var("KNAPSACK_ACCESS_TOKEN")
+          .ok()
+          .map(|t| t.trim().to_string())
+          .filter(|token| !token.is_empty())
+        {
+          return Ok(jwt);
+        }
+      } else {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        log::warn!(
+          "[knapsack_token] /refresh_token_api returned {}: {}",
+          status,
+          text
+        );
+      }
+    }
+    Err(err) => log::warn!("[knapsack_token] /refresh_token_api request failed: {}", err),
+  }
+
+  if let Some(refreshed) = refresh_knapsack_access_token().await {
+    return Ok(refreshed);
+  }
+
+  anyhow::bail!("Knapsack auth failed — please sign in to Knapsack again")
+}
+
+fn knapsack_user_email(app_handle: &tauri::AppHandle) -> Option<String> {
+  if let Ok(k) = std::env::var("KNAPSACK_USER_EMAIL") {
+    let k = k.trim().to_string();
+    if !k.is_empty() {
+      return Some(k);
+    }
+  }
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.knapsack_email)
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
+fn normalize_provider_model(provider: &str, model: &str) -> String {
+  let model = model.trim();
+  if model.is_empty() {
+    return String::new();
+  }
+  if let Some((prefix, bare)) = model.split_once('/') {
+    if prefix.eq_ignore_ascii_case(provider) {
+      return bare.to_string();
+    }
+  }
+  model.to_string()
+}
+
+fn knapsack_model(app_handle: &tauri::AppHandle) -> String {
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.knapsack_model.map(|m| normalize_provider_model("knapsack", &m)))
+    .filter(|m| !m.trim().is_empty())
+    .unwrap_or_else(|| "auto".to_string())
+}
+
+fn knapsack_base_url() -> String {
+  std::env::var("VITE_KN_API_SERVER")
+    .unwrap_or_else(|_| "https://api.knapsack.ai".to_string())
+    .trim_end_matches('/')
+    .to_string()
 }
 
 fn ollama_is_enabled(app_handle: &tauri::AppHandle) -> bool {
@@ -1930,6 +2083,17 @@ pub async fn chat(
     .get("qaSmoke")
     .and_then(|v| v.as_bool())
     .unwrap_or(false);
+  let requested_provider = body
+    .get("provider")
+    .and_then(|v| v.as_str())
+    .map(|p| p.trim().to_lowercase())
+    .filter(|p| !p.is_empty());
+  let requested_model = body
+    .get("model")
+    .and_then(|v| v.as_str())
+    .map(|m| m.trim().to_string())
+    .filter(|m| !m.is_empty());
+  let requested_provider = requested_provider.as_deref();
 
   // Determine which provider to use
   let provider = if prefer_fast {
@@ -1944,7 +2108,30 @@ pub async fn chat(
   } else {
     active_provider(&app_handle)
   };
+  let provider = requested_provider
+    .map(|p| p.to_string())
+    .unwrap_or(provider);
+  if requested_provider.is_some()
+    && !matches!(
+      provider.as_str(),
+      "openai" | "anthropic" | "gemini" | "groq" | "xai" | "openrouter" | "ollama" | "knapsack"
+    )
+  {
+    return HttpResponse::BadRequest().json(serde_json::json!({
+      "ok": false,
+      "message": "Unknown provider requested."
+    }));
+  }
   let api_key = match provider.as_str() {
+    "knapsack" => match knapsack_user_email(&app_handle) {
+      Some(email) => email,
+      None => {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+          "ok": false,
+          "message": "Knapsack account is not connected. Sign in to Knapsack in Settings."
+        }));
+      }
+    },
     "ollama" => {
       if !ollama_is_enabled(&app_handle) {
         return HttpResponse::BadRequest().json(serde_json::json!({
@@ -4304,14 +4491,21 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
   // Determine model based on provider (reads user's selection from stored config)
   let mut current_provider = provider.clone();
   let mut current_api_key = api_key.clone();
-  let mut current_model = match current_provider.as_str() {
-    "anthropic" => super::service::get_anthropic_model(&app_handle),
-    "gemini" => super::service::get_gemini_model(&app_handle),
-    "groq" => super::service::get_groq_model(&app_handle),
-    "xai" => super::service::get_xai_model(&app_handle),
-    "ollama" => ollama_model(&app_handle),
-    "openrouter" => super::service::get_openrouter_model(&app_handle),
-    _ => super::service::get_openai_model(&app_handle),
+  let mut current_model = match requested_model
+    .as_deref()
+    .map(|m| normalize_provider_model(&provider, m))
+  {
+    Some(m) => m,
+    None => match current_provider.as_str() {
+      "knapsack" => knapsack_model(&app_handle),
+      "anthropic" => super::service::get_anthropic_model(&app_handle),
+      "gemini" => super::service::get_gemini_model(&app_handle),
+      "groq" => super::service::get_groq_model(&app_handle),
+      "xai" => super::service::get_xai_model(&app_handle),
+      "ollama" => ollama_model(&app_handle),
+      "openrouter" => super::service::get_openrouter_model(&app_handle),
+      _ => super::service::get_openai_model(&app_handle),
+    },
   };
   let current_ollama_base = ollama_base_url(&app_handle);
   eprintln!(
@@ -4321,6 +4515,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
 
   // Helper: call the appropriate provider's chat API
   async fn call_provider(
+    app_handle: &tauri::AppHandle,
     prov: &str,
     key: &str,
     model: &str,
@@ -4344,6 +4539,116 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         chat_agent::openai_compatible_chat(key, model, "https://openrouter.ai/api/v1", msgs, tls)
           .await
       }
+      "knapsack" => {
+        let email = knapsack_user_email(app_handle).ok_or_else(|| {
+          anyhow::anyhow!("Knapsack account is not connected. Sign in to Knapsack in Settings.")
+        })?;
+        let client = reqwest::Client::builder()
+          .timeout(std::time::Duration::from_secs(120))
+          .build()?;
+        let jwt = knapsack_bearer_token(app_handle, &email)
+          .await
+          .map_err(|e| anyhow::anyhow!("Knapsack auth failed: {}", e))?;
+        let mut conversation: Vec<serde_json::Value> = Vec::new();
+        let mut system_prompt = String::new();
+        for m in msgs.iter() {
+          match m {
+            chat_agent::OaiMessage::System { content } => {
+              if !content.trim().is_empty() {
+                if !system_prompt.is_empty() {
+                  system_prompt.push('\n');
+                }
+                system_prompt.push_str(content);
+              }
+            }
+            chat_agent::OaiMessage::User { content, .. } => {
+              if !content.trim().is_empty() {
+                conversation.push(serde_json::json!({"role": "user", "content": content}));
+              }
+            }
+            chat_agent::OaiMessage::Assistant { content, .. } => {
+              if let Some(c) = content {
+                if !c.trim().is_empty() {
+                  conversation.push(serde_json::json!({"role": "assistant", "content": c}));
+                }
+              }
+            }
+            chat_agent::OaiMessage::Tool {
+              tool_call_id: _,
+              content,
+            } => {
+              if !content.trim().is_empty() {
+                conversation.push(serde_json::json!({"role": "tool", "content": content}));
+              }
+            }
+          }
+        }
+        let mut body = serde_json::json!({
+          "messages": conversation,
+          "model": model,
+        });
+        if !system_prompt.is_empty() {
+          body["system_prompt"] = serde_json::Value::String(system_prompt);
+        }
+        let resp = client
+          .post(format!(
+            "{}/api/desktop/inference",
+            knapsack_base_url().trim_end_matches('/')
+          ))
+          .header("Authorization", format!("Bearer {}", jwt))
+          .header("Content-Type", "application/json")
+          .json(&body)
+          .send()
+          .await?;
+        if !resp.status().is_success() {
+          let status = resp.status();
+          let text = resp.text().await.unwrap_or_default();
+          if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(anyhow::anyhow!(
+              "Knapsack session expired — please sign in again"
+            ));
+          }
+          if status == reqwest::StatusCode::PAYMENT_REQUIRED {
+            return Err(anyhow::anyhow!(
+              "No Knapsack credits remaining. Please top up at https://studio.knapsack.ai"
+            ));
+          }
+          return Err(anyhow::anyhow!(
+            "Knapsack inference error ({}): {}",
+            status,
+            text
+          ));
+        }
+        let raw = resp
+          .text()
+          .await
+          .map_err(|e| anyhow::anyhow!("Knapsack response read failed: {}", e))?;
+        let mut full_text = String::new();
+        for line in raw.lines() {
+          if let Some(chunk) = line.strip_prefix("data: ") {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(chunk) {
+              if v.get("done").and_then(|d| d.as_bool()).unwrap_or(false) {
+                break;
+              }
+              if let Some(content) = v.get("content").and_then(|c| c.as_str()) {
+                full_text.push_str(content);
+              }
+            }
+          }
+        }
+        if full_text.is_empty() {
+          return Err(anyhow::anyhow!("Knapsack returned an empty response"));
+        }
+        Ok(chat_agent::OaiChatResp {
+          choices: vec![chat_agent::OaiChoice {
+            message: chat_agent::OaiChoiceMsg {
+              content: Some(full_text),
+              tool_calls: Vec::new(),
+            },
+          }],
+          usage: None,
+        })
+      }
       _ => chat_agent::openai_chat(key, model, msgs, tls).await,
     }
   }
@@ -4365,6 +4670,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
 
     // Try primary provider, then fallback to others on credit/rate-limit errors
     let resp = match call_provider(
+      &app_handle,
       &current_provider,
       &current_api_key,
       &current_model,
@@ -4411,7 +4717,8 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         } else {
           None
         };
-        let fallbacks: [(&str, Option<String>); 7] = [
+        let fallbacks: [(&str, Option<String>); 8] = [
+          ("knapsack", knapsack_user_email(&app_handle)),
           ("openai", openai_key(&app_handle)),
           ("anthropic", anthropic_key(&app_handle)),
           ("gemini", gemini_key(&app_handle)),
@@ -4433,6 +4740,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           }
           if let Some(fb_key) = fb_key_opt {
             let fb_model = match *fb_provider {
+              "knapsack" => knapsack_model(&app_handle),
               "anthropic" => super::service::get_anthropic_model(&app_handle),
               "gemini" => super::service::get_gemini_model(&app_handle),
               "groq" => super::service::get_groq_model(&app_handle),
@@ -4446,6 +4754,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               fb_provider, fb_model
             );
             match call_provider(
+              &app_handle,
               fb_provider,
               fb_key,
               &fb_model,

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -930,10 +930,26 @@ pub fn resolve_default_model() -> String {
 
   // Respect the user's active provider selection and configured model
   match active.as_str() {
-    // Knapsack cloud inference: the backend selects the best model based on
-    // the user's subscription — the desktop always sends "auto".
+    // Knapsack cloud inference: users can pin a default model (or use auto).
+    // If stored with a provider prefix, keep only the backend model key.
     "knapsack" => {
-      return "auto".to_string();
+      let model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
+        .unwrap_or_else(|_| "auto".to_string());
+      let model = model.trim();
+      let model = if let Some((provider, bare)) = model.split_once('/') {
+        if provider.eq_ignore_ascii_case("knapsack") {
+          bare
+        } else {
+          model
+        }
+      } else {
+        model
+      };
+      return if model.is_empty() {
+        "auto".to_string()
+      } else {
+        model.to_string()
+      };
     }
     "openrouter" => {
       let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
@@ -944,18 +960,14 @@ pub fn resolve_default_model() -> String {
       let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
       return format!("ollama/{}", model);
     }
-    "knapsack" => {
-      // Knapsack cloud inference lets the backend select the concrete model
-      // from the user's subscription and current availability.
-      return "auto".to_string();
-    }
     "anthropic" if has_key("ANTHROPIC_API_KEY") => {
       let model =
         std::env::var("KNAPSACK_ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-opus-4-6".to_string());
       return format!("anthropic/{}", model);
     }
     "openai" if has_key("OPENAI_API_KEY") => {
-      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
+      let model =
+        std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
       return format!("openai/{}", model);
     }
     "groq" if has_key("GROQ_API_KEY") => {
@@ -1006,7 +1018,8 @@ pub fn resolve_default_model() -> String {
       return format!("anthropic/{}", model);
     }
     if has_key("OPENAI_API_KEY") {
-      let model = std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
+      let model =
+        std::env::var("KNAPSACK_OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
       log::warn!(
         "[resolve_default_model] Falling back to openai/{} (active={})",
         model,

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1,13 +1,13 @@
 use actix_web::{get, post, web, HttpResponse, Responder};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use tauri::Manager;
 use std::collections::HashSet;
 use std::fs;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tauri::Manager;
 
 use crate::clawd::gateway_client;
 use crate::clawd::sidecar::SharedClawdbotConfig;
@@ -2954,9 +2954,7 @@ fn ensure_imessage_allowlist_config(cfg: &mut serde_json::Value) -> bool {
     && ch.get("enabled").and_then(|value| value.as_bool()) != Some(false)
   {
     ch.insert("enabled".to_string(), serde_json::json!(false));
-    eprintln!(
-      "[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false"
-    );
+    eprintln!("[clawd/service] Migrated iMessage dmPolicy=disabled to enabled=false");
     patched = true;
   }
 
@@ -3824,6 +3822,19 @@ fn save_tokens(app_handle: &tauri::AppHandle, tokens: &StoredTokens) -> Result<(
   .map_err(|e| format!("Failed writing {}: {}", path.display(), e))?;
   harden_file_permissions(&path);
   Ok(())
+}
+
+fn normalize_provider_model(provider: &str, model: &str) -> String {
+  let model = model.trim();
+  if model.is_empty() {
+    return String::new();
+  }
+  if let Some((prefix, bare)) = model.split_once('/') {
+    if prefix.eq_ignore_ascii_case(provider) {
+      return bare.to_string();
+    }
+  }
+  model.to_string()
 }
 
 /// Get the configured OpenAI model (defaults to gpt-5.4 if not set)
@@ -5953,8 +5964,27 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     || has_gemini_cli
     || has_knapsack;
 
-  let model = tokens.openai_model.clone();
-  let active_provider = tokens.active_provider.clone();
+  let active_provider = tokens
+    .active_provider
+    .clone()
+    .unwrap_or_else(|| "openai".to_string());
+  let model = match active_provider.as_str() {
+    "openai" => tokens.openai_model.clone(),
+    "anthropic" => tokens.anthropic_model.clone(),
+    "gemini" => tokens.gemini_model.clone(),
+    "groq" => tokens.groq_model.clone(),
+    "xai" => tokens.xai_model.clone(),
+    "openrouter" => tokens.openrouter_model.clone(),
+    "ollama" => tokens
+      .ollama_model
+      .clone()
+      .or_else(|| Some("llama3.1:latest".to_string())),
+    "knapsack" => tokens
+      .knapsack_model
+      .clone()
+      .or_else(|| Some("auto".to_string())),
+    _ => tokens.openai_model.clone(),
+  };
 
   let openai_hint = tokens
     .openai_api_key
@@ -6019,7 +6049,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       "No API key configured".to_string()
     },
     model,
-    active_provider,
+    active_provider: Some(active_provider),
     has_openai_key: has_openai,
     has_anthropic_key: has_anthropic,
     has_gemini_key: has_gemini,
@@ -6239,7 +6269,17 @@ pub struct SetApiKeyResponse {
 
 fn normalize_coding_agent(agent: &str) -> Option<String> {
   let agent = agent.trim().to_lowercase();
-  if ["claude", "codex", "antigravity", "agy", "gemini", "grok", "opencode"].contains(&agent.as_str()) {
+  if [
+    "claude",
+    "codex",
+    "antigravity",
+    "agy",
+    "gemini",
+    "grok",
+    "opencode",
+  ]
+  .contains(&agent.as_str())
+  {
     if agent == "agy" {
       return Some("antigravity".to_string());
     }
@@ -6336,10 +6376,7 @@ pub async fn set_api_key(
         .groq_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
-      "xai" => tokens
-        .xai_api_key
-        .as_ref()
-        .map_or(false, |k| !k.is_empty()),
+      "xai" => tokens.xai_api_key.as_ref().map_or(false, |k| !k.is_empty()),
       "openrouter" => tokens
         .openrouter_api_key
         .as_ref()
@@ -6383,7 +6420,7 @@ pub async fn set_api_key(
           tokens.ollama_model = Some(model.trim().to_string());
         }
         "knapsack" => {
-          tokens.knapsack_model = Some(model.trim().to_string());
+          tokens.knapsack_model = Some(normalize_provider_model("knapsack", model));
         }
         _ => {
           tokens.openai_model = Some(model.trim().to_string());
@@ -6618,7 +6655,7 @@ pub async fn set_api_key(
       tokens.knapsack_email = Some(key);
       tokens.active_provider = Some("knapsack".to_string());
       if let Some(model) = &payload.model {
-        tokens.knapsack_model = Some(model.trim().to_string());
+        tokens.knapsack_model = Some(normalize_provider_model("knapsack", model));
       }
       "Knapsack"
     }
@@ -7306,21 +7343,34 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
     "xai" => xai_key.clone(),
     _ => openai_key.clone(),
   };
+  let model = match active {
+    "openai" => tokens.openai_model.clone(),
+    "anthropic" => tokens.anthropic_model.clone(),
+    "gemini" => tokens.gemini_model.clone(),
+    "groq" => tokens.groq_model.clone(),
+    "xai" => tokens.xai_model.clone(),
+    "openrouter" => tokens.openrouter_model.clone(),
+    "ollama" => tokens
+      .ollama_model
+      .or_else(|| Some("llama3.1:latest".to_string())),
+    "knapsack" => tokens.knapsack_model.or_else(|| Some("auto".to_string())),
+    _ => tokens.openai_model,
+  };
 
   HttpResponse::Ok().json(GetApiKeyResponse {
     success: true,
     key,
-    model: tokens.openai_model,
+    model,
     active_provider: tokens.active_provider,
     openai_key,
     anthropic_key,
     gemini_key,
     xai_key,
-    anthropic_model: tokens.anthropic_model,
-    gemini_model: tokens.gemini_model,
-    groq_model: tokens.groq_model,
-    xai_model: tokens.xai_model,
-    openrouter_model: tokens.openrouter_model,
+    anthropic_model: tokens.anthropic_model.clone(),
+    gemini_model: tokens.gemini_model.clone(),
+    groq_model: tokens.groq_model.clone(),
+    xai_model: tokens.xai_model.clone(),
+    openrouter_model: tokens.openrouter_model.clone(),
   })
 }
 
@@ -8055,7 +8105,10 @@ async fn prepare_gateway_config(
                 allow_bundled_arr.push(serde_json::json!(*skill_name));
               }
             } else {
-              skills.insert("allowBundled".to_string(), serde_json::json!(required_allowlist));
+              skills.insert(
+                "allowBundled".to_string(),
+                serde_json::json!(required_allowlist),
+              );
             }
             eprintln!(
               "[clawd/service] Added required macOS bundled skills to skills.allowBundled (peekaboo + computer-use)"
@@ -11525,7 +11578,7 @@ pub async fn oauth_callback(
       }
     }
     _ => oauth_html_page(false, "Unknown OAuth provider."),
-    }
+  }
 }
 
 /// Parse a single query parameter value from a URL string.
@@ -11573,7 +11626,11 @@ async fn exchange_and_store_knapsack_code(
   let status = resp.status();
   let body_text = resp.text().await.unwrap_or_default();
   if !status.is_success() {
-    log::error!("[knapsack_auth] exchange endpoint returned {}: {}", status, body_text);
+    log::error!(
+      "[knapsack_auth] exchange endpoint returned {}: {}",
+      status,
+      body_text
+    );
     return Err(format!("Sign-in failed ({})", status));
   }
 
@@ -11590,8 +11647,13 @@ async fn exchange_and_store_knapsack_code(
   tokens.knapsack_access_token = Some(sign_in.access_token.clone());
   tokens.knapsack_refresh_token = Some(sign_in.refresh_token.clone());
   tokens.knapsack_email = Some(sign_in.email.clone());
-  tokens.knapsack_model
-    .get_or_insert_with(|| "anthropic/claude-haiku-4-5".to_string());
+  let normalized_knapsack_model = tokens
+    .knapsack_model
+    .take()
+    .map(|model| normalize_provider_model("knapsack", &model))
+    .filter(|model| !model.trim().is_empty())
+    .unwrap_or_else(|| "auto".to_string());
+  tokens.knapsack_model = Some(normalized_knapsack_model);
   tokens.active_provider = Some("knapsack".to_string());
 
   if let Err(e) = save_tokens(app_handle, &tokens) {
@@ -11643,13 +11705,12 @@ pub async fn knapsack_auth_callback(
 }
 
 #[post("/api/clawd/service/knapsack-disconnect")]
-pub async fn knapsack_disconnect(
-  app_handle: web::Data<tauri::AppHandle>,
-) -> impl Responder {
+pub async fn knapsack_disconnect(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
   let mut tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
     Err(e) => {
-      return HttpResponse::InternalServerError().json(serde_json::json!({"ok": false, "message": e}));
+      return HttpResponse::InternalServerError()
+        .json(serde_json::json!({"ok": false, "message": e}));
     }
   };
 
@@ -11684,7 +11745,8 @@ pub async fn knapsack_disconnect(
 
   tokens.active_provider = Some(fallback.to_string());
   if let Err(e) = save_tokens(&app_handle, &tokens) {
-    return HttpResponse::InternalServerError().json(serde_json::json!({"ok": false, "message": e}));
+    return HttpResponse::InternalServerError()
+      .json(serde_json::json!({"ok": false, "message": e}));
   }
 
   std::env::remove_var("KNAPSACK_ACCESS_TOKEN");
@@ -11692,8 +11754,14 @@ pub async fn knapsack_disconnect(
   std::env::remove_var("KNAPSACK_USER_EMAIL");
   std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", fallback);
   std::env::remove_var("KNAPSACK_KNAPSACK_MODEL");
-  let _ = app_handle.emit_all("knapsack-disconnected", serde_json::json!({"fallback_provider": fallback}));
-  log::info!("[knapsack_disconnect] disconnected, fallback provider = {}", fallback);
+  let _ = app_handle.emit_all(
+    "knapsack-disconnected",
+    serde_json::json!({"fallback_provider": fallback}),
+  );
+  log::info!(
+    "[knapsack_disconnect] disconnected, fallback provider = {}",
+    fallback
+  );
 
   HttpResponse::Ok().json(serde_json::json!({"ok": true, "fallback_provider": fallback}))
 }

--- a/src/src-tauri/src/connections/api.rs
+++ b/src/src-tauri/src/connections/api.rs
@@ -234,6 +234,31 @@ async fn delete_connection(path: web::Path<String>) -> impl Responder {
 #[get("/api/knapsack/connections/refresh_token_api/{user_email}")]
 async fn refresh_knapsack_api_token(path: web::Path<String>) -> impl Responder {
   let user_email = path.into_inner();
+  let requested_email = user_email.trim().to_lowercase();
+
+  let token_env = std::env::var("KNAPSACK_USER_EMAIL").ok().map(|v| v.trim().to_lowercase());
+  if let (Some(email), Ok(access_token)) = (
+    token_env.as_deref(),
+    std::env::var("KNAPSACK_ACCESS_TOKEN"),
+  ) {
+    if email == requested_email && !access_token.trim().is_empty() {
+      return HttpResponse::Ok().json(json!({
+        "success": true,
+        "token": access_token
+      }));
+    }
+  }
+  if let (Some(email), Ok(refresh_token)) = (
+    token_env.as_deref(),
+    std::env::var("KNAPSACK_REFRESH_TOKEN"),
+  ) {
+    if email == requested_email && !refresh_token.trim().is_empty() {
+      return HttpResponse::Ok().json(json!({
+        "success": true,
+        "token": refresh_token
+      }));
+    }
+  }
 
   match get_knapsack_api_connection(user_email) {
     Ok(user_connection) => match user_connection.refresh_token {

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -38,7 +38,7 @@ struct CompletionUsage {
 
 /// Resolved LLM provider info for meeting notes completion.
 struct ResolvedProvider {
-  name: String, // "openai", "anthropic", "gemini", "groq", "openrouter"
+  name: String, // "openai", "anthropic", "gemini", "groq", "openrouter", "knapsack"
   api_key: String,
   model: String,
   base_url: String,   // e.g. "https://api.openai.com/v1"
@@ -46,7 +46,7 @@ struct ResolvedProvider {
 }
 
 /// Try to resolve the best available LLM provider from env vars.
-/// Priority: active_provider setting → OpenAI → Anthropic → Gemini → Groq
+/// Priority: active_provider setting → OpenAI → Anthropic → Gemini → Groq → OpenRouter → Knapsack
 fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
   let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
   let openai_key = std::env::var("OPENAI_API_KEY")
@@ -66,6 +66,9 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
     .ok()
     .filter(|k| !k.trim().is_empty());
   let ollama_key = std::env::var("OLLAMA_API_KEY")
+    .ok()
+    .filter(|k| !k.trim().is_empty());
+  let knapsack_email = std::env::var("KNAPSACK_USER_EMAIL")
     .ok()
     .filter(|k| !k.trim().is_empty());
   let openai_model =
@@ -139,12 +142,29 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
       });
     }
     "knapsack" => {
-      let access_token = std::env::var("KNAPSACK_ACCESS_TOKEN").unwrap_or_default();
-      if !access_token.trim().is_empty() {
+      if let Some(email) = &knapsack_email {
+        let model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
+          .unwrap_or_else(|_| "auto".to_string());
+        let model = {
+          let model = model.trim();
+          if let Some((provider, bare)) = model.split_once('/') {
+            if provider.eq_ignore_ascii_case("knapsack") {
+              bare.to_string()
+            } else {
+              model.to_string()
+            }
+          } else {
+            model.to_string()
+          }
+        };
         return Ok(ResolvedProvider {
           name: "knapsack".into(),
-          api_key: access_token,
-          model: "auto".into(),
+          api_key: email.to_string(),
+          model: if model.is_empty() {
+            "auto".to_string()
+          } else {
+            model
+          },
           base_url: option_env!("VITE_KN_API_SERVER")
             .unwrap_or("https://api.knapsack.ai")
             .into(),
@@ -174,7 +194,10 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
   let disable_paid = std::env::var("KNAPSACK_DISABLE_PAID_FALLBACK")
     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
     .unwrap_or(true);
-  let active_is_free = matches!(active.as_str(), "groq" | "gemini" | "ollama" | "openrouter");
+  let active_is_free = matches!(
+    active.as_str(),
+    "groq" | "gemini" | "ollama" | "openrouter" | "knapsack"
+  );
 
   if !disable_paid || !active_is_free {
     if let Some(key) = openai_key {
@@ -234,6 +257,34 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
       is_anthropic: false,
     });
   }
+  if let Some(email) = &knapsack_email {
+    let model = std::env::var("KNAPSACK_KNAPSACK_MODEL").unwrap_or_else(|_| "auto".to_string());
+    let model = {
+      let model = model.trim();
+      if let Some((provider, bare)) = model.split_once('/') {
+        if provider.eq_ignore_ascii_case("knapsack") {
+          bare.to_string()
+        } else {
+          model.to_string()
+        }
+      } else {
+        model.to_string()
+      }
+    };
+    return Ok(ResolvedProvider {
+      name: "knapsack".into(),
+      api_key: email.to_string(),
+      model: if model.is_empty() {
+        "auto".to_string()
+      } else {
+        model
+      },
+      base_url: option_env!("VITE_KN_API_SERVER")
+        .unwrap_or("https://api.knapsack.ai")
+        .into(),
+      is_anthropic: false,
+    });
+  }
   if let Some(key) = openrouter_key {
     let openrouter_model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
       .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
@@ -284,7 +335,7 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
   if complexity == "haiku" {
     // Cross-provider routing: if OpenRouter is available and the current provider
     // is a paid one, route simple tasks to OpenRouter's free model instead.
-    if provider.name != "openrouter" && provider.name != "ollama" && provider.name != "groq" {
+    if provider.name != "openrouter" && provider.name != "ollama" && provider.name != "groq" && provider.name != "knapsack" {
       let openrouter_key = std::env::var("OPENROUTER_API_KEY")
         .ok()
         .filter(|k| !k.trim().is_empty());
@@ -319,6 +370,7 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
       "anthropic" => ("claude-haiku-4-5-20251001".to_string(), "Haiku"),
       "gemini" => ("gemini-3.5-flash".to_string(), "Flash"), // already cheap
       "groq" => (provider.model.clone(), "Groq"),            // already cheap
+      "knapsack" => (provider.model.clone(), "Knapsack"),
       "openrouter" => (provider.model.clone(), "OpenRouter"), // user chose this
       "ollama" => (provider.model.clone(), "Ollama"),        // local, no cost
       _ => (provider.model.clone(), "unchanged"),
@@ -441,6 +493,75 @@ async fn refresh_knapsack_token() -> Option<String> {
   std::env::set_var("KNAPSACK_ACCESS_TOKEN", &new_token);
   log::info!("[knapsack_refresh] access token refreshed");
   Some(new_token)
+}
+
+async fn resolve_knapsack_bearer_token(email: &str) -> Result<String, LLMError> {
+  let email = email.trim();
+  if email.is_empty() {
+    return Err(LLMError::ChatCompletionFailed(
+      "Knapsack account email is missing. Sign in to Knapsack in Settings.".to_string(),
+    ));
+  }
+
+  let access_token = std::env::var("KNAPSACK_ACCESS_TOKEN")
+    .ok()
+    .map(|token| token.trim().to_string())
+    .filter(|token| !token.is_empty());
+  if let Some(token) = access_token {
+    return Ok(token);
+  }
+
+  let client = reqwest::Client::new();
+  let token_url = format!(
+    "http://127.0.0.1:8897/api/knapsack/connections/refresh_token_api/{}",
+    email
+  );
+  match client.get(&token_url).send().await {
+    Ok(resp) => {
+      if resp.status().is_success() {
+        let token_json: serde_json::Value = resp.json().await.map_err(|e| {
+          LLMError::ChatCompletionFailed(format!("Knapsack token parse failed: {}", e))
+        })?;
+        if let Some(jwt) = token_json
+          .get("token")
+          .and_then(|t| t.as_str())
+          .filter(|token| !token.trim().is_empty())
+        {
+          return Ok(jwt.to_string());
+        }
+        if let Some(jwt) = token_json
+          .get("access_token")
+          .and_then(|t| t.as_str())
+          .filter(|token| !token.trim().is_empty())
+        {
+          return Ok(jwt.to_string());
+        }
+        log::warn!(
+          "[knapsack_token] /refresh_token_api response missing token field: {}",
+          token_json
+        );
+      } else {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        log::warn!(
+          "[knapsack_token] /refresh_token_api returned {}: {}",
+          status,
+          text
+        );
+      }
+    }
+    Err(err) => {
+      log::warn!("[knapsack_token] /refresh_token_api request failed: {}", err);
+    }
+  }
+
+  if let Some(new_token) = refresh_knapsack_token().await {
+    return Ok(new_token);
+  }
+
+  Err(LLMError::ChatCompletionFailed(
+    "Knapsack auth failed — please sign in to Knapsack in Settings.".to_string(),
+  ))
 }
 
 /// Call an OpenAI-compatible chat completions endpoint (works for OpenAI, Groq, Gemini).
@@ -591,7 +712,6 @@ async fn openai_compatible_completion(
         log::info!("[completion] knapsack 401 — attempting token refresh");
         if let Some(new_token) = refresh_knapsack_token().await {
           // Update body with new bearer and retry (loop continues with attempt=1)
-          last_error = format!("knapsack 401 (refreshed token, retrying)");
           // Re-issue the request directly with the new token so we don't wait for next loop
           let retry_resp = match client
             .post(&url)
@@ -794,36 +914,7 @@ async fn knapsack_completion(
 ) -> Result<String, LLMError> {
   let email = &provider.api_key;
   let client = reqwest::Client::new();
-
-  // Fetch a fresh JWT from the local gateway
-  let token_url = format!(
-    "http://127.0.0.1:8897/api/knapsack/connections/refresh_token_api/{}",
-    email
-  );
-  let token_resp = client
-    .get(&token_url)
-    .send()
-    .await
-    .map_err(|e| LLMError::ChatCompletionFailed(format!("Knapsack token fetch failed: {}", e)))?;
-
-  if !token_resp.status().is_success() {
-    return Err(LLMError::ChatCompletionFailed(
-      "Knapsack auth failed — please sign in to Knapsack again".into(),
-    ));
-  }
-
-  let token_json: serde_json::Value = token_resp
-    .json()
-    .await
-    .map_err(|e| LLMError::ChatCompletionFailed(format!("Knapsack token parse failed: {}", e)))?;
-
-  let token = token_json
-    .get("token")
-    .and_then(|t| t.as_str())
-    .ok_or_else(|| {
-      LLMError::ChatCompletionFailed("Knapsack JWT not found in token response".into())
-    })?
-    .to_string();
+  let token = resolve_knapsack_bearer_token(email).await?;
 
   // Separate system prompt from conversation messages
   let system_prompt: String = messages
@@ -997,8 +1088,37 @@ pub async fn multi_provider_completion(messages: Vec<LlmMessage>) -> Result<Stri
         .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
       let fb_gemini_model =
         std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+      let fb_knapsack_model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
+        .unwrap_or_else(|_| "auto".to_string());
+      let fb_knapsack_model = {
+        let model = fb_knapsack_model.trim();
+        if let Some((provider, bare)) = model.split_once('/') {
+          if provider.eq_ignore_ascii_case("knapsack") {
+            bare.to_string()
+          } else {
+            model.to_string()
+          }
+        } else {
+          model.to_string()
+        }
+      };
+      let fb_knapsack_key = std::env::var("KNAPSACK_USER_EMAIL")
+        .ok()
+        .filter(|k| !k.trim().is_empty());
 
       let fallbacks: Vec<(&str, &Option<String>, String, &str, bool)> = vec![
+        (
+          "knapsack",
+          &fb_knapsack_key,
+          if fb_knapsack_model.is_empty() {
+            "auto".to_string()
+          } else {
+            fb_knapsack_model.clone()
+          },
+          option_env!("VITE_KN_API_SERVER")
+            .unwrap_or("https://api.knapsack.ai"),
+          false,
+        ),
         (
           "openai",
           &fb_openai_key,
@@ -1056,6 +1176,8 @@ pub async fn multi_provider_completion(messages: Vec<LlmMessage>) -> Result<Stri
           };
           let fb_result = if fb_provider.is_anthropic {
             anthropic_completion(&fb_provider, &messages).await
+          } else if fb_provider.name == "knapsack" {
+            knapsack_completion(&fb_provider, &messages).await
           } else {
             openai_compatible_completion(&fb_provider, &messages).await
           };

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -168,9 +168,11 @@ function getActiveModelLabel(): string {
     openai: 'moltbot_openai_model',
     anthropic: 'moltbot_anthropic_model',
     gemini: 'moltbot_gemini_model',
+    knapsack: KNAPSACK_MODEL_STORAGE,
     groq: 'moltbot_groq_model',
     openrouter: 'moltbot_openrouter_model',
     ollama: 'moltbot_ollama_model',
+    xai: 'moltbot_xai_model',
   }
   const model = localStorage.getItem(modelKeys[provider] || '') || ''
   if (model) return `${provider}/${model}`
@@ -2636,6 +2638,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
   // Check whether the currently selected model supports vision (image attachments)
   const currentModelSupportsVision = useCallback((): { supported: boolean; modelName: string; visionModels: string[] } => {
+    if (selectedProvider === 'knapsack') {
+      const currentId = selectedKnapsackModel || 'auto'
+      return {
+        supported: true,
+        modelName: KNAPSACK_MODELS.find(m => m.id === currentId)?.name || currentId,
+        visionModels: [],
+      }
+    }
     const allModels = selectedProvider === 'openai' ? OPENAI_MODELS
       : selectedProvider === 'anthropic' ? ANTHROPIC_MODELS
       : selectedProvider === 'gemini' ? GEMINI_MODELS
@@ -2657,7 +2667,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     const supported = current?.vision ?? false
     const visionModels = allModels.filter(m => m.vision).map(m => m.name)
     return { supported, modelName, visionModels }
-  }, [selectedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel])
+  }, [selectedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel])
 
   // File upload handlers
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -3183,6 +3193,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : selectedProvider === 'groq' ? selectedGroqModel
         : selectedProvider === 'xai' ? selectedXaiModel
         : selectedProvider === 'openrouter' ? selectedOpenRouterModel
+        : selectedProvider === 'knapsack' ? selectedKnapsackModel
         : undefined
       await apiPost('/api/clawd/service/set-api-key', {
         key: apiKey.trim(),
@@ -3202,6 +3213,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(XAI_MODEL_STORAGE, selectedXaiModel)
       } else if (selectedProvider === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
+      } else if (selectedProvider === 'knapsack') {
+        localStorage.setItem(KNAPSACK_MODEL_STORAGE, selectedKnapsackModel)
       }
       setConfirmedProvider(selectedProvider)
       localStorage.setItem(ACTIVE_PROVIDER_STORAGE, selectedProvider)
@@ -3229,6 +3242,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           modelName = XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel
         } else if (selectedProvider === 'openrouter') {
           modelName = OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel
+        } else if (selectedProvider === 'knapsack') {
+          modelName = KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel
         } else {
           modelName = GEMINI_MODELS.find(m => m.id === selectedGeminiModel)?.name || selectedGeminiModel
         }
@@ -3243,7 +3258,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedOllamaModel, selectedProvider, saveOllamaProvider])
+  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel, selectedOllamaModel, selectedProvider, saveOllamaProvider])
 
   // Switch to a provider that already has a saved key (no new key needed)
   const switchProviderModel = useCallback(async (providerId: Provider, alreadyActive = false) => {
@@ -3260,6 +3275,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : providerId === 'groq' ? selectedGroqModel
         : providerId === 'xai' ? selectedXaiModel
         : providerId === 'openrouter' ? selectedOpenRouterModel
+        : providerId === 'knapsack' ? selectedKnapsackModel
         : undefined
       await apiPost('/api/clawd/service/set-api-key', {
         provider: providerId,
@@ -3278,6 +3294,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(XAI_MODEL_STORAGE, selectedXaiModel)
       } else if (providerId === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
+      } else if (providerId === 'knapsack') {
+        localStorage.setItem(KNAPSACK_MODEL_STORAGE, selectedKnapsackModel)
       }
       setSelectedProvider(providerId)
       localStorage.setItem(ACTIVE_PROVIDER_STORAGE, providerId)
@@ -3291,12 +3309,14 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : providerId === 'anthropic' ? ANTHROPIC_MODELS
         : providerId === 'gemini' ? GEMINI_MODELS
         : providerId === 'xai' ? XAI_MODELS
+        : providerId === 'knapsack' ? KNAPSACK_MODELS
         : providerId === 'openrouter' ? OPENROUTER_MODELS
         : GROQ_MODELS
       const mv = providerId === 'openai' ? selectedModel
         : providerId === 'anthropic' ? selectedAnthropicModel
         : providerId === 'gemini' ? selectedGeminiModel
         : providerId === 'xai' ? selectedXaiModel
+        : providerId === 'knapsack' ? selectedKnapsackModel
         : providerId === 'openrouter' ? selectedOpenRouterModel
         : selectedGroqModel
       const modelName = models.find(m => m.id === mv)?.name || mv
@@ -3308,7 +3328,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel])
+  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel])
 
   useEffect(() => {
     const init = async () => {

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -6826,16 +6826,17 @@ ${actualText}`
             <div className="ClawdChannelAccordion">
               {/* ── Cloud providers ── */}
               {PROVIDERS.filter(p => p.id !== 'ollama').map(p => {
-                const isActive = selectedProvider === p.id
+                const isOpen = selectedProvider === p.id
+                const isConfirmedActive = confirmedProvider === p.id
 
                 // ── Knapsack (no API key — uses Knapsack account) ──
                 if (p.id === 'knapsack') {
                   return (
-                    <div key="knapsack" className={`ClawdAccordionItem ${isActive ? 'ClawdAccordionItem--open ClawdAccordionItem--connected' : ''}`}>
+                    <div key="knapsack" className={`ClawdAccordionItem ${isOpen ? 'ClawdAccordionItem--open' : ''} ${isConfirmedActive ? 'ClawdAccordionItem--connected' : ''}`}>
                       <button className="ClawdAccordionHeader" onClick={() => setSelectedProvider('knapsack')}>
                         <div className="ClawdAccordionTitle">{p.name}</div>
                         <span className="ClawdAccordionDesc">{p.description}</span>
-                        {isActive && (
+                        {isConfirmedActive && (
                           <span className="ClawdAccordionCheck">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                           </span>
@@ -6963,6 +6964,7 @@ ${actualText}`
                               try {
                                 await apiPost('/api/clawd/service/set-api-key', { provider: 'knapsack', key: knapsackEmail || '', model: selectedKnapsackModel })
                                 setSelectedProvider('knapsack')
+                                setConfirmedProvider('knapsack')
                                 localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
                                 setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
                                 pushAssistant(`Switched to Knapsack (${KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel}).`)
@@ -6971,7 +6973,7 @@ ${actualText}`
                             }}
                             disabled={savingKey}
                           >
-                            {savingKey ? 'Switching...' : isActive ? 'Select' : 'Use Knapsack'}
+                            {savingKey ? 'Switching...' : isConfirmedActive ? 'Active' : 'Use Knapsack'}
                           </button>
                         </div>
                         <p style={{ margin: '8px 0 0', fontSize: 11, color: '#94a3b8' }}>
@@ -7005,11 +7007,11 @@ ${actualText}`
                   : setSelectedGroqModel
 
                 return (
-                  <div key={p.id} className={`ClawdAccordionItem ${selectedProvider === p.id ? 'ClawdAccordionItem--open' : ''} ${isActive ? 'ClawdAccordionItem--connected' : ''}`}>
+                  <div key={p.id} className={`ClawdAccordionItem ${isOpen ? 'ClawdAccordionItem--open' : ''} ${isConfirmedActive ? 'ClawdAccordionItem--connected' : ''}`}>
                     <button className="ClawdAccordionHeader" onClick={() => { setSelectedProvider(p.id); setApiKey(''); setEditingProviderKey(false) }}>
                       <div className="ClawdAccordionTitle">{p.name}</div>
                       <span className="ClawdAccordionDesc">{p.description}</span>
-                      {isActive && (
+                      {isConfirmedActive && (
                         <span className="ClawdAccordionCheck">
                           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                         </span>
@@ -7036,9 +7038,10 @@ ${actualText}`
                                     : p.id === 'anthropic' ? ANTHROPIC_MODEL_STORAGE
                                     : p.id === 'gemini' ? GEMINI_MODEL_STORAGE
                                     : p.id === 'xai' ? XAI_MODEL_STORAGE
+                                    : p.id === 'openrouter' ? OPENROUTER_MODEL_STORAGE
                                     : GROQ_MODEL_STORAGE
                                   localStorage.setItem(storageKey, newModel)
-                                  if (isActive) {
+                                  if (isConfirmedActive) {
                                     try {
                                       await apiPost('/api/clawd/service/set-api-key', { provider: p.id, model: newModel })
                                       const modelName = models.find(m => m.id === newModel)?.name || newModel
@@ -7056,10 +7059,10 @@ ${actualText}`
                           <div className="ClawdAccordionActions">
                             <button
                               className="ClawdChannelCardAction ClawdChannelCardAction--connect"
-                              onClick={() => switchProviderModel(p.id, isActive)}
+                              onClick={() => switchProviderModel(p.id, isConfirmedActive)}
                               disabled={savingKey}
                             >
-                              {savingKey ? 'Switching...' : isActive ? 'Select' : 'Select ' + p.name}
+                              {savingKey ? 'Switching...' : isConfirmedActive ? 'Active' : 'Select ' + p.name}
                             </button>
                             <button
                               className="ClawdChannelCardAction ClawdChannelCardAction--secondary"


### PR DESCRIPTION
## Summary
Treat Knapsack Studio as a first-class chat provider across the desktop app, direct chat backend, gateway model selection, meeting-note completion path, and QA loop.

## Root Cause
Knapsack could be selected in parts of the UI, but several paths still treated it as an OpenAI-style fallback or stored/read its model through the OpenAI model key. That caused `auto` to be interpreted as an OpenAI model in gateway config and made strict provider validation unreliable.

## Changes
- route direct `/api/clawd/chat` requests with `provider: "knapsack"` through Knapsack desktop inference instead of OpenAI-compatible chat
- store and read `knapsack_model` separately from `openai_model`
- resolve Knapsack email/JWT for the completion path and fallback flow
- let the local refresh-token endpoint return env-backed Knapsack tokens when available
- update the provider picker/model label logic for Knapsack
- update QA loop provider/model mapping, strict mode, explicit model selection, latency reporting, and prod-binary resolution

## Verification
- `PATH="$PWD/node_modules/.bin:$PATH" node node_modules/typescript/bin/tsc --noEmit` from `src/`
- `PATH="$PWD/node_modules/.bin:$PATH" node node_modules/vite/bin/vite.js build` from `src/`
- `node --check src/scripts/qa-loop-runner.cjs`
- `VITE_KN_API_SERVER=https://api.knapsack.ai VITE_GOOGLE_CLIENT_ID=dummy cargo test --no-run` from `src/src-tauri/`

## Notes
- Runtime endpoint validation against a newly restarted dev app was not run in this side thread to avoid disturbing the running desktop instance. The source now compiles and the frontend build completes; the PR is ready for CI/runtime smoke validation.