### PR TITLE
Fix Knapsack cloud chat completions contract

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4597,15 +4597,11 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           .await
           .map_err(|e| anyhow::anyhow!("Knapsack auth failed: {}", e))?;
         let mut conversation: Vec<serde_json::Value> = Vec::new();
-        let mut system_prompt = String::new();
         for m in msgs.iter() {
           match m {
             chat_agent::OaiMessage::System { content } => {
               if !content.trim().is_empty() {
-                if !system_prompt.is_empty() {
-                  system_prompt.push('\n');
-                }
-                system_prompt.push_str(content);
+                conversation.push(serde_json::json!({"role": "system", "content": content}));
               }
             }
             chat_agent::OaiMessage::User { content, .. } => {
@@ -4614,18 +4610,33 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               }
             }
             chat_agent::OaiMessage::Assistant { content, .. } => {
+              let mut message = serde_json::json!({"role": "assistant"});
               if let Some(c) = content {
                 if !c.trim().is_empty() {
-                  conversation.push(serde_json::json!({"role": "assistant", "content": c}));
+                  message["content"] = serde_json::Value::String(c.clone());
                 }
+              }
+              if let chat_agent::OaiMessage::Assistant {
+                tool_calls: Some(tool_calls),
+                ..
+              } = m
+              {
+                if !tool_calls.is_empty() {
+                  message["tool_calls"] = serde_json::to_value(tool_calls)?;
+                }
+              }
+              if message.get("content").is_some() || message.get("tool_calls").is_some() {
+                conversation.push(message);
               }
             }
             chat_agent::OaiMessage::Tool {
-              tool_call_id: _,
+              tool_call_id,
               content,
             } => {
               if !content.trim().is_empty() {
-                conversation.push(serde_json::json!({"role": "tool", "content": content}));
+                conversation.push(
+                  serde_json::json!({"role": "tool", "tool_call_id": tool_call_id, "content": content}),
+                );
               }
             }
           }
@@ -4634,12 +4645,12 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           "messages": conversation,
           "model": model,
         });
-        if !system_prompt.is_empty() {
-          body["system_prompt"] = serde_json::Value::String(system_prompt);
+        if !tls.is_empty() {
+          body["tools"] = serde_json::to_value(&tls)?;
         }
         let resp = client
           .post(format!(
-            "{}/api/desktop/inference",
+            "{}/chat/completions",
             knapsack_base_url().trim_end_matches('/')
           ))
           .header("Authorization", format!("Bearer {}", jwt))
@@ -4666,35 +4677,27 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             text
           ));
         }
-        let raw = resp
-          .text()
+        let out: chat_agent::OaiChatResp = resp
+          .json()
           .await
           .map_err(|e| anyhow::anyhow!("Knapsack response read failed: {}", e))?;
-        let mut full_text = String::new();
-        for line in raw.lines() {
-          if let Some(chunk) = line.strip_prefix("data: ") {
-            if let Ok(v) = serde_json::from_str::<serde_json::Value>(chunk) {
-              if v.get("done").and_then(|d| d.as_bool()).unwrap_or(false) {
-                break;
-              }
-              if let Some(content) = v.get("content").and_then(|c| c.as_str()) {
-                full_text.push_str(content);
-              }
-            }
-          }
-        }
-        if full_text.is_empty() {
+        let has_reply = out
+          .choices
+          .first()
+          .map(|choice| {
+            choice
+              .message
+              .content
+              .as_ref()
+              .map(|c| !c.trim().is_empty())
+              .unwrap_or(false)
+              || !choice.message.tool_calls.is_empty()
+          })
+          .unwrap_or(false);
+        if !has_reply {
           return Err(anyhow::anyhow!("Knapsack returned an empty response"));
         }
-        Ok(chat_agent::OaiChatResp {
-          choices: vec![chat_agent::OaiChoice {
-            message: chat_agent::OaiChoiceMsg {
-              content: Some(full_text),
-              tool_calls: Vec::new(),
-            },
-          }],
-          usage: None,
-        })
+        Ok(out)
       }
       _ => chat_agent::openai_chat(key, model, msgs, tls).await,
     }

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -906,7 +906,7 @@ async fn anthropic_completion(
   )))
 }
 
