### PR TITLE
Stabilize gateway, browser, and channel QA startup

### DIFF
--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -19,12 +19,14 @@
  */
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { execSync } = require('child_process');
 
 // Source (checked-in) clawdbot dir
 const SOURCE_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources', 'clawdbot');
 // Tauri dev target dir — only present during/after `tauri dev`
 const TARGET_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'target', 'debug', 'resources', 'clawdbot');
+const FORCE_EXTENSION_LOCAL_DEPS = new Set(['slack', 'telegram', 'whatsapp']);
 
 function runNpmInstall(cwd, label) {
   // Prefer `npm ci` when a lockfile is present — it does a clean install from the
@@ -37,6 +39,39 @@ function runNpmInstall(cwd, label) {
     : 'npm install --omit=dev --ignore-scripts --no-audit --no-fund';
   console.log(`[ensure-clawdbot-deps] ${hasLockfile ? 'npm ci' : 'npm install'} in ${label}...`);
   execSync(cmd, { cwd, stdio: 'inherit' });
+}
+
+function runtimeDependencySpecs(pkg) {
+  return Object.entries(pkg.dependencies || {})
+    .filter(([, version]) => typeof version === 'string'
+      && !version.startsWith('file:')
+      && !version.startsWith('link:')
+      && !version.startsWith('workspace:')
+      && !version.startsWith('portal:'))
+    .map(([dep, version]) => `${dep}@${version}`);
+}
+
+function runPluginRuntimeDepsInstall(cwd, label, specs) {
+  if (!specs.length) return;
+  const quotedSpecs = specs.map((spec) => JSON.stringify(spec)).join(' ');
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'knapsack-plugin-deps-'));
+  const cmd = `npm install ${quotedSpecs} --no-save --omit=dev --ignore-scripts --no-audit --no-fund`;
+  console.log(`[ensure-clawdbot-deps] npm install targeted runtime deps for ${label}: ${specs.join(', ')}`);
+  try {
+    execSync(cmd, { cwd: stagingDir, stdio: 'inherit' });
+    const sourceNm = path.join(stagingDir, 'node_modules');
+    const targetNm = path.join(cwd, 'node_modules');
+    fs.mkdirSync(targetNm, { recursive: true });
+    for (const entry of fs.readdirSync(sourceNm)) {
+      fs.cpSync(path.join(sourceNm, entry), path.join(targetNm, entry), {
+        recursive: true,
+        force: true,
+        verbatimSymlinks: true,
+      });
+    }
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
 }
 
 function needsMainInstall(clawdbotDir) {
@@ -82,7 +117,9 @@ function findPluginsNeedingRuntimeDeps(clawdbotDir) {
       const pluginDeps = Object.keys(pkg.dependencies || {});
       // Prefer the root bundle's node_modules. This avoids extension-local
       // installs for upstream package.json files that contain workspace: deps.
-      if (pluginDeps.length > 0 && pluginDeps.every(dep => fs.existsSync(path.join(rootNodeModules, dep)))) {
+      if (!FORCE_EXTENSION_LOCAL_DEPS.has(entry.name)
+        && pluginDeps.length > 0
+        && pluginDeps.every(dep => fs.existsSync(path.join(rootNodeModules, dep)))) {
         continue;
       }
       // Skip if the plugin's own node_modules already has all deps.
@@ -91,7 +128,10 @@ function findPluginsNeedingRuntimeDeps(clawdbotDir) {
         const allPresent = pluginDeps.every(dep => fs.existsSync(path.join(pluginNodeModules, dep)));
         if (allPresent) continue;
       }
-      plugins.push(entry.name);
+      plugins.push({
+        name: entry.name,
+        specs: runtimeDependencySpecs(pkg),
+      });
     } catch {
       // Ignore unreadable package.json
     }
@@ -129,14 +169,18 @@ for (const dir of clawdbotDirs) {
   const pluginsToInstall = findPluginsNeedingRuntimeDeps(dir);
   if (pluginsToInstall.length > 0) {
     console.log(
-      `[ensure-clawdbot-deps] Installing runtime deps for ${pluginsToInstall.length} bundled plugin(s) in ${path.relative(path.join(__dirname, '..'), extensionsDir)}: ${pluginsToInstall.join(', ')}`,
+      `[ensure-clawdbot-deps] Installing runtime deps for ${pluginsToInstall.length} bundled plugin(s) in ${path.relative(path.join(__dirname, '..'), extensionsDir)}: ${pluginsToInstall.map((plugin) => plugin.name).join(', ')}`,
     );
     for (const plugin of pluginsToInstall) {
       try {
-        runNpmInstall(path.join(extensionsDir, plugin), `extensions/${plugin}/`);
+        runPluginRuntimeDepsInstall(
+          path.join(extensionsDir, plugin.name),
+          `extensions/${plugin.name}/`,
+          plugin.specs,
+        );
       } catch (err) {
         // Non-fatal: a plugin dep failure just means that plugin won't load.
-        console.warn(`[ensure-clawdbot-deps] WARNING: failed to install deps for ${plugin}: ${err.message}`);
+        console.warn(`[ensure-clawdbot-deps] WARNING: failed to install deps for ${plugin.name}: ${err.message}`);
       }
     }
   }

--- a/src/scripts/install-bundled-plugin-deps.cjs
+++ b/src/scripts/install-bundled-plugin-deps.cjs
@@ -22,6 +22,7 @@
  */
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { execSync } = require('child_process');
 
 const CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources', 'clawdbot');
@@ -40,7 +41,7 @@ const FORCE_STAGE_RUNTIME_DEPS = new Set(['browser']);
 // Channels that Knapsack exposes directly in the UI need their own dependency
 // trees bundled with the extension. Root node_modules is still useful for shared
 // resolution, but it is not enough for channel-local imports and verifier gates.
-const FORCE_EXTENSION_LOCAL_DEPS = new Set(['slack', 'whatsapp']);
+const FORCE_EXTENSION_LOCAL_DEPS = new Set(['slack', 'telegram', 'whatsapp']);
 
 if (!fs.existsSync(EXTENSIONS_DIR)) {
   console.log('[install-bundled-plugin-deps] dist/extensions not found — skipping.');
@@ -51,6 +52,42 @@ const entries = fs.readdirSync(EXTENSIONS_DIR, { withFileTypes: true });
 let installed = 0;
 let alreadyPresent = 0;
 let skipped = 0;
+
+function runtimeDependencyEntries(pkg) {
+  return Object.entries(pkg.dependencies || {})
+    .filter(([, version]) => typeof version === 'string'
+      && !version.startsWith('file:')
+      && !version.startsWith('link:')
+      && !version.startsWith('workspace:')
+      && !version.startsWith('portal:'));
+}
+
+function runtimeDependencySpecs(pkg) {
+  return runtimeDependencyEntries(pkg).map(([dep, version]) => `${dep}@${version}`);
+}
+
+function installPluginRuntimeDeps(pluginDir, specs) {
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'knapsack-plugin-deps-'));
+  try {
+    const quotedSpecs = specs.map((spec) => JSON.stringify(spec)).join(' ');
+    execSync(`npm install ${quotedSpecs} --no-save --omit=dev --ignore-scripts --no-audit --no-fund`, {
+      cwd: stagingDir,
+      stdio: 'inherit',
+    });
+    const sourceNm = path.join(stagingDir, 'node_modules');
+    const targetNm = path.join(pluginDir, 'node_modules');
+    fs.mkdirSync(targetNm, { recursive: true });
+    for (const entry of fs.readdirSync(sourceNm)) {
+      fs.cpSync(path.join(sourceNm, entry), path.join(targetNm, entry), {
+        recursive: true,
+        force: true,
+        verbatimSymlinks: true,
+      });
+    }
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
 
 for (const entry of entries) {
   if (!entry.isDirectory()) continue;
@@ -85,7 +122,7 @@ for (const entry of entries) {
   const needsStage = pkg?.openclaw?.bundle?.stageRuntimeDependencies === true || forceLocalDeps;
   if (!needsStage) continue;
 
-  const deps = Object.keys(pkg.dependencies || {});
+  const deps = runtimeDependencyEntries(pkg).map(([dep]) => dep);
   if (deps.length === 0) continue;
 
   const missingRootDeps = deps.filter((dep) => !fs.existsSync(path.join(CLAWDBOT_DIR, 'node_modules', dep)));
@@ -105,10 +142,7 @@ for (const entry of entries) {
 
   console.log(`[install-bundled-plugin-deps] ${pluginName}: installing ${deps.join(', ')}...`);
   try {
-    execSync('npm install --omit=dev --ignore-scripts --no-audit --no-fund', {
-      cwd: pluginDir,
-      stdio: 'inherit',
-    });
+    installPluginRuntimeDeps(pluginDir, runtimeDependencySpecs(pkg));
     console.log(`[install-bundled-plugin-deps] ${pluginName}: done`);
     installed++;
   } catch (err) {
@@ -146,10 +180,9 @@ for (const entry of entries) {
 
   let pkg;
   try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); } catch { continue; }
-  if (FORCE_EXTENSION_LOCAL_DEPS.has(pluginName)) continue;
   if (pkg?.openclaw?.bundle?.stageRuntimeDependencies !== true) continue;
 
-  for (const dep of Object.keys(pkg.dependencies || {})) {
+  for (const dep of runtimeDependencyEntries(pkg).map(([name]) => name)) {
     if (!fs.existsSync(path.join(ROOT_NM, dep)) && !missingFromRoot.includes(dep)) {
       missingFromRoot.push(dep);
     }

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -34,6 +34,8 @@ const launchAgentPlist = path.join(
   "ai.knap.knapsack.clawdbot.plist",
 );
 const qaStateDir = path.join(projectDir, ".qa-dev-openclaw-state");
+const sourceClawdbotDir = path.join(tauriDir, "resources", "clawdbot");
+const targetClawdbotDir = path.join(tauriDir, "target", "debug", "resources", "clawdbot");
 
 function qaEnv(extra = {}) {
   const env = {
@@ -479,11 +481,41 @@ function binaryNeedsRebuild() {
   return rustSourceMtime > binaryMtime;
 }
 
+function syncDevClawdbotResources() {
+  if (!fs.existsSync(sourceClawdbotDir) || !fs.existsSync(targetClawdbotDir)) return;
+  let copied = 0;
+  const syncTree = (sourceDir, targetDir) => {
+    fs.mkdirSync(targetDir, { recursive: true });
+    for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue;
+      const sourcePath = path.join(sourceDir, entry.name);
+      const targetPath = path.join(targetDir, entry.name);
+      if (entry.isDirectory()) {
+        syncTree(sourcePath, targetPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const sourceStat = fs.statSync(sourcePath);
+      const targetStat = fs.existsSync(targetPath) ? fs.statSync(targetPath) : null;
+      if (targetStat && targetStat.mtimeMs >= sourceStat.mtimeMs && targetStat.size === sourceStat.size) continue;
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.copyFileSync(sourcePath, targetPath);
+      fs.utimesSync(targetPath, sourceStat.atime, sourceStat.mtime);
+      copied++;
+    }
+  };
+  syncTree(sourceClawdbotDir, targetClawdbotDir);
+  if (copied > 0) {
+    console.log(`[qa-dev-run] synced ${copied} updated clawdbot resource file(s) into target/debug/resources`);
+  }
+}
+
 async function main() {
   runChecked(process.execPath, [path.join(projectDir, "scripts", "fix-rollup-native.cjs")]);
   runChecked(process.execPath, [
     path.join(projectDir, "scripts", "ensure-clawdbot-deps.cjs"),
   ]);
+  syncDevClawdbotResources();
   const prepareOnly = String(process.env.KNAPSACK_QA_PREPARE_ONLY || "").trim() === "1";
   fs.mkdirSync(qaStateDir, { recursive: true });
   bootoutLaunchAgent();

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -95,8 +95,9 @@ function configuredChannelPluginIdsForQa() {
   if (String(process.env.KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS || "0").trim() === "0") {
     return [];
   }
-  if (!process.env.APPDATA) return [];
-  const configPath = path.join(process.env.APPDATA, "ai.knap.knapsack", "clawdbot", "openclaw.json");
+  const appDataRoot = knapsackAppDataRoot();
+  if (!appDataRoot) return [];
+  const configPath = path.join(appDataRoot, "clawdbot", "openclaw.json");
   if (!existsSync(configPath)) return [];
   try {
     const config = JSON.parse(fs.readFileSync(configPath, "utf8").replace(/^\uFEFF/, ""));
@@ -110,6 +111,140 @@ function configuredChannelPluginIdsForQa() {
   } catch {
     return [];
   }
+}
+
+function readOpenClawConfigForQa() {
+  const appDataRoot = knapsackAppDataRoot();
+  if (!appDataRoot) return null;
+  const configPath = path.join(appDataRoot, "clawdbot", "openclaw.json");
+  if (!existsSync(configPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(configPath, "utf8").replace(/^\uFEFF/, ""));
+  } catch {
+    return null;
+  }
+}
+
+function firstString(value, options = {}) {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = firstString(item, options);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function firstConcreteTarget(value, options = {}) {
+  const found = firstString(value, options);
+  if (!found || found === "*") return null;
+  return found;
+}
+
+function slackTargetLooksPostable(target) {
+  const value = String(target || "").trim();
+  return /^user:[A-Z0-9]{8,}$/i.test(value)
+    || /^channel:[A-Z0-9]{8,}$/i.test(value)
+    || /^slack:[A-Z0-9]{8,}$/i.test(value)
+    || /^<@[A-Z0-9]{8,}>$/i.test(value)
+    || /^[CDGUW][A-Z0-9]{8,}$/i.test(value);
+}
+
+async function fetchSlackAuthUserId(token) {
+  if (!token || !String(token).trim()) return null;
+  const response = await fetchWithTimeout(
+    "https://slack.com/api/auth.test",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${String(token).trim()}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: "",
+    },
+    10_000,
+  ).catch(() => null);
+  const userId = response?.body?.user_id;
+  return typeof userId === "string" && /^U[A-Z0-9]{8,}$/i.test(userId) ? `user:${userId}` : null;
+}
+
+async function qaSlackSendTarget(channelConfig) {
+  const explicit = firstConcreteTarget(channelConfig.qaTarget)
+    || firstConcreteTarget(channelConfig.defaultTo)
+    || firstConcreteTarget(channelConfig.defaultTarget)
+    || firstConcreteTarget(channelConfig.notifyTarget)
+    || firstConcreteTarget(channelConfig.channel);
+  if (explicit && slackTargetLooksPostable(explicit)) return explicit;
+
+  const userTokenTarget = await fetchSlackAuthUserId(
+    channelConfig.userTokenReadOnly || channelConfig.userToken,
+  );
+  if (userTokenTarget) return userTokenTarget;
+
+  return null;
+}
+
+async function qaChannelSendTarget(channel) {
+  const upper = String(channel || "").trim().toUpperCase();
+  const envValue = process.env[`KNAPSACK_QA_${upper}_TO`]
+    || process.env[`KNAPSACK_QA_CHANNEL_${upper}_TO`];
+  if (envValue && envValue.trim()) return envValue.trim();
+
+  const config = readOpenClawConfigForQa();
+  const channelConfig = config?.channels?.[channel];
+  if (!channelConfig || typeof channelConfig !== "object") return null;
+  if (channel === "telegram") {
+    return firstConcreteTarget(channelConfig.allowFrom)
+      || firstConcreteTarget(channelConfig.groupAllowFrom)
+      || firstConcreteTarget(Object.values(channelConfig.accounts || {}).map((account) => account?.allowFrom))
+      || firstConcreteTarget(Object.values(channelConfig.accounts || {}).map((account) => account?.groupAllowFrom));
+  }
+  if (channel === "slack") {
+    return qaSlackSendTarget(channelConfig);
+  }
+  if (channel === "whatsapp" || channel === "imessage") {
+    return firstConcreteTarget(channelConfig.allowFrom);
+  }
+  return null;
+}
+
+async function qaChannelSendRequests(channel) {
+  const to = await qaChannelSendTarget(channel);
+  if (channel !== "slack") return [{ channel, to, accountId: null, label: channel }];
+
+  const config = readOpenClawConfigForQa();
+  const accounts = config?.channels?.slack?.accounts;
+  if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) {
+    return [{ channel, to, accountId: null, label: "slack" }];
+  }
+  return Object.entries(accounts)
+    .filter(([, account]) => !account || account.enabled !== false)
+    .map(([accountId, account]) => ({
+      channel,
+      to,
+      accountId,
+      label: `slack/${accountId === "default" ? "merlin" : accountId}`,
+      accountName: account?.name,
+    }));
+}
+
+function knapsackAppDataRoot() {
+  if (process.platform === "darwin") {
+    return process.env.HOME
+      ? path.join(process.env.HOME, "Library", "Application Support", "ai.knap.knapsack")
+      : null;
+  }
+  if (process.platform === "win32") {
+    return process.env.APPDATA
+      ? path.join(process.env.APPDATA, "ai.knap.knapsack")
+      : null;
+  }
+  return process.env.XDG_CONFIG_HOME
+    ? path.join(process.env.XDG_CONFIG_HOME, "ai.knap.knapsack")
+    : process.env.HOME
+      ? path.join(process.env.HOME, ".config", "ai.knap.knapsack")
+      : null;
 }
 
 function bundledChannelPluginAvailableForQa(channel) {
@@ -159,8 +294,9 @@ function patchOpenClawConfigForQa({ pluginAllowlist, provider }) {
   }
 
   const startupModel = qaStartupModelForProvider(provider);
-  if ((!pluginAllowlist && !startupModel) || !process.env.APPDATA) return null;
-  const configPath = path.join(process.env.APPDATA, "ai.knap.knapsack", "clawdbot", "openclaw.json");
+  const appDataRoot = knapsackAppDataRoot();
+  if ((!pluginAllowlist && !startupModel) || !appDataRoot) return null;
+  const configPath = path.join(appDataRoot, "clawdbot", "openclaw.json");
   if (!existsSync(configPath)) return null;
 
   const original = fs.readFileSync(configPath, "utf8");
@@ -341,10 +477,11 @@ function parseArgs() {
     chatRetries: 2,
     chatRetryDelayMs: 800,
     startupBudgetMs: 120_000,
-    functionalTimeoutMs: 90_000,
-    readinessHealthTimeoutMs: 60_000,
+    functionalTimeoutMs: null,
+    readinessHealthTimeoutMs: null,
     coreOnly: false,
     strictReadiness: false,
+    globalProviderSwitch: false,
     providers: null,
     models: null,
   };
@@ -397,6 +534,10 @@ function parseArgs() {
     }
     if (arg === "--strict-readiness" || arg === "--strict-chat" || arg === "--no-fallback") {
       opts.strictReadiness = true;
+      continue;
+    }
+    if (arg === "--global-provider-switch" || arg === "--set-active-provider") {
+      opts.globalProviderSwitch = true;
       continue;
     }
     if (arg === "--chat-retries") {
@@ -1270,6 +1411,18 @@ function isTransientChatFailure(message) {
     || text.includes("rate limit");
 }
 
+function isNonRetryableQaFailure(message) {
+  const text = String(message || "").toLowerCase();
+  return text.includes("session expired")
+    || text.includes("please sign in")
+    || text.includes("api key is not set")
+    || text.includes("api key cannot be empty")
+    || text.includes("not connected")
+    || text.includes("not authenticated")
+    || text.includes("authentication required")
+    || text.includes("invalid api key");
+}
+
 async function runReadinessChatWithFallback(provider, model, options = {}) {
   const chatOptions = {
     chatRetries: Number(options.chatRetries),
@@ -1356,7 +1509,7 @@ async function runChatSmoke(provider, model, options = {}) {
   try {
     const startedAt = Date.now();
     const latency = {};
-    if (!options.skipModelSetup) {
+    if (options.globalProviderSwitch === true) {
       const setting = await setProviderAndModel(provider, model);
       latency.providerSwitchMs = setting.elapsedMs;
       if (!setting.ok) {
@@ -1380,6 +1533,8 @@ async function runChatSmoke(provider, model, options = {}) {
       sessionId: `qa-${provider}-${model}`.replace(/[^A-Za-z0-9._-]/g, "-"),
       disableFallback: true,
       qaSmoke: true,
+      provider,
+      model,
     };
     const chatRetries = Number.isFinite(options.chatRetries)
       ? Math.max(1, Number.parseInt(options.chatRetries, 10))
@@ -1683,6 +1838,109 @@ async function createMockMeeting() {
   return { ok: true };
 }
 
+function summarizeChannelDiagnostics(body) {
+  if (!body || typeof body !== "object") return "no diagnostics body";
+  const configured = Array.isArray(body.configuredChannels)
+    ? body.configuredChannels.join(",")
+    : "";
+  const summaryCount = Array.isArray(body.channelSummary) ? body.channelSummary.length : 0;
+  const states = Array.isArray(body.channelStates)
+    ? body.channelStates
+      .map((state) => {
+        if (!state || typeof state !== "object") return null;
+        return `${state.channel || "unknown"}{configured=${Boolean(state.configured)},allowed=${Boolean(state.pluginAllowed)},active=${Boolean(state.active)},deferred=${Boolean(state.deferred)}}`;
+      })
+      .filter(Boolean)
+      .join(";")
+    : "";
+  const issues = Array.isArray(body.issues) ? body.issues.join("; ") : "";
+  return `configured=[${configured}] summary=${summaryCount} states=[${states}] issues=[${issues}]`;
+}
+
+async function waitForConfiguredChannelDiagnostics(expectedChannels, timeoutMs) {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  let last = null;
+  while (Date.now() <= deadline) {
+    last = await fetchWithTimeout(
+      `${API_BASE}/api/clawd/channels/diagnostics`,
+      { method: "GET" },
+      30_000,
+    ).catch((error) => ({
+      ok: false,
+      status: 0,
+      body: { error: normalizeResult(error?.message || error) },
+    }));
+
+    const states = Array.isArray(last?.body?.channelStates) ? last.body.channelStates : [];
+    const configuredStates = states.filter((state) => state && state.configured);
+    const stateByChannel = new Map(configuredStates.map((state) => [state.channel, state]));
+    const allExpectedPresent = expectedChannels.every((channel) => stateByChannel.has(channel));
+    const inactive = expectedChannels
+      .map((channel) => stateByChannel.get(channel))
+      .filter((state) => state && !state.deferred && !state.active);
+
+    if (last?.ok && allExpectedPresent && inactive.length === 0) {
+      return last;
+    }
+    await sleep(5_000);
+  }
+  return last;
+}
+
+async function checkChannelSends(channels) {
+  if (String(process.env.KNAPSACK_QA_SEND_CHANNEL_MESSAGES || "").trim() !== "1") {
+    return { enabled: false, results: [] };
+  }
+  const results = [];
+  const timestamp = new Date().toISOString();
+  for (const channel of channels) {
+    const requests = await qaChannelSendRequests(channel);
+    for (const request of requests) {
+      if (!request.to) {
+        results.push({
+          channel,
+          accountId: request.accountId,
+          label: request.label,
+          ok: false,
+          skipped: true,
+          reason: `missing KNAPSACK_QA_${channel.toUpperCase()}_TO`,
+        });
+        continue;
+      }
+      const message = `Knapsack QA channel send test (${request.label}) ${timestamp}`;
+      const response = await fetchWithTimeout(
+        `${API_BASE}/api/clawd/channels/send`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            channel,
+            to: request.to,
+            message,
+            ...(request.accountId ? { accountId: request.accountId } : {}),
+          }),
+        },
+        60_000,
+      ).catch((error) => ({
+        ok: false,
+        status: 0,
+        body: { message: normalizeResult(error?.message || error) },
+      }));
+      const ok = Boolean(response?.ok && response.body?.success === true);
+      results.push({
+        channel,
+        accountId: request.accountId,
+        label: request.label,
+        ok,
+        skipped: false,
+        status: response?.status || 0,
+        message: ok ? "sent" : normalizeResult(response?.body?.message || response?.body || "send failed"),
+      });
+    }
+  }
+  return { enabled: true, results };
+}
+
 async function checkInterfaceAccess(includeUi) {
   const retryWithDelay = async (thunk, attempts = 3, delayMs = 500) => {
     let result = null;
@@ -1712,11 +1970,17 @@ async function checkInterfaceAccess(includeUi) {
     1_000,
   );
 
-  const channels = await retryWithDelay(
-    () => fetchWithTimeout(`${API_BASE}/api/clawd/channels/diagnostics`, { method: "GET" }, 30_000),
-    3,
-    1_000,
-  );
+  const strictChannelTransports =
+    String(process.env.KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS || "").trim() === "1";
+  const expectedChannels = strictChannelTransports ? configuredChannelPluginIdsForQa() : [];
+  const channelTimeoutMs = Number(process.env.KNAPSACK_QA_CHANNEL_READY_TIMEOUT_MS || 120_000);
+  const channels = strictChannelTransports && expectedChannels.length > 0
+    ? await waitForConfiguredChannelDiagnostics(expectedChannels, channelTimeoutMs)
+    : await retryWithDelay(
+      () => fetchWithTimeout(`${API_BASE}/api/clawd/channels/diagnostics`, { method: "GET" }, 30_000),
+      3,
+      1_000,
+    );
   const automations = await retryWithDelay(
     () => fetchWithTimeout(`${API_BASE}/api/knapsack/automations`, { method: "GET" }, 10_000),
     3,
@@ -1747,6 +2011,7 @@ async function checkInterfaceAccess(includeUi) {
       3,
       750,
     );
+  const channelSendResults = await checkChannelSends(expectedChannels);
 
   const failures = [];
   if (!root || !root.ok) failures.push("service/status unhealthy");
@@ -1757,14 +2022,25 @@ async function checkInterfaceAccess(includeUi) {
     ? channels.body.channelStates
     : [];
   const configuredChannelStates = channelStates.filter((state) => state && state.configured);
-  const strictChannelTransports =
-    String(process.env.KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS || "").trim() === "1";
   if (strictChannelTransports) {
+    if (expectedChannels.length > 0 && configuredChannelStates.length === 0) {
+      failures.push(`configured channel diagnostics missing for: ${expectedChannels.join(", ")} (${summarizeChannelDiagnostics(channels?.body)})`);
+    }
     const inactiveConfiguredChannels = configuredChannelStates
       .filter((state) => !state.deferred && !state.active)
       .map((state) => `${state.channel}:${state.reason || "not active"}`);
     if (inactiveConfiguredChannels.length > 0) {
-      failures.push(`configured channel transports inactive: ${inactiveConfiguredChannels.join("; ")}`);
+      failures.push(`configured channel transports inactive: ${inactiveConfiguredChannels.join("; ")} (${summarizeChannelDiagnostics(channels?.body)})`);
+    }
+    if (channelSendResults.enabled) {
+      const requireChannelSends =
+        String(process.env.KNAPSACK_QA_REQUIRE_CHANNEL_SENDS || "").trim() === "1";
+      const failedSends = channelSendResults.results
+        .filter((result) => !result.ok && (requireChannelSends || !result.skipped))
+        .map((result) => `${result.channel}:${result.reason || result.message || "send failed"}`);
+      if (failedSends.length > 0) {
+        failures.push(`channel send checks failed: ${failedSends.join("; ")}`);
+      }
     }
   }
   if (!skills || !skills.ok || skills.body?.success !== true) failures.push("skills status unavailable");
@@ -1791,6 +2067,8 @@ async function checkInterfaceAccess(includeUi) {
       feedApi: Boolean(feed?.ok),
       browserControl: Boolean(uiBrowserOk),
       channelStates,
+      channelDiagnostics: summarizeChannelDiagnostics(channels?.body),
+      channelSendResults,
       configuredChannelsActive: configuredChannelStates.filter((state) => state.active).map((state) => state.channel),
       configuredChannelsDeferred: configuredChannelStates.filter((state) => state.deferred).map((state) => state.channel),
       strictChannelTransports,
@@ -1988,6 +2266,7 @@ async function runMode(mode, opts = {}) {
             chatRetries: Number.isFinite(opts.chatRetries) ? opts.chatRetries : undefined,
             chatRetryDelayMs: Number.isFinite(opts.chatRetryDelayMs) ? opts.chatRetryDelayMs : undefined,
             strictReadiness: Boolean(opts.strictReadiness),
+            globalProviderSwitch: Boolean(opts.globalProviderSwitch),
           });
           chatChecks.push(check);
           functionalProgress.chatChecks = chatChecks;
@@ -2108,9 +2387,13 @@ async function runLoop() {
       if (modeResult.ok) break;
       const failedDuringPrepare = modeResult.phase === "prepare"
         || String(modeResult.message || "").includes("prepare failed");
-      if (attempt >= attemptsPerMode || failedDuringPrepare) {
+      const nonRetryableFailure = isNonRetryableQaFailure(modeResult.message);
+      if (attempt >= attemptsPerMode || failedDuringPrepare || nonRetryableFailure) {
         if (failedDuringPrepare) {
           abortAllModes = true;
+        }
+        if (nonRetryableFailure) {
+          modeResult.nonRetryable = true;
         }
         break;
       }

--- a/src/src-tauri/resources/clawdbot/dist/discovery-GEDtU7uI.js
+++ b/src/src-tauri/resources/clawdbot/dist/discovery-GEDtU7uI.js
@@ -233,6 +233,17 @@ async function tracePluginLifecyclePhaseAsync(phase, fn, details) {
 	}
 }
 //#endregion
+//#region src/plugins/plugin-discovery-allowlist.ts
+function parsePluginDiscoveryAllowlist(env) {
+	const raw = normalizeOptionalString(env.OPENCLAW_PLUGIN_DISCOVERY_ALLOWLIST);
+	if (!raw) return null;
+	const ids = raw.split(",").map((value) => value.trim()).filter(Boolean);
+	return ids.length > 0 ? new Set(ids) : null;
+}
+function isDiscoveryPluginIdAllowed(pluginId, allowlist) {
+	return !allowlist || Boolean(pluginId && allowlist.has(pluginId));
+}
+//#endregion
 //#region src/plugins/roots.ts
 function resolvePluginSourceRoots(params) {
 	const env = params.env ?? process.env;
@@ -514,10 +525,11 @@ function mergeDiscoveryResult(target, source, seenSources, seenDiagnostics) {
 		target.diagnostics.push(diagnostic);
 	}
 }
-function collectInstalledPluginRecordPaths(installRecords, env) {
+function collectInstalledPluginRecordPaths(installRecords, env, allowlist) {
 	const paths = [];
 	const seen = /* @__PURE__ */ new Set();
-	for (const record of Object.values(installRecords ?? {})) {
+	for (const [pluginId, record] of Object.entries(installRecords ?? {})) {
+		if (!isDiscoveryPluginIdAllowed(pluginId, allowlist)) continue;
 		const rawPath = typeof record.installPath === "string" && record.installPath.trim() ? record.installPath : typeof record.sourcePath === "string" && record.sourcePath.trim() ? record.sourcePath : void 0;
 		if (!rawPath) continue;
 		const resolved = resolveUserPath(rawPath, env);
@@ -527,15 +539,18 @@ function collectInstalledPluginRecordPaths(installRecords, env) {
 	}
 	return paths;
 }
-function collectManagedPluginRecordPaths(installRecords, env) {
+function collectManagedPluginRecordPaths(installRecords, env, allowlist) {
 	const paths = [];
 	const seen = /* @__PURE__ */ new Set();
-	for (const record of Object.values(installRecords ?? {})) for (const rawPath of [record.installPath, record.sourcePath]) {
+	for (const [pluginId, record] of Object.entries(installRecords ?? {})) {
+		if (!isDiscoveryPluginIdAllowed(pluginId, allowlist)) continue;
+		for (const rawPath of [record.installPath, record.sourcePath]) {
 		if (typeof rawPath !== "string" || !rawPath.trim()) continue;
 		const resolved = resolveUserPath(rawPath, env);
 		if (seen.has(resolved) || !fs.existsSync(resolved)) continue;
 		seen.add(resolved);
 		paths.push(resolved);
+	}
 	}
 	return paths;
 }
@@ -740,11 +755,13 @@ function discoverInDirectory(params) {
 		const entryType = resolveScannedEntryType(entry, fullPath);
 		if (entryType === "file") {
 			if (!isExtensionFile(fullPath)) continue;
+			const idHint = path.basename(entry.name, path.extname(entry.name));
+			if (!isDiscoveryPluginIdAllowed(idHint, params.pluginDiscoveryAllowlist)) continue;
 			addCandidate({
 				candidates: params.candidates,
 				diagnostics: params.diagnostics,
 				seen: params.seen,
-				idHint: path.basename(entry.name, path.extname(entry.name)),
+				idHint,
 				source: fullPath,
 				rootDir: path.dirname(fullPath),
 				origin: params.origin,
@@ -755,6 +772,7 @@ function discoverInDirectory(params) {
 			continue;
 		}
 		if (entryType !== "directory") continue;
+		if (!isDiscoveryPluginIdAllowed(entry.name, params.pluginDiscoveryAllowlist)) continue;
 		if (params.skipDirectories?.has(entry.name)) continue;
 		if (shouldIgnoreScannedDirectory(entry.name)) continue;
 		const fullPathRealPath = safeRealpathSync(fullPath, params.realpathCache) ?? void 0;
@@ -925,11 +943,13 @@ function discoverFromPath(params) {
 			});
 			return;
 		}
+		const idHint = path.basename(resolved, path.extname(resolved));
+		if (!isDiscoveryPluginIdAllowed(idHint, params.pluginDiscoveryAllowlist)) return;
 		addCandidate({
 			candidates: params.candidates,
 			diagnostics: params.diagnostics,
 			seen: params.seen,
-			idHint: path.basename(resolved, path.extname(resolved)),
+			idHint,
 			source: resolved,
 			rootDir: path.dirname(resolved),
 			origin: params.origin,
@@ -940,6 +960,7 @@ function discoverFromPath(params) {
 		return;
 	}
 	if (stat.isDirectory()) {
+		if (!isDiscoveryPluginIdAllowed(path.basename(resolved), params.pluginDiscoveryAllowlist)) return;
 		const resolvedRealPath = safeRealpathSync(resolved, params.realpathCache) ?? void 0;
 		const requireBuiltRuntimeEntry = params.requireBuiltRuntimeEntry ?? isManagedPluginDir({
 			dir: resolved,
@@ -1062,6 +1083,7 @@ function discoverFromPath(params) {
 			seen: params.seen,
 			realpathCache: params.realpathCache,
 			packageManifestCache: params.packageManifestCache,
+			...params.pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist: params.pluginDiscoveryAllowlist } : {},
 			...params.requireBuiltRuntimeEntry !== void 0 ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry } : {},
 			...params.managedPluginDirs ? { managedPluginDirs: params.managedPluginDirs } : {},
 			...params.skipRootDirKeys ? { skipRootDirKeys: params.skipRootDirKeys } : {}
@@ -1071,6 +1093,7 @@ function discoverFromPath(params) {
 }
 function discoverOpenClawPlugins(params) {
 	const env = params.env ?? process.env;
+	const pluginDiscoveryAllowlist = parsePluginDiscoveryAllowlist(env);
 	const workspaceDir = normalizeOptionalString(params.workspaceDir);
 	const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir, env) : void 0;
 	const roots = resolvePluginSourceRoots({
@@ -1109,7 +1132,8 @@ function discoverOpenClawPlugins(params) {
 				diagnostics: result.diagnostics,
 				seen,
 				realpathCache,
-				packageManifestCache
+				packageManifestCache,
+				...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {}
 			});
 		}
 		const workspaceMatchesBundledRoot = resolvesToSameDirectory(workspaceRoot, roots.stock, realpathCache);
@@ -1123,7 +1147,8 @@ function discoverOpenClawPlugins(params) {
 			diagnostics: result.diagnostics,
 			seen,
 			realpathCache,
-			packageManifestCache
+			packageManifestCache,
+			...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {}
 		});
 		return result;
 	}, {
@@ -1149,7 +1174,8 @@ function discoverOpenClawPlugins(params) {
 				diagnostics: result.diagnostics,
 				seen,
 				realpathCache,
-				packageManifestCache
+				packageManifestCache,
+				...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {}
 			});
 			result.diagnostics.push({
 				level: "warn",
@@ -1172,7 +1198,8 @@ function discoverOpenClawPlugins(params) {
 			diagnostics: result.diagnostics,
 			seen,
 			realpathCache,
-			packageManifestCache
+			packageManifestCache,
+			...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {}
 		});
 		const sourceCheckoutExtensionsDir = resolveBundledSourceCheckoutExtensionsDir(roots.stock);
 		const sourceCheckoutMatchesBundledRoot = resolvesToSameDirectory(sourceCheckoutExtensionsDir, roots.stock, realpathCache);
@@ -1186,11 +1213,12 @@ function discoverOpenClawPlugins(params) {
 			seen,
 			realpathCache,
 			packageManifestCache,
+			...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {},
 			skipDirectories: readChildDirectoryNames(roots.stock)
 		});
-		const installedPaths = collectInstalledPluginRecordPaths(params.installRecords, env);
+		const installedPaths = collectInstalledPluginRecordPaths(params.installRecords, env, pluginDiscoveryAllowlist);
 		const installedPluginDirKeys = collectManagedPluginDirKeys(installedPaths, realpathCache);
-		const managedPluginDirs = collectManagedPluginDirKeys(collectManagedPluginRecordPaths(params.installRecords, env), realpathCache);
+		const managedPluginDirs = collectManagedPluginDirKeys(collectManagedPluginRecordPaths(params.installRecords, env, pluginDiscoveryAllowlist), realpathCache);
 		for (const installedPath of installedPaths) discoverFromPath({
 			rawPath: installedPath,
 			origin: "global",
@@ -1203,7 +1231,8 @@ function discoverOpenClawPlugins(params) {
 			diagnostics: result.diagnostics,
 			seen,
 			realpathCache,
-			packageManifestCache
+			packageManifestCache,
+			...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {}
 		});
 		discoverInDirectory({
 			dir: roots.global,
@@ -1216,7 +1245,8 @@ function discoverOpenClawPlugins(params) {
 			diagnostics: result.diagnostics,
 			seen,
 			realpathCache,
-			packageManifestCache
+			packageManifestCache,
+			...pluginDiscoveryAllowlist ? { pluginDiscoveryAllowlist } : {}
 		});
 		return result;
 	}, { scope: "shared" });

--- a/src/src-tauri/resources/clawdbot/dist/manifest-metadata-scan-CK8TFnhN.js
+++ b/src/src-tauri/resources/clawdbot/dist/manifest-metadata-scan-CK8TFnhN.js
@@ -13,6 +13,19 @@ function isRecord(value) {
 function normalizeTrimmedString(value) {
 	return typeof value === "string" && value.trim() ? value.trim() : void 0;
 }
+function parsePluginDiscoveryAllowlist(env) {
+	const raw = normalizeTrimmedString(env.OPENCLAW_PLUGIN_DISCOVERY_ALLOWLIST);
+	if (!raw) return null;
+	const ids = raw.split(",").map((value) => value.trim()).filter(Boolean);
+	return ids.length > 0 ? new Set(ids) : null;
+}
+function isPluginCandidateAllowed(candidate, allowlist) {
+	if (!allowlist) return true;
+	const manifest = readManifestObject(candidate.pluginDir);
+	const manifestId = normalizeTrimmedString(manifest?.id);
+	const basename = path.basename(candidate.pluginDir);
+	return Boolean(manifestId && allowlist.has(manifestId) || basename && allowlist.has(basename));
+}
 function resolveUserPath(value, env) {
 	if (value === "~" || value.startsWith("~/")) {
 		const home = env.OPENCLAW_HOME ?? env.HOME ?? env.USERPROFILE ?? os.homedir();
@@ -114,6 +127,7 @@ function uniqueCandidateDirs(candidates) {
 	return [...byPath.values()].toSorted((left, right) => left.rank - right.rank || left.order - right.order);
 }
 function listOpenClawPluginManifestMetadata(env = process.env) {
+	const allowlist = parsePluginDiscoveryAllowlist(env);
 	const candidates = [];
 	let order = 0;
 	candidates.push(...listPersistedIndexPluginDirs(env, order));
@@ -121,7 +135,7 @@ function listOpenClawPluginManifestMetadata(env = process.env) {
 	candidates.push(...listChildPluginDirs(resolveBundledPluginRoot(env), 2, order, "bundled"));
 	order = candidates.length;
 	candidates.push(...listChildPluginDirs(path.join(resolveStateDir(env), "extensions"), 4, order, "global"));
-	const uniqueCandidates = uniqueCandidateDirs(candidates);
+	const uniqueCandidates = uniqueCandidateDirs(candidates).filter((candidate) => isPluginCandidateAllowed(candidate, allowlist));
 	const cacheKey = JSON.stringify(uniqueCandidates.map((candidate) => [
 		candidate.pluginDir,
 		candidate.rank,

--- a/src/src-tauri/resources/clawdbot/dist/manifest-registry-Cy1cBr1u.js
+++ b/src/src-tauri/resources/clawdbot/dist/manifest-registry-Cy1cBr1u.js
@@ -477,6 +477,7 @@ function loadPluginManifestRegistry(params = {}) {
 	const config = params.config ?? {};
 	const normalized = normalizePluginsConfigWithResolver(config.plugins);
 	const env = params.env ?? process.env;
+	const pluginIdSet = params.pluginIds?.length ? new Set(params.pluginIds) : null;
 	let installRecords = params.installRecords;
 	let installRecordsLoaded = Boolean(params.installRecords);
 	const getInstallRecords = () => {
@@ -527,6 +528,7 @@ function loadPluginManifestRegistry(params = {}) {
 			continue;
 		}
 		const manifest = manifestRes.manifest;
+		if (pluginIdSet && !pluginIdSet.has(manifest.id)) continue;
 		if (candidate.origin !== "bundled") {
 			const allowLegacyBareMinHostVersion = candidate.origin === "global" && matchesInstalledPluginRecord({
 				pluginId: manifest.id,

--- a/src/src-tauri/resources/clawdbot/dist/model-provider-auth-DAG1ddFR.js
+++ b/src/src-tauri/resources/clawdbot/dist/model-provider-auth-DAG1ddFR.js
@@ -14,6 +14,10 @@ import { r as createRuntimeProviderAuthLookup, s as hasRuntimeAvailableProviderA
 let currentProviderAuthStates = null;
 const configFingerprintCache = /* @__PURE__ */ new WeakMap();
 let currentProviderAuthStateGeneration = 0;
+function shouldPrewarmExternalCliAuth(env = process.env) {
+	const raw = env.OPENCLAW_PROVIDER_AUTH_PREWARM_EXTERNAL_CLI?.trim().toLowerCase();
+	return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
 function clearCurrentProviderAuthState() {
 	currentProviderAuthStates = null;
 	currentProviderAuthStateGeneration += 1;
@@ -107,13 +111,14 @@ async function warmCurrentProviderAuthState(cfg, options = {}) {
 			cfg,
 			workspaceDir
 		});
-		const store = ensureAuthProfileStore(agentDir, {
+		const prewarmExternalCliAuth = shouldPrewarmExternalCliAuth();
+		const store = prewarmExternalCliAuth ? ensureAuthProfileStore(agentDir, {
 			config: cfg,
 			externalCli: externalCliDiscoveryForProviders({
 				cfg,
 				providers: providerList
 			})
-		});
+		}) : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, { allowKeychainPrompt: false });
 		const state = /* @__PURE__ */ new Map();
 		for (const provider of providers) {
 			if (isWarmStale()) return;
@@ -123,7 +128,8 @@ async function warmCurrentProviderAuthState(cfg, options = {}) {
 				workspaceDir,
 				agentId,
 				store,
-				runtimeAuthLookup
+				runtimeAuthLookup,
+				discoverExternalCliAuth: prewarmExternalCliAuth
 			});
 			state.set(provider, value);
 		}

--- a/src/src-tauri/resources/clawdbot/dist/plugin-metadata-snapshot-C-_V3F5M.js
+++ b/src/src-tauri/resources/clawdbot/dist/plugin-metadata-snapshot-C-_V3F5M.js
@@ -245,6 +245,7 @@ const MEMO_RELEVANT_ENV_KEYS = [
 	"OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY",
 	"OPENCLAW_HOME",
 	"OPENCLAW_NIX_MODE",
+	"OPENCLAW_PLUGIN_DISCOVERY_ALLOWLIST",
 	"OPENCLAW_STATE_DIR",
 	"USERPROFILE",
 	"XDG_CONFIG_HOME"
@@ -276,6 +277,12 @@ function readJsonObject(filePath) {
 }
 function normalizeString(value) {
 	return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function parsePluginDiscoveryAllowlist(env) {
+	const raw = normalizeString(env.OPENCLAW_PLUGIN_DISCOVERY_ALLOWLIST);
+	if (!raw) return;
+	const ids = raw.split(",").map((value) => value.trim()).filter(Boolean);
+	return ids.length > 0 ? ids : void 0;
 }
 function stableMemoValue(value) {
 	if (Array.isArray(value)) return value.map(stableMemoValue);
@@ -708,6 +715,7 @@ function canMemoizePluginMetadataSnapshotResult(result) {
 }
 function loadPluginMetadataSnapshotImpl(params) {
 	const totalStartedAt = performance.now();
+	const pluginIds = parsePluginDiscoveryAllowlist(params.env ?? process.env);
 	const registryStartedAt = performance.now();
 	const registryResult = loadPluginRegistrySnapshotWithMetadata({
 		config: params.config,
@@ -729,13 +737,15 @@ function loadPluginMetadataSnapshotImpl(params) {
 		workspaceDir: params.workspaceDir,
 		env: params.env,
 		diagnostics: [...index.diagnostics],
-		installRecords: index.installRecords
+		installRecords: index.installRecords,
+		...pluginIds ? { pluginIds } : {}
 	}) : loadPluginManifestRegistryForInstalledIndex({
 		index,
 		config: params.config,
 		workspaceDir: params.workspaceDir,
 		env: params.env,
-		includeDisabled: true
+		includeDisabled: true,
+		...pluginIds ? { pluginIds } : {}
 	});
 	const manifestRegistryMs = performance.now() - manifestStartedAt;
 	const normalizePluginId = createPluginRegistryIdNormalizer(index, { manifestRegistry });

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-post-attach-ezNyN6B3.js
@@ -14,8 +14,10 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PRIMARY_MODEL_PREWARM_TIMEOUT_MS = 5e3;
 const STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS = 5e3;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1e3;
+const DESKTOP_PROVIDER_AUTH_PREWARM_START_DELAY_MS = 18e4;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1e3;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
+const PROVIDER_AUTH_PREWARM_DELAY_ENV = "OPENCLAW_PROVIDER_AUTH_PREWARM_DELAY_MS";
 const QMD_STARTUP_IDLE_DELAY_MS = 12e4;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 function stopPostReadySidecarsAfterCloseStarted(params) {
@@ -48,6 +50,14 @@ function shouldCheckRestartSentinel(env = process.env) {
 function shouldSkipStartupModelPrewarm(env = process.env) {
 	const raw = env[SKIP_STARTUP_MODEL_PREWARM_ENV]?.trim().toLowerCase();
 	return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+function resolveProviderAuthPrewarmDelayMs(fallbackDelayMs, env = process.env) {
+	const raw = env[PROVIDER_AUTH_PREWARM_DELAY_ENV]?.trim();
+	if (raw) {
+		const parsed = Number.parseInt(raw, 10);
+		if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+	}
+	return fallbackDelayMs;
 }
 function resolveGatewayMemoryStartupPolicy(cfg) {
 	if (cfg.memory?.backend !== "qmd") return { mode: "off" };
@@ -99,7 +109,7 @@ function scheduleProviderAuthStatePrewarm(params) {
 	let rewarmInFlight = false;
 	let pendingRewarmReason;
 	const isStopped = () => stopped;
-	const delayMs = params.delayMs ?? PROVIDER_AUTH_PREWARM_START_DELAY_MS;
+	const delayMs = resolveProviderAuthPrewarmDelayMs(params.delayMs ?? PROVIDER_AUTH_PREWARM_START_DELAY_MS);
 	(async () => {
 		const { clearCurrentProviderAuthState, warmCurrentProviderAuthState } = await import("./model-provider-auth-Drz7aXVk.js");
 		const { setAuthProfileFailureHook } = await import("./auth-profiles-AGNxPMTm.js");
@@ -665,7 +675,7 @@ async function startGatewayPostAttachRuntime(params, runtimeDeps = defaultGatewa
 		if (params.providerAuthPrewarm?.enabled !== false) gatewayLifetimeSidecars.push(scheduleProviderAuthStatePrewarm({
 			getConfig: params.providerAuthPrewarm?.getConfig ?? (() => params.cfgAtStart),
 			log: params.log,
-			delayMs: params.providerAuthPrewarm?.delayMs ?? (desktopManagedGateway ? 60000 : void 0)
+			delayMs: params.providerAuthPrewarm?.delayMs ?? (desktopManagedGateway ? DESKTOP_PROVIDER_AUTH_PREWARM_START_DELAY_MS : void 0)
 		}));
 		params.onPostReadySidecars?.(postReadySidecars);
 		params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
@@ -2572,6 +2572,8 @@ async function startGatewayServer(port = 18789, opts = {}) {
 					});
 				}
 				const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
+				const configuredDesktopChannelPluginIds = String(process.env.OPENCLAW_BUNDLED_CHANNEL_FALLBACK_IDS ?? "").split(",").map((id) => id.trim()).filter(Boolean);
+				const deferredStartupPluginIds = [...new Set([...startupPluginIds, ...(loadOptions.includeDeferred === true ? [...deferredConfiguredChannelPluginIds, ...configuredDesktopChannelPluginIds] : [])])];
 				return loadGatewayStartupPluginRuntime({
 					cfg: gatewayPluginConfigAtStart,
 					activationSourceConfig: startupActivationSourceConfig,
@@ -2580,7 +2582,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 					baseMethods,
 					coreGatewayMethodNames,
 					hostServices: pluginHostServices,
-					...(startupPluginIds.length > 0 && { startupPluginIds }),
+					...(deferredStartupPluginIds.length > 0 && { startupPluginIds: deferredStartupPluginIds }),
 					...(pluginLookUpTable !== void 0 && { pluginLookUpTable }),
 					startupTrace
 				});

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -655,7 +655,10 @@ async fn knapsack_bearer_token(
         );
       }
     }
-    Err(err) => log::warn!("[knapsack_token] /refresh_token_api request failed: {}", err),
+    Err(err) => log::warn!(
+      "[knapsack_token] /refresh_token_api request failed: {}",
+      err
+    ),
   }
 
   if let Some(refreshed) = refresh_knapsack_access_token().await {
@@ -695,7 +698,10 @@ fn normalize_provider_model(provider: &str, model: &str) -> String {
 fn knapsack_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
-    .and_then(|t| t.knapsack_model.map(|m| normalize_provider_model("knapsack", &m)))
+    .and_then(|t| {
+      t.knapsack_model
+        .map(|m| normalize_provider_model("knapsack", &m))
+    })
     .filter(|m| !m.trim().is_empty())
     .unwrap_or_else(|| "auto".to_string())
 }
@@ -2448,6 +2454,7 @@ pub async fn chat(
 
       // Don't use "efficient" mode - it truncates too much and loses important content
       let mut snap_query = json!({"profile": profile, "format": "ai", "refs": "aria"});
+      let mut target_id_was_cleared = false;
       if let Some(tid) = target_id {
         snap_query["targetId"] = json!(tid);
       }
@@ -2468,6 +2475,12 @@ pub async fn chat(
               || last_err.contains("not running")
               || last_err.contains("not ready");
             if is_transient && attempt < 2 {
+              if last_err.contains("tab not found") && !target_id_was_cleared {
+                if let Some(obj) = snap_query.as_object_mut() {
+                  obj.remove("targetId");
+                }
+                target_id_was_cleared = true;
+              }
               eprintln!(
                 "[clawd/chat] snapshot attempt {} failed ({}), retrying...",
                 attempt + 1,
@@ -4675,7 +4688,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         if !tls.is_empty() {
           body["tools"] = serde_json::to_value(&tls)?;
         }
-        let resp = client
+        let mut resp = client
           .post(format!(
             "{}/chat/completions",
             knapsack_base_url().trim_end_matches('/')
@@ -4685,6 +4698,20 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           .json(&body)
           .send()
           .await?;
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+          if let Some(refreshed_jwt) = refresh_knapsack_access_token().await {
+            resp = client
+              .post(format!(
+                "{}/chat/completions",
+                knapsack_base_url().trim_end_matches('/')
+              ))
+              .header("Authorization", format!("Bearer {}", refreshed_jwt))
+              .header("Content-Type", "application/json")
+              .json(&body)
+              .send()
+              .await?;
+          }
+        }
         if !resp.status().is_success() {
           let status = resp.status();
           let text = resp.text().await.unwrap_or_default();
@@ -4871,7 +4898,8 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             }
             // Skip paid providers if paid fallback is disabled and the user's
             // active provider is not itself a paid provider
-            if disable_paid && is_paid_provider(fb_provider) && !is_paid_provider(&current_provider) {
+            if disable_paid && is_paid_provider(fb_provider) && !is_paid_provider(&current_provider)
+            {
               eprintln!("[clawd/chat] Skipping paid fallback provider {} (KNAPSACK_DISABLE_PAID_FALLBACK=true)", fb_provider);
               continue;
             }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -100,6 +100,11 @@ fn runtime_channel<'a>(snapshot: &'a Value, channel: &str) -> Option<&'a Value> 
 }
 
 fn configured_channel(channel: &str) -> Option<Value> {
+  read_config_from_disk()
+    .and_then(|config| config.pointer(&format!("/channels/{}", channel)).cloned())
+}
+
+fn read_config_from_disk() -> Option<Value> {
   let mut candidates = Vec::new();
   if let Ok(dir) = std::env::var("OPENCLAW_STATE_DIR") {
     candidates.push(std::path::PathBuf::from(dir).join("openclaw.json"));
@@ -130,11 +135,52 @@ fn configured_channel(channel: &str) -> Option<Value> {
     let Ok(config) = serde_json::from_str::<Value>(&raw) else {
       continue;
     };
-    if let Some(entry) = config.pointer(&format!("/channels/{}", channel)) {
-      return Some(entry.clone());
-    }
+    return Some(config);
   }
   None
+}
+
+fn configured_channels_from_disk() -> Vec<String> {
+  let mut channels = read_config_from_disk()
+    .and_then(|config| {
+      config
+        .get("channels")
+        .and_then(|channels| channels.as_object())
+        .map(|channels| {
+          channels
+            .iter()
+            .filter_map(|(name, value)| {
+              if value.is_null() {
+                None
+              } else {
+                Some(name.clone())
+              }
+            })
+            .collect::<Vec<_>>()
+        })
+    })
+    .unwrap_or_default();
+  channels.sort();
+  channels
+}
+
+fn plugin_allow_from_disk() -> Vec<String> {
+  let mut plugins = read_config_from_disk()
+    .and_then(|config| {
+      config
+        .pointer("/plugins/allow")
+        .and_then(|value| value.as_array())
+        .map(|allow| {
+          allow
+            .iter()
+            .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+            .collect::<Vec<_>>()
+        })
+    })
+    .unwrap_or_default();
+  plugins.sort();
+  plugins.dedup();
+  plugins
 }
 
 fn runtime_status_response(
@@ -216,6 +262,9 @@ async fn gateway_or_bail() -> Option<HttpResponse> {
 struct SendMessageRequest {
   /// Channel to send through: "whatsapp" or "imessage"
   channel: String,
+  /// Optional account/profile inside the channel (for example Slack "john" or "mindy").
+  #[serde(rename = "accountId")]
+  account_id: Option<String>,
   /// Recipient address: phone number (WhatsApp) or email/phone (iMessage)
   to: String,
   /// The message text
@@ -1312,7 +1361,7 @@ pub async fn voice_enable(
   }
 }
 
-/// Send a message through a connected channel (WhatsApp or iMessage).
+/// Send a message through a connected channel.
 ///
 /// Wraps the gateway's `send` JSON-RPC method. The frontend calls this
 /// to push notification content to the user via their connected channels.
@@ -1322,10 +1371,10 @@ pub async fn send_channel_message(
   body: web::Json<SendMessageRequest>,
 ) -> impl Responder {
   let channel = body.channel.to_lowercase();
-  if channel != "whatsapp" && channel != "imessage" && channel != "telegram" {
+  if channel != "whatsapp" && channel != "imessage" && channel != "telegram" && channel != "slack" {
     return HttpResponse::BadRequest().json(SendMessageResponse {
       success: false,
-      message: Some("Channel must be 'whatsapp', 'imessage', or 'telegram'".to_string()),
+      message: Some("Channel must be 'whatsapp', 'imessage', 'telegram', or 'slack'".to_string()),
     });
   }
 
@@ -1338,12 +1387,20 @@ pub async fn send_channel_message(
     rand::random::<u32>()
   );
 
-  let params = serde_json::json!({
+  let mut params = serde_json::json!({
       "to": body.to,
       "message": body.message,
       "channel": channel,
       "idempotencyKey": idempotency_key,
   });
+  if let Some(account_id) = body
+    .account_id
+    .as_ref()
+    .map(|value| value.trim())
+    .filter(|value| !value.is_empty())
+  {
+    params["accountId"] = serde_json::json!(account_id);
+  }
 
   match gateway_client::call_channel_method("send", Some(params), None).await {
     Ok(_result) => HttpResponse::Ok().json(SendMessageResponse {
@@ -3002,8 +3059,8 @@ pub async fn channel_allowlist_update(
           };
           patch_inner.insert("allowFrom".to_string(), serde_json::json!(allow));
           if channel == "telegram" {
-            if let Some(accounts) = config_snapshot["config"]["channels"]["telegram"]["accounts"]
-              .as_object()
+            if let Some(accounts) =
+              config_snapshot["config"]["channels"]["telegram"]["accounts"].as_object()
             {
               let mut accounts_patch = serde_json::Map::new();
               for (account_id, account) in accounts {
@@ -3491,11 +3548,34 @@ pub async fn channel_diagnostics() -> impl Responder {
         }
       }
 
+      let channels = if channels.is_empty() {
+        let fallback = configured_channels_from_disk();
+        if !fallback.is_empty() {
+          issues.push(
+            "Gateway config RPC returned no channel configs; using disk config fallback"
+              .to_string(),
+          );
+        }
+        fallback
+      } else {
+        channels
+      };
+      let plugin_allow = if plugin_allow.is_empty() {
+        plugin_allow_from_disk()
+      } else {
+        plugin_allow
+      };
+
       (hm, m, channels, plugin_allow)
     }
     Err(e) => {
       issues.push(format!("Cannot fetch gateway config: {}", e));
-      (false, None, vec![], vec![])
+      let configured_channels = configured_channels_from_disk();
+      let plugin_allow = plugin_allow_from_disk();
+      if !configured_channels.is_empty() {
+        issues.push("Using disk config fallback for configured channels".to_string());
+      }
+      (false, None, configured_channels, plugin_allow)
     }
   };
 
@@ -3532,12 +3612,11 @@ pub async fn channel_diagnostics() -> impl Responder {
         .iter()
         .any(|existing| existing == channel);
       let summary = channel_summary_line(&channel_summary, channel);
-      let active = channel_summary_active(summary.as_deref())
-        || service::gateway_log_has_channel_started(channel);
+      let active = channel_summary_active(summary.as_deref());
       let plugin_allowed = plugin_allow.iter().any(|plugin| plugin == channel);
       let deferred = configured && !active && !plugin_allowed;
       let reason = if active {
-        "active according to gateway summary or startup log".to_string()
+        "active according to gateway channel summary".to_string()
       } else if deferred {
         "configured but plugin is not in startup allowlist; channel is deferred until opened"
           .to_string()
@@ -3557,6 +3636,15 @@ pub async fn channel_diagnostics() -> impl Responder {
       }
     })
     .collect::<Vec<_>>();
+
+  for state in &channel_states {
+    if state.configured && state.plugin_allowed && !state.active {
+      issues.push(format!(
+        "Configured channel '{}' is allowed but not active in the gateway channel summary",
+        state.channel
+      ));
+    }
+  }
 
   HttpResponse::Ok().json(ChannelDiagnostics {
     success: issues.is_empty(),

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -1472,17 +1472,17 @@ fn bundled_plugins_dir(app_handle: &tauri::AppHandle) -> PathBuf {
   }
 }
 
-fn configured_channel_fallback_ids(config_path: &Path) -> String {
+fn configured_channel_plugin_ids(config_path: &Path) -> Vec<String> {
   let content = match fs::read_to_string(config_path) {
     Ok(content) => content,
-    Err(_) => return String::new(),
+    Err(_) => return Vec::new(),
   };
   let json: serde_json::Value = match serde_json::from_str(&content) {
     Ok(value) => value,
-    Err(_) => return String::new(),
+    Err(_) => return Vec::new(),
   };
   let Some(channels) = json.get("channels").and_then(|value| value.as_object()) else {
-    return String::new();
+    return Vec::new();
   };
   let mut ids: Vec<String> = channels
     .iter()
@@ -1498,14 +1498,110 @@ fn configured_channel_fallback_ids(config_path: &Path) -> String {
       let trimmed = id.trim().to_ascii_lowercase();
       if trimmed.is_empty() {
         None
-      } else {
+      } else if KNAPSACK_BUNDLED_CHANNEL_PLUGIN_IDS
+        .iter()
+        .any(|channel_id| *channel_id == trimmed)
+      {
         Some(trimmed)
+      } else {
+        None
       }
     })
     .collect();
   ids.sort();
   ids.dedup();
+  ids
+}
+
+fn configured_channel_fallback_ids(config_path: &Path) -> String {
+  configured_channel_plugin_ids(config_path).join(",")
+}
+
+fn configured_desktop_plugin_discovery_allowlist(config_path: &Path) -> String {
+  let mut ids: Vec<String> = KNAPSACK_REQUIRED_PLUGINS
+    .iter()
+    .map(|plugin| plugin.to_string())
+    .collect();
+  ids.extend(configured_channel_plugin_ids(config_path));
+  ids.sort();
+  ids.dedup();
   ids.join(",")
+}
+
+fn configured_channel_plugin_filter(config_path: &Path) -> Option<HashSet<String>> {
+  let ids = configured_channel_plugin_ids(config_path);
+  if ids.is_empty() {
+    None
+  } else {
+    Some(ids.into_iter().collect())
+  }
+}
+
+async fn gateway_status_rpc_ok(token: &str, timeout: std::time::Duration) -> bool {
+  tokio::time::timeout(timeout, gateway_client::get_channel_status(Some(token)))
+    .await
+    .map(|result| result.is_ok())
+    .unwrap_or(false)
+}
+
+fn plugin_runtime_deps_staging_dir(plugin_name: &str) -> PathBuf {
+  let safe_plugin_name = plugin_name
+    .chars()
+    .map(|ch| {
+      if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+        ch
+      } else {
+        '-'
+      }
+    })
+    .collect::<String>();
+  let unique = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map(|d| d.as_nanos())
+    .unwrap_or_default();
+  std::env::temp_dir().join(format!(
+    "knapsack-plugin-deps-{}-{}-{}",
+    safe_plugin_name,
+    std::process::id(),
+    unique
+  ))
+}
+
+fn copy_plugin_node_modules_entries(source_nm: &Path, target_nm: &Path) -> std::io::Result<()> {
+  fs::create_dir_all(target_nm)?;
+  for entry in fs::read_dir(source_nm)? {
+    let entry = entry?;
+    let source_path = entry.path();
+    let target_path = target_nm.join(entry.file_name());
+    let file_type = entry.file_type()?;
+    if file_type.is_dir() {
+      if target_path.exists() {
+        fs::remove_dir_all(&target_path)?;
+      }
+      copy_plugin_node_modules_entries(&source_path, &target_path)?;
+    } else if file_type.is_symlink() {
+      if target_path.exists() {
+        let _ = fs::remove_file(&target_path).or_else(|_| fs::remove_dir_all(&target_path));
+      }
+      let target = fs::read_link(&source_path)?;
+      #[cfg(unix)]
+      std::os::unix::fs::symlink(target, &target_path)?;
+      #[cfg(windows)]
+      {
+        if source_path.is_dir() {
+          std::os::windows::fs::symlink_dir(target, &target_path)?;
+        } else {
+          std::os::windows::fs::symlink_file(target, &target_path)?;
+        }
+      }
+    } else {
+      if target_path.exists() {
+        let _ = fs::remove_file(&target_path);
+      }
+      fs::copy(&source_path, &target_path)?;
+    }
+  }
+  Ok(())
 }
 
 /// Install runtime dependencies for bundled plugins that declare
@@ -1518,6 +1614,7 @@ fn configured_channel_fallback_ids(config_path: &Path) -> String {
 fn install_bundled_plugin_runtime_deps(
   node_path: &std::path::Path,
   extensions_dir: &std::path::Path,
+  plugin_filter: Option<&HashSet<String>>,
 ) {
   let _install_guard = ROOT_PLUGIN_DEPS_INSTALL_MUTEX
     .lock()
@@ -1588,6 +1685,13 @@ fn install_bundled_plugin_runtime_deps(
     if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
       continue;
     }
+    let plugin_name = entry.file_name().to_string_lossy().to_string();
+    if plugin_filter
+      .map(|filter| !filter.contains(&plugin_name))
+      .unwrap_or(false)
+    {
+      continue;
+    }
     let plugin_dir = entry.path();
     let pkg_path = plugin_dir.join("package.json");
     if !pkg_path.exists() {
@@ -1610,10 +1714,24 @@ fn install_bundled_plugin_runtime_deps(
       continue;
     }
 
-    let deps: Vec<String> = pkg
+    let deps: Vec<(String, String)> = pkg
       .get("dependencies")
       .and_then(|v| v.as_object())
-      .map(|m| m.keys().cloned().collect())
+      .map(|m| {
+        m.iter()
+          .filter_map(|(dep, version)| {
+            let version = version.as_str()?;
+            if version.starts_with("file:")
+              || version.starts_with("link:")
+              || version.starts_with("workspace:")
+              || version.starts_with("portal:")
+            {
+              return None;
+            }
+            Some((dep.clone(), version.to_string()))
+          })
+          .collect()
+      })
       .unwrap_or_default();
 
     // On Windows CI builds the extension node_modules is packed into
@@ -1622,7 +1740,7 @@ fn install_bundled_plugin_runtime_deps(
     ensure_node_modules_extracted(&plugin_dir);
 
     let nm_dir = plugin_dir.join("node_modules");
-    let all_present = !deps.is_empty() && deps.iter().all(|dep| nm_dir.join(dep).exists());
+    let all_present = !deps.is_empty() && deps.iter().all(|(dep, _)| nm_dir.join(dep).exists());
     if all_present {
       eprintln!(
         "[clawd/service] Plugin {} runtime deps already present",
@@ -1631,19 +1749,44 @@ fn install_bundled_plugin_runtime_deps(
       continue;
     }
 
-    let plugin_name = entry.file_name().to_string_lossy().to_string();
     eprintln!(
       "[clawd/service] Installing runtime deps for plugin {}...",
       plugin_name
     );
 
-    let npm_args = [
-      "install",
+    if deps.is_empty() {
+      eprintln!(
+        "[clawd/service] Plugin {} has no registry runtime deps to install",
+        plugin_name
+      );
+      continue;
+    }
+
+    let dep_specs = deps
+      .iter()
+      .map(|(dep, version)| format!("{}@{}", dep, version))
+      .collect::<Vec<_>>();
+    let mut npm_args: Vec<&str> = vec!["install"];
+    let dep_refs = dep_specs
+      .iter()
+      .map(|spec| spec.as_str())
+      .collect::<Vec<_>>();
+    npm_args.extend(dep_refs.iter().copied());
+    npm_args.extend([
+      "--no-save",
       "--omit=dev",
       "--ignore-scripts",
       "--no-audit",
       "--no-fund",
-    ];
+    ]);
+    let staging_dir = plugin_runtime_deps_staging_dir(&plugin_name);
+    if let Err(err) = fs::create_dir_all(&staging_dir) {
+      eprintln!(
+        "[clawd/service] WARNING: could not create plugin runtime deps staging dir for {}: {}",
+        plugin_name, err
+      );
+      continue;
+    }
     #[cfg(target_os = "windows")]
     let result = {
       use std::os::windows::process::CommandExt;
@@ -1651,13 +1794,13 @@ fn install_bundled_plugin_runtime_deps(
       match &npm_runner {
         NpmRunner::NpmCli(npm_cli) => std::process::Command::new(node_path)
           .arg(npm_cli)
-          .args(npm_args)
-          .current_dir(&plugin_dir)
+          .args(&npm_args)
+          .current_dir(&staging_dir)
           .creation_flags(CREATE_NO_WINDOW)
           .status(),
         NpmRunner::NpmBin(npm_bin) => std::process::Command::new(npm_bin)
-          .args(npm_args)
-          .current_dir(&plugin_dir)
+          .args(&npm_args)
+          .current_dir(&staging_dir)
           .creation_flags(CREATE_NO_WINDOW)
           .status(),
       }
@@ -1666,20 +1809,28 @@ fn install_bundled_plugin_runtime_deps(
     let result = match &npm_runner {
       NpmRunner::NpmCli(npm_cli) => std::process::Command::new(node_path)
         .arg(npm_cli)
-        .args(npm_args)
-        .current_dir(&plugin_dir)
+        .args(&npm_args)
+        .current_dir(&staging_dir)
         .status(),
       NpmRunner::NpmBin(npm_bin) => std::process::Command::new(npm_bin)
-        .args(npm_args)
-        .current_dir(&plugin_dir)
+        .args(&npm_args)
+        .current_dir(&staging_dir)
         .status(),
     };
 
     match result {
-      Ok(s) if s.success() => eprintln!(
-        "[clawd/service] Plugin {} runtime deps installed",
-        plugin_name
-      ),
+      Ok(s) if s.success() => {
+        match copy_plugin_node_modules_entries(&staging_dir.join("node_modules"), &nm_dir) {
+          Ok(()) => eprintln!(
+            "[clawd/service] Plugin {} runtime deps installed",
+            plugin_name
+          ),
+          Err(e) => eprintln!(
+            "[clawd/service] WARNING: copying runtime deps for plugin {} failed: {}",
+            plugin_name, e
+          ),
+        }
+      }
       Ok(s) => eprintln!(
         "[clawd/service] WARNING: npm install for plugin {} exited {}",
         plugin_name, s
@@ -1689,6 +1840,7 @@ fn install_bundled_plugin_runtime_deps(
         plugin_name, e
       ),
     }
+    let _ = fs::remove_dir_all(&staging_dir);
   }
 
   // Pass 2: Shared bundler chunks (e.g. sticker-cache.js) sit in the root dist/ and
@@ -1756,6 +1908,13 @@ fn install_bundled_plugin_runtime_deps(
   if let Ok(root_entries) = fs::read_dir(extensions_dir) {
     for entry in root_entries.flatten() {
       if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        continue;
+      }
+      let plugin_name = entry.file_name().to_string_lossy().to_string();
+      if plugin_filter
+        .map(|filter| !filter.contains(&plugin_name))
+        .unwrap_or(false)
+      {
         continue;
       }
       let pkg: serde_json::Value = match fs::read_to_string(entry.path().join("package.json"))
@@ -2851,6 +3010,11 @@ async fn browser_cdp_port_open(timeout: std::time::Duration) -> bool {
     tokio::time::timeout(timeout, tokio::net::TcpStream::connect(addr)).await,
     Ok(Ok(_))
   )
+}
+
+fn browser_cdp_port_open_sync(timeout: std::time::Duration) -> bool {
+  let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 18800u16));
+  std::net::TcpStream::connect_timeout(&addr, timeout).is_ok()
 }
 
 async fn gateway_tcp_port_open(timeout: std::time::Duration) -> bool {
@@ -4633,7 +4797,7 @@ async fn run_gateway_self_heal_cycle(
 
   let extensions_dir = bundled_plugins_dir(&app_handle);
   if !cfg!(debug_assertions) {
-    install_bundled_plugin_runtime_deps(&setup.node_path, &extensions_dir);
+    install_bundled_plugin_runtime_deps(&setup.node_path, &extensions_dir, None);
     ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
   }
 
@@ -5099,6 +5263,10 @@ fn spawn_startup_browser_start_nudge(gateway_token: String) {
 
 #[cfg(target_os = "macos")]
 fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), String> {
+  if browser_cdp_port_open_sync(std::time::Duration::from_millis(250)) {
+    return Ok(());
+  }
+
   let chrome = Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
   if !chrome.exists() {
     return Err("Google Chrome app binary was not found".to_string());
@@ -5140,6 +5308,10 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
 
 #[cfg(target_os = "windows")]
 fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), String> {
+  if browser_cdp_port_open_sync(std::time::Duration::from_millis(250)) {
+    return Ok(());
+  }
+
   let program_files =
     std::env::var("PROGRAMFILES").unwrap_or_else(|_| r"C:\Program Files".to_string());
   let program_files_x86 =
@@ -5266,12 +5438,16 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     // Gateway health is intentionally unauthenticated. A bound TCP port is not
     // enough: during startup the gateway can accept connections while the Node
     // event loop is still too busy to answer `/health`.
-    let gateway_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
+    let mut gateway_ok = gateway_reachable_or_ready(GATEWAY_LOCAL_HEALTH_TIMEOUT).await;
     let gateway_listening = if gateway_ok {
       true
     } else {
       gateway_tcp_port_open(std::time::Duration::from_millis(150)).await
     };
+    if !gateway_ok && gateway_listening {
+      gateway_ok =
+        gateway_status_rpc_ok(&tokens.gateway_token, std::time::Duration::from_millis(900)).await;
+    }
     let gateway_probe_failed = !gateway_ok;
 
     // Track gateway state transitions for recovery logic.
@@ -5825,8 +6001,8 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
 pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> impl Responder {
   use crate::clawd::{gateway_supervisor, gateway_ws};
 
-  const STARTUP_READY_BUDGET_MS: u64 = 15_000;
-  const GATEWAY_READY_BUDGET_MS: u64 = 13_500;
+  const STARTUP_READY_BUDGET_MS: u64 = 45_000;
+  const GATEWAY_READY_BUDGET_MS: u64 = 42_000;
 
   let tokens = match load_or_create_tokens(&app_handle) {
     Ok(t) => t,
@@ -5919,7 +6095,8 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
 
   let gateway_listening_for_startup =
     gateway_tcp_port_open(std::time::Duration::from_millis(150)).await;
-  let startup_progress_for_desktop = (gateway_listening_for_startup && gateway_startup_in_progress())
+  let startup_progress_for_desktop = (gateway_listening_for_startup
+    && gateway_startup_in_progress())
     || gateway_post_bind_startup_in_progress()
     || gateway_runtime_deps_startup_in_progress()
     || gateway_launch_grace_active().is_some();
@@ -6022,7 +6199,7 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
     } else if ready {
       "Gateway is ready; browser and channels are still starting up".to_string()
     } else {
-      "Gateway did not become ready within 15s".to_string()
+      "Gateway did not become ready within 45s".to_string()
     },
     diagnostic_type: None,
   })
@@ -9323,6 +9500,7 @@ async fn prepare_gateway_config(
   let bundled_plugins_dir = bundled_plugins_dir(app_handle);
   let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
   let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
+  let plugin_discovery_allowlist = configured_desktop_plugin_discovery_allowlist(&config_path);
 
   let node_dir = node_path
     .parent()
@@ -9395,11 +9573,19 @@ async fn prepare_gateway_config(
       "OPENCLAW_BUNDLED_PLUGINS_DIR".to_string(),
       bundled_plugins_dir_str,
     ),
+    (
+      "OPENCLAW_DISABLE_BUNDLED_PLUGINS".to_string(),
+      "0".to_string(),
+    ),
     ("OPENCLAW_QUIET_CONFIG_VERSION".to_string(), "1".to_string()),
     ("OPENCLAW_DISABLE_BONJOUR".to_string(), "1".to_string()),
     (
       "OPENCLAW_BUNDLED_CHANNEL_FALLBACK_IDS".to_string(),
       configured_channel_fallback_ids,
+    ),
+    (
+      "OPENCLAW_PLUGIN_DISCOVERY_ALLOWLIST".to_string(),
+      plugin_discovery_allowlist,
     ),
     // Keep optional network warmups/providers from delaying the local gateway
     // port. Channels can continue connecting after the UI is already usable.
@@ -9414,6 +9600,10 @@ async fn prepare_gateway_config(
     (
       "OPENCLAW_DEFER_STARTUP_SIDECARS".to_string(),
       "1".to_string(),
+    ),
+    (
+      "OPENCLAW_PROVIDER_AUTH_PREWARM_DELAY_MS".to_string(),
+      "180000".to_string(),
     ),
     (
       "OPENCLAW_DESKTOP_MANAGED_GATEWAY".to_string(),
@@ -9635,13 +9825,18 @@ async fn prepare_gateway_config(
 
   // Install runtime deps for bundled plugins (e.g. grammy for telegram).
   // Must happen AFTER resource files are in place (i.e. here, not in beforeDevCommand).
-  if !cfg!(debug_assertions) {
+  if cfg!(debug_assertions) {
+    if let Some(plugin_filter) = configured_channel_plugin_filter(&config_path) {
+      install_bundled_plugin_runtime_deps(&node_path, &bundled_plugins_dir, Some(&plugin_filter));
+      ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
+    }
+  } else {
     let warm_node_path = node_path.clone();
     let warm_bundled_plugins_dir = bundled_plugins_dir.clone();
     let warm_clawdbot_home = app_clawdbot_home(app_handle);
     std::thread::spawn(move || {
       std::thread::sleep(std::time::Duration::from_secs(180));
-      install_bundled_plugin_runtime_deps(&warm_node_path, &warm_bundled_plugins_dir);
+      install_bundled_plugin_runtime_deps(&warm_node_path, &warm_bundled_plugins_dir, None);
       ensure_plugin_runtime_deps_openclaw_links(&warm_clawdbot_home);
     });
     eprintln!(
@@ -10200,14 +10395,13 @@ pub async fn set_service_enabled(
         }
       }
 
-      // Install runtime deps for bundled plugins (e.g. grammy for telegram).
       if !cfg!(debug_assertions) {
         let warm_node_path = node_path.clone();
         let warm_bundled_plugins_dir = bundled_plugins_dir.clone();
         let warm_clawdbot_home = clawdbot_home.clone();
         std::thread::spawn(move || {
           std::thread::sleep(std::time::Duration::from_secs(180));
-          install_bundled_plugin_runtime_deps(&warm_node_path, &warm_bundled_plugins_dir);
+          install_bundled_plugin_runtime_deps(&warm_node_path, &warm_bundled_plugins_dir, None);
           ensure_plugin_runtime_deps_openclaw_links(&warm_clawdbot_home);
         });
       }
@@ -10220,6 +10414,16 @@ pub async fn set_service_enabled(
       // Use openclaw.json (preferred in 2026.2+); also check for legacy clawdbot.json.
       let config_path = clawdbot_home.join("openclaw.json");
       let legacy_config_path = clawdbot_home.join("clawdbot.json");
+      if cfg!(debug_assertions) {
+        if let Some(plugin_filter) = configured_channel_plugin_filter(&config_path) {
+          install_bundled_plugin_runtime_deps(
+            &node_path,
+            &bundled_plugins_dir,
+            Some(&plugin_filter),
+          );
+          ensure_plugin_runtime_deps_openclaw_links(&clawdbot_home);
+        }
+      }
       // If the legacy config exists but the new one doesn't, rename it.
       if legacy_config_path.exists() && !config_path.exists() {
         match fs::rename(&legacy_config_path, &config_path) {
@@ -11089,6 +11293,7 @@ pub async fn set_service_enabled(
       // bundled_plugins_dir was resolved earlier (before config patching)
       let bundled_plugins_dir_str = bundled_plugins_dir.to_string_lossy().to_string();
       let configured_channel_fallback_ids = configured_channel_fallback_ids(&config_path);
+      let plugin_discovery_allowlist = configured_desktop_plugin_discovery_allowlist(&config_path);
       eprintln!(
         "[clawd/service] Skipping blocking OpenClaw doctor --fix during startup config preparation"
       );
@@ -11156,6 +11361,10 @@ pub async fn set_service_enabled(
           "OPENCLAW_BUNDLED_PLUGINS_DIR".to_string(),
           bundled_plugins_dir_str,
         ),
+        (
+          "OPENCLAW_DISABLE_BUNDLED_PLUGINS".to_string(),
+          "0".to_string(),
+        ),
         // Suppress the repetitive "Config was last written by a newer OpenClaw" warning.
         // The gateway logs this on every config read; setting this env var tells it to
         // log the warning only once on startup instead of on every read cycle.
@@ -11164,6 +11373,10 @@ pub async fn set_service_enabled(
         (
           "OPENCLAW_BUNDLED_CHANNEL_FALLBACK_IDS".to_string(),
           configured_channel_fallback_ids,
+        ),
+        (
+          "OPENCLAW_PLUGIN_DISCOVERY_ALLOWLIST".to_string(),
+          plugin_discovery_allowlist,
         ),
         // Keep optional network warmups/providers from delaying the local gateway
         // port. Channels can continue connecting after the UI is already usable.
@@ -11178,6 +11391,10 @@ pub async fn set_service_enabled(
         (
           "OPENCLAW_DEFER_STARTUP_SIDECARS".to_string(),
           "1".to_string(),
+        ),
+        (
+          "OPENCLAW_PROVIDER_AUTH_PREWARM_DELAY_MS".to_string(),
+          "180000".to_string(),
         ),
         (
           "OPENCLAW_DESKTOP_MANAGED_GATEWAY".to_string(),


### PR DESCRIPTION
## Summary
- constrain desktop-managed OpenClaw plugin discovery/startup to the required browser plugin plus configured channel plugins
- make bundled channel runtime dependency repair/install targeted and macOS-aware so Slack/Telegram startup does not drag unrelated plugins into dev/prod startup
- harden browser/control readiness and provider-auth prewarm so startup reaches user-visible ready state faster and avoids stale browser targets
- improve channel diagnostics and QA coverage for configured Slack/Telegram transports, including account-specific Slack labels for Merlin/default, John, and Mindy
- add optional `accountId` support to the desktop channel send endpoint and make QA distinguish Slack inbound allowlists from real outbound send targets

## Dev QA Evidence
Command:

```sh
KNAPSACK_QA_INCLUDE_CHANNEL_PLUGINS=1 \
KNAPSACK_QA_REQUIRE_CHANNEL_TRANSPORTS=1 \
KNAPSACK_QA_SEND_CHANNEL_MESSAGES=1 \
KNAPSACK_QA_CHANNEL_READY_TIMEOUT_MS=60000 \
KNAPSACK_QA_PREPARE_TIMEOUT_MS=900000 \
KNAPSACK_QA_CHAT_TIMEOUT_MS=120000 \
KNAPSACK_QA_FUNCTIONAL_TIMEOUT_MS=600000 \
npm run qa:loop -- --dev --providers knapsack,gemini,openrouter,ollama --startup-budget-ms 45000 --readiness-health-timeout-ms 60000 --chat-retries 1 1
```

Result:
- PASSED
- active+stable readiness in 7,668ms against a 45s target
- chat checks passed: knapsack/auto, gemini-2.5-flash, openrouter/openai/gpt-4o-mini, ollama/markheynen/knapsack-7b-chat-metal:latest
- browser control healthy
- Slack and Telegram configured/allowed/active in channel diagnostics
- Telegram send succeeded
- Slack accounts detected as active: Merlin/default, John, Mindy

Slack send note: the local config does not currently expose a postable Slack target (`KNAPSACK_QA_SLACK_TO`, `qaTarget`, etc.). The previous harness incorrectly used `allowFrom: ["*"]` as an outbound destination, which produced false `channel_not_found` failures. This PR makes that distinction explicit. A real Slack send gate can be enabled by providing `KNAPSACK_QA_SLACK_TO=user:<slack-user-id>` or `channel:<slack-channel-id>`.

## Other Verification
- `node --check` on all edited JS files
- `rustfmt --check` on edited Rust files
- `git diff --check`
- `cargo check` was attempted; it progressed through dependency/crate checking but was stopped after several minutes of no output in the known local Tauri check stall. No errors were emitted before stopping; existing patched-wry warnings were observed.
