### PR TITLE
Fix model compatibility, fallback resilience, and voice guardrails

### DIFF
--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -54,9 +54,7 @@ const MODELS_BY_PROVIDER = {
   knapsack: ["auto"],
   openai: [
     "gpt-5.5",
-    "gpt-5.5-pro",
     "gpt-5.4",
-    "gpt-5.4-pro",
     "o3",
     "gpt-5-mini",
   ],
@@ -199,7 +197,7 @@ function qaStartupModelForProvider(provider) {
     ollama: "ollama/markheynen/knapsack-7b-chat-metal:latest",
     groq: "groq/llama-3.3-70b-versatile",
     knapsack: "knapsack/auto",
-    openai: "openai/gpt-5.4",
+    openai: "openai/gpt-5.5",
     openrouter: "openrouter/auto",
     xai: "xai/grok-4",
   };

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -689,8 +689,13 @@ fn normalize_provider_model(provider: &str, model: &str) -> String {
   }
   if let Some((prefix, bare)) = model.split_once('/') {
     if prefix.eq_ignore_ascii_case(provider) {
-      return bare.to_string();
+      return normalize_provider_model(provider, bare);
     }
+  }
+  if provider.eq_ignore_ascii_case("openai")
+    && (model.eq_ignore_ascii_case("gpt-5.4-pro") || model.eq_ignore_ascii_case("gpt-5.5-pro"))
+  {
+    return "gpt-5.5".to_string();
   }
   model.to_string()
 }
@@ -807,12 +812,38 @@ fn is_credit_or_rate_error(err_lower: &str) -> bool {
     || err_lower.contains("high demand")
 }
 
+fn is_transient_or_internal_provider_error(err_lower: &str) -> bool {
+  err_lower.contains("500")
+    || err_lower.contains("502")
+    || err_lower.contains("504")
+    || err_lower.contains("internal server error")
+    || err_lower.contains("server had an error")
+    || err_lower.contains("temporarily unavailable")
+    || err_lower.contains("gateway timeout")
+    || err_lower.contains("bad gateway")
+    || err_lower.contains("exceptions must derive from baseexception")
+    || err_lower.contains("timed out")
+    || err_lower.contains("timeout")
+    || err_lower.contains("fetch failed")
+    || err_lower.contains("connection")
+    || err_lower.contains("socket")
+    || err_lower.contains("econnreset")
+    || err_lower.contains("econnrefused")
+}
+
+fn should_attempt_fallback_for_provider_error(err_lower: &str) -> bool {
+  is_credit_or_rate_error(err_lower) || is_transient_or_internal_provider_error(err_lower)
+}
+
 fn should_retry_knapsack_before_fallback(err_lower: &str) -> bool {
   err_lower.contains("429")
     || err_lower.contains("503")
+    || err_lower.contains("500")
     || err_lower.contains("rate")
     || err_lower.contains("unavailable")
     || err_lower.contains("high demand")
+    || err_lower.contains("internal server error")
+    || err_lower.contains("exceptions must derive from baseexception")
     || err_lower.contains("timed out")
     || err_lower.contains("timeout")
     || err_lower.contains("fetch failed")
@@ -5114,7 +5145,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
     }
 
-    // Try primary provider, then fallback to others on credit/rate-limit errors.
+    // Try primary provider, then fallback to others on transient, credit, or rate-limit errors.
     // For Knapsack specifically, give the selected provider a bounded exponential
     // backoff window before switching away so first-party issues are visible.
     let provider_messages = compact_messages_for_provider(&messages, &current_provider);
@@ -5324,7 +5355,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           }
 
           if recovered_resp.is_none() {
-            if !is_credit_or_rate_error(&err_lower) {
+            if !should_attempt_fallback_for_provider_error(&err_lower) {
               return HttpResponse::InternalServerError().json(
                 serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, err_str)}),
               );
@@ -5344,7 +5375,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             );
             err_lower = err_str.to_lowercase();
           }
-        } else if !is_credit_or_rate_error(&err_lower) {
+        } else if !should_attempt_fallback_for_provider_error(&err_lower) {
           return HttpResponse::InternalServerError().json(
             serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, err_str)}),
           );
@@ -5361,7 +5392,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           }
           // Respects KNAPSACK_DISABLE_PAID_FALLBACK to avoid silent charges on expensive providers
           eprintln!(
-            "[clawd/chat] {} hit credit/rate limit: {}",
+            "[clawd/chat] {} failed; attempting fallback providers: {}",
             current_provider, err_str
           );
           let disable_paid = is_paid_fallback_disabled();
