### PR TITLE
[codex] Fix live desktop regressions

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4197,17 +4197,19 @@ When the user says "go to [site] and [do something]", you must:
 
 Examples:
 - "go to LinkedIn and summarize my notifications" → list_tabs() to check, then navigate("https://www.linkedin.com") or focus_tab(), then snapshot() and summarize
-- "check Gmail and find emails from John" → navigate("https://mail.google.com"), then snapshot() and search
+- "check Gmail and find emails from John" → if native email/calendar context is already available in the prompt, answer from that first; otherwise navigate("https://mail.google.com"), then snapshot() and search
 - "open Twitter and show my mentions" → navigate("https://x.com"), then snapshot() and find mentions
 
 **NEVER pass the entire user request as a URL.** Extract the website name and construct a proper URL.
 
 ## Quick Access to Common Services
-- "check my email" / "Gmail" → navigate("https://mail.google.com")
+- If the user's prompt is only asking about their emails, inbox, schedule, meetings, or calendar, and the prompt already includes native Knapsack email/calendar context, answer from that context first instead of opening the browser.
+- Only use browser navigation for Gmail/Calendar/Drive when the user explicitly asks to use the web UI or when the native context/tooling cannot answer the request.
+- "check my email" / "Gmail" → prefer native email context first; only navigate("https://mail.google.com") if native context is unavailable or insufficient
 - "search for X" → navigate("https://www.google.com/search?q=X")  (only the search query goes in the URL)
-- "calendar" → navigate("https://calendar.google.com")
+- "calendar" → prefer native calendar context first; only navigate("https://calendar.google.com") if native context is unavailable or insufficient
 - "tasks" / "Google Tasks" → navigate("https://tasks.google.com")
-- "drive" / "docs" → navigate("https://drive.google.com")
+- "drive" / "docs" → prefer native Drive context when provided; otherwise navigate("https://drive.google.com")
 - "LinkedIn" → navigate("https://www.linkedin.com")
 - "Twitter" / "X" → navigate("https://x.com")
 - "GitHub" → navigate("https://github.com")

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -1931,15 +1931,25 @@ pub async fn generic_channel_status(
     });
   }
 
-  return HttpResponse::Ok().json(ChannelStatusResponse {
-    success: true,
-    enabled: false,
-    configured: false,
-    linked: Some(false),
-    provider: None,
-    message: Some(format!("{} is not available in this build.", channel)),
-    account: None,
-  });
+  if let Some(bail) = gateway_or_bail().await {
+    return bail;
+  }
+
+  match channel_runtime_snapshot(Some(&channel)).await {
+    Ok(status) => HttpResponse::Ok().json(runtime_status_response(&status, &channel, true, None)),
+    Err(e) => {
+      log::error!("[channels] {}_status gateway error: {}", channel, e);
+      HttpResponse::Ok().json(ChannelStatusResponse {
+        success: service::gateway_log_has_channel_started(&channel),
+        enabled: false,
+        configured: false,
+        linked: Some(false),
+        provider: None,
+        message: Some(format!("Gateway error: {}", e)),
+        account: None,
+      })
+    }
+  }
 }
 
 /// Request body for generic channel configuration.

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -5219,6 +5219,37 @@ async fn browser_control_status(
   }
 }
 
+async fn browser_control_rpc_ready(gateway_token: &str, timeout: std::time::Duration) -> bool {
+  match tokio::time::timeout(
+    timeout,
+    gateway_client::browser_request(
+      "GET",
+      "/tabs",
+      Some(serde_json::json!({ "profile": "openclaw" })),
+      None,
+      Some(gateway_token),
+    ),
+  )
+  .await
+  {
+    Ok(Ok(_)) => true,
+    Ok(Err(e)) => {
+      eprintln!(
+        "[clawd/service] browser control RPC fallback probe failed: {}",
+        e
+      );
+      false
+    }
+    Err(_) => {
+      eprintln!(
+        "[clawd/service] browser control RPC fallback probe timed out ({}ms)",
+        timeout.as_millis()
+      );
+      false
+    }
+  }
+}
+
 async fn browser_control_start_direct(
   gateway_token: &str,
   timeout: std::time::Duration,
@@ -5325,7 +5356,7 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
     .arg("--disable-features=Translate,OptimizationHints,MediaRouter")
     .arg("--disable-sync")
     .arg("--no-proxy-server")
-    .arg("about:blank")
+    .arg("--no-startup-window")
     .stdin(Stdio::null())
     .stdout(Stdio::null())
     .stderr(Stdio::null())
@@ -5401,7 +5432,7 @@ fn start_openclaw_chrome_direct(app_handle: &tauri::AppHandle) -> Result<(), Str
     .arg("--disable-features=Translate,OptimizationHints,MediaRouter")
     .arg("--disable-sync")
     .arg("--no-proxy-server")
-    .arg("about:blank")
+    .arg("--no-startup-window")
     .stdin(Stdio::null())
     .stdout(Stdio::null())
     .stderr(Stdio::null())
@@ -5687,6 +5718,16 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
       {
         browser_probe = BrowserControlProbe::Starting;
       }
+    }
+    if gateway_ok
+      && browser_probe != BrowserControlProbe::Ready
+      && browser_control_rpc_ready(
+        &tokens.gateway_token,
+        std::time::Duration::from_millis(1200),
+      )
+      .await
+    {
+      browser_probe = BrowserControlProbe::Ready;
     }
     let browser_ok = browser_probe == BrowserControlProbe::Ready;
 