-/// Call Knapsack's cloud inference API (`POST /api/desktop/inference`).
+/// Call Knapsack's cloud chat completions API (`POST /chat/completions`).
 /// Fetches a fresh JWT from the local gateway before each request.
 async fn knapsack_completion(
   provider: &ResolvedProvider,
@@ -916,37 +916,25 @@ async fn knapsack_completion(
   let client = reqwest::Client::new();
   let token = resolve_knapsack_bearer_token(email).await?;
 
-  // Separate system prompt from conversation messages
-  let system_prompt: String = messages
-    .iter()
-    .filter(|m| matches!(m.sender, MessageSender::System))
-    .map(|m| m.content.as_str())
-    .collect::<Vec<_>>()
-    .join("\n");
-
   let conversation: Vec<serde_json::Value> = messages
     .iter()
-    .filter(|m| !matches!(m.sender, MessageSender::System))
     .map(|m| {
       let role = match m.sender {
+        MessageSender::System => "system",
         MessageSender::User => "user",
         MessageSender::Bot => "assistant",
-        _ => "user",
       };
       serde_json::json!({"role": role, "content": &m.content})
     })
     .collect();
 
-  let mut body = serde_json::json!({
+  let body = serde_json::json!({
     "messages": conversation,
     "model": &provider.model,
   });
-  if !system_prompt.is_empty() {
-    body["system_prompt"] = serde_json::Value::String(system_prompt);
-  }
 
   let resp = client
-    .post(format!("{}/api/desktop/inference", &provider.base_url))
+    .post(format!("{}/chat/completions", &provider.base_url))
     .header("Authorization", format!("Bearer {}", token))
     .header("Content-Type", "application/json")
     .json(&body)
@@ -975,26 +963,19 @@ async fn knapsack_completion(
     )));
   }
 
-  // Consume SSE stream and concatenate content chunks
-  let body_bytes = resp
-    .bytes()
+  let response_json: serde_json::Value = resp
+    .json()
     .await
     .map_err(|e| LLMError::ChatCompletionFailed(format!("Knapsack response read failed: {}", e)))?;
-  let body_str = String::from_utf8_lossy(&body_bytes);
-
-  let mut full_text = String::new();
-  for line in body_str.lines() {
-    if let Some(data) = line.strip_prefix("data: ") {
-      if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
-        if json.get("done").and_then(|d| d.as_bool()).unwrap_or(false) {
-          break;
-        }
-        if let Some(content) = json.get("content").and_then(|c| c.as_str()) {
-          full_text.push_str(content);
-        }
-      }
-    }
-  }
+  let full_text = response_json
+    .get("choices")
+    .and_then(|choices| choices.as_array())
+    .and_then(|choices| choices.first())
+    .and_then(|choice| choice.get("message"))
+    .and_then(|message| message.get("content"))
+    .and_then(|content| content.as_str())
+    .unwrap_or_default()
+    .to_string();
 
   if full_text.is_empty() {
     return Err(LLMError::ChatCompletionFailed(


### PR DESCRIPTION
## Summary
- switch Knapsack cloud desktop requests from `/api/desktop/inference` to `/chat/completions`
- send system instructions as normal chat messages and pass through tool metadata for Knapsack requests
- parse OpenAI-style JSON chat completion responses instead of SSE chunks

## Testing
- `VITE_KN_API_SERVER=https://api.knapsack.ai VITE_GOOGLE_CLIENT_ID=dummy cargo check --manifest-path Cargo.toml`

## Notes
- This restores the current desktop-to-cloud API contract.
- The backend still appears to ignore the requested Knapsack cloud model, so selector behavior may need a backend follow-up after this desktop fix.