### PR TITLE
Fix QA-direct startup status diagnostics

### DIFF
--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5735,6 +5735,37 @@ pub async fn service_logs(query: web::Query<ServiceLogsParams>) -> impl Responde
   }
 }
 
+fn mac_service_status_summary(
+  installed: bool,
+  launchctl_running: bool,
+  gateway_ready: bool,
+  gateway_listening: bool,
+  launch_grace_ms: Option<u64>,
+  qa_direct_grace_ms: Option<u64>,
+  qa_direct_running: bool,
+) -> (bool, String) {
+  let running = launchctl_running
+    || gateway_ready
+    || gateway_listening
+    || launch_grace_ms.is_some()
+    || qa_direct_grace_ms.is_some()
+    || qa_direct_running;
+
+  let message = if let Some(ms) = launch_grace_ms.or(qa_direct_grace_ms) {
+    format!("Clawdbot gateway is starting ({}ms)", ms)
+  } else if gateway_listening && !gateway_ready {
+    "Clawdbot gateway is listening but still completing startup".to_string()
+  } else if running {
+    "Clawdbot service is running".to_string()
+  } else if installed {
+    "Clawdbot service is installed but not running".to_string()
+  } else {
+    "Clawdbot service not installed".to_string()
+  };
+
+  (running, message)
+}
+
 #[get("/api/clawd/service/status")]
 pub async fn service_status() -> impl Responder {
   #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -5798,6 +5829,11 @@ pub async fn service_status() -> impl Responder {
     let installed = plist_path.exists();
 
     let port_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
+    let gateway_listening = if port_ok {
+      true
+    } else {
+      gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
+    };
 
     // Best-effort fallback: `launchctl print gui/<uid>/<label>` exits 0 when loaded.
     let uid = unsafe { libc::getuid() };
@@ -5816,24 +5852,24 @@ pub async fn service_status() -> impl Responder {
     };
 
     let launch_grace_ms = gateway_launch_grace_active();
-    let running = launchctl_running || port_ok || launch_grace_ms.is_some();
+    let qa_direct_grace_ms = qa_direct_gateway_grace_active();
+    let qa_direct_running = qa_direct_gateway_mode() && qa_direct_gateway_process_active();
+    let (running, message) = mac_service_status_summary(
+      installed,
+      launchctl_running,
+      port_ok,
+      gateway_listening,
+      launch_grace_ms,
+      qa_direct_grace_ms,
+      qa_direct_running,
+    );
 
     HttpResponse::Ok().json(ServiceStatusResponse {
       success: true,
       installed,
       running,
       label: LAUNCH_AGENT_LABEL.to_string(),
-      message: if running {
-        if let Some(ms) = launch_grace_ms {
-          format!("Clawdbot gateway is starting ({}ms)", ms)
-        } else {
-          "Clawdbot service is running".to_string()
-        }
-      } else if installed {
-        "Clawdbot service is installed but not running".to_string()
-      } else {
-        "Clawdbot service not installed".to_string()
-      },
+      message,
     })
   }
 }
@@ -13203,5 +13239,19 @@ mod provider_key_tests {
     // Don't clobber custom providers the user may have configured out-of-band.
     assert!(model_ref_has_key("custom/my-model"));
     assert!(model_ref_has_key("minimax/m2.5"));
+  }
+}
+
+#[cfg(test)]
+mod service_status_message_tests {
+  use super::mac_service_status_summary;
+
+  #[test]
+  fn qa_direct_startup_is_not_reported_as_not_running() {
+    let (running, message) =
+      mac_service_status_summary(true, false, false, true, None, Some(123_u64), true);
+
+    assert!(running);
+    assert_eq!(message, "Clawdbot gateway is starting (123ms)");
   }
 }


### PR DESCRIPTION
## Summary
- align macOS `service/status` with QA-direct startup signals so a listening direct gateway is no longer reported as "installed but not running"
- factor the status message/running decision into a helper and cover the QA-direct startup case with a focused unit test

## QA Evidence
- `curl /api/clawd/service/health` during `npm run qa:dev` showed `diagnostic_type: gateway_starting` while `curl /api/clawd/service/status` incorrectly returned `running: false` / `Clawdbot service is installed but not running`
- after the patch and restart, `curl /api/clawd/service/status` returned `running: true` with `Clawdbot gateway is starting (...)`
- local check: `env VITE_KN_API_SERVER=https://api.knapsack.ai VITE_GOOGLE_CLIENT_ID=963137762742-tqs7tiv9bkh80t5io8hm5q8e798ab85s.apps.googleusercontent.com cargo test service_status_message_tests`

## Remaining QA Gaps / Blockers
- full end-to-end desktop/UI QA is still incomplete in this environment
- in-app browser automation against `http://127.0.0.1:1420` failed with `net::ERR_BLOCKED_BY_CLIENT`
- `computer_use` inspection of the live desktop/browser windows was unreliable
- browser-control health is still noisy in this run (`127.0.0.1:18791` sometimes returns plain `OK`, causing invalid-JSON probe failures)
- a stale/misleading health banner still reproduced on relaunch in some startup windows and needs separate follow-up
