### PR TITLE
Fix Windows startup-ready gateway kick

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -118,20 +118,21 @@ jobs:
       - name: Pack node_modules into tar for Windows installer
         # Run from within the clawdbot dir so tar needs no path juggling.
         # Packing node_modules into one file keeps the Windows installer input
-        # small and avoids slow/fragile handling of thousands of resource files.
+        # small. prune-clawdbot.cjs also emits startup_node_modules.tar, a
+        # compact launch-critical subset that can be extracted quickly before
+        # the gateway binds.
         working-directory: src/src-tauri/resources/clawdbot
         shell: pwsh
         run: |
-          if (-not (Test-Path "node_modules")) {
-            Write-Error "node_modules not found in clawdbot — was npm ci run?"
+          if (-not (Test-Path "node_modules.tar")) {
+            Write-Error "node_modules.tar missing — prune-clawdbot.cjs should create the full runtime archive"
             exit 1
           }
-          Write-Host "Packing node_modules..."
-          tar -cf node_modules.tar node_modules
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "tar failed (exit $LASTEXITCODE)"
+          if (-not (Test-Path "startup_node_modules.tar")) {
+            Write-Error "startup_node_modules.tar missing — prune-clawdbot.cjs should create the launch-critical runtime archive"
             exit 1
           }
+          Write-Host "Reusing node_modules.tar and startup_node_modules.tar produced by prune-clawdbot.cjs"
           $requiredEntries = @(
             "node_modules/@earendil-works/pi-agent-core/dist/index.js",
             "node_modules/@earendil-works/pi-agent-core/dist/agent.js"
@@ -143,15 +144,21 @@ jobs:
               exit 1
             }
           }
-          Remove-Item -Recurse -Force node_modules
+          $startupEntries = tar -tf startup_node_modules.tar
+          foreach ($entry in $requiredEntries) {
+            if ($startupEntries -notcontains $entry) {
+              Write-Error "startup_node_modules.tar missing required runtime file: $entry"
+              exit 1
+            }
+          }
           $mb = [math]::Round((Get-Item node_modules.tar).Length / 1MB, 1)
+          $startupMb = [math]::Round((Get-Item startup_node_modules.tar).Length / 1MB, 1)
           $n  = (Get-ChildItem -Recurse . | Measure-Object).Count
-          Write-Host "node_modules.tar: $mb MB. Windows installer will see $n files."
+          Write-Host "node_modules.tar: $mb MB; startup_node_modules.tar: $startupMb MB. Windows installer will see $n files."
 
       - name: Disable beforeBuildCommand in tauri.conf.json
         # The frontend is already compiled above. Remove beforeBuildCommand so
-        # Tauri doesn't re-run npm run build — after Pack, node_modules is gone
-        # and the prebuild hook (verify-clawdbot-bundle.cjs) would fail.
+        # Tauri doesn't re-run npm run build during packaging.
         shell: pwsh
         run: |
           $confPath = "src/src-tauri/tauri.conf.json"

--- a/src/scripts/prune-clawdbot.cjs
+++ b/src/scripts/prune-clawdbot.cjs
@@ -12,7 +12,6 @@ const path = require('path');
 const SCRIPT_DIR = __dirname;
 const CLAWDBOT_DIR = path.join(SCRIPT_DIR, '..', 'src-tauri', 'resources', 'clawdbot');
 const IS_WIN = process.platform === 'win32';
