### PR TITLE
Stabilize QA diagnostics and compact oversized chat context

### DIFF
--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -34,8 +34,43 @@ const launchAgentPlist = path.join(
   "ai.knap.knapsack.clawdbot.plist",
 );
 const qaStateDir = path.join(projectDir, ".qa-dev-openclaw-state");
+const prodStateDir = path.join(
+  process.env.HOME || "",
+  "Library",
+  "Application Support",
+  "ai.knap.knapsack",
+  "clawdbot",
+);
+const prodConfigPath = path.join(prodStateDir, "openclaw.json");
+const qaConfigPath = path.join(qaStateDir, "openclaw.json");
 const sourceClawdbotDir = path.join(tauriDir, "resources", "clawdbot");
 const targetClawdbotDir = path.join(tauriDir, "target", "debug", "resources", "clawdbot");
+const qaTokensPath = path.join(qaStateDir, "tokens.json");
+const prodTokensPath = path.join(prodStateDir, "tokens.json");
+const qaSeededTokenKeys = [
+  "active_provider",
+  "groq_api_key",
+  "groq_model",
+  "openai_api_key",
+  "openai_model",
+  "anthropic_api_key",
+  "anthropic_model",
+  "gemini_api_key",
+  "gemini_model",
+  "xai_api_key",
+  "xai_model",
+  "openrouter_api_key",
+  "openrouter_model",
+  "ollama_enabled",
+  "ollama_model",
+  "ollama_base_url",
+  "extra_provider_keys",
+  "preferred_coding_agent",
+  "knapsack_email",
+  "knapsack_model",
+  "knapsack_access_token",
+  "knapsack_refresh_token",
+];
 
 function npmCommand() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
@@ -108,6 +143,129 @@ function runChecked(command, args, options = {}) {
   }
 }
 