@@ -5441,7 +5472,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             Some(r) => r,
             None => {
               return HttpResponse::Ok().json(
-                serde_json::json!({"ok": false, "message": format!("All AI providers are unavailable. Your primary provider hit its credit/rate limit and no fallback provider could handle the request. Add additional API keys in Settings for automatic failover.")}),
+                serde_json::json!({"ok": false, "message": format!("All AI providers are currently unavailable. Your active provider failed and no fallback provider could handle the request. Please try again in a moment, or add another provider in Settings for automatic failover.")}),
               );
             }
           }

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -553,13 +553,13 @@ pub async fn openai_compatible_chat(
     .timeout(Duration::from_secs(timeout_secs))
     .build()?;
 
-  // OpenAI reasoning models only support temperature=1 (default); passing any value errors.
-  // gpt-5-mini and gpt-5.2-pro are also reasoning models per OpenAI's API.
-  let is_reasoning_model = model.starts_with("o1")
-    || model.starts_with("o3")
-    || model.starts_with("o4")
-    || model == "gpt-5.2-pro"
-    || model == "gpt-5-mini";
+  // Newer OpenAI reasoning / GPT-5 family models reject custom temperature on
+  // this direct chat-completions path, so let the provider use its default.
+  let normalized_model = model.trim().to_lowercase();
+  let is_reasoning_model = normalized_model.starts_with("o1")
+    || normalized_model.starts_with("o3")
+    || normalized_model.starts_with("o4")
+    || normalized_model.starts_with("gpt-5");
   let temperature = if is_reasoning_model { None } else { Some(0.2) };
 
   // Build messages JSON manually to support multi-part content (text + images) for vision

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -4268,8 +4268,13 @@ fn normalize_provider_model(provider: &str, model: &str) -> String {
   }
   if let Some((prefix, bare)) = model.split_once('/') {
     if prefix.eq_ignore_ascii_case(provider) {
-      return bare.to_string();
+      return normalize_provider_model(provider, bare);
     }
+  }
+  if provider.eq_ignore_ascii_case("openai")
+    && (model.eq_ignore_ascii_case("gpt-5.4-pro") || model.eq_ignore_ascii_case("gpt-5.5-pro"))
+  {
+    return "gpt-5.5".to_string();
   }
   model.to_string()
 }
@@ -4279,7 +4284,9 @@ pub fn get_openai_model(app_handle: &tauri::AppHandle) -> String {
   load_or_create_tokens(app_handle)
     .ok()
     .and_then(|t| t.openai_model)
-    .unwrap_or_else(|| "gpt-5.4".to_string())
+    .map(|model| normalize_provider_model("openai", &model))
+    .filter(|model| !model.trim().is_empty())
+    .unwrap_or_else(|| "gpt-5.5".to_string())
 }
 
 /// Get the configured Anthropic model (defaults to claude-sonnet-4-5-20250929 if not set)
