### PR TITLE
[codex] Fix Telegram account allowlist propagation

### DIFF
--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -1916,6 +1916,29 @@ pub async fn generic_channel_configure(
   // Merge the user-provided config with standard channel defaults.
   // Discord, Slack, and GoogleChat use nested dm: { policy, allowFrom };
   // Telegram and Signal use top-level dmPolicy / allowFrom.
+  fn propagate_telegram_allow_from_to_accounts(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+  ) {
+    let Some(allow_from) = obj.get("allowFrom").and_then(|v| v.as_array()).cloned() else {
+      return;
+    };
+    let Some(accounts) = obj.get_mut("accounts").and_then(|v| v.as_object_mut()) else {
+      return;
+    };
+
+    for account in accounts.values_mut() {
+      let Some(account_obj) = account.as_object_mut() else {
+        continue;
+      };
+      if account_obj.get("allowFrom").is_none() {
+        account_obj.insert(
+          "allowFrom".to_string(),
+          serde_json::Value::Array(allow_from.clone()),
+        );
+      }
+    }
+  }
+
   // All schemas are .strict() so unrecognized keys cause validation errors.
   let mut channel_config = body.config.clone();
   if let Some(obj) = channel_config.as_object_mut() {
@@ -1966,6 +1989,9 @@ pub async fn generic_channel_configure(
       _ => {
         if !obj.contains_key("dmPolicy") {
           obj.insert("dmPolicy".to_string(), serde_json::json!("pairing"));
+        }
+        if channel == "telegram" {
+          propagate_telegram_allow_from_to_accounts(obj);
         }
       }
     }
@@ -2963,6 +2989,29 @@ pub async fn channel_allowlist_update(
             allow.clone()
           };
           patch_inner.insert("allowFrom".to_string(), serde_json::json!(allow));
+          if channel == "telegram" {
+            if let Some(accounts) = config_snapshot["config"]["channels"]["telegram"]["accounts"]
+              .as_object()
+            {
+              let mut accounts_patch = serde_json::Map::new();
+              for (account_id, account) in accounts {
+                if account.get("allowFrom").is_none() {
+                  accounts_patch.insert(
+                    account_id.clone(),
+                    serde_json::json!({
+                      "allowFrom": allow,
+                    }),
+                  );
+                }
+              }
+              if !accounts_patch.is_empty() {
+                patch_inner.insert(
+                  "accounts".to_string(),
+                  serde_json::Value::Object(accounts_patch),
+                );
+              }
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## What changed
This updates the Telegram channel config path so a top-level `channels.telegram.allowFrom` is propagated into per-account `allowFrom` entries when accounts are present but missing their own allowlist.

It also repairs existing multi-account Telegram configs when the allowlist is updated through the app API by copying the top-level allowlist into any account that does not already define one.

## Why
We hit a prod failure where Telegram was enabled and the top-level allowlist contained the correct user ID, but `merlin` still would not reply because the account-level allowlist was missing. In practice that left multi-account Telegram setups in a partially configured state that looked valid but silently dropped DMs for specific accounts.

## User impact
Users with multi-account Telegram setups should no longer need a manual config edit to get account-level bots responding after migration or allowlist changes.

## Root cause
The config path handled top-level Telegram `dmPolicy` / `allowFrom`, but did not normalize that allowlist down into `channels.telegram.accounts.<account>.allowFrom` for accounts missing it.

## Validation
Not run. This change was kept intentionally narrow and limited to config normalization and allowlist patch generation.