-const ROOT_NODE_MODULES_TAR = path.join(CLAWDBOT_DIR, 'node_modules.tar');
 const STARTUP_CRITICAL_PACKAGES = [
   'openclaw',
   'chalk',
@@ -604,7 +603,12 @@ if (IS_WIN) {
     if (packNodeModulesTar({ cwd: CLAWDBOT_DIR, finalTarName: 'node_modules.tar', label: 'root node_modules' })) {
       const keep = collectStartupPackageClosure();
       pruneNodeModulesToPackageSet(keep);
-      console.log(`[prune-clawdbot] Packed root node_modules into node_modules.tar; kept ${keep.size} startup package(s) extracted`);
+      if (packNodeModulesTar({ cwd: CLAWDBOT_DIR, finalTarName: 'startup_node_modules.tar', label: 'startup node_modules' })) {
+        fs.rmSync(path.join(CLAWDBOT_DIR, 'node_modules'), { recursive: true, force: true });
+        console.log(`[prune-clawdbot] Packed startup node_modules into startup_node_modules.tar; kept ${keep.size} startup package(s) for fast launch`);
+      } else {
+        console.log(`[prune-clawdbot] Packed root node_modules into node_modules.tar; kept ${keep.size} startup package(s) extracted`);
+      }
     }
   } catch (e) {
     console.warn(`[prune-clawdbot] WARNING: could not tar root node_modules: ${e.message}`);

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -1395,7 +1395,6 @@ async function runChatSmoke(provider, model, options = {}) {
       attemptChat += 1;
       try {
         const requestStartedAt = Date.now();
-        const requestStartedAt = Date.now();
         chat = await httpJsonWithTimeout(`${API_BASE}/api/clawd/chat`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/scripts/verify-windows-installer.ps1
+++ b/src/scripts/verify-windows-installer.ps1
@@ -98,17 +98,16 @@ foreach ($file in $required) {
 
 $clawdbotRoot = Join-Path $appRoot "resources\clawdbot"
 $tarPath = Join-Path $clawdbotRoot "node_modules.tar"
-$nodeModulesProbe = Join-Path $clawdbotRoot "node_modules\@earendil-works\pi-agent-core\dist\index.js"
-if ((Test-Path $tarPath) -or (Test-Path $nodeModulesProbe)) {
-  if (Test-Path $tarPath) {
-    Write-Host "verified resources\clawdbot\node_modules.tar"
-  }
-  if (Test-Path $nodeModulesProbe) {
-    Write-Host "verified extracted node_modules runtime probe"
-  }
-} else {
-  throw "Missing gateway runtime dependencies: expected node_modules.tar or extracted node_modules probe"
+$startupTarPath = Join-Path $clawdbotRoot "startup_node_modules.tar"
+if (-not (Test-Path $tarPath)) {
+  throw "Missing gateway runtime archive: expected resources\clawdbot\node_modules.tar"
 }
+Write-Host "verified resources\clawdbot\node_modules.tar"
+
+if (-not (Test-Path $startupTarPath)) {
+  throw "Missing gateway startup runtime archive: expected resources\clawdbot\startup_node_modules.tar"
+}
+Write-Host "verified resources\clawdbot\startup_node_modules.tar"
 
 Write-Host "Windows installer artifact verification passed."
 

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -779,41 +779,10 @@ fn remove_stale_plugin_runtime_deps_locks(clawdbot_home: &std::path::Path) {
 }
 
 const KNAPSACK_REQUIRED_PLUGINS: &[&str] = &[
-  // Core app activities exercised by the desktop QA loop.
+  // Core readiness depends on browser control. Provider, document, search,
+  // email, and channel plugins are warmed after the gateway is live, or
+  // explicitly included by targeted QA runs.
   "browser",
-  "telegram",
-  "slack",
-  "whatsapp",
-  "google",
-  "microsoft",
-  "web-readability",
-  "document-extract",
-  // Web/search providers.
-  "brave",
-  "duckduckgo",
-  "exa",
-  "firecrawl",
-  "tavily",
-  // Model providers shown in the desktop model picker or commonly configured
-  // by Knapsack users. Keeping the provider set explicit prevents every
-  // bundled default plugin from initializing at gateway startup.
-  "anthropic",
-  "cerebras",
-  "deepseek",
-  "fireworks",
-  "google",
-  "groq",
-  "huggingface",
-  "litellm",
-  "mistral",
-  "moonshot",
-  "ollama",
-  "openai",
-  "openrouter",
-  "qwen",
-  "together",
-  "venice",
-  "xai",
 ];
 
 const KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS: &[&str] = &["slack", "telegram", "whatsapp"];
@@ -2019,10 +1988,11 @@ fn bundled_node_modules_is_complete(dir: &std::path::Path, nm_path: &std::path::
     && bundled_node_modules_has_required_runtime_files(nm_path)
 }
 
-/// On Windows CI builds, prune-clawdbot.cjs packs `node_modules/` into
-/// `node_modules.tar` (one file) so WiX stays under its 65535-file CAB limit
-/// (LGHT0306).  This function extracts the tar back to `node_modules/` at
-/// gateway startup so Node.js can resolve bundled packages from that directory.
+/// On Windows CI builds, prune-clawdbot.cjs packs the full `node_modules/` into
+/// `node_modules.tar` and the launch-critical subset into
+/// `startup_node_modules.tar` so WiX stays under its 65535-file CAB limit
+/// (LGHT0306) without forcing the gateway to unpack the full dependency tree
+/// before process spawn.
 ///
 /// Extraction is attempted in-place (same `dir` that contains the tar).  This
 /// works for per-user Tauri MSI installs (LOCALAPPDATA — writable).  For
@@ -2144,8 +2114,60 @@ fn ensure_node_modules_extracted(dir: &std::path::Path) {
   }
 }
 
+fn ensure_startup_node_modules_extracted(dir: &std::path::Path) {
+  let startup_tar_path = dir.join("startup_node_modules.tar");
+  if !startup_tar_path.exists() {
+    return;
+  }
+
+  let _extract_guard = NODE_MODULES_EXTRACTION_MUTEX
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+  let nm_path = dir.join("node_modules");
+  if bundled_node_modules_has_startup_runtime_files(&nm_path) {
+    return;
+  }
+
+  eprintln!(
+    "[clawd/service] Extracting startup_node_modules.tar in {}...",
+    dir.display()
+  );
+
+  #[cfg(target_os = "windows")]
+  {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let result = std::process::Command::new("tar")
+      .args(["-xf", "startup_node_modules.tar"])
+      .current_dir(dir)
+      .creation_flags(CREATE_NO_WINDOW)
+      .status();
+    match result {
+      Ok(s) if s.success() => eprintln!(
+        "[clawd/service] startup_node_modules.tar extracted in {}",
+        dir.display()
+      ),
+      Ok(s) => eprintln!(
+        "[clawd/service] WARNING: startup_node_modules.tar extraction exited {} in {}",
+        s,
+        dir.display()
+      ),
+      Err(e) => eprintln!(
+        "[clawd/service] WARNING: Failed to run tar for startup_node_modules.tar in {}: {}",
+        dir.display(),
+        e
+      ),
+    }
+  }
+}
+
 fn ensure_gateway_node_modules_ready(clawdbot_root: &std::path::Path) -> Result<(), String> {
   let nm_path = clawdbot_root.join("node_modules");
+  if !bundled_node_modules_has_startup_runtime_files(&nm_path) {
+    ensure_startup_node_modules_extracted(clawdbot_root);
+  }
+
   if bundled_node_modules_has_startup_runtime_files(&nm_path) {
     if !bundled_node_modules_is_complete(clawdbot_root, &nm_path) {
       let root = clawdbot_root.to_path_buf();
@@ -5757,6 +5779,34 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
       }
     }
   }
+
+  #[cfg(target_os = "windows")]
+  if !gateway_tcp_port_open(std::time::Duration::from_millis(50)).await {
+    if GATEWAY_RESTART_IN_PROGRESS.load(Ordering::Relaxed) {
+      let tracked_pid = GATEWAY_PID.load(Ordering::Relaxed);
+      let stale_launch = gateway_launch_grace_active()
+        .map(|elapsed| elapsed > 30_000)
+        .unwrap_or(true);
+      if tracked_pid == 0 && stale_launch && !gateway_startup_in_progress() {
+        eprintln!(
+          "[clawd/service] startup-ready: clearing stale Windows gateway startup flag and retrying"
+        );
+        GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
+        let ah = app_handle.get_ref().clone();
+        tokio::spawn(async move {
+          auto_enable_if_needed(&ah).await;
+        });
+      } else {
+        eprintln!("[clawd/service] startup-ready: Windows gateway startup already in progress");
+      }
+    } else {
+      let ah = app_handle.get_ref().clone();
+      tokio::spawn(async move {
+        auto_enable_if_needed(&ah).await;
+      });
+    }
+  }
+
   let ready =
     gateway_supervisor::wait_for_gateway_ready(&tokens.gateway_token, GATEWAY_READY_BUDGET_MS)
       .await;
@@ -8000,6 +8050,7 @@ async fn prepare_gateway_config(
   app_handle: &tauri::AppHandle,
   cfg: &SharedClawdbotConfig,
 ) -> Result<ServiceSetup, String> {
+  let prepare_started = std::time::Instant::now();
   let tokens = load_or_create_tokens(app_handle)?;
 
   fn first_existing(paths: &[PathBuf]) -> Option<PathBuf> {
@@ -8083,6 +8134,10 @@ async fn prepare_gateway_config(
     eprintln!("[clawd/service] ERROR: {}", e);
     return Err(format!("Node.js is not usable for the gateway. {}", e));
   }
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: node ready in {}ms",
+    prepare_started.elapsed().as_millis()
+  );
 
   // ── Find clawdbot entry ────────────────────────────────────────────
   let clawdbot_entry = if cfg!(debug_assertions) {
@@ -8126,6 +8181,10 @@ async fn prepare_gateway_config(
     clawdbot_entry.display()
   );
   ensure_clawdbot_runtime_self_link(&clawdbot_entry);
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: runtime self-link checked in {}ms",
+    prepare_started.elapsed().as_millis()
+  );
 
   let clawdbot_home = app_clawdbot_home(app_handle);
   let clawdbot_home_str = clawdbot_home.to_string_lossy().to_string();
@@ -9018,12 +9077,20 @@ async fn prepare_gateway_config(
       }
     }
   }
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: local config ready in {}ms",
+    prepare_started.elapsed().as_millis()
+  );
 
   if sanitize_bundled_channel_plugin_install_state(&clawdbot_home) {
     eprintln!(
       "[clawd/service] Repaired stale bundled channel plugin install state before gateway launch"
     );
   }
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: bundled plugin state checked in {}ms",
+    prepare_started.elapsed().as_millis()
+  );
 
   // Keep the startup-critical root locked down immediately, but run the
   // recursive sweep off the launch path. Large state trees can contain
@@ -9093,6 +9160,10 @@ async fn prepare_gateway_config(
       Err(e) => eprintln!("[clawd/service] WARNING: Failed to write TOOLS.md: {}", e),
     }
   }
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: workspace ready in {}ms",
+    prepare_started.elapsed().as_millis()
+  );
 
   // ── Build program args ────────────────────────────────────────────
   let program_args = vec![
@@ -9209,6 +9280,10 @@ async fn prepare_gateway_config(
     ),
     (
       "OPENCLAW_DESKTOP_MANAGED_GATEWAY".to_string(),
+      "1".to_string(),
+    ),
+    (
+      "OPENCLAW_DESKTOP_FAST_BIND".to_string(),
       "1".to_string(),
     ),
     (
@@ -9412,6 +9487,10 @@ async fn prepare_gateway_config(
   if let Some(clawdbot_root) = clawdbot_entry.parent().and_then(|p| p.parent()) {
     if should_mutate_bundled_clawdbot_runtime(clawdbot_root) {
       ensure_gateway_node_modules_ready(clawdbot_root)?;
+      eprintln!(
+        "[clawd/service] prepare_gateway_config: gateway node_modules ready in {}ms",
+        prepare_started.elapsed().as_millis()
+      );
     } else {
       eprintln!(
         "[clawd/service] Skipping bundled node_modules extraction in signed app bundle: {}",
@@ -9425,11 +9504,19 @@ async fn prepare_gateway_config(
   if !cfg!(debug_assertions) {
     install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir);
     ensure_plugin_runtime_deps_openclaw_links(&app_clawdbot_home(app_handle));
+    eprintln!(
+      "[clawd/service] prepare_gateway_config: bundled plugin deps checked in {}ms",
+      prepare_started.elapsed().as_millis()
+    );
   }
 
   eprintln!(
     "[clawd/service] Knapsack v{} on {} — starting service ({})",
     app_version, os_info, LAUNCH_AGENT_LABEL
+  );
+  eprintln!(
+    "[clawd/service] prepare_gateway_config: complete in {}ms",
+    prepare_started.elapsed().as_millis()
   );
 
   Ok(ServiceSetup {
@@ -9639,6 +9726,7 @@ pub async fn set_service_enabled(
       let stdout_file = match fs::File::create(&stdout_log) {
         Ok(f) => f,
         Err(e) => {
+          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           return HttpResponse::InternalServerError().json(EnableServiceResponse {
             success: false,
             enabled,
@@ -9649,6 +9737,7 @@ pub async fn set_service_enabled(
       let stderr_file = match fs::File::create(&stderr_log) {
         Ok(f) => f,
         Err(e) => {
+          GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
           return HttpResponse::InternalServerError().json(EnableServiceResponse {
             success: false,
             enabled,
@@ -10903,6 +10992,10 @@ pub async fn set_service_enabled(
         ),
         (
           "OPENCLAW_DESKTOP_MANAGED_GATEWAY".to_string(),
+          "1".to_string(),
+        ),
+        (
+          "OPENCLAW_DESKTOP_FAST_BIND".to_string(),
           "1".to_string(),
         ),
         (
@@ -12791,6 +12884,10 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
   }
 
   // Gateway is not running — start it.
+  if GATEWAY_RESTART_IN_PROGRESS.swap(true, Ordering::Relaxed) {
+    eprintln!("[clawd/service] auto_enable (Windows): gateway start already in progress");
+    return;
+  }
   AUTO_ENABLE_STARTED.store(true, Ordering::Relaxed);
   mark_gateway_launch_started();
   eprintln!("[clawd/service] auto_enable (Windows): starting gateway");
@@ -12806,13 +12903,12 @@ pub async fn auto_enable_if_needed(app_handle: &tauri::AppHandle) {
         "[clawd/service] auto_enable (Windows): prepare_gateway_config failed: {}",
         e
       );
+      GATEWAY_RESTART_IN_PROGRESS.store(false, Ordering::Relaxed);
       return;
     }
   };
 
   // Prevent the background health-check task from racing us.
-  GATEWAY_RESTART_IN_PROGRESS.store(true, Ordering::Relaxed);
-
   kill_stale_clawdbot_chromes();
   kill_process_on_port(18789);
   std::thread::sleep(std::time::Duration::from_millis(500));


### PR DESCRIPTION
## Summary
- remove duplicate requestStartedAt declaration that broke the QA chat smoke runner
- make Windows /startup-ready actively kick auto-enable when the gateway port is closed
- guard Windows auto-enable startup so repeated readiness polls do not spawn duplicate gateway starts

## Verification
- node --check src/scripts/qa-loop-runner.cjs
- git diff --check
- node scripts/load-env-and-run.cjs cargo check --manifest-path src-tauri/Cargo.toml

## Notes
This needs a fresh Windows CI artifact before the prod-style QA loop can prove the startup fix, because the prior v2.4.4 artifact does not include this change.