### PR TITLE
Fix gateway channels.status RPC for channel diagnostics

### DIFF
--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -2405,7 +2405,11 @@ fn resolve_token(token: Option<&str>) -> Result<String, String> {
 /// Get channel status from the gateway (pooled).
 pub async fn get_channel_status(token: Option<&str>) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  gateway_request_pooled("status", None, &t).await
+  let params = serde_json::json!({
+    "probe": false,
+    "timeoutMs": 2500
+  });
+  call_channel_method("channels.status", Some(params), Some(&t)).await
 }
 
 /// Call a channel method on the gateway (pooled).


### PR DESCRIPTION
## Summary
- fix clawd channel status call to use  with 
- validated with staged QA loop passes (dev/prod core and functional)

## QA evidence
-  passed
-  passed
-  passed
-  passed