### PR TITLE
fix: harden mac packaging for UI bundle assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,70 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+      - name: Verify macOS bundle includes bundled UI assets
+        working-directory: src
+        run: |
+          APP=$(ls -d src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app | head -1)
+          if [ -z "$APP" ]; then
+            echo "ERROR: No macOS app bundle found after build."
+            exit 1
+          fi
+
+          RESOURCES="$APP/Contents/Resources"
+          has_main=0
+          has_notification=0
+          has_overlay=0
+          has_recording_indicator=0
+
+          for path in \
+            "index.html" \
+            "dist/index.html"; do
+            if [ -f "$RESOURCES/$path" ]; then
+              has_main=1
+              break
+            fi
+          done
+
+          for path in \
+            "notification.html" \
+            "dist/notification.html"; do
+            if [ -f "$RESOURCES/$path" ]; then
+              has_notification=1
+              break
+            fi
+          done
+
+          for path in \
+            "overlay.html" \
+            "dist/overlay.html"; do
+            if [ -f "$RESOURCES/$path" ]; do
+              has_overlay=1
+              break
+            fi
+          done
+
+          for path in \
+            "recording-indicator.html" \
+            "dist/recording-indicator.html"; do
+            if [ -f "$RESOURCES/$path" ]; then
+              has_recording_indicator=1
+              break
+            fi
+          done
+
+          if [ "$has_main" -ne 1 ] || [ "$has_notification" -ne 1 ] || [ "$has_overlay" -ne 1 ] || [ "$has_recording_indicator" -ne 1 ]; then
+            echo "ERROR: Built app bundle is missing required UI assets in $RESOURCES."
+            echo "Missing assets:"
+            [ "$has_main" -eq 1 ] || echo "  - index.html"
+            [ "$has_notification" -eq 1 ] || echo "  - notification.html"
+            [ "$has_overlay" -eq 1 ] || echo "  - overlay.html"
+            [ "$has_recording_indicator" -eq 1 ] || echo "  - recording-indicator.html"
+            echo "This indicates a packaging regression. Aborting release."
+            exit 1
+          fi
+
+          echo "Validated bundled UI assets are present in $APP."
+
       - name: Import signing certificate
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/src/src-tauri/build.rs
+++ b/src/src-tauri/build.rs
@@ -27,6 +27,23 @@ fn remove_broken_symlinks_recursive(dir: &Path) {
 }
 
 fn main() {
+  let dist_dir = Path::new("../dist");
+  let dist_pages = [
+    "index.html",
+    "notification.html",
+    "overlay.html",
+    "recording-indicator.html",
+  ];
+
+  for page in dist_pages {
+    let candidate = dist_dir.join(page);
+    if !candidate.exists() {
+      panic!(
+        "Missing packaged UI asset: {candidate:?}. This indicates the frontend build did not finish before the Rust build step.",
+      );
+    }
+  }
+
   let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
   let node_modules = Path::new("resources/clawdbot/node_modules");
   let openclaw_self_link = node_modules.join("openclaw");

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -121,6 +121,30 @@ const NOTIF_END_X_OFFSET: i32 = 20;
 const NOTIF_ANIMATION_DURATION: u32 = 90;
 const NOTIF_FRAME_TIME: u64 = 8;
 
+fn validate_bundled_ui_asset(app: &tauri::App, page: &str, label: &str) -> Option<String> {
+  let candidate_paths = vec![page.to_string(), format!("dist/{page}")];
+  let found = candidate_paths.iter().find_map(|candidate| {
+    app
+      .path_resolver()
+      .resolve_resource(candidate)
+      .map(|path| {
+        log::info!("Resolved {label} UI asset: {:?}", path);
+        candidate.clone()
+      })
+  });
+
+  if let Some(path) = &found {
+    log::info!("Using {label} UI asset at {path}");
+    return Some(path.to_string());
+  }
+
+  let tried = candidate_paths.join(", ");
+  log::error!(
+    "Missing required bundled UI asset for {label}. Tried: {tried}. This is usually a packaging issue; please reinstall the app from the latest release."
+  );
+  None
+}
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum Release {
@@ -1610,6 +1634,27 @@ async fn main() {
     .manage(semantic_service.clone())
     .manage(recording_state)
     .setup(move |app| {
+      #[cfg(not(debug_assertions))]
+      {
+        let mut missing = Vec::new();
+        let mut assert_asset = |page, label| {
+          if validate_bundled_ui_asset(app, page, label).is_none() {
+            missing.push(format!("{page} ({label})"));
+          }
+        };
+        assert_asset("index.html", "main window");
+        assert_asset("notification.html", "notification window");
+        assert_asset("overlay.html", "overlay window");
+        assert_asset("recording-indicator.html", "recording indicator window");
+
+        if !missing.is_empty() {
+          return Err(Box::new(tauri::Error::AssetNotFound(format!(
+            "Bundled UI assets missing (packaging issue): {}. Reinstall from the latest release and report this crash report.",
+            missing.join(", ")
+          ))));
+        }
+      }
+
       // Create window with specified logical size
       let mut window_builder = WindowBuilder::new(
         app,

--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -170,6 +170,7 @@
       },
       "publisher": "Knap",
       "resources": [
+        "../dist",
         "resources/signin_success.html",
         "resources/signin_error.html",
         "resources/node/**/*",


### PR DESCRIPTION
## Why
- 2.4.9 crash report shows the mac app panics in prepare_uri_scheme_protocol due missing packaged UI assets.
- Installed /Applications/Knapsack.app/Contents/Resources/dist does not exist.

## Fix
- Add explicit build-time guard in src-tauri/build.rs to panic early if required dist assets are missing before tauri build.
- Ensure macOS bundle includes ../dist resources in tauri.conf.json.
- Add release workflow validation step in .github/workflows/release.yml after mac build that asserts bundled HTML assets exist.
- Add release-time runtime guard in src-tauri/src/main.rs to fail with a clear packaging error when required assets are absent (non-debug builds).

## Scope
- Non-functional change to catch packaging regressions before release instead of shipping crash-prone binaries.

## Validation
- Diff reviewed against main; this commit is isolated to packaging/regression handling and should not change runtime feature behavior.