### PR TITLE
[codex] Fix empty Email Autopilot refresh

### DIFF
--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -69,7 +69,6 @@ const reply_actions = [
 ]
 
 const MAX_RETRIES = 5
-const STARTUP_EMAIL_AUTOPILOT_DELAY_MS = 5 * 60_000
 export const STATIONARY_ITEMS = 'stationary'
 export interface IFeed {
   updateFeedItemTitle?: (key: string, itemId: number, newTitle: string) => void
@@ -391,30 +390,6 @@ export function useFeed(
   }
 
   const lastEmailId = useRef<number | undefined>(undefined)
-  const feedMountedAt = useRef(Date.now())
-  const startupEmailAutopilotTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const runEmailAutopilotAfterStartup = () => {
-    const elapsed = Date.now() - feedMountedAt.current
-    const remaining = STARTUP_EMAIL_AUTOPILOT_DELAY_MS - elapsed
-    if (remaining <= 0) {
-      runEmailAutopilot()
-      return
-    }
-    if (startupEmailAutopilotTimer.current) return
-    startupEmailAutopilotTimer.current = setTimeout(() => {
-      startupEmailAutopilotTimer.current = null
-      runEmailAutopilot()
-    }, remaining)
-  }
-
-  useEffect(() => {
-    return () => {
-      if (startupEmailAutopilotTimer.current) {
-        clearTimeout(startupEmailAutopilotTimer.current)
-      }
-    }
-  }, [])
 
   const selectEmailCategory = useCallback(() => {
     const getTabCount = (category: EmailImportance): number => {
@@ -484,7 +459,9 @@ export function useFeed(
         loggedEmailAutopilot &&
         getTotalClassifiedEmailsCount() <= 0
       ) {
-        runEmailAutopilotAfterStartup()
+        // When the user explicitly opens Email Autopilot, refresh immediately
+        // instead of waiting for the background startup delay.
+        runEmailAutopilot()
       }
     } catch (error) {
       console.error(error)
@@ -751,11 +728,6 @@ export function useFeed(
       // Fetch 7 days so starred / unread emails older than 24h are still
       // picked up.  The unread+starred filter below keeps the set manageable.
       let allMessages = await dataFetcher.getRecentGmailMessages(7, 5000)
-
-      if (allMessages.length === emailAutopilotStatus.progress?.total) {
-        setEmailAutopilotStatus({ status: 'complete' })
-        return
-      }
 
       if (allMessages.length === 0) {
         setEmailAutopilotStatus({ status: 'complete' })


### PR DESCRIPTION
## What changed
This updates Email Autopilot so that opening the Email Autopilot view triggers an immediate refresh when there are no classified emails in memory.

It also removes an early completion check that could short-circuit reruns when the count of recent emails matched the prior progress total.

## Why
Email Autopilot could show an empty "You're all caught up!" state even when there were unread emails available locally.

The root cause was that explicitly opening the Email Autopilot feed item reused a delayed startup path instead of refreshing immediately, so the UI could stay blank until the background delay elapsed. On top of that, the progress-count equality check could incorrectly mark a rerun complete before classification actually happened.

## Impact
Users who open Email Autopilot should now see a fresh classification run immediately instead of waiting for the startup timer.

This keeps the empty state aligned with the actual local inbox contents more reliably.

## Validation
- Verified the local email database contained synced unread messages while the UI could still appear empty.
- Ran `npx tsc --noEmit --pretty false` in the original workspace after the targeted change.
- Full `npm run build` remains blocked by an unrelated local OpenClaw config issue in `/Users/markheynen/.openclaw/openclaw.json`.
