### PR TITLE
Harden release retries and QA dev bootstrap

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -142,6 +142,18 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload updater artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: knapsack-macos-updater
+          path: |
+            src/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz
+            src/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
+          if-no-files-found: warn
+
+      - name: Upload updater artifact (best effort for pull requests)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: knapsack-macos-updater

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   workflow_dispatch:
 
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -19,6 +23,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -35,10 +40,21 @@ jobs:
           TAG="${{ steps.bump.outputs.tag }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main --tags
           git add -A
-          git commit -m "release: $TAG"
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+          else
+            git commit -m "release: $TAG"
+          fi
+          git rebase origin/main
+          git push origin HEAD:main
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
+            echo "ERROR: tag $TAG already exists on origin; refusing to reuse it for a new release commit."
+            exit 1
+          fi
           git tag "$TAG"
-          git push origin HEAD --tags
+          git push origin "refs/tags/$TAG"
 
   # ---------------------------------------------------------------------------
   # macOS — Universal binary (arm64 + x86_64), signed & notarized

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -37,6 +37,10 @@ const qaStateDir = path.join(projectDir, ".qa-dev-openclaw-state");
 const sourceClawdbotDir = path.join(tauriDir, "resources", "clawdbot");
 const targetClawdbotDir = path.join(tauriDir, "target", "debug", "resources", "clawdbot");
 
+function npmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
 function qaEnv(extra = {}) {
   const env = {
     ...process.env,
@@ -80,6 +84,16 @@ function spawnVite() {
       env: qaEnv(),
     },
   );
+}
+
+function rootNodeModulesReady() {
+  return fs.existsSync(viteJs) || fs.existsSync(viteBin);
+}
+
+function ensureRootNodeModules() {
+  if (rootNodeModulesReady()) return;
+  console.log("[qa-dev-run] root node_modules missing; running npm install");
+  runChecked(npmCommand(), ["install"], { cwd: projectDir });
 }
 
 function runChecked(command, args, options = {}) {
@@ -511,6 +525,7 @@ function syncDevClawdbotResources() {
 }
 
 async function main() {
+  ensureRootNodeModules();
   runChecked(process.execPath, [path.join(projectDir, "scripts", "fix-rollup-native.cjs")]);
   runChecked(process.execPath, [
     path.join(projectDir, "scripts", "ensure-clawdbot-deps.cjs"),


### PR DESCRIPTION
## Summary
- make the release workflow rebase on the latest `origin/main`, push `main` before creating the tag, and serialize release runs
- fail cleanly if the target tag already exists instead of half-publishing a release
- make `qa-dev-run.cjs` install root app deps automatically when a fresh worktree is missing Vite/node_modules

## Validation
- `node --check src/scripts/qa-dev-run.cjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml ok"'`
- `node scripts/qa-loop-runner.cjs --dev --provider gemini,knapsack,ollama,openrouter --strict-readiness --max-attempts 1 --startup-budget-ms 120000 --functional-timeout-ms 180000`

## Context
- PR #524 merged cleanly and the merged dev build passed QA.
- Two release workflow runs then failed in `bump-version` due a stale-main race followed by an already-existing tag (`v2.5.3`).
- This change makes future retries safe and removes the fresh-worktree QA bootstrap footgun we hit during validation.