+function readJsonFile(file) {
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonFile(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function seedQaProviderTokensFromProd() {
+  const prodTokens = readJsonFile(prodTokensPath);
+  if (!prodTokens || typeof prodTokens !== "object") return;
+
+  const existingQaTokens = readJsonFile(qaTokensPath);
+  const qaTokens =
+    existingQaTokens && typeof existingQaTokens === "object" ? existingQaTokens : {};
+
+  let seeded = 0;
+  for (const key of qaSeededTokenKeys) {
+    if (!(key in prodTokens)) continue;
+    const next = prodTokens[key];
+    const prev = qaTokens[key];
+    if (JSON.stringify(prev) === JSON.stringify(next)) continue;
+    qaTokens[key] = next;
+    seeded += 1;
+  }
+
+  if (seeded > 0) {
+    writeJsonFile(qaTokensPath, qaTokens);
+    console.log(
+      `[qa-dev-run] seeded ${seeded} provider token field(s) into isolated QA state`,
+    );
+  }
+}
+
+function seedQaConfigFromProd() {
+  const prodConfig = readJsonFile(prodConfigPath);
+  if (!prodConfig || typeof prodConfig !== "object") return;
+
+  const existingQaConfig = readJsonFile(qaConfigPath);
+  const qaConfig =
+    existingQaConfig && typeof existingQaConfig === "object"
+      ? existingQaConfig
+      : {};
+
+  const next = { ...qaConfig };
+
+  for (const section of ["channels", "models", "tools", "agents", "skills"]) {
+    if (prodConfig[section] !== undefined) {
+      next[section] = cloneJson(prodConfig[section]);
+    }
+  }
+
+  // Let the desktop gateway discover bundled plugins from the channel config
+  // instead of inheriting stale plugin install metadata from prod.
+  delete next.plugins;
+
+  const prodBrowser =
+    prodConfig.browser && typeof prodConfig.browser === "object"
+      ? cloneJson(prodConfig.browser)
+      : {};
+  next.browser = {
+    ...prodBrowser,
+    enabled: true,
+    headless: false,
+    defaultProfile: "openclaw",
+  };
+
+  if (qaConfig.gateway !== undefined) {
+    next.gateway = cloneJson(qaConfig.gateway);
+  }
+
+  if (
+    next.tools &&
+    typeof next.tools === "object" &&
+    next.tools.web &&
+    typeof next.tools.web === "object" &&
+    next.tools.web.search &&
+    typeof next.tools.web.search === "object" &&
+    next.tools.web.search.provider === "duckduckgo"
+  ) {
+    delete next.tools.web.search.provider;
+    if (Object.keys(next.tools.web.search).length === 0) {
+      delete next.tools.web.search;
+    }
+    if (Object.keys(next.tools.web).length === 0) {
+      delete next.tools.web;
+    }
+  }
+
+  const knapsackAccessToken =
+    readJsonFile(qaTokensPath)?.knapsack_access_token || "";
+  if (
+    knapsackAccessToken &&
+    next.agents &&
+    typeof next.agents === "object" &&
+    next.agents.defaults &&
+    typeof next.agents.defaults === "object" &&
+    next.agents.defaults.model &&
+    typeof next.agents.defaults.model === "object" &&
+    next.agents.defaults.model.primary === "auto"
+  ) {
+    next.agents.defaults.model.primary = "knapsack/auto";
+  }
+
+  if (JSON.stringify(next) !== JSON.stringify(qaConfig)) {
+    writeJsonFile(qaConfigPath, next);
+    console.log(
+      "[qa-dev-run] seeded isolated QA openclaw.json from prod config",
+    );
+  }
+}
+
 function waitForUrl(url, timeoutMs = 30_000) {
   const started = Date.now();
   return new Promise((resolve, reject) => {
@@ -154,10 +312,15 @@ function waitForFreshLaunchAgentPlist(minMtimeMs, timeoutMs = 45_000) {
           const mtimeMs = fs.statSync(launchAgentPlist).mtimeMs;
           const plist = readLaunchAgentPlist();
           const entry = plist.ProgramArguments?.[1] || "";
+          const plistStateDir =
+            plist.EnvironmentVariables?.OPENCLAW_STATE_DIR ||
+            plist.EnvironmentVariables?.OPENCLAW_HOME ||
+            "";
           if (
             entry.startsWith(
               path.join(projectDir, "src-tauri", "resources", "clawdbot"),
-            )
+            ) &&
+            path.resolve(plistStateDir || ".") === path.resolve(qaStateDir)
           ) {
             if (mtimeMs < minMtimeMs) {
               console.warn(
@@ -450,6 +613,12 @@ function startDirectGatewayFromPlist() {
     plist.EnvironmentVariables?.OPENCLAW_STATE_DIR ||
     plist.EnvironmentVariables?.OPENCLAW_HOME ||
     qaStateDir;
+  if (path.resolve(gatewayStateDir) !== path.resolve(qaStateDir)) {
+    console.warn(
+      `[qa-dev-run] Skipping direct gateway: plist state dir is not isolated to this checkout (${gatewayStateDir})`,
+    );
+    return null;
+  }
 
   console.log(
     "[qa-dev-run] Starting direct dev gateway from LaunchAgent plist",
@@ -466,6 +635,70 @@ function startDirectGatewayFromPlist() {
     }),
     windowsHide: true,
   });
+}
+
+function configuredBundledChannelPlugins() {
+  const cfg = readJsonFile(qaConfigPath);
+  const channels = cfg && typeof cfg === "object" ? cfg.channels : null;
+  if (!channels || typeof channels !== "object") return [];
+  const supported = new Set(["slack", "telegram", "whatsapp"]);
+  const plugins = [];
+  for (const [name, value] of Object.entries(channels)) {
+    if (!supported.has(name)) continue;
+    if (
+      value &&
+      typeof value === "object" &&
+      Object.prototype.hasOwnProperty.call(value, "enabled") &&
+      value.enabled === false
+    ) {
+      continue;
+    }
+    plugins.push(name);
+  }
+  return [...new Set(plugins)].sort();
+}
+
+function pluginRuntimeDepsReady(pluginName) {
+  const pluginDir = path.join(sourceClawdbotDir, "dist", "extensions", pluginName);
+  const pkg = readJsonFile(path.join(pluginDir, "package.json"));
+  if (!pkg || typeof pkg !== "object") return true;
+  const needsStage =
+    !!pkg.openclaw &&
+    !!pkg.openclaw.bundle &&
+    pkg.openclaw.bundle.stageRuntimeDependencies === true;
+  if (!needsStage) return true;
+  const deps = pkg.dependencies && typeof pkg.dependencies === "object" ? pkg.dependencies : {};
+  const depNames = Object.keys(deps).filter((dep) => {
+    const version = deps[dep];
+    return (
+      typeof version === "string" &&
+      !version.startsWith("file:") &&
+      !version.startsWith("link:") &&
+      !version.startsWith("workspace:") &&
+      !version.startsWith("portal:")
+    );
+  });
+  if (depNames.length === 0) return true;
+  return depNames.every((dep) =>
+    fs.existsSync(path.join(pluginDir, "node_modules", dep)),
+  );
+}
+
+async function waitForBundledPluginRuntimeDepsReady(timeoutMs = 60_000) {
+  const plugins = configuredBundledChannelPlugins();
+  if (plugins.length === 0) return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pending = plugins.filter((pluginName) => !pluginRuntimeDepsReady(pluginName));
+    if (pending.length === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  const pending = plugins.filter((pluginName) => !pluginRuntimeDepsReady(pluginName));
+  if (pending.length > 0) {
+    throw new Error(
+      `Timed out waiting for bundled plugin runtime deps: ${pending.join(", ")}`,
+    );
+  }
 }
 
 function latestMtimeMs(dir, shouldInclude) {
@@ -533,6 +766,8 @@ async function main() {
   syncDevClawdbotResources();
   const prepareOnly = String(process.env.KNAPSACK_QA_PREPARE_ONLY || "").trim() === "1";
   fs.mkdirSync(qaStateDir, { recursive: true });
+  seedQaProviderTokensFromProd();
+  seedQaConfigFromProd();
   bootoutLaunchAgent();
   killStaleGateways();
   killStaleOpenClawChrome();
@@ -615,6 +850,7 @@ async function main() {
   await waitForUrl("http://127.0.0.1:8897/api/clawd/service/status", 45_000);
   if (process.platform === "darwin") {
     await waitForFreshLaunchAgentPlist(appStartedAt, 60_000);
+    await waitForBundledPluginRuntimeDepsReady(60_000);
     startManagedGateway();
   }
 

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -937,6 +937,345 @@ fn load_history_from_transcript(
   messages
 }
 
+fn take_prefix_chars(value: &str, max_chars: usize) -> String {
+  let mut chars = value.chars();
+  let head: String = chars.by_ref().take(max_chars).collect();
+  if chars.next().is_some() {
+    format!("{}...", head)
+  } else {
+    head
+  }
+}
+
+fn estimate_message_chars(message: &chat_agent::OaiMessage) -> usize {
+  match message {
+    chat_agent::OaiMessage::System { content } => content.chars().count(),
+    chat_agent::OaiMessage::User { content, images } => {
+      content.chars().count() + images.len() * 256
+    }
+    chat_agent::OaiMessage::Assistant {
+      content,
+      tool_calls,
+    } => {
+      let content_len = content
+        .as_ref()
+        .map(|value| value.chars().count())
+        .unwrap_or(0);
+      let tool_calls_len = tool_calls
+        .as_ref()
+        .map(|calls| {
+          serde_json::to_string(calls)
+            .map(|s| s.chars().count())
+            .unwrap_or(0)
+        })
+        .unwrap_or(0);
+      content_len + tool_calls_len
+    }
+    chat_agent::OaiMessage::Tool {
+      tool_call_id,
+      content,
+    } => tool_call_id.chars().count() + content.chars().count(),
+  }
+}
+
+fn provider_compaction_limits(provider: &str) -> (usize, usize) {
+  match provider {
+    "ollama" => (6usize, 18_000usize),
+    "knapsack" => (18usize, 40_000usize),
+    _ => (18usize, 32_000usize),
+  }
+}
+
+fn provider_aggressive_compaction_limits(provider: &str) -> (usize, usize) {
+  match provider {
+    "ollama" => (4usize, 12_000usize),
+    "knapsack" => (10usize, 18_000usize),
+    _ => (10usize, 14_000usize),
+  }
+}
+
+fn summarize_compacted_message(
+  message: &chat_agent::OaiMessage,
+  max_chars: usize,
+) -> Option<String> {
+  match message {
+    chat_agent::OaiMessage::System { content } => {
+      let trimmed = content.trim();
+      if trimmed.is_empty() {
+        None
+      } else {
+        Some(format!(
+          "Earlier summary: {}",
+          take_prefix_chars(trimmed, max_chars)
+        ))
+      }
+    }
+    chat_agent::OaiMessage::User { content, .. } => {
+      let trimmed = content.trim();
+      if trimmed.is_empty() {
+        None
+      } else {
+        Some(format!("User: {}", take_prefix_chars(trimmed, max_chars)))
+      }
+    }
+    chat_agent::OaiMessage::Assistant {
+      content,
+      tool_calls,
+    } => {
+      let mut parts: Vec<String> = Vec::new();
+      if let Some(value) = content.as_ref().map(|v| v.trim()).filter(|v| !v.is_empty()) {
+        parts.push(format!(
+          "Assistant: {}",
+          take_prefix_chars(value, max_chars)
+        ));
+      }
+      if let Some(calls) = tool_calls.as_ref().filter(|calls| !calls.is_empty()) {
+        let names = calls
+          .iter()
+          .take(4)
+          .map(|call| call.function.name.clone())
+          .collect::<Vec<_>>()
+          .join(", ");
+        if !names.is_empty() {
+          let suffix = if calls.len() > 4 { ", ..." } else { "" };
+          parts.push(format!("Assistant requested tools: {}{}", names, suffix));
+        }
+      }
+      if parts.is_empty() {
+        None
+      } else {
+        Some(parts.join(" | "))
+      }
+    }
+    chat_agent::OaiMessage::Tool { content, .. } => {
+      let trimmed = content.trim();
+      if trimmed.is_empty() {
+        None
+      } else {
+        Some(format!(
+          "Tool result: {}",
+          take_prefix_chars(trimmed, max_chars)
+        ))
+      }
+    }
+  }
+}
+
+fn build_compaction_summary(
+  dropped_messages: &[chat_agent::OaiMessage],
+  max_chars: usize,
+) -> Option<chat_agent::OaiMessage> {
+  if dropped_messages.is_empty() || max_chars < 96 {
+    return None;
+  }
+
+  let line_budget = max_chars.min(240);
+  let mut lines: Vec<String> = Vec::new();
+  let mut used_chars = 0usize;
+
+  for line in dropped_messages
+    .iter()
+    .filter_map(|message| summarize_compacted_message(message, line_budget))
+  {
+    let line_chars = line.chars().count();
+    if !lines.is_empty() && used_chars + line_chars + 1 > max_chars {
+      break;
+    }
+    used_chars += line_chars + usize::from(!lines.is_empty());
+    lines.push(line);
+  }
+
+  if lines.is_empty() {
+    return None;
+  }
+
+  Some(chat_agent::OaiMessage::System {
+    content: format!(
+      "[Earlier conversation compacted to fit the model context budget ({} messages summarized):\n{}]",
+      dropped_messages.len(),
+      lines.join("\n")
+    ),
+  })
+}
+
+fn shrink_message_to_budget(
+  message: &chat_agent::OaiMessage,
+  max_chars: usize,
+) -> chat_agent::OaiMessage {
+  let payload_budget = max_chars.max(64);
+  match message {
+    chat_agent::OaiMessage::System { content } => chat_agent::OaiMessage::System {
+      content: format!(
+        "{} [truncated to fit model context budget]",
+        take_prefix_chars(content, payload_budget)
+      ),
+    },
+    chat_agent::OaiMessage::User { content, images } => chat_agent::OaiMessage::User {
+      content: format!(
+        "{} [truncated to fit model context budget]",
+        take_prefix_chars(content, payload_budget)
+      ),
+      images: images.clone(),
+    },
+    chat_agent::OaiMessage::Assistant {
+      content,
+      tool_calls,
+    } => chat_agent::OaiMessage::Assistant {
+      content: content.as_ref().map(|value| {
+        format!(
+          "{} [truncated to fit model context budget]",
+          take_prefix_chars(value, payload_budget)
+        )
+      }),
+      tool_calls: tool_calls.clone(),
+    },
+    chat_agent::OaiMessage::Tool {
+      tool_call_id,
+      content,
+    } => chat_agent::OaiMessage::Tool {
+      tool_call_id: tool_call_id.clone(),
+      content: format!(
+        "{} [truncated to fit model context budget]",
+        take_prefix_chars(content, payload_budget)
+      ),
+    },
+  }
+}
+
+fn compact_messages_with_limits(
+  messages: &[chat_agent::OaiMessage],
+  max_non_system_messages: usize,
+  max_total_chars: usize,
+) -> Vec<chat_agent::OaiMessage> {
+  if messages.is_empty() {
+    return Vec::new();
+  }
+
+  let total_chars: usize = messages.iter().map(estimate_message_chars).sum();
+  let non_system_messages = messages
+    .iter()
+    .filter(|message| !matches!(message, chat_agent::OaiMessage::System { .. }))
+    .count();
+  let needs_compaction =
+    total_chars > max_total_chars || non_system_messages > max_non_system_messages;
+  if !needs_compaction {
+    return messages.to_vec();
+  }
+
+  let mut selected: Vec<chat_agent::OaiMessage> = Vec::new();
+  let mut dropped: Vec<chat_agent::OaiMessage> = Vec::new();
+  let mut selected_chars = 0usize;
+  let mut seen_non_system = 0usize;
+
+  let system_message = match messages.first() {
+    Some(chat_agent::OaiMessage::System { .. }) => Some(messages[0].clone()),
+    _ => None,
+  };
+  if let Some(system) = system_message.clone() {
+    selected_chars += estimate_message_chars(&system);
+  }
+
+  let start_index = usize::from(system_message.is_some());
+  for message in messages[start_index..].iter().rev() {
+    let per_message_budget = (max_total_chars / 2).clamp(512usize, 6_000usize);
+    let candidate = if estimate_message_chars(message) > per_message_budget {
+      shrink_message_to_budget(message, per_message_budget)
+    } else {
+      message.clone()
+    };
+    let message_chars = estimate_message_chars(&candidate);
+    let would_fit = seen_non_system < max_non_system_messages
+      && (selected.is_empty() || selected_chars + message_chars <= max_total_chars);
+    if would_fit {
+      selected.push(candidate);
+      selected_chars += message_chars;
+      if !matches!(message, chat_agent::OaiMessage::System { .. }) {
+        seen_non_system += 1;
+      }
+    } else {
+      dropped.push(message.clone());
+    }
+  }
+
+  selected.reverse();
+  dropped.reverse();
+
+  let summary_budget = (max_total_chars / 4).clamp(256usize, 4_000usize);
+  let summary_message = build_compaction_summary(&dropped, summary_budget);
+
+  let mut compacted = Vec::with_capacity(
+    selected.len() + usize::from(system_message.is_some()) + usize::from(summary_message.is_some()),
+  );
+  if let Some(system) = system_message {
+    compacted.push(system);
+  }
+  if let Some(summary) = summary_message {
+    compacted.push(summary);
+  }
+  compacted.extend(selected);
+
+  while compacted.len()
+    > usize::from(
+      compacted
+        .first()
+        .map(|m| matches!(m, chat_agent::OaiMessage::System { .. }))
+        .unwrap_or(false),
+    )
+    && compacted.iter().map(estimate_message_chars).sum::<usize>() > max_total_chars
+  {
+    let remove_at = if compacted.len() > 2
+      && matches!(
+        compacted.get(1),
+        Some(chat_agent::OaiMessage::System { .. })
+      ) {
+      2
+    } else {
+      1
+    };
+    if remove_at >= compacted.len() {
+      break;
+    }
+    compacted.remove(remove_at);
+  }
+
+  compacted
+}
+
+fn compact_messages_for_provider(
+  messages: &[chat_agent::OaiMessage],
+  provider: &str,
+) -> Vec<chat_agent::OaiMessage> {
+  let (max_non_system_messages, max_total_chars) = if provider == "ollama" {
+    provider_aggressive_compaction_limits(provider)
+  } else {
+    provider_compaction_limits(provider)
+  };
+  compact_messages_with_limits(messages, max_non_system_messages, max_total_chars)
+}
+
+fn aggressively_compact_messages_for_provider(
+  messages: &[chat_agent::OaiMessage],
+  provider: &str,
+) -> Vec<chat_agent::OaiMessage> {
+  let (max_non_system_messages, max_total_chars) = provider_aggressive_compaction_limits(provider);
+  compact_messages_with_limits(messages, max_non_system_messages, max_total_chars)
+}
+
+fn is_context_window_error(error_lower: &str) -> bool {
+  [
+    "message too large",
+    "context window",
+    "maximum context length",
+    "prompt is too long",
+    "too many tokens",
+    "input tokens",
+    "context length",
+    "token limit exceeded",
+  ]
+  .iter()
+  .any(|needle| error_lower.contains(needle))
+}
+
 /// Append user and assistant messages to the gateway's JSONL transcript.
 fn append_to_transcript(session_id: &str, messages: &[chat_agent::OaiMessage]) {
   let path = match gateway_transcript_path(session_id) {
@@ -4760,6 +5099,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
   }
 
   let mut tool_iter = 0u32;
+  let mut prompt_compaction_alerted = false;
   for _ in 0..75 {
     tool_iter += 1;
     // Pace API calls to avoid rate limits (especially Anthropic/Gemini).
@@ -4777,12 +5117,78 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
     // Try primary provider, then fallback to others on credit/rate-limit errors.
     // For Knapsack specifically, give the selected provider a bounded exponential
     // backoff window before switching away so first-party issues are visible.
+    let provider_messages = compact_messages_for_provider(&messages, &current_provider);
+    let original_chars: usize = messages.iter().map(estimate_message_chars).sum();
+    let compacted_chars: usize = provider_messages.iter().map(estimate_message_chars).sum();
+    let original_non_system_messages = messages
+      .iter()
+      .filter(|message| !matches!(message, chat_agent::OaiMessage::System { .. }))
+      .count();
+    let compacted_non_system_messages = provider_messages
+      .iter()
+      .filter(|message| !matches!(message, chat_agent::OaiMessage::System { .. }))
+      .count();
+    let (max_non_system_messages, max_total_chars) = provider_compaction_limits(&current_provider);
+    if provider_messages.len() != messages.len() || compacted_chars != original_chars {
+      eprintln!(
+        "[clawd/chat] compacted provider messages {} -> {} for {} (chars {} -> {}, non-system {} -> {})",
+        messages.len(), provider_messages.len(), current_provider, original_chars, compacted_chars, original_non_system_messages, compacted_non_system_messages
+      );
+      if !prompt_compaction_alerted {
+        prompt_compaction_alerted = true;
+        sentry::with_scope(
+          |scope| {
+            scope.set_tag("component", "clawd_chat");
+            scope.set_tag("provider", current_provider.clone());
+            scope.set_tag("model", current_model.clone());
+            scope.set_extra(
+              "original_message_count",
+              sentry::protocol::Value::from(messages.len() as i64),
+            );
+            scope.set_extra(
+              "compacted_message_count",
+              sentry::protocol::Value::from(provider_messages.len() as i64),
+            );
+            scope.set_extra(
+              "original_non_system_messages",
+              sentry::protocol::Value::from(original_non_system_messages as i64),
+            );
+            scope.set_extra(
+              "compacted_non_system_messages",
+              sentry::protocol::Value::from(compacted_non_system_messages as i64),
+            );
+            scope.set_extra(
+              "original_chars",
+              sentry::protocol::Value::from(original_chars as i64),
+            );
+            scope.set_extra(
+              "compacted_chars",
+              sentry::protocol::Value::from(compacted_chars as i64),
+            );
+            scope.set_extra(
+              "max_non_system_messages",
+              sentry::protocol::Value::from(max_non_system_messages as i64),
+            );
+            scope.set_extra(
+              "max_total_chars",
+              sentry::protocol::Value::from(max_total_chars as i64),
+            );
+            sentry::capture_message(
+              "[clawd/chat] provider prompt compaction applied",
+              sentry::Level::Warning,
+            );
+          },
+          || {},
+        );
+      }
+    }
+
     let resp = match call_provider(
       &app_handle,
       &current_provider,
       &current_api_key,
       &current_model,
-      messages.clone(),
+      provider_messages.clone(),
       tools.clone(),
       &current_ollama_base,
       !disable_fallback,
@@ -4795,7 +5201,88 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         let mut err_lower = err_str.to_lowercase();
         let mut recovered_resp: Option<chat_agent::OaiChatResp> = None;
 
-        if current_provider == "knapsack" && should_retry_knapsack_before_fallback(&err_lower) {
+        if is_context_window_error(&err_lower) {
+          let aggressive_messages =
+            aggressively_compact_messages_for_provider(&messages, &current_provider);
+          if aggressive_messages.len() < provider_messages.len()
+            || aggressive_messages
+              .iter()
+              .map(estimate_message_chars)
+              .sum::<usize>()
+              < provider_messages
+                .iter()
+                .map(estimate_message_chars)
+                .sum::<usize>()
+          {
+            eprintln!(
+              "[clawd/chat] provider={} hit context-window style error; retrying with aggressive compaction",
+              current_provider
+            );
+            sentry::with_scope(
+              |scope| {
+                scope.set_tag("component", "clawd_chat");
+                scope.set_tag("provider", current_provider.clone());
+                scope.set_tag("model", current_model.clone());
+                scope.set_extra("error", sentry::protocol::Value::from(err_str.clone()));
+                scope.set_extra(
+                  "original_message_count",
+                  sentry::protocol::Value::from(messages.len() as i64),
+                );
+                scope.set_extra(
+                  "aggressively_compacted_message_count",
+                  sentry::protocol::Value::from(aggressive_messages.len() as i64),
+                );
+                sentry::capture_message(
+                  "[clawd/chat] provider context limit triggered aggressive compaction retry",
+                  sentry::Level::Warning,
+                );
+              },
+              || {},
+            );
+
+            match call_provider(
+              &app_handle,
+              &current_provider,
+              &current_api_key,
+              &current_model,
+              aggressive_messages,
+              tools.clone(),
+              &current_ollama_base,
+              !disable_fallback,
+            )
+            .await
+            {
+              Ok(r) => {
+                eprintln!(
+                  "[clawd/chat] aggressive compaction retry succeeded for provider={}",
+                  current_provider
+                );
+                recovered_resp = Some(r);
+              }
+              Err(retry_err) => {
+                err_str = retry_err.to_string();
+                err_lower = err_str.to_lowercase();
+                if is_context_window_error(&err_lower) {
+                  sentry::capture_message(
+                    "[clawd/chat] provider still rejected aggressively compacted prompt",
+                    sentry::Level::Error,
+                  );
+                }
+                // fall through to the normal retry / fallback path below
+              }
+            }
+          } else {
+            sentry::capture_message(
+              "[clawd/chat] provider context limit hit but aggressive compaction could not shrink prompt further",
+              sentry::Level::Warning,
+            );
+          };
+        }
+
+        if recovered_resp.is_none()
+          && current_provider == "knapsack"
+          && should_retry_knapsack_before_fallback(&err_lower)
+        {
           let mut attempts_used = 0u32;
           let max_retries = 3u32;
           let mut total_wait_secs = 0.0_f64;
@@ -4815,7 +5302,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               &current_provider,
               &current_api_key,
               &current_model,
-              messages.clone(),
+              provider_messages.clone(),
               tools.clone(),
               &current_ollama_base,
               !disable_fallback,
@@ -4925,7 +5412,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
                 fb_provider,
                 fb_key,
                 &fb_model,
-                messages.clone(),
+                provider_messages.clone(),
                 tools.clone(),
                 &current_ollama_base,
                 true,
@@ -5085,13 +5572,14 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           }
         }
       };
-      const TOOL_RESULT_MAX: usize = 50_000;
+      const TOOL_RESULT_MAX: usize = 12_000;
       let result_str = result.to_string();
-      let content = if result_str.len() > TOOL_RESULT_MAX {
+      let result_chars = result_str.chars().count();
+      let content = if result_chars > TOOL_RESULT_MAX {
         format!(
-          "{}... [truncated — tool returned {} bytes, limit {}]",
-          &result_str[..TOOL_RESULT_MAX],
-          result_str.len(),
+          "{} [truncated — tool returned {} chars, limit {}]",
+          take_prefix_chars(&result_str, TOOL_RESULT_MAX),
+          result_chars,
           TOOL_RESULT_MAX
         )
       } else {
@@ -5726,4 +6214,116 @@ fn strip_html_tags(html: &str) -> String {
     }
   }
   out
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{
+    aggressively_compact_messages_for_provider, compact_messages_for_provider,
+    is_context_window_error, provider_compaction_limits,
+  };
+  use crate::clawd::chat_agent::OaiMessage;
+
+  fn system_message() -> OaiMessage {
+    OaiMessage::System {
+      content: "system".to_string(),
+    }
+  }
+
+  fn user_message(content: String) -> OaiMessage {
+    OaiMessage::User {
+      content,
+      images: Vec::new(),
+    }
+  }
+
+  #[test]
+  fn compact_messages_preserves_knapsack_history_under_budget() {
+    let messages = vec![
+      system_message(),
+      user_message("plan my day".to_string()),
+      OaiMessage::Assistant {
+        content: Some("Sure".to_string()),
+        tool_calls: None,
+      },
+      user_message("check ai news".to_string()),
+    ];
+
+    let compacted = compact_messages_for_provider(&messages, "knapsack");
+
+    assert_eq!(compacted.len(), messages.len());
+  }
+
+  #[test]
+  fn compact_messages_limits_knapsack_history_when_message_count_is_too_high() {
+    let mut messages = vec![system_message()];
+    for idx in 0..25 {
+      messages.push(user_message(format!("message-{idx}")));
+    }
+
+    let compacted = compact_messages_for_provider(&messages, "knapsack");
+    let (max_non_system_messages, _) = provider_compaction_limits("knapsack");
+
+    assert_eq!(compacted.len(), max_non_system_messages + 2);
+    assert!(matches!(compacted.first(), Some(OaiMessage::System { .. })));
+    assert!(matches!(
+      compacted.get(1),
+      Some(OaiMessage::System { content }) if content.contains("Earlier conversation compacted")
+    ));
+    assert!(matches!(
+      compacted.last(),
+      Some(OaiMessage::User { content, .. }) if content == "message-24"
+    ));
+  }
+
+  #[test]
+  fn compact_messages_limits_knapsack_history_when_tool_result_is_huge() {
+    let (_, max_total_chars) = provider_compaction_limits("knapsack");
+    let messages = vec![
+      system_message(),
+      user_message("plan tomorrow".to_string()),
+      OaiMessage::Tool {
+        tool_call_id: "tool-1".to_string(),
+        content: "x".repeat(max_total_chars + 5_000),
+      },
+    ];
+
+    let compacted = compact_messages_for_provider(&messages, "knapsack");
+
+    assert!(compacted.len() >= 2);
+    assert!(compacted.len() <= 3);
+    assert!(matches!(compacted.first(), Some(OaiMessage::System { .. })));
+    assert!(matches!(compacted.last(), Some(OaiMessage::Tool { .. })));
+  }
+
+  #[test]
+  fn aggressive_compaction_shrinks_prompt_further_after_context_error() {
+    let (_, max_total_chars) = provider_compaction_limits("knapsack");
+    let mut messages = vec![system_message()];
+    for idx in 0..8 {
+      messages.push(user_message(format!("message-{idx} {}", "x".repeat(1_500))));
+    }
+    messages.push(OaiMessage::Tool {
+      tool_call_id: "tool-1".to_string(),
+      content: "y".repeat(max_total_chars / 2),
+    });
+
+    let standard = compact_messages_for_provider(&messages, "knapsack");
+    let aggressive = aggressively_compact_messages_for_provider(&messages, "knapsack");
+
+    let standard_chars: usize = standard.iter().map(super::estimate_message_chars).sum();
+    let aggressive_chars: usize = aggressive.iter().map(super::estimate_message_chars).sum();
+    assert!(aggressive_chars < standard_chars);
+  }
+
+  #[test]
+  fn context_window_error_detection_matches_user_visible_failures() {
+    assert!(is_context_window_error(
+      "message too large for this model".to_string().as_str()
+    ));
+    assert!(is_context_window_error(
+      "maximum context length exceeded".to_string().as_str()
+    ));
+    assert!(!is_context_window_error("rate limit exceeded"));
+  }
 }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -95,6 +95,73 @@ async fn channel_runtime_snapshot(channel: Option<&str>) -> Result<Value, String
   }
 }
 
+async fn channel_runtime_snapshot_with_fallback(channel: &str) -> Result<Value, String> {
+  match channel_runtime_snapshot(Some(channel)).await {
+    Ok(snapshot) => {
+      let needs_full_snapshot = runtime_channel(&snapshot, channel)
+        .map(|status| {
+          let has_detail = ["enabled", "configured", "connected", "running", "accountId"]
+            .iter()
+            .any(|key| status.get(*key).is_some())
+            || status
+              .get("lastError")
+              .and_then(|value| value.as_str())
+              .map(|value| !value.trim().is_empty())
+              .unwrap_or(false);
+          let has_summary = channel_summary_line(
+            snapshot
+              .get("channelSummary")
+              .and_then(|value| value.as_array())
+              .map(|items| {
+                items
+                  .iter()
+                  .filter_map(|item| item.as_str().map(|text| text.to_string()))
+                  .collect::<Vec<_>>()
+              })
+              .unwrap_or_default()
+              .as_slice(),
+            channel,
+          )
+          .is_some();
+          !has_detail && !has_summary && configured_channel(channel).is_some()
+        })
+        .unwrap_or_else(|| configured_channel(channel).is_some());
+
+      if !needs_full_snapshot {
+        return Ok(snapshot);
+      }
+
+      log::warn!(
+        "[channels] {} filtered status snapshot lacked details; retrying with full snapshot",
+        channel
+      );
+      channel_runtime_snapshot(None).await
+    }
+    Err(filtered_error) => {
+      let filtered_lower = filtered_error.to_ascii_lowercase();
+      let looks_filter_specific = filtered_lower.contains("timed out")
+        || filtered_lower.contains("unknown method")
+        || filtered_lower.contains("invalid params")
+        || filtered_lower.contains("schema");
+      if !looks_filter_specific {
+        return Err(filtered_error);
+      }
+
+      log::warn!(
+        "[channels] {} status filter failed ({}); retrying with full snapshot",
+        channel,
+        filtered_error
+      );
+      channel_runtime_snapshot(None).await.map_err(|full_error| {
+        format!(
+          "{} (full snapshot retry also failed: {})",
+          filtered_error, full_error
+        )
+      })
+    }
+  }
+}
+
 fn runtime_channel<'a>(snapshot: &'a Value, channel: &str) -> Option<&'a Value> {
   snapshot.get("channels")?.get(channel)
 }
@@ -183,6 +250,12 @@ fn plugin_allow_from_disk() -> Vec<String> {
   plugins
 }
 
+fn plugin_allowed_in_config(plugin_id: &str) -> bool {
+  plugin_allow_from_disk()
+    .iter()
+    .any(|plugin| plugin == plugin_id)
+}
+
 fn runtime_status_response(
   snapshot: &Value,
   channel: &str,
@@ -191,6 +264,8 @@ fn runtime_status_response(
 ) -> ChannelStatusResponse {
   let status = runtime_channel(snapshot, channel);
   let config = configured_channel(channel);
+  let (summary_enabled, summary_linked, summary_configured) =
+    parse_channel_from_summary(snapshot, channel);
   let enabled = status
     .and_then(|s| s.get("enabled"))
     .and_then(|v| v.as_bool())
@@ -200,11 +275,11 @@ fn runtime_status_response(
         .and_then(|s| s.get("enabled"))
         .and_then(|v| v.as_bool())
     })
-    .unwrap_or_else(|| config.is_some());
+    .unwrap_or(summary_enabled || config.is_some());
   let configured = status
     .and_then(|s| s.get("configured"))
     .and_then(|v| v.as_bool())
-    .unwrap_or_else(|| enabled || config.is_some());
+    .unwrap_or(summary_configured || summary_linked || enabled || config.is_some());
   let running = status
     .and_then(|s| s.get("running"))
     .and_then(|v| v.as_bool())
@@ -212,12 +287,13 @@ fn runtime_status_response(
   let connected = status
     .and_then(|s| s.get("connected"))
     .and_then(|v| v.as_bool())
-    .unwrap_or(running);
+    .unwrap_or(summary_linked || running);
   let account = status
     .and_then(|s| s.get("accountId"))
     .and_then(|v| v.as_str())
     .filter(|id| !id.is_empty() && *id != "default")
     .map(|id| id.to_string());
+  let account = account.or_else(|| parse_account_from_summary(snapshot, channel));
   let message = status
     .and_then(|s| s.get("lastError"))
     .and_then(|v| v.as_str())
@@ -452,25 +528,35 @@ fn has_browser_enabled(snapshot: &serde_json::Value) -> bool {
     .unwrap_or(false)
 }
 
-/// Check whether `tools.sandbox.tools.allow` includes the minimum set of
-/// tools required for channel messages (Telegram, WhatsApp, etc.) to work.
-/// Without these, the gateway's sandbox mode blocks browser, web, and exec
-/// tools — so the agent silently fails to respond to channel messages even
-/// though the channel shows as "connected" in the UI.
-fn has_sandbox_tools(snapshot: &serde_json::Value) -> bool {
+/// Check whether the channel reply toolchain is present in both the main
+/// allowlist and the sandbox allowlist.
+///
+/// Channel-routed sessions need the `message` tool for explicit reply actions,
+/// and they still rely on browser/web/exec/session tools for typical Knapsack
+/// flows. If either allowlist is missing these entries, the UI can show the
+/// channel as "connected" while routed replies still fail.
+fn has_channel_reply_tools(snapshot: &serde_json::Value) -> bool {
   let config = snapshot.get("config").unwrap_or(snapshot);
-  let allow = match config
+  let tools_allow = match config.pointer("/tools/allow").and_then(|v| v.as_array()) {
+    Some(arr) => arr,
+    None => return false,
+  };
+  let sandbox_allow = match config
     .pointer("/tools/sandbox/tools/allow")
     .and_then(|v| v.as_array())
   {
     Some(arr) => arr,
     None => return false,
   };
-  // Check for a few critical tools that must be present
-  let required = ["exec", "browser", "sessions_send"];
-  required
+  let required_tools_allow = ["message", "browser", "group:web", "exec"];
+  let required_sandbox_allow = ["message", "exec", "browser", "sessions_send"];
+  let has_main = required_tools_allow
     .iter()
-    .all(|tool| allow.iter().any(|item| item.as_str() == Some(tool)))
+    .all(|tool| tools_allow.iter().any(|item| item.as_str() == Some(tool)));
+  let has_sandbox = required_sandbox_allow
+    .iter()
+    .all(|tool| sandbox_allow.iter().any(|item| item.as_str() == Some(tool)));
+  has_main && has_sandbox
 }
 
 fn channel_plugin_requested_by_patch(patch: &serde_json::Value) -> Option<String> {
@@ -559,18 +645,18 @@ fn ensure_channel_plugin_enabled_in_patch(
 /// Also ensures `browser.enabled` is true so the auto-reply agent can use
 /// browser automation (e.g. "check my email" from Telegram).
 ///
-/// Also ensures `tools.sandbox.tools.allow` and `tools.sandbox.tools.deny`
-/// are set so that channel messages can use browser, exec, web, and session
-/// tools.  Without this, channels show "connected" but the AI cannot
-/// respond because sandbox mode blocks all the tools it needs.
+/// Also ensures `tools.allow` plus `tools.sandbox.tools.allow` /
+/// `tools.sandbox.tools.deny` are set so that channel messages can use the
+/// `message` tool alongside browser, exec, web, and session tools.
+/// Without this, channels show "connected" but the AI cannot respond.
 fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> String {
   let needs_model = !has_default_model(snapshot);
   let needs_browser = !has_browser_enabled(snapshot);
-  let needs_sandbox_tools = !has_sandbox_tools(snapshot);
+  let needs_channel_reply_tools = !has_channel_reply_tools(snapshot);
   let parsed_patch: serde_json::Value = serde_json::from_str(channel_patch).unwrap();
   let channel_plugin_id = channel_plugin_requested_by_patch(&parsed_patch);
 
-  if !needs_model && !needs_browser && !needs_sandbox_tools && channel_plugin_id.is_none() {
+  if !needs_model && !needs_browser && !needs_channel_reply_tools && channel_plugin_id.is_none() {
     return channel_patch.to_string();
   }
 
@@ -591,7 +677,7 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
       .insert("browser".to_string(), serde_json::json!({"enabled": true}));
   }
 
-  if needs_sandbox_tools {
+  if needs_channel_reply_tools {
     // Merge sandbox tools into the patch.  This mirrors what service.rs
     // does at startup, but ensures it also happens when a channel is
     // enabled/reconnected after a config reset (when service.rs startup
@@ -601,6 +687,7 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
             "tools": {
                 "deny": ["canvas", "nodes", "cron", "gateway"],
                 "allow": [
+                    "message",
                     "exec", "process", "group:fs",
                     "image", "sessions_list", "sessions_history",
                     "sessions_send", "sessions_spawn", "session_status",
@@ -609,9 +696,9 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
             }
         }
     });
-    // Also ensure normal-mode tools.allow includes browser + group:web
+    // Also ensure normal-mode tools.allow includes browser + group:web + message
     let mut tools_val = serde_json::json!({
-        "allow": ["browser", "group:web", "exec", "process", "group:fs"],
+        "allow": ["message", "browser", "group:web", "exec", "process", "group:fs"],
         "deny": ["canvas", "nodes", "cron", "gateway"],
         "exec": {"applyPatch": {"enabled": true}},
         "media": {"image": {"enabled": true}}
@@ -626,7 +713,7 @@ fn build_enable_patch(channel_patch: &str, snapshot: &serde_json::Value) -> Stri
       .as_object_mut()
       .unwrap()
       .insert("tools".to_string(), tools_val);
-    eprintln!("[channels] build_enable_patch: added sandbox tools to config patch");
+    eprintln!("[channels] build_enable_patch: added channel reply tools to config patch");
   }
 
   if let Some(plugin_id) = channel_plugin_id {
@@ -1425,7 +1512,7 @@ pub async fn telegram_status(_cfg: web::Data<SharedClawdbotConfig>) -> impl Resp
   if let Some(bail) = gateway_or_bail().await {
     return bail;
   }
-  match channel_runtime_snapshot(Some("telegram")).await {
+  match channel_runtime_snapshot(None).await {
     Ok(status) => HttpResponse::Ok().json(runtime_status_response(&status, "telegram", true, None)),
     Err(e) => {
       log::error!("[channels] telegram_status gateway error: {}", e);
@@ -1935,9 +2022,34 @@ pub async fn generic_channel_status(
     return bail;
   }
 
-  match channel_runtime_snapshot(Some(&channel)).await {
+  let configured = configured_channel(&channel).is_some();
+  let plugin_allowed = plugin_allowed_in_config(&channel);
+  if !configured && !plugin_allowed {
+    return HttpResponse::Ok().json(ChannelStatusResponse {
+      success: true,
+      enabled: false,
+      configured: false,
+      linked: Some(false),
+      provider: None,
+      message: Some("Channel is not configured in this build".to_string()),
+      account: None,
+    });
+  }
+
+  match channel_runtime_snapshot(None).await {
     Ok(status) => HttpResponse::Ok().json(runtime_status_response(&status, &channel, true, None)),
     Err(e) => {
+      if e.to_ascii_lowercase().contains("unknown channel") {
+        return HttpResponse::Ok().json(ChannelStatusResponse {
+          success: true,
+          enabled: false,
+          configured,
+          linked: Some(false),
+          provider: None,
+          message: Some("Channel plugin is unavailable in the current gateway runtime".to_string()),
+          account: None,
+        });
+      }
       log::error!("[channels] {}_status gateway error: {}", channel, e);
       HttpResponse::Ok().json(ChannelStatusResponse {
         success: service::gateway_log_has_channel_started(&channel),
@@ -3190,6 +3302,12 @@ struct ChannelReadiness {
   active: bool,
   deferred: bool,
   summary: Option<String>,
+  #[serde(rename = "runtimeConnected")]
+  runtime_connected: bool,
+  #[serde(rename = "runtimeConfigured")]
+  runtime_configured: bool,
+  #[serde(rename = "runtimeRunning")]
+  runtime_running: bool,
   reason: String,
 }
 
@@ -3219,6 +3337,35 @@ fn channel_summary_active(summary: Option<&str>) -> bool {
     || status.starts_with("running")
     || status.starts_with("ready")
     || status.contains(" connected")
+}
+
+fn runtime_channel_active(runtime: Option<&Value>, summary: Option<&str>) -> bool {
+  if channel_summary_active(summary) {
+    return true;
+  }
+
+  let Some(runtime) = runtime else {
+    return false;
+  };
+
+  let runtime_connected = runtime
+    .get("connected")
+    .and_then(|value| value.as_bool())
+    .unwrap_or(false);
+  let runtime_running = runtime
+    .get("running")
+    .and_then(|value| value.as_bool())
+    .unwrap_or(false);
+  let runtime_enabled = runtime
+    .get("enabled")
+    .and_then(|value| value.as_bool())
+    .unwrap_or(false);
+  let runtime_configured = runtime
+    .get("configured")
+    .and_then(|value| value.as_bool())
+    .unwrap_or(false);
+
+  runtime_connected || runtime_running || (runtime_enabled && runtime_configured)
 }
 
 /// Diagnose channel configuration and auto-repair common issues.
@@ -3268,17 +3415,8 @@ pub async fn channel_diagnostics() -> impl Responder {
   }
 
   // Fetch channel status from gateway
-  let channel_summary: Vec<String> = match gateway_client::get_channel_status(None).await {
-    Ok(status) => status
-      .get("channelSummary")
-      .and_then(|cs| cs.as_array())
-      .map(|arr| {
-        arr
-          .iter()
-          .filter_map(|v| v.as_str().map(String::from))
-          .collect::<Vec<_>>()
-      })
-      .unwrap_or_default(),
+  let gateway_status = match gateway_client::get_channel_status(None).await {
+    Ok(status) => status,
     Err(e) => {
       return HttpResponse::Ok().json(ChannelDiagnostics {
         success: false,
@@ -3294,6 +3432,23 @@ pub async fn channel_diagnostics() -> impl Responder {
       });
     }
   };
+
+  let channel_summary: Vec<String> = gateway_status
+    .get("channelSummary")
+    .and_then(|cs| cs.as_array())
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+
+  let runtime_channels = gateway_status
+    .get("channels")
+    .and_then(|channels| channels.as_object())
+    .cloned()
+    .unwrap_or_default();
 
   // Fetch gateway config to check model and channel configs
   let (has_model, model, configured_channels, plugin_allow) = match gateway_client::config_get(None)
@@ -3359,10 +3514,9 @@ pub async fn channel_diagnostics() -> impl Responder {
 
       // ── Web search provider fallback ──────────────────────────────────
       // Priority order:
-      //   1. Brave API  (BRAVE_API_KEY present — explicit config or env var)
+      //   1. Explicit gateway provider / Brave API key
       //   2. Browser CDP  (bundled Chromium available — /api/clawd/browser/search)
-      //   3. DuckDuckGo  (key-free HTTP fallback, browser unavailable)
-      //   4. Surface API key prompt  (only if all above fail)
+      //   3. Surface the missing dependency instead of patching an unsupported fallback
       {
         let brave_key_in_config = snapshot
           .pointer("/plugins/entries/brave/config/webSearch/apiKey")
@@ -3414,68 +3568,37 @@ pub async fn channel_diagnostics() -> impl Responder {
           if browser_ok {
             // Browser CDP is available — it serves as the primary search
             // mechanism via GET /api/clawd/browser/search.
-            // Ensure the gateway web_search tool also has a key-free provider
-            // (DDG) so the AI can use web_search as a secondary path, but
-            // log clearly that browser is the primary.
+            // Do not patch a synthetic DuckDuckGo fallback here: the bundled
+            // gateway schema on some desktop builds only accepts Brave, and
+            // forcing an unsupported provider creates noisy false warnings
+            // during an otherwise healthy startup.
             log::info!("[channels] web_search: browser CDP available — using browser as primary search (BRAVE_API_KEY not set)");
             repairs.push(
-                            "Browser CDP available — using /api/clawd/browser/search as primary \
-                             web search (BRAVE_API_KEY not set). DuckDuckGo configured as secondary."
-                                .to_string(),
-                        );
-            // Also wire up DDG as secondary so web_search tool itself works
-            let re_snapshot = gateway_client::config_get(None).await;
-            if let Ok(snap) = re_snapshot {
-              let bh = extract_base_hash(&snap);
-              let ddg_patch = serde_json::json!({
-                  "tools": { "web": { "search": { "provider": "duckduckgo" } } }
-              })
-              .to_string();
-              match gateway_client::config_patch(&ddg_patch, &bh, None).await {
-                Ok(_) => log::info!("[channels] web_search: DDG configured as secondary provider"),
-                Err(e) => log::warn!("[channels] web_search DDG secondary patch failed: {}", e),
-              }
-            }
+              "Browser CDP available — using /api/clawd/browser/search as primary \
+                             web search (BRAVE_API_KEY not set)."
+                .to_string(),
+            );
           } else {
-            // Browser not available — configure DDG as the sole fallback.
-            log::info!("[channels] web_search: browser unavailable — configuring DuckDuckGo (BRAVE_API_KEY not set)");
-            let re_snapshot = gateway_client::config_get(None).await;
-            if let Ok(snap) = re_snapshot {
-              let bh = extract_base_hash(&snap);
-              let ddg_patch = serde_json::json!({
-                  "tools": { "web": { "search": { "provider": "duckduckgo" } } }
-              })
-              .to_string();
-              match gateway_client::config_patch(&ddg_patch, &bh, None).await {
-                Ok(_) => {
-                  repairs.push(
-                    "Configured DuckDuckGo as web_search provider \
-                                         (BRAVE_API_KEY not set, browser unavailable)."
-                      .to_string(),
-                  );
-                }
-                Err(e) => {
-                  log::warn!("[channels] web_search DDG patch failed: {}", e);
-                  // Both browser and DDG unavailable → surface the API key prompt
-                  issues.push(format!(
-                                        "BRAVE_API_KEY not set, browser unavailable, and DuckDuckGo \
-                                         fallback patch failed: {}. Set BRAVE_API_KEY to enable web search.",
-                                        e
-                                    ));
-                }
-              }
-            }
+            log::info!(
+              "[channels] web_search: browser unavailable and no provider configured \
+               (BRAVE_API_KEY not set)"
+            );
+            issues.push(
+              "BRAVE_API_KEY not set and browser unavailable — web_search is disabled in this \
+               gateway build until browser control recovers or Brave is configured."
+                .to_string(),
+            );
           }
         }
       }
 
-      // Auto-repair: if sandbox tools are missing, patch them.
-      // This is critical after a config reset — without sandbox tools,
-      // channel messages (Telegram, WhatsApp, etc.) are silently dropped
-      // because the gateway's sandbox mode blocks all tools.
-      if !has_sandbox_tools(&snapshot) {
+      // Auto-repair: if channel reply tools are missing, patch them.
+      // This is critical after a config reset — without the `message` tool
+      // plus browser/web/exec coverage, channel messages can look connected
+      // while routed replies still fail.
+      if !has_channel_reply_tools(&snapshot) {
         issues.push(
-          "tools.sandbox.tools.allow is missing or incomplete — channel messages cannot use tools"
+          "Channel reply tools are missing or incomplete — channel messages cannot use reply/web tools"
             .to_string(),
         );
         let re_snapshot = gateway_client::config_get(None).await;
@@ -3483,7 +3606,7 @@ pub async fn channel_diagnostics() -> impl Responder {
           let bh = extract_base_hash(&snap);
           let sandbox_patch = serde_json::json!({
               "tools": {
-                  "allow": ["browser", "group:web", "exec", "process", "group:fs"],
+                  "allow": ["message", "browser", "group:web", "exec", "process", "group:fs"],
                   "deny": ["canvas", "nodes", "cron", "gateway"],
                   "exec": {"applyPatch": {"enabled": true}},
                   "media": {"image": {"enabled": true}},
@@ -3491,6 +3614,7 @@ pub async fn channel_diagnostics() -> impl Responder {
                       "tools": {
                           "deny": ["canvas", "nodes", "cron", "gateway"],
                           "allow": [
+                              "message",
                               "exec", "process", "group:fs",
                               "image", "sessions_list", "sessions_history",
                               "sessions_send", "sessions_spawn", "session_status",
@@ -3502,8 +3626,9 @@ pub async fn channel_diagnostics() -> impl Responder {
           })
           .to_string();
           match gateway_client::config_patch(&sandbox_patch, &bh, None).await {
-            Ok(_) => repairs
-              .push("Added tools.sandbox.tools.allow with browser + web + exec tools".to_string()),
+            Ok(_) => repairs.push(
+              "Added channel reply tools with message + browser + web + exec coverage".to_string(),
+            ),
             Err(e) => issues.push(format!("Failed to repair sandbox tools: {}", e)),
           }
         }
@@ -3622,14 +3747,33 @@ pub async fn channel_diagnostics() -> impl Responder {
         .iter()
         .any(|existing| existing == channel);
       let summary = channel_summary_line(&channel_summary, channel);
-      let active = channel_summary_active(summary.as_deref());
+      let runtime = runtime_channels.get(channel);
+      let runtime_configured = runtime
+        .and_then(|value| value.get("configured"))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+      let runtime_connected = runtime
+        .and_then(|value| value.get("connected"))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+      let runtime_running = runtime
+        .and_then(|value| value.get("running"))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+      let active = runtime_channel_active(runtime, summary.as_deref());
       let plugin_allowed = plugin_allow.iter().any(|plugin| plugin == channel);
       let deferred = configured && !active && !plugin_allowed;
       let reason = if active {
-        "active according to gateway channel summary".to_string()
+        if channel_summary_active(summary.as_deref()) {
+          "active according to gateway channel summary".to_string()
+        } else {
+          "active according to gateway runtime snapshot".to_string()
+        }
       } else if deferred {
         "configured but plugin is not in startup allowlist; channel is deferred until opened"
           .to_string()
+      } else if configured && runtime.is_some() {
+        "configured and present in gateway runtime snapshot, but not yet connected".to_string()
       } else if configured {
         "configured but no active gateway channel summary was observed".to_string()
       } else {
@@ -3642,6 +3786,9 @@ pub async fn channel_diagnostics() -> impl Responder {
         active,
         deferred,
         summary,
+        runtime_connected,
+        runtime_configured,
+        runtime_running,
         reason,
       }
     })
@@ -3650,7 +3797,7 @@ pub async fn channel_diagnostics() -> impl Responder {
   for state in &channel_states {
     if state.configured && state.plugin_allowed && !state.active {
       issues.push(format!(
-        "Configured channel '{}' is allowed but not active in the gateway channel summary",
+        "Configured channel '{}' is allowed but not active in the gateway runtime snapshot",
         state.channel
       ));
     }
@@ -4895,7 +5042,7 @@ pub async fn telegram_get_agent_bot_statuses() -> impl Responder {
 
 #[cfg(test)]
 mod reconnect_retry_tests {
-  use super::{build_enable_patch, is_connection_level_error};
+  use super::{build_enable_patch, is_connection_level_error, runtime_channel_active};
 
   #[test]
   fn connection_closed_is_retryable() {
@@ -4930,6 +5077,7 @@ mod reconnect_retry_tests {
         "browser": {"enabled": true},
         "plugins": {"allow": ["browser", "duckduckgo"]},
         "tools": {
+          "allow": ["browser", "group:web", "exec", "process", "group:fs"],
           "sandbox": {
             "tools": {
               "allow": ["exec", "browser", "sessions_send"],
@@ -4957,5 +5105,69 @@ mod reconnect_retry_tests {
       patch.pointer("/plugins/entries/whatsapp/enabled"),
       Some(&serde_json::json!(true))
     );
+  }
+
+  #[test]
+  fn enable_patch_adds_message_tool_for_channel_replies() {
+    let snapshot = serde_json::json!({
+      "config": {
+        "agents": {"defaults": {"model": "openai/gpt-5.4"}},
+        "browser": {"enabled": true},
+        "plugins": {"allow": ["browser", "duckduckgo"]},
+        "tools": {
+          "allow": ["browser", "group:web", "exec", "process", "group:fs"],
+          "sandbox": {
+            "tools": {
+              "allow": ["exec", "browser", "sessions_send"],
+              "deny": []
+            }
+          }
+        }
+      }
+    });
+
+    let patch = build_enable_patch(
+      r#"{"channels":{"slack":{"accounts":{"default":{"botToken":"xoxb-test","appToken":"xapp-test"}}}}}"#,
+      &snapshot,
+    );
+    let patch: serde_json::Value = serde_json::from_str(&patch).unwrap();
+
+    let allow = patch
+      .pointer("/tools/allow")
+      .and_then(|value| value.as_array())
+      .unwrap();
+    assert!(allow.iter().any(|tool| tool.as_str() == Some("message")));
+    let sandbox_allow = patch
+      .pointer("/tools/sandbox/tools/allow")
+      .and_then(|value| value.as_array())
+      .unwrap();
+    assert!(sandbox_allow
+      .iter()
+      .any(|tool| tool.as_str() == Some("message")));
+  }
+
+  #[test]
+  fn runtime_channel_active_trusts_runtime_when_summary_is_missing() {
+    let runtime = serde_json::json!({
+      "enabled": true,
+      "configured": true,
+      "connected": false,
+      "running": true
+    });
+
+    assert!(runtime_channel_active(Some(&runtime), None));
+  }
+
+  #[test]
+  fn runtime_channel_active_stays_false_without_summary_or_runtime_signal() {
+    let runtime = serde_json::json!({
+      "enabled": true,
+      "configured": false,
+      "connected": false,
+      "running": false
+    });
+
+    assert!(!runtime_channel_active(Some(&runtime), None));
+    assert!(!runtime_channel_active(None, None));
   }
 }

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -930,13 +930,13 @@ pub fn resolve_default_model() -> String {
 
   // Respect the user's active provider selection and configured model
   match active.as_str() {
-    // Knapsack cloud inference: users can pin a default model (or use auto).
-    // If stored with a provider prefix, keep only the backend model key.
+    // Knapsack cloud inference: keep the provider prefix explicit.
+    // Bare `auto` gets interpreted inconsistently by some gateway paths,
+    // whereas `knapsack/auto` is unambiguous and matches the desktop UI.
     "knapsack" => {
-      let model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
-        .unwrap_or_else(|_| "auto".to_string());
+      let model = std::env::var("KNAPSACK_KNAPSACK_MODEL").unwrap_or_else(|_| "auto".to_string());
       let model = model.trim();
-      let model = if let Some((provider, bare)) = model.split_once('/') {
+      let bare = if let Some((provider, bare)) = model.split_once('/') {
         if provider.eq_ignore_ascii_case("knapsack") {
           bare
         } else {
@@ -945,10 +945,10 @@ pub fn resolve_default_model() -> String {
       } else {
         model
       };
-      return if model.is_empty() {
-        "auto".to_string()
+      return if bare.is_empty() {
+        "knapsack/auto".to_string()
       } else {
-        model.to_string()
+        format!("knapsack/{}", bare)
       };
     }
     "openrouter" => {
@@ -2092,15 +2092,18 @@ pub async fn ensure_gateway_and_wait() {
   }
 }
 
-/// Make a request using a persistent gateway connection.
-///
-/// Adds:
-/// - bounded in-flight requests (backpressure)
-/// - circuit breaker to avoid thrashing when gateway is down
-pub async fn gateway_request_pooled(
+fn should_retry_unknown_method(error: &str, method: &str) -> bool {
+  let needle = format!("unknown method: {}", method);
+  error
+    .to_ascii_lowercase()
+    .contains(&needle.to_ascii_lowercase())
+}
+
+async fn gateway_request_pooled_inner(
   method: &str,
   params: Option<Value>,
   token: &str,
+  allow_unknown_method_retry: bool,
 ) -> Result<Value, String> {
   let client = get_or_connect(token).await?;
 
@@ -2123,6 +2126,7 @@ pub async fn gateway_request_pooled(
     .map_err(|_| "Gateway request queue closed".to_string())?;
 
   let id = next_request_id();
+  let retry_params = params.clone();
   let frame = RequestFrame {
     frame_type: "req",
     method: method.to_string(),
@@ -2194,7 +2198,38 @@ pub async fn gateway_request_pooled(
   }
 
   drop(permit);
+  if allow_unknown_method_retry {
+    if let Err(ref error) = out {
+      if should_retry_unknown_method(error, method) {
+        eprintln!(
+          "[gateway_client] {} returned stale unknown-method response; reconnecting and retrying once",
+          method
+        );
+        invalidate_client();
+        return Box::pin(gateway_request_pooled_inner(
+          method,
+          retry_params,
+          token,
+          false,
+        ))
+        .await;
+      }
+    }
+  }
   out
+}
+
+/// Make a request using a persistent gateway connection.
+///
+/// Adds:
+/// - bounded in-flight requests (backpressure)
+/// - circuit breaker to avoid thrashing when gateway is down
+pub async fn gateway_request_pooled(
+  method: &str,
+  params: Option<Value>,
+  token: &str,
+) -> Result<Value, String> {
+  gateway_request_pooled_inner(method, params, token, true).await
 }
 
 /// Make a two-phase request (like `agent`) using the persistent gateway
@@ -2402,10 +2437,17 @@ fn resolve_token(token: Option<&str>) -> Result<String, String> {
   })
 }
 
+fn default_channel_status_params() -> Value {
+  serde_json::json!({
+    "probe": false,
+    "timeoutMs": 2500
+  })
+}
+
 /// Get channel status from the gateway (pooled).
 pub async fn get_channel_status(token: Option<&str>) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  gateway_request_pooled("status", None, &t).await
+  gateway_request_pooled("channels.status", Some(default_channel_status_params()), &t).await
 }
 
 /// Call a channel method on the gateway (pooled).
@@ -2629,8 +2671,7 @@ pub async fn agent_run(
 
 /// Get current config from gateway (pooled).
 pub async fn config_get(token: Option<&str>) -> Result<Value, String> {
-  let t = resolve_token(token)?;
-  gateway_request_pooled("config.get", None, &t).await
+  crate::clawd::gateway_ws::config_get(token).await
 }
 
 /// Patch config on gateway (pooled) - requires baseHash from config.get.
@@ -2697,6 +2738,28 @@ mod tests {
     let cfg = json!({"agents": {"defaults": {}}});
     // Must return "" (empty), NOT "null" or some other non-empty sentinel
     assert_eq!(read_model_from_config(&cfg), "");
+  }
+
+  #[test]
+  fn channel_status_request_uses_channels_status_rpc_defaults() {
+    assert_eq!(
+      default_channel_status_params(),
+      json!({
+        "probe": false,
+        "timeoutMs": 2500
+      })
+    );
+  }
+
+  #[test]
+  fn knapsack_default_model_keeps_provider_prefix() {
+    std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "knapsack");
+    std::env::set_var("KNAPSACK_KNAPSACK_MODEL", "auto");
+    assert_eq!(resolve_default_model(), "knapsack/auto");
+    std::env::set_var("KNAPSACK_KNAPSACK_MODEL", "knapsack/gemini-2.5-flash");
+    assert_eq!(resolve_default_model(), "knapsack/gemini-2.5-flash");
+    std::env::remove_var("KNAPSACK_KNAPSACK_MODEL");
+    std::env::remove_var("KNAPSACK_ACTIVE_PROVIDER");
   }
 
   // ── ensure_browser_config_at: no spurious change when already correct ───
@@ -2906,5 +2969,17 @@ mod tests {
       Some(&tailscale_val),
       "gateway.tailscale must be preserved unchanged through any patch"
     );
+  }
+
+  #[test]
+  fn retries_only_when_gateway_reports_unknown_requested_method() {
+    assert!(should_retry_unknown_method(
+      "Request failed: Object {\"code\":\"INVALID_REQUEST\",\"message\":\"unknown method: config.get\"}",
+      "config.get"
+    ));
+    assert!(!should_retry_unknown_method(
+      "Request failed: Object {\"code\":\"INVALID_REQUEST\",\"message\":\"unknown method: status\"}",
+      "config.get"
+    ));
   }
 }


### PR DESCRIPTION
## Summary
- harden the fresh-worktree QA launcher so the installed app does not contaminate dev validation
- switch channel status/diagnostic flows onto the runtime snapshot and pooled channels.status RPC path
- compact oversized chat prompts by summarizing dropped history and retry once with aggressive compaction when providers reject for context-window size

## Validation
- `cargo test clawd::browser::tests:: --manifest-path src-tauri/Cargo.toml`
- `cargo test channel_status_request_uses_channels_status_rpc_defaults --manifest-path src-tauri/Cargo.toml`
- `npm run qa:dev`
- live probes: `/api/clawd/service/health` returned gateway/browser healthy; `/api/clawd/channels/diagnostics` returned promptly with configured-but-not-linked channel state
- oversized dev request to `/api/clawd/chat` returned `200 OK` after compaction on the fallback path instead of surfacing a context-window failure

## Notes
- a direct `provider=knapsack` oversized request still exposed a separate backend 500 after compaction (`exceptions must derive from BaseException`), which looks independent of the context-window fix and should be tracked separately if it reproduces outside this dev environment.