@@ -8207,6 +8214,7 @@ pub struct GetApiKeyResponse {
   pub openai_key: Option<String>,
   pub anthropic_key: Option<String>,
   pub gemini_key: Option<String>,
+  pub groq_key: Option<String>,
   pub xai_key: Option<String>,
   pub anthropic_model: Option<String>,
   pub gemini_model: Option<String>,
@@ -8228,6 +8236,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
         openai_key: None,
         anthropic_key: None,
         gemini_key: None,
+        groq_key: None,
         xai_key: None,
         anthropic_model: None,
         gemini_model: None,
@@ -8241,6 +8250,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
   let openai_key = tokens.openai_api_key.filter(|k| !k.trim().is_empty());
   let anthropic_key = tokens.anthropic_api_key.filter(|k| !k.trim().is_empty());
   let gemini_key = tokens.gemini_api_key.filter(|k| !k.trim().is_empty());
+  let groq_key = tokens.groq_api_key.filter(|k| !k.trim().is_empty());
   let xai_key = tokens.xai_api_key.filter(|k| !k.trim().is_empty());
 
   // Return the currently active provider's key as `key` for backwards compatibility (voice/TTS)
@@ -8248,6 +8258,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
   let key = match active {
     "anthropic" => anthropic_key.clone(),
     "gemini" => gemini_key.clone(),
+    "groq" => groq_key.clone(),
     "xai" => xai_key.clone(),
     _ => openai_key.clone(),
   };
@@ -8273,6 +8284,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
     openai_key,
     anthropic_key,
     gemini_key,
+    groq_key,
     xai_key,
     anthropic_model: tokens.anthropic_model.clone(),
     gemini_model: tokens.gemini_model.clone(),

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -191,6 +191,9 @@ function friendlyError(raw: string, activeModel?: string): string {
   if (lower.includes('all fallback providers also failed')) {
     return `⚠️ **All AI providers are unavailable** (active: \`${activeModel}\`). Your primary provider hit its credit/rate limit and no fallback provider could handle the request. Add additional API keys in Settings for automatic failover.\n\n${addApiKeyAction}`
   }
+  if (lower.includes('all ai providers are currently unavailable')) {
+    return `⚠️ **All AI providers are unavailable** (active: \`${activeModel}\`). Your active provider failed and no backup provider could handle the request. Please try again in a moment, or add another provider in Settings for automatic failover.\n\n${addApiKeyAction}`
+  }
   // OpenAI quota / billing errors
   if (lower.includes('insufficient_quota') || lower.includes('exceeded your current quota')) {
     return `⚠️ **API quota exceeded** (active: \`${activeModel}\`). Your OpenAI account has run out of credits or hit its spending limit. Add another provider's API key in Settings for automatic failover, or check your billing at [platform.openai.com/settings/organization/billing](https://platform.openai.com/settings/organization/billing).\n\n${addApiKeyAction}`
@@ -282,6 +285,9 @@ function friendlyError(raw: string, activeModel?: string): string {
   // Unsupported parameter value (e.g. temperature on reasoning models)
   if (lower.includes('unsupported value') && lower.includes('temperature')) {
     return `⚠️ **Parameter not supported by \`${activeModel}\`.** This is a reasoning model that doesn't allow custom temperature. This has been fixed — please try again.`
+  }
+  if (lower.includes('knapsack inference error') || lower.includes('exceptions must derive from baseexception') || (lower.includes('internal server error') && lower.includes('knapsack'))) {
+    return `⚠️ **Knapsack is temporarily unavailable** (active: \`${activeModel}\`). The request hit a server-side issue. Please try again in a moment, or switch to a backup model in Settings → Provider.\n\n${switchProviderAction}`
   }
   // If it looks like raw JSON, extract the meaningful part
   if (raw.includes('"message"') && raw.includes('"error"')) {
@@ -545,6 +551,16 @@ const API_BASE = 'http://127.0.0.1:8897'
 // API key is now stored server-side in tokens.json (not localStorage) for security.
 // This in-memory cache avoids repeated backend calls during a single session.
 let _cachedApiKey: string | null = null
+let _cachedSpeechToTextAuth: { provider: 'openai' | 'groq'; apiKey: string; model: string; endpoint: string } | null = null
+
+type GetApiKeyPayload = {
+  success: boolean
+  key?: string
+  model?: string
+  active_provider?: string
+  openai_key?: string
+  groq_key?: string
+}
 
 async function getOpenAIKey(): Promise<string | null> {
   if (_cachedApiKey) return _cachedApiKey
@@ -557,10 +573,36 @@ async function getOpenAIKey(): Promise<string | null> {
     localStorage.removeItem('moltbot_openai_key')
   }
   try {
-    const resp = await apiGet<{ success: boolean; key?: string; model?: string }>('/api/clawd/service/get-api-key')
-    if (resp.key) {
-      _cachedApiKey = resp.key
-      return resp.key
+    const resp = await apiGet<GetApiKeyPayload>('/api/clawd/service/get-api-key')
+    if (resp.openai_key) {
+      _cachedApiKey = resp.openai_key
+      return resp.openai_key
+    }
+  } catch { /* backend not reachable */ }
+  return null
+}
+
+async function getSpeechToTextAuth(): Promise<{ provider: 'openai' | 'groq'; apiKey: string; model: string; endpoint: string } | null> {
+  if (_cachedSpeechToTextAuth) return _cachedSpeechToTextAuth
+  try {
+    const resp = await apiGet<GetApiKeyPayload>('/api/clawd/service/get-api-key')
+    if (resp.openai_key) {
+      _cachedSpeechToTextAuth = {
+        provider: 'openai',
+        apiKey: resp.openai_key,
+        model: 'whisper-1',
+        endpoint: 'https://api.openai.com/v1/audio/transcriptions',
+      }
+      return _cachedSpeechToTextAuth
+    }
+    if (resp.groq_key) {
+      _cachedSpeechToTextAuth = {
+        provider: 'groq',
+        apiKey: resp.groq_key,
+        model: 'whisper-large-v3-turbo',
+        endpoint: 'https://api.groq.com/openai/v1/audio/transcriptions',
+      }
+      return _cachedSpeechToTextAuth
     }
   } catch { /* backend not reachable */ }
   return null
@@ -575,6 +617,9 @@ const OPENROUTER_MODEL_STORAGE = 'moltbot_openrouter_model'
 const OLLAMA_MODEL_STORAGE = 'moltbot_ollama_model'
 const TONE_STORAGE = 'moltbot_tone'
 const VOICE_MODE_STORAGE = 'moltbot_voice_mode'
+const MIN_VOICE_RECORDING_MS = 900
+const MIN_VOICE_BLOB_BYTES = 4096
+const MIN_VOICE_CHUNK_COUNT = 2
 const CHAT_HISTORY_STORAGE = 'moltbot_chat_history'
 const AUTONOMY_MODE_STORAGE = 'moltbot_autonomy_mode'
 const PROACTIVE_MODE_STORAGE = 'moltbot_proactive_mode'
@@ -595,6 +640,15 @@ type OpenAIModelOption = {
   vision?: boolean
 }
 
+function normalizeOpenAIModelSelection(model: string | null | undefined): string {
+  const trimmed = model?.trim()
+  if (!trimmed) return 'gpt-5.5'
+  if (trimmed === 'gpt-5.4-pro' || trimmed === 'gpt-5.5-pro') {
+    return 'gpt-5.5'
+  }
+  return trimmed
+}
+
 const OPENAI_MODELS: OpenAIModelOption[] = [
   {
     id: 'gpt-5.5',
@@ -606,12 +660,6 @@ const OPENAI_MODELS: OpenAIModelOption[] = [
     id: 'gpt-5.4',
     name: 'GPT-5.4',
     description: 'Highly capable, great balance of performance and cost',
-    vision: true,
-  },
-  {
-    id: 'gpt-5.4-pro',
-    name: 'GPT-5.4 Pro',
-    description: 'GPT-5.4 with extended thinking',
     vision: true,
   },
   {
@@ -1764,7 +1812,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [apiKey, setApiKey] = useState('')
   const [editingProviderKey, setEditingProviderKey] = useState(false)
   const [selectedModel, setSelectedModel] = useState<string>(() => {
-    return localStorage.getItem(OPENAI_MODEL_STORAGE) || 'gpt-5-mini'
+    return normalizeOpenAIModelSelection(localStorage.getItem(OPENAI_MODEL_STORAGE))
   })
   const [selectedAnthropicModel, setSelectedAnthropicModel] = useState<string>(() => {
     return localStorage.getItem(ANTHROPIC_MODEL_STORAGE) || 'claude-sonnet-4-5-20250929'
@@ -1942,6 +1990,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   })
   const audioChunksRef = useRef<Blob[]>([])
   const currentAudioRef = useRef<HTMLAudioElement | null>(null)
+  const recordingStartedAtRef = useRef<number>(0)
 
   // Audio device selection - using system defaults (setters kept for future device picker UI)
   const [selectedInputDevice, _setSelectedInputDevice] = useState<string>('')
@@ -2112,8 +2161,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           if (activeProvider === 'openai') {
             const localModel = localStorage.getItem(OPENAI_MODEL_STORAGE)
             if (!localModel) {
-              setSelectedModel(backendModel)
-              localStorage.setItem(OPENAI_MODEL_STORAGE, backendModel)
+              const normalizedModel = normalizeOpenAIModelSelection(backendModel)
+              setSelectedModel(normalizedModel)
+              localStorage.setItem(OPENAI_MODEL_STORAGE, normalizedModel)
             }
           } else if (activeProvider === 'anthropic') {
             const localModel = localStorage.getItem(ANTHROPIC_MODEL_STORAGE)
@@ -2498,6 +2548,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
       const recorder = new MediaRecorder(stream, { mimeType: selectedMimeType })
       audioChunksRef.current = []
+      recordingStartedAtRef.current = Date.now()
 
       // Set up Web Audio API for silence detection
       const audioContext = new AudioContext()
@@ -2573,7 +2624,17 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         // Use the extension we determined at recording start
         console.log('[Voice] Recording stopped, using extension:', recordingExtension)
 
+        const elapsedMs = Date.now() - recordingStartedAtRef.current
+        const chunkCount = audioChunksRef.current.length
         const audioBlob = new Blob(audioChunksRef.current, { type: selectedMimeType })
+        console.log('[Voice] Recording stats', { elapsedMs, chunkCount, mimeType: selectedMimeType, size: audioBlob.size })
+
+        if (chunkCount < MIN_VOICE_CHUNK_COUNT || audioBlob.size < MIN_VOICE_BLOB_BYTES || elapsedMs < MIN_VOICE_RECORDING_MS) {
+          audioChunksRef.current = []
+          pushAssistantRef.current?.('🎤 I didn’t catch enough audio. Please try again and speak for a second or two after the mic turns on.')
+          return
+        }
+
         await transcribeAudio(audioBlob, recordingExtension)
       }
 
@@ -2601,6 +2662,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     analyserRef.current = null
 
     if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      const elapsedMs = Date.now() - recordingStartedAtRef.current
+      if (elapsedMs < MIN_VOICE_RECORDING_MS) return
       mediaRecorder.stop()
       setIsRecording(false)
     }
@@ -2609,25 +2672,23 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const transcribeAudio = useCallback(async (audioBlob: Blob, extension: string = 'webm') => {
     setIsTranscribing(true)
     try {
-      // Get the API key from backend
-      const storedKey = await getOpenAIKey()
-      if (!storedKey) {
-        pushAssistantRef.current?.('🎤 Please set your OpenAI API key first to use voice input.')
+      const speechAuth = await getSpeechToTextAuth()
+      if (!speechAuth) {
+        pushAssistantRef.current?.('🎤 Voice input needs an OpenAI or Groq API key right now. Add one in Settings → AI Provider to use speech-to-text.')
         setShowKeyPrompt(true)
         return
       }
 
-      console.log('[Voice] Sending transcription request, format:', extension, 'size:', audioBlob.size)
+      console.log('[Voice] Sending transcription request via', speechAuth.provider, 'format:', extension, 'size:', audioBlob.size)
 
-      // Send to OpenAI Whisper API
       const formData = new FormData()
       formData.append('file', audioBlob, `recording.${extension}`)
-      formData.append('model', 'whisper-1')
+      formData.append('model', speechAuth.model)
 
-      const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      const res = await fetch(speechAuth.endpoint, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${storedKey}`,
+          'Authorization': `Bearer ${speechAuth.apiKey}`,
         },
         body: formData,
       })
@@ -2641,9 +2702,17 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       if (data.text && data.text.trim()) {
         // Auto-send the transcribed text — queues if chat is busy mid-inference
         handleSendWithTextRef.current?.(data.text)
+      } else {
+        pushAssistantRef.current?.('🎤 I didn’t catch any speech. Try again and start speaking after the mic turns on.')
       }
     } catch (e: any) {
-      pushAssistantRef.current?.(`🎤 Transcription failed: ${e?.message || String(e)}`)
+      const raw = e?.message || String(e)
+      const lower = raw.toLowerCase()
+      if (lower.includes('invalid file format') || lower.includes('"seconds":0') || lower.includes('supported formats')) {
+        pushAssistantRef.current?.('🎤 I couldn’t hear usable audio in that recording. Please try again and speak for a second or two after the mic turns on.')
+      } else {
+        pushAssistantRef.current?.(`🎤 Transcription failed: ${raw}`)
+      }
     } finally {
       setIsTranscribing(false)
     }
@@ -3213,6 +3282,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         model: modelForProvider,
         provider: selectedProvider,
       })
+      _cachedSpeechToTextAuth = null
       if (selectedProvider === 'openai') {
         _cachedApiKey = apiKey.trim() // Update in-memory cache for voice/TTS
         localStorage.setItem(OPENAI_MODEL_STORAGE, selectedModel)


### PR DESCRIPTION
## Summary
- normalize unsupported OpenAI model selections and stop sending temperature to GPT-5 family models on the direct chat path
- broaden provider fallback so transient Knapsack/internal failures and Gemini-style rate limits fail over more gracefully
- harden voice input with local recording guardrails, Groq STT fallback, and friendlier transcription failures
- align the QA loop startup model list with the supported OpenAI choices

## Notes
- `git diff --check` passes
- I interrupted long-running `cargo check` attempts after dependency warmup; they produced only existing upstream `wry` warnings before interruption, so this still needs the usual CI/runtime validation
- `npm exec tsc -- --noEmit` is not usable in this repo as configured (it returns the repo's existing `This is not the tsc command you are looking for` wrapper message)

## User-facing fixes
- remove the broken `gpt-5.4-pro`/`gpt-5.5-pro` path from direct OpenAI selection by normalizing those choices to `gpt-5.5`
- default fresh OpenAI selection to `gpt-5.5`
- translate Knapsack internal inference failures into a calm temporary-unavailable message instead of raw backend internals
- avoid uploading empty/too-short voice recordings and show clearer retry guidance when no usable speech was captured
- use OpenAI Whisper when an OpenAI key exists, otherwise Groq Whisper when a Groq key exists
