### PR TITLE
fix: repair mac release asset check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           for path in \
             "overlay.html" \
             "dist/overlay.html"; do
-            if [ -f "$RESOURCES/$path" ]; do
+            if [ -f "$RESOURCES/$path" ]; then
               has_overlay=1
               break
             fi


### PR DESCRIPTION
## Summary
- fix the shell typo in the macOS bundled UI asset verification step
- keep the packaging guard in place so missing UI assets still fail the release
- unblock publishing a real macOS release artifact from current main

## Testing
- inspected failed release log for run 27591624537
- verified the workflow step now uses valid shell syntax
