### PR TITLE
Improve startup readiness QA and Windows bundle warmup

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -18,6 +18,7 @@
     "preqa:dev": "node scripts/fix-rollup-native.cjs",
     "qa:loop": "node scripts/qa-loop-runner.cjs",
     "preqa:loop": "node scripts/fix-rollup-native.cjs",
+    "qa:rendered-ui": "node scripts/qa-rendered-ui-smoke.cjs",
     "pretauri": "node scripts/fix-rollup-native.cjs",
     "tauri": "node scripts/load-env-and-run.cjs tauri",
     "postinstall": "node scripts/fix-rollup-native.cjs",

--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -12,6 +12,45 @@ const path = require('path');
 const SCRIPT_DIR = __dirname;
 const CLAWDBOT_DIR = path.join(SCRIPT_DIR, '..', 'src-tauri', 'resources', 'clawdbot');
 const IS_WIN = process.platform === 'win32';
+const ROOT_NODE_MODULES_TAR = path.join(CLAWDBOT_DIR, 'node_modules.tar');
+const STARTUP_CRITICAL_PACKAGES = [
+  'openclaw',
+  'chalk',
+  'commander',
+  'chokidar',
+  'ws',
+  'yaml',
+  'zod',
+  'dotenv',
+  'undici',
+  'ajv',
+  'croner',
+  'json5',
+  'tar',
+  'jszip',
+  'markdown-it',
+  '@earendil-works/pi-coding-agent',
+  '@earendil-works/pi-ai',
+  '@earendil-works/pi-agent-core',
+  'typebox',
+  '@clack/core',
+  '@clack/prompts',
+  '@agentclientprotocol/sdk',
+  '@modelcontextprotocol/sdk',
+  '@openclaw/fs-safe',
+  '@openclaw/proxyline',
+  'file-type',
+  'jiti',
+  'web-push',
+  'express',
+  'kysely',
+  'grammy',
+  '@google/genai',
+  'playwright-core',
+  'qrcode',
+  'tokenjuice',
+  'tslog',
+];
 
 if (!fs.existsSync(path.join(CLAWDBOT_DIR, 'node_modules'))) {
   console.log('[prune-clawdbot] No node_modules found — skipping.');
@@ -48,6 +87,85 @@ function rmDir(dir) {
     return true;
   }
   return false;
+}
+
+function packNodeModulesTar({ cwd, finalTarName, label }) {
+  const tar = require(path.join(CLAWDBOT_DIR, 'node_modules', 'tar'));
+  const tmpTarName = `${finalTarName}.tmp`;
+  const finalTarPath = path.join(cwd, finalTarName);
+  const tmpTarPath = path.join(cwd, tmpTarName);
+  fs.rmSync(finalTarPath, { force: true });
+  fs.rmSync(tmpTarPath, { force: true });
+
+  try {
+    tar.c({
+      cwd,
+      file: tmpTarPath,
+      sync: true,
+    }, ['node_modules']);
+    fs.renameSync(tmpTarPath, finalTarPath);
+    return true;
+  } catch (error) {
+    fs.rmSync(tmpTarPath, { force: true });
+    console.warn(`[prune-clawdbot] WARNING: ${label} tar failed: ${error.message}`);
+    return false;
+  }
+}
+
+function packageDir(packageName) {
+  return path.join(nodeModules, ...packageName.split('/'));
+}
+
+function readPackageJson(packageName) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(packageDir(packageName), 'package.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function collectStartupPackageClosure() {
+  const keep = new Set();
+  const queue = [...STARTUP_CRITICAL_PACKAGES];
+  while (queue.length > 0) {
+    const packageName = queue.shift();
+    if (keep.has(packageName)) continue;
+    const pkg = readPackageJson(packageName);
+    if (!pkg) continue;
+    keep.add(packageName);
+    for (const depGroup of ['dependencies', 'optionalDependencies']) {
+      const deps = pkg[depGroup] && typeof pkg[depGroup] === 'object' ? Object.keys(pkg[depGroup]) : [];
+      for (const dep of deps) {
+        if (!keep.has(dep) && fs.existsSync(path.join(packageDir(dep), 'package.json'))) {
+          queue.push(dep);
+        }
+      }
+    }
+  }
+  return keep;
+}
+
+function pruneNodeModulesToPackageSet(keep) {
+  for (const entry of fs.readdirSync(nodeModules, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const entryPath = path.join(nodeModules, entry.name);
+    if (entry.name.startsWith('@')) {
+      for (const scopedEntry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+        if (!scopedEntry.isDirectory()) continue;
+        const scopedName = `${entry.name}/${scopedEntry.name}`;
+        if (!keep.has(scopedName)) {
+          rmDir(path.join(entryPath, scopedEntry.name));
+        }
+      }
+      try {
+        if (fs.readdirSync(entryPath).length === 0) fs.rmdirSync(entryPath);
+      } catch { /* best effort */ }
+      continue;
+    }
+    if (!keep.has(entry.name)) {
+      rmDir(entryPath);
+    }
+  }
 }
 
 function hasRuntimeDefaultExport(sourcePath) {
@@ -102,6 +220,20 @@ function materializeOpenClawAliasPackage() {
     console.warn('[prune-clawdbot] WARNING: dist/plugin-sdk missing; skipped openclaw alias package');
     return;
   }
+
+  const aliasPackagePath = path.join(aliasDir, 'package.json');
+  const aliasIndexPath = path.join(aliasDir, 'index.js');
+  const aliasPluginSdkIndexPath = path.join(aliasDir, 'plugin-sdk', 'index.js');
+  try {
+    const existingPackage = JSON.parse(fs.readFileSync(aliasPackagePath, 'utf8'));
+    if (existingPackage?.name === 'openclaw-bundle-alias'
+        && existingPackage?.type === 'module'
+        && fs.existsSync(aliasIndexPath)
+        && fs.existsSync(aliasPluginSdkIndexPath)) {
+      console.log('[prune-clawdbot] Reusing materialized openclaw alias package');
+      return;
+    }
+  } catch { /* materialize below */ }
 
   rmDir(aliasDir);
   fs.mkdirSync(aliasDir, { recursive: true });
@@ -246,6 +378,14 @@ const SPECIFIC_DIRS_TO_REMOVE = [
   // CSS/SCSS themes — not needed for Node.js terminal output
   'highlight.js/styles',
   'highlight.js/scss',
+  // Type-only SDK payloads with deeply nested paths that WiX cannot reliably
+  // link from the repository checkout on Windows.
+  '@aws-sdk/core/dist-types',
+  '@aws-sdk/nested-clients/dist-types',
+  '@smithy/core/dist-types',
+  '@earendil-works/pi-ai/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs',
+  '@earendil-works/pi-ai/node_modules/@aws-sdk/client-bedrock-runtime/dist-es',
+  '@earendil-works/pi-ai/node_modules/@aws-sdk/client-bedrock-runtime/dist-types',
 ];
 for (const relDir of SPECIFIC_DIRS_TO_REMOVE) {
   const target = path.join(nodeModules, relDir);
@@ -356,6 +496,15 @@ const LONG_PATH_PACKAGE_SUBDIRS = [
   path.join('@mistralai', 'mistralai', 'src'),
 ];
 
+if (IS_WIN) {
+  for (const subdir of LONG_PATH_PACKAGE_SUBDIRS) {
+    const target = path.join(nodeModules, subdir);
+    if (rmDir(target)) {
+      console.log(`[prune-clawdbot]     removed root long-path subdir: node_modules/${subdir.replace(/\\/g, '/')}`);
+    }
+  }
+}
+
 const EXTENSION_UNUSED_PACKAGES = [
   // Optional native image acceleration pulled in under WhatsApp/Jimp. The
   // channel only needs Jimp's JS QR/media path for Knapsack's bundled runtime,
@@ -419,17 +568,9 @@ if (fs.existsSync(distExtensionsDir)) {
           }
 
           try {
-            const { spawnSync } = require('child_process');
-            const result = spawnSync('tar', ['-cf', 'node_modules.tar', 'node_modules'], {
-              cwd: extDir,
-              stdio: 'pipe',
-            });
-            if (result.status === 0) {
+            if (packNodeModulesTar({ cwd: extDir, finalTarName: 'node_modules.tar', label: `${extEntry.name} extension node_modules` })) {
               fs.rmSync(extNodeModules, { recursive: true, force: true });
               console.log(`[prune-clawdbot]     tarred extension node_modules: ${extEntry.name}`);
-            } else {
-              const err = result.stderr ? result.stderr.toString().trim() : 'unknown error';
-              console.warn(`[prune-clawdbot]     WARNING: tar failed for ${extEntry.name}: ${err}`);
             }
           } catch (e) {
             console.warn(`[prune-clawdbot]     WARNING: could not tar ${extEntry.name}: ${e.message}`);
@@ -457,6 +598,18 @@ try {
   }
 } catch { /* not present — nothing to do */ }
 materializeOpenClawAliasPackage();
+
+if (IS_WIN) {
+  try {
+    if (packNodeModulesTar({ cwd: CLAWDBOT_DIR, finalTarName: 'node_modules.tar', label: 'root node_modules' })) {
+      const keep = collectStartupPackageClosure();
+      pruneNodeModulesToPackageSet(keep);
+      console.log(`[prune-clawdbot] Packed root node_modules into node_modules.tar; kept ${keep.size} startup package(s) extracted`);
+    }
+  } catch (e) {
+    console.warn(`[prune-clawdbot] WARNING: could not tar root node_modules: ${e.message}`);
+  }
+}
 
 // Step 6: Report results
 if (!IS_WIN) {

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -2,6 +2,7 @@
 const fs = require("node:fs");
 const { existsSync } = fs;
 const { spawn, spawnSync } = require("node:child_process");
+const http = require("node:http");
 const net = require("node:net");
 const path = require("node:path");
 const process = require("node:process");
@@ -55,6 +56,7 @@ const MODELS_BY_PROVIDER = {
     "grok-4",
   ],
   openrouter: [
+    "openai/gpt-4o-mini",
     "openrouter/free",
     "openrouter/auto",
     "qwen/qwen3-coder-480b-a35b-instruct:free",
@@ -619,15 +621,19 @@ async function killOpenClawProcessesForQa() {
 }
 
 function fetchWithTimeout(url, options = {}, timeoutMs = 8_000) {
+  const { qaSkipBody, ...fetchOptions } = options || {};
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   return fetch(url, {
-    ...options,
+    ...fetchOptions,
     signal: controller.signal,
   })
     .finally(() => clearTimeout(timer))
     .then(async (res) => {
       const headers = Object.fromEntries(res.headers.entries());
+      if (qaSkipBody) {
+        return { ok: res.ok, status: res.status, headers, body: null };
+      }
       const text = await res.text();
       let body = text;
       try {
@@ -637,6 +643,50 @@ function fetchWithTimeout(url, options = {}, timeoutMs = 8_000) {
       }
       return { ok: res.ok, status: res.status, headers, body };
     });
+}
+
+function httpJsonWithTimeout(url, options = {}, timeoutMs = 8_000) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const method = options.method || "GET";
+    const body = options.body || null;
+    const headers = { ...(options.headers || {}) };
+    if (body && !headers["Content-Length"] && !headers["content-length"]) {
+      headers["Content-Length"] = Buffer.byteLength(body);
+    }
+    const req = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: `${parsed.pathname}${parsed.search}`,
+      method,
+      headers,
+    }, (res) => {
+      const chunks = [];
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => {
+        const text = chunks.join("");
+        let parsedBody = text;
+        try {
+          parsedBody = JSON.parse(text);
+        } catch {
+          // keep text
+        }
+        resolve({
+          ok: res.statusCode >= 200 && res.statusCode < 300,
+          status: res.statusCode || 0,
+          headers: res.headers,
+          body: parsedBody,
+        });
+      });
+    });
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`request timed out after ${timeoutMs}ms`));
+    });
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
 }
 
 function isExpectedStatusSuccess(payload, endpoint) {
@@ -1021,7 +1071,8 @@ async function waitForStartupReady({ label, startupBudgetMs = 30_000 }) {
     if (active && stableTicks >= 2) {
       return {
         ok: true,
-        startupMs: startupReady?.startup_elapsed_ms || Date.now() - start,
+        startupMs: Date.now() - start,
+        startupEndpointMs: startupReady?.startup_elapsed_ms || null,
         payload: {
           startup: startupReady,
           status,
@@ -1332,11 +1383,11 @@ async function runChatSmoke(provider, model, options = {}) {
     };
     const chatRetries = Number.isFinite(options.chatRetries)
       ? Math.max(1, Number.parseInt(options.chatRetries, 10))
-      : 1;
+      : Math.max(1, Number(process.env.KNAPSACK_QA_CHAT_RETRIES || 6));
     const chatRetryDelayMs = Number.isFinite(options.chatRetryDelayMs)
       ? Math.max(100, Number.parseInt(options.chatRetryDelayMs, 10))
       : 1_000;
-    const chatTimeoutMs = Number(process.env.KNAPSACK_QA_CHAT_TIMEOUT_MS || 45_000);
+    const chatTimeoutMs = Number(process.env.KNAPSACK_QA_CHAT_TIMEOUT_MS || 60_000);
     let attemptChat = 0;
     let chat;
 
@@ -1344,7 +1395,8 @@ async function runChatSmoke(provider, model, options = {}) {
       attemptChat += 1;
       try {
         const requestStartedAt = Date.now();
-        chat = await fetchWithTimeout(`${API_BASE}/api/clawd/chat`, {
+        const requestStartedAt = Date.now();
+        chat = await httpJsonWithTimeout(`${API_BASE}/api/clawd/chat`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
@@ -1364,7 +1416,7 @@ async function runChatSmoke(provider, model, options = {}) {
           message.includes("socket hang up")
         );
         if (retryable && attemptChat < chatRetries) {
-          await sleep(chatRetryDelayMs);
+          await sleep(Math.max(chatRetryDelayMs, Math.min(15_000, 5_000 * attemptChat)));
           continue;
         }
         return {
@@ -1656,7 +1708,7 @@ async function checkInterfaceAccess(includeUi) {
     1_000,
   );
   const workspaces = await retryWithDelay(
-    () => fetchWithTimeout(`${API_BASE}/api/knapsack/workspaces`, { method: "GET" }, 8_000),
+    () => fetchWithTimeout(`${API_BASE}/api/knapsack/workspaces`, { method: "GET", qaSkipBody: true }, 5_000),
     4,
     1_000,
   );
@@ -1677,7 +1729,7 @@ async function checkInterfaceAccess(includeUi) {
     1_000,
   );
   const feed = await retryWithDelay(
-    () => fetchWithTimeout(`${API_BASE}/api/knapsack/feed_items`, { method: "GET" }, 8_000),
+    () => fetchWithTimeout(`${API_BASE}/api/knapsack/feed_items`, { method: "GET", qaSkipBody: true }, 5_000),
     4,
     1_000,
   );
@@ -1688,11 +1740,14 @@ async function checkInterfaceAccess(includeUi) {
       1_000,
     )
     : { ok: true };
-  const browserControl = await retryWithDelay(
-    () => probeBrowserControl(20_000),
-    8,
-    1_000,
-  );
+  const healthBrowserOk = Boolean(health?.body?.browser_ok);
+  const browserControl = healthBrowserOk
+    ? true
+    : await retryWithDelay(
+      () => probeBrowserControl(3_000),
+      3,
+      750,
+    );
 
   const failures = [];
   if (!root || !root.ok) failures.push("service/status unhealthy");
@@ -1724,7 +1779,7 @@ async function checkInterfaceAccess(includeUi) {
     failures.push("automations unavailable");
   }
   if (includeUi && (!ui || !ui.ok)) failures.push("UI /home unreachable");
-  const uiBrowserOk = browserControl || Boolean(health?.body?.browser_ok);
+  const uiBrowserOk = browserControl || healthBrowserOk;
   if (!uiBrowserOk) failures.push("browser control not reachable");
   return {
     ok: failures.length === 0,
@@ -1917,6 +1972,11 @@ async function runMode(mode, opts = {}) {
         };
       }
       functionalProgress.gatewayHealth = gatewayHealth;
+      const chatSettleMs = Math.max(0, Number(process.env.KNAPSACK_QA_CHAT_SETTLE_MS || 5_000));
+      if (chatSettleMs > 0) {
+        functionalProgress.step = "chat settle";
+        await sleep(chatSettleMs);
+      }
 
       for (const [provider, models] of providers) {
           for (const modelEntry of models) {
@@ -1957,6 +2017,7 @@ async function runMode(mode, opts = {}) {
           chatChecks,
         };
       }
+      functionalProgress.mockMeeting = meeting;
 
       let interfaces = null;
       for (let interfaceAttempt = 1; interfaceAttempt <= 3; interfaceAttempt++) {
@@ -2018,6 +2079,7 @@ async function runMode(mode, opts = {}) {
     phase: "complete",
     startup,
     chatChecks: functionalResult.chatChecks,
+    mockMeeting: functionalResult.progress?.mockMeeting || functionalProgress.mockMeeting || { ok: true },
     interfaceCoverage: functionalResult.interfaceCoverage,
   };
 }
@@ -2094,6 +2156,12 @@ async function runLoop() {
         ? `[qa-loop] ${mode} hit core active+stable within ${modeResult.startup?.startupMs || "n/a"}ms on attempt ${attempt}.`
         : `[qa-loop] ${mode} hit active+stable within ${modeResult.startup?.startupMs || "n/a"}ms on attempt ${attempt}.`,
     );
+    if (!opts.coreOnly && Array.isArray(modeResult.chatChecks)) {
+      console.log(`[qa-loop] ${mode} chat checks: ${JSON.stringify(modeResult.chatChecks)}`);
+    }
+    if (!opts.coreOnly && modeResult.mockMeeting) {
+      console.log(`[qa-loop] ${mode} mock meeting: ${JSON.stringify(modeResult.mockMeeting)}`);
+    }
     if (modeResult.interfaceCoverage) {
       console.log(`[qa-loop] ${mode} interface coverage: ${JSON.stringify(modeResult.interfaceCoverage)}`);
     }

--- a/src/scripts/qa-rendered-ui-smoke.cjs
+++ b/src/scripts/qa-rendered-ui-smoke.cjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+const process = require("node:process");
+
+const DEFAULT_CDP = "http://127.0.0.1:9223";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchJson(url, timeoutMs = 2_000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseArgs() {
+  const opts = {
+    cdp: process.env.KNAPSACK_QA_CDP_URL || DEFAULT_CDP,
+    timeoutMs: Number(process.env.KNAPSACK_QA_RENDERED_TIMEOUT_MS || 30_000),
+  };
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith("--cdp=")) opts.cdp = arg.slice("--cdp=".length);
+    if (arg.startsWith("--timeout-ms=")) {
+      const value = Number(arg.slice("--timeout-ms=".length));
+      if (Number.isFinite(value)) opts.timeoutMs = value;
+    }
+  }
+  opts.cdp = opts.cdp.replace(/\/$/, "");
+  return opts;
+}
+
+async function waitForTarget(cdpBase, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const targets = await fetchJson(`${cdpBase}/json/list`, 2_000);
+      const pages = Array.isArray(targets)
+        ? targets.filter((target) => target.type === "page" && target.webSocketDebuggerUrl)
+        : [];
+      const appPage =
+        pages.find((target) => /\/home(?:$|[?#])/i.test(target.url || "")) ||
+        pages.find((target) => /(?:^|\/)index\.html(?:$|[?#])/i.test(target.url || "")) ||
+        pages.find((target) =>
+          /tauri|localhost|127\.0\.0\.1|home|index/i.test(`${target.url || ""} ${target.title || ""}`),
+        ) ||
+        pages[0];
+      if (appPage) return appPage;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(500);
+  }
+  throw new Error(`no debuggable app page found at ${cdpBase}: ${lastError?.message || "timed out"}`);
+}
+
+function connectCdp(webSocketDebuggerUrl) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(webSocketDebuggerUrl);
+    let nextId = 1;
+    const callbacks = new Map();
+    const timeout = setTimeout(() => reject(new Error("CDP websocket connection timed out")), 5_000);
+
+    ws.addEventListener("open", () => {
+      clearTimeout(timeout);
+      resolve({
+        send(method, params = {}) {
+          const id = nextId++;
+          ws.send(JSON.stringify({ id, method, params }));
+          return new Promise((innerResolve, innerReject) => {
+            callbacks.set(id, { resolve: innerResolve, reject: innerReject });
+          });
+        },
+        close() {
+          ws.close();
+        },
+      });
+    });
+    ws.addEventListener("error", () => reject(new Error("CDP websocket connection failed")));
+    ws.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (!message.id || !callbacks.has(message.id)) return;
+      const callback = callbacks.get(message.id);
+      callbacks.delete(message.id);
+      if (message.error) {
+        callback.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        callback.resolve(message.result);
+      }
+    });
+  });
+}
+
+async function evaluate(client, expression, timeoutMs = 5_000) {
+  const result = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+    timeout: timeoutMs,
+  });
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.text || "Runtime.evaluate failed");
+  }
+  return result.result?.value;
+}
+
+function renderedSmokeExpression() {
+  return `(${async function qaRenderedSmoke() {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const visible = (el) => {
+      if (!el) return false;
+      const style = window.getComputedStyle(el);
+      const rect = el.getBoundingClientRect();
+      return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
+    };
+    const waitFor = async (selector, timeoutMs = 10_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const el = document.querySelector(selector);
+        if (visible(el)) return el;
+        await sleep(150);
+      }
+      throw new Error("missing visible selector: " + selector);
+    };
+    const waitForAny = async (selectors, timeoutMs = 10_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        for (const selector of selectors) {
+          const el = document.querySelector(selector);
+          if (visible(el)) return { el, selector };
+        }
+        await sleep(150);
+      }
+      throw new Error("missing visible selector: " + selectors.join(", "));
+    };
+    const textIncludes = (el, text) => (el?.textContent || "").toLowerCase().includes(text.toLowerCase());
+    const findVisibleByText = (selector, text) =>
+      Array.from(document.querySelectorAll(selector)).find((el) => visible(el) && textIncludes(el, text));
+    const waitForVisibleText = async (selector, text, timeoutMs = 10_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const el = findVisibleByText(selector, text);
+        if (el) return el;
+        await sleep(150);
+      }
+      throw new Error(`missing visible text "${text}" in ${selector}`);
+    };
+    const click = async (selector) => {
+      const el = await waitFor(selector);
+      if (typeof el.click === "function") {
+        el.click();
+      } else {
+        el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+      }
+      await sleep(250);
+      return true;
+    };
+    const clickAny = async (selectors, fallbackSelector, fallbackText) => {
+      try {
+        const found = await waitForAny(selectors, 2_500);
+        if (typeof found.el.click === "function") found.el.click();
+        else found.el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+        await sleep(250);
+        return found.selector;
+      } catch {
+        const el = await waitForVisibleText(fallbackSelector, fallbackText, 10_000);
+        if (typeof el.click === "function") el.click();
+        else el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+        await sleep(250);
+        return `${fallbackSelector}:text(${fallbackText})`;
+      }
+    };
+
+    const chatInput = await waitFor('[data-testid="qa-clawd-chat-input"]', 15_000);
+    if (typeof chatInput.focus === "function") {
+      chatInput.focus();
+    }
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+    if (setter) {
+      setter.call(chatInput, "QA rendered typing smoke");
+    } else {
+      chatInput.value = "QA rendered typing smoke";
+    }
+    chatInput.dispatchEvent(new Event("input", { bubbles: true }));
+    chatInput.dispatchEvent(new Event("change", { bubbles: true }));
+    if (chatInput.value !== "QA rendered typing smoke") {
+      throw new Error("chat input did not accept typed text");
+    }
+
+    const emailNavSelector = await clickAny(
+      [
+        '[data-testid="qa-nav-email-autopilot"]',
+        'button[title="Email Autopilot"]',
+      ],
+      "button",
+      "Email",
+    );
+    const emailPanel = await waitForAny(
+      [
+        '[data-testid="qa-email-autopilot-panel"]',
+        ".EmailTabView",
+        ".EmailAutopilot",
+      ],
+      10_000,
+    );
+
+    const gbrainNavSelector = await clickAny(
+      [
+        '[data-testid="qa-nav-gbrain"]',
+        'button[title="GBrain"]',
+      ],
+      "button",
+      "GBrain",
+    );
+    const gbrainPanel = await waitForAny(
+      [
+        '[data-testid="qa-gbrain-panel"]',
+        ".GBrain",
+        ".GBrainHeader",
+      ],
+      10_000,
+    ).catch(async () => ({ el: await waitForVisibleText("body", "GBrain", 10_000), selector: "body:text(GBrain)" }));
+
+    return {
+      ok: true,
+      title: document.title,
+      url: location.href,
+      checks: {
+        chatInputTyped: true,
+        emailAutopilotRendered: true,
+        gbrainRendered: true,
+      },
+      selectors: {
+        emailNav: emailNavSelector,
+        emailPanel: emailPanel.selector,
+        gbrainNav: gbrainNavSelector,
+        gbrainPanel: gbrainPanel.selector,
+      },
+    };
+  }.toString()})()`;
+}
+
+async function main() {
+  const opts = parseArgs();
+  const target = await waitForTarget(opts.cdp, opts.timeoutMs);
+  const client = await connectCdp(target.webSocketDebuggerUrl);
+  try {
+    await client.send("Runtime.enable");
+    const result = await evaluate(client, renderedSmokeExpression(), opts.timeoutMs);
+    console.log(`[qa-rendered-ui] target: ${target.title || "(untitled)"} ${target.url || ""}`);
+    console.log(`[qa-rendered-ui] result: ${JSON.stringify(result)}`);
+    if (!result?.ok) {
+      process.exitCode = 1;
+    }
+  } finally {
+    client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(`[qa-rendered-ui] failed: ${error?.stack || error}`);
+  process.exit(1);
+});

--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -332,6 +332,27 @@ function verifyOpenClawAliasPackage() {
   const nodeModulesDir = path.join(CLAWDBOT_DIR, 'node_modules');
   const aliasDir = path.join(nodeModulesDir, 'openclaw');
   if (!fs.existsSync(aliasDir)) {
+    const tarPath = path.join(CLAWDBOT_DIR, 'node_modules.tar');
+    if (fs.existsSync(tarPath)) {
+      const tarEntries = new Set(listTarEntries(tarPath));
+      const requiredAliasEntries = [
+        'node_modules/openclaw/package.json',
+        'node_modules/openclaw/index.js',
+        'node_modules/openclaw/plugin-sdk/index.js',
+        'node_modules/openclaw/plugin-sdk/channel-message.js',
+      ];
+      const missingAliasEntries = requiredAliasEntries.filter((entry) => !tarEntries.has(entry));
+      if (missingAliasEntries.length > 0) {
+        console.error(`[verify-clawdbot] MISSING OPENCLAW ALIAS ENTRIES IN node_modules.tar (${missingAliasEntries.length}):`);
+        for (const entry of missingAliasEntries) {
+          console.error(`[verify-clawdbot]   - ${entry}`);
+        }
+        errors += missingAliasEntries.length;
+      } else {
+        console.log('[verify-clawdbot] openclaw alias package: verified in node_modules.tar ✓');
+      }
+      return;
+    }
     console.error('[verify-clawdbot] MISSING: node_modules/openclaw alias package');
     errors++;
     return;
@@ -527,6 +548,7 @@ const CRITICAL_PACKAGE_FILES = [
 ];
 
 const nodeModulesDir = path.join(CLAWDBOT_DIR, 'node_modules');
+const rootNodeModulesTar = path.join(CLAWDBOT_DIR, 'node_modules.tar');
 if (fs.existsSync(nodeModulesDir)) {
   const missing = [];
   const missingFiles = [];
@@ -573,17 +595,20 @@ if (fs.existsSync(nodeModulesDir)) {
   if (missing.length === 0 && missingFiles.length === 0) {
     console.log(`[verify-clawdbot] critical packages: ${CRITICAL_PACKAGES.length} verified in node_modules ✓`);
   }
-} else {
+} else if (!fs.existsSync(rootNodeModulesTar)) {
   console.error('[verify-clawdbot] CRITICAL: node_modules directory is missing entirely');
   errors++;
+} else {
+  console.log('[verify-clawdbot] node_modules directory is packed as node_modules.tar');
 }
 
-const rootNodeModulesTar = path.join(CLAWDBOT_DIR, 'node_modules.tar');
 if (fs.existsSync(rootNodeModulesTar)) {
   const tarEntries = new Set(listTarEntries(rootNodeModulesTar));
-  const missingTarFiles = CRITICAL_PACKAGE_FILES
-    .map((file) => `node_modules/${file}`)
-    .filter((file) => !tarEntries.has(file));
+  const criticalTarFiles = [
+    ...CRITICAL_PACKAGE_FILES.map((file) => `node_modules/${file}`),
+    ...CRITICAL_PACKAGES.map((pkg) => `node_modules/${pkg}/package.json`),
+  ];
+  const missingTarFiles = criticalTarFiles.filter((file) => !tarEntries.has(file));
   if (missingTarFiles.length > 0) {
     console.error(`[verify-clawdbot] MISSING CRITICAL FILES IN node_modules.tar (${missingTarFiles.length}):`);
     for (const file of missingTarFiles) {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -300,6 +300,9 @@ static GATEWAY_LIFECYCLE_MUTEX: once_cell::sync::Lazy<tokio::sync::Mutex<()>> =
 static ROOT_PLUGIN_DEPS_INSTALL_MUTEX: once_cell::sync::Lazy<std::sync::Mutex<()>> =
   once_cell::sync::Lazy::new(|| std::sync::Mutex::new(()));
 
+static NODE_MODULES_EXTRACTION_MUTEX: once_cell::sync::Lazy<std::sync::Mutex<()>> =
+  once_cell::sync::Lazy::new(|| std::sync::Mutex::new(()));
+
 struct GatewayRestartProgressGuard;
 
 impl GatewayRestartProgressGuard {
@@ -1920,6 +1923,102 @@ fn install_bundled_plugin_runtime_deps(
   ensure_openclaw_self_link(&root_nm);
 }
 
+fn bundled_node_modules_has_declared_dependencies(
+  dir: &std::path::Path,
+  nm_path: &std::path::Path,
+) -> bool {
+  let pkg_path = dir.join("package.json");
+  let Ok(raw) = fs::read_to_string(&pkg_path) else {
+    return false;
+  };
+  let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&raw) else {
+    return false;
+  };
+  let deps = pkg.get("dependencies").and_then(|v| v.as_object());
+  if deps.map(|deps| deps.is_empty()).unwrap_or(true) {
+    return nm_path
+      .read_dir()
+      .map(|mut entries| entries.any(|entry| entry.is_ok()))
+      .unwrap_or(false);
+  }
+
+  deps
+    .unwrap()
+    .keys()
+    .all(|dep| nm_path.join(dep).join("package.json").exists())
+}
+
+fn bundled_node_modules_has_required_runtime_files(nm_path: &std::path::Path) -> bool {
+  [
+    "@earendil-works/pi-agent-core/package.json",
+    "@earendil-works/pi-agent-core/dist/index.js",
+    "@earendil-works/pi-agent-core/dist/agent.js",
+  ]
+  .iter()
+  .all(|rel| {
+    rel
+      .split('/')
+      .fold(nm_path.to_path_buf(), |path, part| path.join(part))
+      .exists()
+  })
+}
+
+fn bundled_node_modules_has_startup_runtime_files(nm_path: &std::path::Path) -> bool {
+  [
+    "openclaw/package.json",
+    "openclaw/plugin-sdk/index.js",
+    "chalk/package.json",
+    "commander/package.json",
+    "chokidar/package.json",
+    "ws/package.json",
+    "yaml/package.json",
+    "zod/package.json",
+    "dotenv/package.json",
+    "undici/package.json",
+    "ajv/package.json",
+    "croner/package.json",
+    "json5/package.json",
+    "tar/package.json",
+    "jszip/package.json",
+    "markdown-it/package.json",
+    "@earendil-works/pi-coding-agent/package.json",
+    "@earendil-works/pi-ai/package.json",
+    "@earendil-works/pi-agent-core/package.json",
+    "@earendil-works/pi-agent-core/dist/index.js",
+    "@earendil-works/pi-agent-core/dist/agent.js",
+    "typebox/package.json",
+    "@clack/core/package.json",
+    "@clack/prompts/package.json",
+    "@agentclientprotocol/sdk/package.json",
+    "@modelcontextprotocol/sdk/package.json",
+    "@openclaw/fs-safe/package.json",
+    "@openclaw/proxyline/package.json",
+    "file-type/package.json",
+    "jiti/package.json",
+    "web-push/package.json",
+    "express/package.json",
+    "kysely/package.json",
+    "grammy/package.json",
+    "@google/genai/package.json",
+    "playwright-core/package.json",
+    "qrcode/package.json",
+    "tokenjuice/package.json",
+    "tslog/package.json",
+  ]
+  .iter()
+  .all(|rel| {
+    rel
+      .split('/')
+      .fold(nm_path.to_path_buf(), |path, part| path.join(part))
+      .exists()
+  })
+}
+
+fn bundled_node_modules_is_complete(dir: &std::path::Path, nm_path: &std::path::Path) -> bool {
+  bundled_node_modules_has_declared_dependencies(dir, nm_path)
+    && bundled_node_modules_has_required_runtime_files(nm_path)
+}
+
 /// On Windows CI builds, prune-clawdbot.cjs packs `node_modules/` into
 /// `node_modules.tar` (one file) so WiX stays under its 65535-file CAB limit
 /// (LGHT0306).  This function extracts the tar back to `node_modules/` at
@@ -1940,8 +2039,65 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
     return; // No tar — dev build or macOS/Linux (uses real node_modules dir).
   }
 
+  let _extract_guard = NODE_MODULES_EXTRACTION_MUTEX
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner());
+
   let nm_path = dir.join("node_modules");
+  let marker_path = nm_path.join(".knapsack-extracted-from-tar.json");
+  let tar_meta = fs::metadata(&tar_path).ok();
+  let tar_len = tar_meta.as_ref().map(|m| m.len()).unwrap_or(0);
+  let tar_mtime_secs = tar_meta
+    .as_ref()
+    .and_then(|m| m.modified().ok())
+    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+    .map(|d| d.as_secs())
+    .unwrap_or(0);
+
   if nm_path.is_dir() {
+    let marker_current = fs::read_to_string(&marker_path)
+      .ok()
+      .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+      .map(|v| {
+        v.get("tar_len").and_then(|n| n.as_u64()) == Some(tar_len)
+          && v.get("tar_mtime_secs").and_then(|n| n.as_u64()) == Some(tar_mtime_secs)
+      })
+      .unwrap_or(false);
+    if marker_current && bundled_node_modules_is_complete(dir, &nm_path) {
+      return;
+    }
+    if bundled_node_modules_is_complete(dir, &nm_path) {
+      let marker = serde_json::json!({
+        "tar_len": tar_len,
+        "tar_mtime_secs": tar_mtime_secs,
+      });
+      let _ = fs::write(&marker_path, marker.to_string());
+      eprintln!(
+        "[clawd/service] node_modules present and complete in {} - skipping tar extraction",
+        dir.display()
+      );
+      return;
+    }
+    eprintln!(
+      "[clawd/service] node_modules.tar extraction marker missing/stale in {} - re-extracting",
+      dir.display()
+    );
+    if bundled_node_modules_has_startup_runtime_files(&nm_path) {
+      eprintln!(
+        "[clawd/service] startup node_modules subset present in {} - merging node_modules.tar",
+        dir.display()
+      );
+    } else {
+      let _ = fs::remove_dir_all(&nm_path);
+    }
+  }
+
+  if nm_path.is_dir()
+    && !(
+      bundled_node_modules_has_startup_runtime_files(&nm_path)
+        && !bundled_node_modules_is_complete(dir, &nm_path)
+    )
+  {
     // Already extracted — check if the tar is newer (app was updated in-place).
     let tar_mtime = fs::metadata(&tar_path).and_then(|m| m.modified()).ok();
     let nm_mtime = fs::metadata(&nm_path).and_then(|m| m.modified()).ok();
@@ -1986,6 +2142,33 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
       ),
     }
   }
+}
+
+fn ensure_gateway_node_modules_ready(clawdbot_root: &std::path::Path) -> Result<(), String> {
+  let nm_path = clawdbot_root.join("node_modules");
+  if bundled_node_modules_has_startup_runtime_files(&nm_path) {
+    if !bundled_node_modules_is_complete(clawdbot_root, &nm_path) {
+      let root = clawdbot_root.to_path_buf();
+      std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(60));
+        ensure_node_modules_extracted(&root);
+      });
+    }
+    return Ok(());
+  }
+
+  ensure_node_modules_extracted(clawdbot_root);
+  if bundled_node_modules_is_complete(clawdbot_root, &nm_path) {
+    return Ok(());
+  }
+  if bundled_node_modules_has_startup_runtime_files(&nm_path) {
+    return Ok(());
+  }
+
+  Err(format!(
+    "Bundled gateway startup dependencies are not ready at {} after node_modules.tar extraction",
+    nm_path.display()
+  ))
 }
 
 /// Create `node_modules/openclaw -> ..` (or a junction on Windows) so that
@@ -9228,7 +9411,7 @@ async fn prepare_gateway_config(
   // (dist/entry.js → dist/ → clawdbot/).
   if let Some(clawdbot_root) = clawdbot_entry.parent().and_then(|p| p.parent()) {
     if should_mutate_bundled_clawdbot_runtime(clawdbot_root) {
-      ensure_node_modules_extracted(clawdbot_root);
+      ensure_gateway_node_modules_ready(clawdbot_root)?;
     } else {
       eprintln!(
         "[clawd/service] Skipping bundled node_modules extraction in signed app bundle: {}",
@@ -9726,7 +9909,17 @@ pub async fn set_service_enabled(
       // Extract node_modules.tar if present (Windows CI/release builds only).
       if let Some(clawdbot_root) = clawdbot_entry.parent().and_then(|p| p.parent()) {
         if should_mutate_bundled_clawdbot_runtime(clawdbot_root) {
-          ensure_node_modules_extracted(clawdbot_root);
+          if let Err(error) = ensure_gateway_node_modules_ready(clawdbot_root) {
+            eprintln!(
+              "[clawd/service] ERROR: Failed to prepare gateway node_modules: {}",
+              error
+            );
+            return HttpResponse::InternalServerError().json(EnableServiceResponse {
+              success: false,
+              enabled,
+              message: format!("Failed to prepare gateway runtime: {}", error),
+            });
+          }
         } else {
           eprintln!(
             "[clawd/service] Skipping bundled node_modules extraction in signed app bundle: {}",

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -137,6 +137,8 @@ export interface HomeProps {
   googleAuthControls: {
     showGoogleAuthPopup: boolean
     setShowGoogleAuthPopup: (show: boolean) => void
+    requiredGoogleConnectionKeys: ConnectionKeys[]
+    setRequiredGoogleConnectionKeys: (keys: ConnectionKeys[]) => void
   }
   handleAutomationPreview: (
     automation: Automation,
@@ -914,6 +916,7 @@ function App() {
     openNotificationWindow,
   } = useAutomations({
     userEmail,
+    connections,
     automationHelperFunctions: {
       submitWebSearch,
       stopLLMExecution,

--- a/src/src/api/connections.tsx
+++ b/src/src/api/connections.tsx
@@ -74,6 +74,18 @@ export const getGoogleGmailConnections = (
 export const hasGoogleCalendar = (connections: Record<string, Connection>): boolean =>
   getGoogleCalendarConnections(connections).length > 0
 
+/** True if at least one Google Gmail account is connected. */
+export const hasGoogleGmail = (connections: Record<string, Connection>): boolean =>
+  getGoogleGmailConnections(connections).length > 0
+
+/** True if a calendar-backed experience can run. */
+export const hasCalendarCapability = (connections: Record<string, Connection>): boolean =>
+  hasGoogleCalendar(connections) || !!connections[ConnectionKeys.MICROSOFT_CALENDAR]
+
+/** True if an email-backed experience can run. */
+export const hasEmailCapability = (connections: Record<string, Connection>): boolean =>
+  hasGoogleGmail(connections) || !!connections[ConnectionKeys.MICROSOFT_OUTLOOK]
+
 export const isConnectionReadyToSync = (connection?: Connection) => {
   return connection?.state && connection.state !== ConnectionStates.SYNCING
 }

--- a/src/src/components/organisms/EmailTabView/index.tsx
+++ b/src/src/components/organisms/EmailTabView/index.tsx
@@ -58,7 +58,7 @@ const EmailTabView = ({
   // If not logged in to email, show login prompt
   if (!feed.loggedEmailAutopilot) {
     return (
-      <div className="EmailTabView w-full h-full">
+      <div className="EmailTabView w-full h-full" data-testid="qa-email-autopilot-panel">
         <LoginWarningAutopilot
           onConnectAccountClick={(key: ConnectionKeys) => {
             feed.setEmailAutopilotStatus({ status: 'sync-email' })
@@ -72,7 +72,7 @@ const EmailTabView = ({
   }
 
   return (
-    <div className="EmailTabView w-full h-full overflow-hidden">
+    <div className="EmailTabView w-full h-full overflow-hidden" data-testid="qa-email-autopilot-panel">
       <div className="EmailTabView__header">
         <h1 className="EmailTabView__title">Email Autopilot</h1>
       </div>

--- a/src/src/components/organisms/GBrainView/index.tsx
+++ b/src/src/components/organisms/GBrainView/index.tsx
@@ -591,7 +591,7 @@ const GBrainView: React.FC<GBrainViewProps> = ({ feed, onOpenMeeting, onOpenWork
   ]
 
   return (
-    <div className="flex flex-col h-full bg-white">
+    <div className="flex flex-col h-full bg-white" data-testid="qa-gbrain-panel">
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100 flex-shrink-0">
         <div className="flex flex-col min-w-0">

--- a/src/src/components/organisms/GoogleAuthPopUp/index.tsx
+++ b/src/src/components/organisms/GoogleAuthPopUp/index.tsx
@@ -13,12 +13,14 @@ const googlePermissions: Record<string, boolean> = {
 interface GoogleAuthPopupProps {
   onClose: () => void;
   onAuth: () => Promise<void>;
+  requiredConnectionKeys?: ConnectionKeys[];
   userEmail: string;
 }
 
 const GoogleAuthPopup: React.FC<GoogleAuthPopupProps> = ({
     onClose,
     onAuth,
+    requiredConnectionKeys = [ConnectionKeys.GOOGLE_PROFILE],
     userEmail,
   }) => {
     const [authError, setAuthError] = useState<string | null>(null);
@@ -30,7 +32,7 @@ const GoogleAuthPopup: React.FC<GoogleAuthPopupProps> = ({
         if (!isActive) return;
 
         try {
-          await getAccessToken(userEmail, ConnectionKeys.GOOGLE_PROFILE);
+          await Promise.all(requiredConnectionKeys.map(key => getAccessToken(userEmail, key)));
           if (isActive) {
             await onAuth();
             onClose();
@@ -48,23 +50,24 @@ const GoogleAuthPopup: React.FC<GoogleAuthPopupProps> = ({
         isActive = false;
         clearInterval(interval);
       };
-    }, [userEmail, onAuth, onClose]);
+    }, [requiredConnectionKeys, userEmail, onAuth, onClose]);
 
   const handleAuth = async () => {
     setAuthError(null);
     try {
-      await getAccessToken(userEmail, ConnectionKeys.GOOGLE_PROFILE);
+      await Promise.all(requiredConnectionKeys.map(key => getAccessToken(userEmail, key)));
       onAuth();
       onClose();
     } catch {
-      let scopes: string[] = [];
-      for (const [key, googlePermission] of Object.entries(googlePermissions)) {
-        if (googlePermission) {
-          scopes = [...scopes, ...googleConnections[key].scopes];
+      const scopedKeys = requiredConnectionKeys.length > 0 ? requiredConnectionKeys : [ConnectionKeys.GOOGLE_PROFILE]
+      let scopes: string[] = []
+      for (const key of scopedKeys) {
+        if (googlePermissions[key]) {
+          scopes = [...scopes, ...googleConnections[key].scopes]
         }
       }
       try {
-        openGoogleAuthScreen(scopes.join(' '));
+        openGoogleAuthScreen([...new Set(scopes)].join(' '));
       } catch (error) {
         if (error instanceof GoogleAuthError) {
           setAuthError(error.message);

--- a/src/src/components/organisms/MeetingsTabView/index.tsx
+++ b/src/src/components/organisms/MeetingsTabView/index.tsx
@@ -4,9 +4,8 @@ import { invoke } from '@tauri-apps/api/tauri'
 import { IThread, ThreadType } from 'src/api/threads'
 import {
   Connection,
-  ConnectionKeys,
-  getGoogleGmailConnections,
-  hasGoogleCalendar,
+  hasCalendarCapability,
+  hasEmailCapability,
 } from 'src/api/connections'
 import { LLMParams } from 'src/App'
 import { IFeed } from 'src/hooks/feed/useFeed'
@@ -342,7 +341,7 @@ const MeetingsTabView = ({
                   </button>
                 </div>
                 {/* Calendar connection prompt */}
-                {connections && !hasGoogleCalendar(connections) && !connections[ConnectionKeys.MICROSOFT_CALENDAR] && onConnectCalendar && (
+                {connections && !hasCalendarCapability(connections) && onConnectCalendar && (
                   <div className="MeetingsTabView__calendar-prompt MeetingsTabView__calendar-prompt--notetaker">
                     <div className="MeetingsTabView__calendar-prompt-content">
                       <img src={CalendarIcon} alt="Calendar" className="MeetingsTabView__calendar-prompt-icon" />
@@ -393,11 +392,7 @@ const MeetingsTabView = ({
                       handleOpenInsights={handleOpenInsights}
                       onEmailClick={onEmailClick}
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
-                      hasEmailContext={
-                        !!connections &&
-                        (getGoogleGmailConnections(connections).length > 0 ||
-                          !!connections[ConnectionKeys.MICROSOFT_OUTLOOK])
-                      }
+                      hasEmailContext={!!connections && hasEmailCapability(connections)}
                       onConnectEmail={onConnectEmail}
                       userEmail={userEmail}
                       userName={userName}

--- a/src/src/components/organisms/NotetakerSidebar/index.tsx
+++ b/src/src/components/organisms/NotetakerSidebar/index.tsx
@@ -6,7 +6,7 @@ import { IFeed, STATIONARY_ITEMS } from 'src/hooks/feed/useFeed'
 import KNDateUtils from 'src/utils/KNDateUtils'
 import { ThreadType } from 'src/api/threads'
 import { getAppVersion } from 'src/utils/app'
-import { Connection, ConnectionKeys, hasGoogleCalendar } from 'src/api/connections'
+import { Connection, hasCalendarCapability } from 'src/api/connections'
 import { TabChoices } from 'src/components/TabBar'
 import { listWorkspaces, Workspace } from 'src/api/workspaces'
 import { RecordingContextProps } from 'src/components/organisms/MeetingNotesMode/RecordingContext'
@@ -70,10 +70,7 @@ function NotetakerSidebar({
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
-  const hasCalendarConnected = useMemo(
-    () => !!(hasGoogleCalendar(connections) || connections[ConnectionKeys.MICROSOFT_CALENDAR]),
-    [connections],
-  )
+  const hasCalendarConnected = useMemo(() => hasCalendarCapability(connections), [connections])
 
   useEffect(() => {
     if (!searchQuery.trim()) {
@@ -745,6 +742,7 @@ function NotetakerSidebar({
             className={`notetaker-sidebar__bottom-action ${isEmailActive ? 'notetaker-sidebar__bottom-action--active' : ''}`}
             onClick={() => onTabChange(TabChoices.Email)}
             title="Email Autopilot"
+            data-testid="qa-nav-email-autopilot"
           >
             {emailIcon}
             <span>Email</span>
@@ -753,6 +751,7 @@ function NotetakerSidebar({
             className={`notetaker-sidebar__bottom-action ${isGBrainActive ? 'notetaker-sidebar__bottom-action--active' : ''}`}
             onClick={() => onTabChange(TabChoices.GBrain)}
             title="GBrain"
+            data-testid="qa-nav-gbrain"
           >
             {gbrainIcon}
             <span>GBrain</span>

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -268,10 +268,7 @@ function Home({
   )
 
   const handleGoogleMenuItemClick = (connectionKeys: ConnectionKeys[]) => {
-    const scopes = [
-      ...googleConnections[ConnectionKeys.GOOGLE_PROFILE].scopes,
-      ...connectionKeys.map(key => googleConnections[key].scopes),
-    ].join(' ')
+    const scopes = [...new Set(connectionKeys.flatMap(key => googleConnections[key].scopes))].join(' ')
     openGoogleAuthScreen(scopes)
   }
 
@@ -388,9 +385,13 @@ function Home({
     <div className="KNMainContainer">
       {googleAuthControls.showGoogleAuthPopup && (
         <GoogleAuthPopup
-          onClose={() => googleAuthControls.setShowGoogleAuthPopup(false)}
+          onClose={() => {
+            googleAuthControls.setShowGoogleAuthPopup(false)
+            googleAuthControls.setRequiredGoogleConnectionKeys([])
+          }}
           onAuth={async () => {
             googleAuthControls.setShowGoogleAuthPopup(false)
+            googleAuthControls.setRequiredGoogleConnectionKeys([])
             // if (googleAuthControls.currentAutomation && googleAuthControls.currentFeedItem) {
             //   feed.handleCustomFeedAutomation(
             //     googleAuthControls.currentAutomation,
@@ -398,6 +399,7 @@ function Home({
             //   )
             // }
           }}
+          requiredConnectionKeys={googleAuthControls.requiredGoogleConnectionKeys}
           userEmail={userEmail}
         />
       )}

--- a/src/src/hooks/automation/useAutomations.tsx
+++ b/src/src/hooks/automation/useAutomations.tsx
@@ -8,10 +8,22 @@ import {
   scheduleRuns,
   updateAutomationAPI,
 } from 'src/api/automations'
-import { ConnectionKeys, getAccessToken } from 'src/api/connections'
+import {
+  Connection,
+  ConnectionKeys,
+  getAccessToken,
+  getGoogleCalendarConnections,
+  getGoogleDriveConnections,
+  getGoogleGmailConnections,
+} from 'src/api/connections'
 import { FeedItem } from 'src/api/feed_items'
 import { CreateAutomationProps, LLMParams, WebSearchResponse } from 'src/App'
-import { Automation, AutomationRun, AutomationTrigger } from 'src/automations/automation'
+import {
+  Automation,
+  AutomationRun,
+  AutomationTrigger,
+  convertAutomationDataSourceToConnectionKey,
+} from 'src/automations/automation'
 import { StepExecuteContext } from 'src/automations/steps/Base'
 import { IFeed } from 'src/hooks/feed/useFeed'
 import DataFetcher from 'src/utils/data_fetch'
@@ -25,12 +37,56 @@ import { ButtonConfig } from 'src/components/molecules/MeetingNotification'
 import { listen } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/tauri'
 
-const checkAuth = async (userEmail: string) => {
-  try {
-    await getAccessToken(userEmail, ConnectionKeys.GOOGLE_PROFILE)
-  } catch (error) {
-    throw error
+const hasRequiredConnection = (
+  connections: Record<string, Connection>,
+  connectionKey: ConnectionKeys,
+) => {
+  switch (connectionKey) {
+    case ConnectionKeys.GOOGLE_CALENDAR:
+      return getGoogleCalendarConnections(connections).length > 0
+    case ConnectionKeys.GOOGLE_DRIVE:
+      return getGoogleDriveConnections(connections).length > 0
+    case ConnectionKeys.GOOGLE_GMAIL:
+      return getGoogleGmailConnections(connections).length > 0
+    default:
+      return !!connections[connectionKey]
   }
+}
+
+const isGoogleConnectionKey = (
+  key: ConnectionKeys | undefined,
+): key is
+  | ConnectionKeys.GOOGLE_CALENDAR
+  | ConnectionKeys.GOOGLE_DRIVE
+  | ConnectionKeys.GOOGLE_GMAIL =>
+  key === ConnectionKeys.GOOGLE_CALENDAR ||
+  key === ConnectionKeys.GOOGLE_DRIVE ||
+  key === ConnectionKeys.GOOGLE_GMAIL
+
+const getAutomationGoogleConnectionKeys = (automation: Automation): ConnectionKeys[] =>
+  automation
+    .getDataSources()
+    .map(source => convertAutomationDataSourceToConnectionKey(source))
+    .filter(isGoogleConnectionKey)
+
+const checkAutomationAuth = async (
+  userEmail: string,
+  automation: Automation,
+  connections: Record<string, Connection>,
+) => {
+  const requiredGoogleKeys = getAutomationGoogleConnectionKeys(automation)
+
+  for (const key of requiredGoogleKeys) {
+    if (!hasRequiredConnection(connections, key)) {
+      return { needsAuth: true, requiredGoogleKeys }
+    }
+  }
+
+  for (const key of requiredGoogleKeys) {
+    await getAccessToken(userEmail, key)
+  }
+
+  return { needsAuth: false, requiredGoogleKeys }
 }
 
 type AutomationHelperFunctions = {
@@ -62,6 +118,7 @@ export type HandleAutomationCallArgs = {
 
 type UseAutomationProps = {
   userEmail: string
+  connections: Record<string, Connection>
   feed?: IFeed
   automationHelperFunctions: AutomationHelperFunctions
 }
@@ -82,6 +139,8 @@ type NotificationService = {
 export interface IGoogleAuthControls {
   showGoogleAuthPopup: boolean
   setShowGoogleAuthPopup: (show: boolean) => void
+  requiredGoogleConnectionKeys: ConnectionKeys[]
+  setRequiredGoogleConnectionKeys: (keys: ConnectionKeys[]) => void
   currentAutomation: string | undefined
   setCurrentAutomation: (automation: string | undefined) => void
   currentFeedItem: FeedItem | undefined
@@ -108,10 +167,12 @@ export type HandleAutomationArgs = {
 
 export function useAutomations({
   userEmail,
+  connections,
   automationHelperFunctions: { submitWebSearch, stopLLMExecution, handleError, addToLLMQueue },
 }: UseAutomationProps) {
   const [automations, setAutomations] = useState<Record<number, Automation>>({})
   const [showGoogleAuthPopup, setShowGoogleAuthPopup] = useState(false)
+  const [requiredGoogleConnectionKeys, setRequiredGoogleConnectionKeys] = useState<ConnectionKeys[]>([])
   const [currentAutomation, setCurrentAutomation] = useState<string>()
   const [currentFeedItem, setCurrentFeedItem] = useState<FeedItem>()
   const [notificationServices, setNotificationServices] = useState<NotificationService[]>([
@@ -226,10 +287,17 @@ export function useAutomations({
       }
       setCurrentFeedItem(args.args?.feedItem)
       try {
-        await checkAuth(userEmail)
+        const authState = await checkAutomationAuth(userEmail, args.automation, connections)
+        if (authState.needsAuth) {
+          setCurrentAutomation(args.automation.getName())
+          setRequiredGoogleConnectionKeys(authState.requiredGoogleKeys)
+          setShowGoogleAuthPopup(authState.requiredGoogleKeys.length > 0)
+          return true
+        }
       } catch {
         setCurrentAutomation(args.automation.getName())
-        // setShowGoogleAuthPopup(true)
+        setRequiredGoogleConnectionKeys(getAutomationGoogleConnectionKeys(args.automation))
+        setShowGoogleAuthPopup(true)
         return true
       }
 
@@ -316,7 +384,7 @@ export function useAutomations({
         return false
       }
     },
-    [userEmail, dataFetcher, handleAutomationError, handleChatbotAutomationRun, submitWebSearch],
+    [userEmail, connections, dataFetcher, handleAutomationError, handleChatbotAutomationRun, submitWebSearch, showGoogleAuthPopup],
   )
 
   const handleAutomationPreview = useCallback(
@@ -553,6 +621,8 @@ export function useAutomations({
   const googleAuthControls: IGoogleAuthControls = {
     showGoogleAuthPopup,
     setShowGoogleAuthPopup,
+    requiredGoogleConnectionKeys,
+    setRequiredGoogleConnectionKeys,
     currentAutomation,
     setCurrentAutomation,
     currentFeedItem,

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -1,7 +1,12 @@
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { insertAutomationRun } from 'src/api/automations'
-import { Connection, ConnectionKeys, ConnectionStates, getGoogleGmailConnections } from 'src/api/connections'
+import {
+  Connection,
+  ConnectionKeys,
+  ConnectionStates,
+  hasEmailCapability,
+} from 'src/api/connections'
 import { getEmailThread } from 'src/api/data_source'
 import {
   deleteFeedItem,
@@ -2046,7 +2051,7 @@ export function useFeed(
   }, [feedContent])
 
   const loggedEmailAutopilot = useMemo(() => {
-    return getGoogleGmailConnections(connections).length > 0 || !!connections[ConnectionKeys.MICROSOFT_OUTLOOK]
+    return hasEmailCapability(connections)
   }, [connections])
 
   const [composedEmailDraft, setComposedEmailDraft] = useState<ComposedEmailDraft | null>(null)


### PR DESCRIPTION
﻿## Summary
- keep a startup-critical Windows `node_modules` subset extracted beside `node_modules.tar`, with the full dependency extraction deferred after launch
- gate gateway startup on critical dependency readiness and serialize tar extraction so first launch does not race gateway imports
- harden QA loop chat/startup checks and add rendered UI smoke coverage for chat input, Email Autopilot, and GBrain
- improve provider/model smoke handling so QA chat returns quickly or reports a clear error

## QA evidence
- `node scripts/verify-clawdbot-bundle.cjs` ✅
- `node scripts/load-env-and-run.cjs cargo check --manifest-path src-tauri/Cargo.toml` ✅
- `node scripts/load-env-and-run.cjs cargo build --release --manifest-path src-tauri/Cargo.toml` ✅
- subset+tar first-launch prod QA: active+stable in 25.642s on attempt 1; chat, mock meeting, and interface checks passed ✅
- rendered UI smoke from subset+tar candidate: chat typing, Email Autopilot, and GBrain rendered ✅

## Notes
- channel transport status is still only proven for the current local config, where no channel transports are enabled/configured for strict live checks
- generated QA logs, release artifacts, and release-signing workflow edits were intentionally left out of this PR