@@ -6221,7 +6262,15 @@ pub async fn service_startup_ready(app_handle: web::Data<tauri::AppHandle>) -> i
           browser_control_status(&tokens.gateway_token, std::time::Duration::from_millis(500))
             .await;
       }
-      probe == BrowserControlProbe::Ready
+      if probe == BrowserControlProbe::Ready {
+        true
+      } else {
+        browser_control_rpc_ready(
+          &tokens.gateway_token,
+          std::time::Duration::from_millis(1200),
+        )
+        .await
+      }
     }
   } else {
     false
@@ -14210,6 +14259,14 @@ mod service_status_message_tests {
     );
     assert_eq!(
       parse_browser_control_status_body(r#"{"running":true,"cdpReady":true}"#),
+      BrowserControlProbe::Ready
+    );
+  }
+
+  #[test]
+  fn plain_ok_browser_sidecar_response_is_not_treated_as_ready() {
+    assert_ne!(
+      parse_browser_control_status_body("OK"),
       BrowserControlProbe::Ready
     );
   }

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -950,6 +950,25 @@ async function fetchEmailCalendarContext(): Promise<string> {
   return contextParts.join('\n')
 }
 
+function shouldPrefetchNativeEmailCalendarContext(text: string): boolean {
+  const lowerText = text.toLowerCase()
+  const mentionsEmail =
+    lowerText.includes('email') || lowerText.includes('gmail') || lowerText.includes('inbox')
+  const mentionsCalendar =
+    lowerText.includes('calendar') || lowerText.includes('schedule') || lowerText.includes('meeting')
+  const browserSpecific =
+    lowerText.includes('browser')
+    || lowerText.includes('tab')
+    || lowerText.includes('website')
+    || lowerText.includes('gmail.com')
+    || lowerText.includes('calendar.google.com')
+    || lowerText.includes('open ')
+    || lowerText.includes('click ')
+    || lowerText.includes('navigate')
+
+  return (mentionsEmail || mentionsCalendar) && !browserSpecific
+}
+
 // Maps skill names to keywords that indicate the skill would be useful.
 // Checked against each user message; the first match whose skill isn't yet
 // installed is surfaced as an inline suggestion below the AI response.
@@ -1205,15 +1224,15 @@ const ChatMessage = memo(function ChatMessage({
             </div>
           </div>
         )}
-        {m.isClickable ? (
+        {staleGatewayDiagnostic ? (
+          <p>
+            Live status is healthy now. This earlier diagnostic is stale, so its old
+            recovery steps have been hidden.
+          </p>
+        ) : m.isClickable ? (
           <p>{m.text}</p>
         ) : (
           <ReactMarkdown remarkPlugins={mdPlugins} components={mdComponents}>{cleaned}</ReactMarkdown>
-        )}
-        {staleGatewayDiagnostic && (
-          <div className="ClawdStaleDiagnosticNote">
-            Live status is healthy now. This older diagnostic may be stale, so its recovery actions are hidden.
-          </div>
         )}
         {visibleActions.length > 0 && (
           <div className="ClawdPromptActions">
@@ -4401,6 +4420,21 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           } catch {
             // If pre-fetch fails, fall back to original behavior
             actualText = `${text}\n\nAfter checking my email and calendar, recommend 5 specific things I should do based on what you find.`
+          }
+        }
+
+        if (!isSmartPrompt && shouldPrefetchNativeEmailCalendarContext(text)) {
+          try {
+            const context = await fetchEmailCalendarContext()
+            if (context) {
+              actualText = `${text}
+
+Use the native Knapsack email/calendar context below first. Only use browser automation if the native context is missing something required to answer accurately.
+
+${context}`
+            }
+          } catch (err) {
+            console.warn('[ClawdChat] Failed to pre-fetch native email/calendar context:', err)
           }
         }
 

--- a/src/src/hooks/dataSources/useEmailAutopilot.tsx
+++ b/src/src/hooks/dataSources/useEmailAutopilot.tsx
@@ -117,6 +117,11 @@ export function useEmailAutopilot(
 
     const errorCallbackFollowUp = (error: Error) => {
       console.error(error)
+      logError(error, {
+        additionalInfo: 'Email classification request failed',
+        error: error.message,
+      })
+      handleFailMessagesClassified(emails)
     }
 
     const nonStarredEmails = emails.filter(email => !email.isStarred)

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -1636,6 +1636,26 @@ export function useFeed(
 
   const startCalendarMeeting = async (item: FeedItem) => {
     const saveTranscript = await shouldSaveTranscript()
+    const parseNumericEventId = (value: unknown): number => {
+      if (typeof value === 'number' && Number.isFinite(value)) return value
+      if (typeof value === 'string') {
+        const parsed = Number.parseInt(value, 10)
+        if (Number.isFinite(parsed)) return parsed
+      }
+      return 0
+    }
+    const runtimeEventId = (() => {
+      if (item.run?.runParams) {
+        try {
+          const parsed = JSON.parse(item.run.runParams as string)
+          if (typeof parsed?.event_id === 'number') return parsed.event_id
+        } catch {
+          // Fall through to the attached calendar event ID below.
+        }
+      }
+
+      return parseNumericEventId(item.calendarEvent?.id)
+    })()
 
     if (item.id != null) {
       const thread = item.threads?.[0]
@@ -1643,7 +1663,7 @@ export function useFeed(
       const timelineKey = KNDateUtils.timelineKeyFromTimestamp(item.timestamp)
       await selectFeedItem(timelineKey, item.id)
       try {
-        await startRecord(thread.id, item.id, 0, saveTranscript)
+        await startRecord(thread.id, item.id, runtimeEventId, saveTranscript)
         setIsRecording(item)
       } catch (recordErr: any) {
         logError(new Error('Failed to start recording for calendar meeting'), {
@@ -1703,7 +1723,12 @@ export function useFeed(
       setSelectedFeedItem(feedItem)
       setSubTab(SubTabChoices.Workspace)
       try {
-        await startRecord(thread.id, feedItem.id, 0, saveTranscript)
+        await startRecord(
+          thread.id,
+          feedItem.id,
+          parseNumericEventId(meeting.id),
+          saveTranscript,
+        )
         setIsRecording(feedItem)
       } catch (recordErr: any) {
         logError(new Error('Failed to start recording for calendar meeting'), {


### PR DESCRIPTION
## Summary
- fix the browser health false-negative path by falling back to a bounded real browser RPC when the direct 18791 probe flakes
- make Slack generic status use the live gateway runtime snapshot instead of always claiming Slack is unavailable in the build
- hide stale gateway/browser diagnostic text once live status is healthy again instead of continuing to show scary stale recovery guidance
- preserve the real calendar event id when starting a scheduled meeting recording from feed items
- make Email Autopilot fail closed by marking messages failed instead of hanging forever when follow-up classification errors
- bias simple email/calendar prompts toward native Knapsack context before browser automation

## Root cause
We had a cluster of live regressions rather than one bug:
- browser readiness could be falsely reported as down even while browser-backed app APIs were succeeding, because the cheap direct sidecar probe intermittently failed with local transport errors
- Slack status in the desktop shell was still using a placeholder response instead of the gateway's runtime status
- the Diagnose flow could show stale, confidence-eroding recovery text even after gateway/browser health had already recovered
- scheduled notetaker launches were sometimes starting Quick Note because feed-item launches dropped the calendar event id and passed `0`
- Email Autopilot could get stuck in an empty/spinning state if the follow-up classification call failed before the failure path marked those emails handled

## Validation
- `./node_modules/.bin/tsc --noEmit`
- repeated `curl http://127.0.0.1:8897/api/clawd/service/health` polling after the browser-health fix: 25/25 returned `browser_ok=true`
- `curl http://127.0.0.1:8897/api/clawd/browser/search?q=weather%20in%20Tokyo&count=3` succeeded while validating the false-negative browser-health root cause
- `curl http://127.0.0.1:8897/api/clawd/channels/diagnostics` now reports Slack and Telegram configured/active in dev
- dev Email Autopilot populated real content after load instead of remaining permanently empty

## Notes
- This is intentionally a draft because I validated the targeted regressions in dev, but I have not yet rerun the broader full QA loop end to end after this commit.
- The clean worktree still has unrelated unstaged local modifications outside this commit from the wider repo state; they are not part of this PR.
