### PR TITLE
fix: accept packaged updater UI asset layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,8 @@ jobs:
 
           for path in \
             "index.html" \
-            "dist/index.html"; do
+            "dist/index.html" \
+            "_up_/dist/index.html"; do
             if [ -f "$RESOURCES/$path" ]; then
               has_main=1
               break
@@ -152,7 +153,8 @@ jobs:
 
           for path in \
             "notification.html" \
-            "dist/notification.html"; do
+            "dist/notification.html" \
+            "_up_/dist/notification.html"; do
             if [ -f "$RESOURCES/$path" ]; then
               has_notification=1
               break
@@ -161,7 +163,8 @@ jobs:
 
           for path in \
             "overlay.html" \
-            "dist/overlay.html"; do
+            "dist/overlay.html" \
+            "_up_/dist/overlay.html"; do
             if [ -f "$RESOURCES/$path" ]; then
               has_overlay=1
               break
@@ -170,7 +173,8 @@ jobs:
 
           for path in \
             "recording-indicator.html" \
-            "dist/recording-indicator.html"; do
+            "dist/recording-indicator.html" \
+            "_up_/dist/recording-indicator.html"; do
             if [ -f "$RESOURCES/$path" ]; then
               has_recording_indicator=1
               break

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -122,7 +122,11 @@ const NOTIF_ANIMATION_DURATION: u32 = 90;
 const NOTIF_FRAME_TIME: u64 = 8;
 
 fn validate_bundled_ui_asset(app: &tauri::App, page: &str, label: &str) -> Option<String> {
-  let candidate_paths = vec![page.to_string(), format!("dist/{page}")];
+  let candidate_paths = vec![
+    page.to_string(),
+    format!("dist/{page}"),
+    format!("_up_/dist/{page}"),
+  ];
   let found = candidate_paths.iter().find_map(|candidate| {
     app
       .path_resolver()


### PR DESCRIPTION
## Summary
- accept the observed mac packaged UI asset layout under `Contents/Resources/_up_/dist`
- keep the release guard in place while matching the actual successful bundle structure
- let startup validation recognize the same packaged layout so the app does not self-report a false packaging failure

## Evidence
- release run `27594285854` failed only because the verifier expected `Resources/dist/*`
- successful mac updater artifact from run `27591622290` contains the pages at `Resources/_up_/dist/*`
- local check against the extracted artifact found all four required pages with the widened lookup
