### PR TITLE
Fix dev startup panic on missing llm resource

### DIFF
--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -1840,11 +1840,6 @@ async fn main() {
           .unwrap();
       }
 
-      let llm_path = app
-        .path_resolver()
-        .resolve_resource("resources/llm.gguf")
-        .expect("failed to resolve resource");
-
       // EMBEDDER_PATH.set(
       //   app
       //     .path_resolver()


### PR DESCRIPTION
## Summary
- remove the stale  lookup from desktop startup
- allow fresh checkouts to boot even when that unused local model asset is absent
- keep the change scoped to the dead startup dependency only

## Validation
- npm run qa:loop -- --dev
