### PR TITLE
Handle benign same-session writes during embedded prompt release

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/selection-hR-AeOeU.js
+++ b/src/src-tauri/resources/clawdbot/dist/selection-hR-AeOeU.js
@@ -8025,6 +8025,20 @@ function isTranscriptOnlyOpenClawAssistantLine(line) {
 		return false;
 	}
 }
+function isBenignReleasedPromptAppendLine(line) {
+	try {
+		const parsed = JSON.parse(line);
+		if (!isJsonRecord(parsed)) return false;
+		if (parsed.type === "custom_message") return parsed.customType === "openclaw.runtime-context";
+		if (parsed.type !== "message") return false;
+		const message = parsed.message;
+		if (!isJsonRecord(message)) return false;
+		if (message.role === "user") return true;
+		return message.role === "assistant" && message.provider === "openclaw" && typeof message.model === "string" && TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(message.model);
+	} catch {
+		return false;
+	}
+}
 function normalizeTranscriptEntryId(value) {
 	return typeof value === "string" && value.trim().length > 0 ? value : void 0;
 }
@@ -8092,7 +8106,7 @@ async function sessionFenceAdvanceIsBenign(params) {
 	});
 	if (!text?.endsWith("\n")) return false;
 	const lines = text.split("\n").map((line) => line.trim()).filter(Boolean);
-	return lines.length > 0 && lines.every(isTranscriptOnlyOpenClawAssistantLine);
+	return lines.length > 0 && lines.every(isBenignReleasedPromptAppendLine);
 }
 async function sessionFenceRewriteIsBenign(params) {
 	if (!params.previous?.fingerprint.exists || !params.current.exists || !params.previous.text || !sameSessionFileIdentity(params.previous.fingerprint, params.current) || params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES) || params.current.size > MAX_SAFE_FILE_OFFSET) return false;


### PR DESCRIPTION
## Summary
- treat same-session user message appends as benign while the embedded prompt lock is temporarily released
- also allow injected runtime-context appends in that same window
- keep rewrite/takeover detection strict for non-benign session mutations

## Validation
- `node --check src/src-tauri/resources/clawdbot/dist/selection-hR-AeOeU.js`
- replayed the real offending session-file patterns from `/Users/markheynen/Library/Application Support/ai.knap.knapsack/clawdbot/agents/main/sessions/2355eaf2-a7a8-49b5-8e96-92a6c9c6f641-topic-1781028984.683599.jsonl` to confirm appended `message:user` and `custom_message:openclaw.runtime-context` lines now classify as benign
- launched a clean dev worktree with `npm run qa:dev`; the app/gateway stack came up, but the dev build still showed a separate gateway/browser readiness wobble (`Gateway: not loaded`, `Browser: waiting for gateway`), so that remains follow-up work outside this narrow patch

## Root cause
The embedded session takeover guard only treated appended assistant mirror lines as safe while the prompt submission lock was released. In the failing Slack threads, the same session file was being appended with new user messages and `openclaw.runtime-context` records during long-running browser tool calls. Those append-only same-thread updates tripped `EmbeddedAttemptSessionTakeoverError` even though the session had not been taken over by a different writer.