### PR TITLE
Fix release QA blockers in dev build

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "knapsack",
       "version": "2.5.7",
+      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
         "@amplitude/analytics-browser": "^1.3.0",

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -47,7 +47,11 @@ const sourceClawdbotDir = path.join(tauriDir, "resources", "clawdbot");
 const targetClawdbotDir = path.join(tauriDir, "target", "debug", "resources", "clawdbot");
 const qaTokensPath = path.join(qaStateDir, "tokens.json");
 const prodTokensPath = path.join(prodStateDir, "tokens.json");
+const prodDbPath = path.join(process.env.HOME || "", ".knapsack.db");
+const qaDbPath = path.join(qaStateDir, "knapsack-qa.db");
 const qaSeededTokenKeys = [
+  "gateway_token",
+  "browser_control_token",
   "active_provider",
   "groq_api_key",
   "groq_model",
@@ -188,6 +192,32 @@ function seedQaProviderTokensFromProd() {
   }
 }
 
+function removeSqliteSidecars(basePath) {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      fs.rmSync(`${basePath}${suffix}`, { force: true });
+    } catch {
+      // Best effort cleanup; sqlite will recreate these files as needed.
+    }
+  }
+}
+
+function seedQaDatabaseFromProd() {
+  if (!fs.existsSync(prodDbPath)) return;
+  fs.mkdirSync(path.dirname(qaDbPath), { recursive: true });
+  removeSqliteSidecars(qaDbPath);
+  const result = spawnSync("sqlite3", [prodDbPath, `.backup ${qaDbPath}`], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(
+      `Failed to seed isolated QA database from ${prodDbPath}${stderr ? `: ${stderr}` : ""}`,
+    );
+  }
+  console.log("[qa-dev-run] seeded isolated QA database snapshot from prod");
+}
+
 function seedQaConfigFromProd() {
   const prodConfig = readJsonFile(prodConfigPath);
   if (!prodConfig || typeof prodConfig !== "object") return;
@@ -312,15 +342,10 @@ function waitForFreshLaunchAgentPlist(minMtimeMs, timeoutMs = 45_000) {
           const mtimeMs = fs.statSync(launchAgentPlist).mtimeMs;
           const plist = readLaunchAgentPlist();
           const entry = plist.ProgramArguments?.[1] || "";
-          const plistStateDir =
-            plist.EnvironmentVariables?.OPENCLAW_STATE_DIR ||
-            plist.EnvironmentVariables?.OPENCLAW_HOME ||
-            "";
           if (
             entry.startsWith(
               path.join(projectDir, "src-tauri", "resources", "clawdbot"),
-            ) &&
-            path.resolve(plistStateDir || ".") === path.resolve(qaStateDir)
+            )
           ) {
             if (mtimeMs < minMtimeMs) {
               console.warn(
@@ -453,6 +478,41 @@ function gatewayPortHolderPids() {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((pid) => /^\d+$/.test(pid) && pid !== String(process.pid));
+}
+
+function listeningPortHolderPids(port) {
+  const result = spawnSync("lsof", ["-tiTCP:" + String(port), "-sTCP:LISTEN"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0 || !result.stdout) return [];
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((pid) => /^\d+$/.test(pid) && pid !== String(process.pid));
+}
+
+function killStaleVitePort() {
+  const vitePort = 1420;
+  if (process.platform === "win32") {
+    killWindowsListenersOnPorts([vitePort]);
+    return;
+  }
+  if (process.platform !== "darwin") return;
+
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const holders = listeningPortHolderPids(vitePort);
+    if (holders.length === 0) return;
+    sleep(150);
+  }
+
+  const holders = listeningPortHolderPids(vitePort);
+  if (holders.length > 0) {
+    console.warn(
+      `[qa-dev-run] Force-killing stale Vite port holder(s): ${holders.join(", ")}`,
+    );
+    spawnSync("kill", ["-KILL", ...holders], { stdio: "ignore" });
+  }
 }
 
 function openClawChromePids(profileNeedles) {
@@ -609,15 +669,18 @@ function startDirectGatewayFromPlist() {
     return null;
   }
 
-  const gatewayStateDir =
+  const gatewayStateDir = qaStateDir;
+  const plistStateDir =
     plist.EnvironmentVariables?.OPENCLAW_STATE_DIR ||
     plist.EnvironmentVariables?.OPENCLAW_HOME ||
-    qaStateDir;
-  if (path.resolve(gatewayStateDir) !== path.resolve(qaStateDir)) {
+    "";
+  if (
+    plistStateDir &&
+    path.resolve(plistStateDir) !== path.resolve(qaStateDir)
+  ) {
     console.warn(
-      `[qa-dev-run] Skipping direct gateway: plist state dir is not isolated to this checkout (${gatewayStateDir})`,
+      `[qa-dev-run] Overriding stale plist state dir ${plistStateDir} with isolated QA state ${qaStateDir}`,
     );
-    return null;
   }
 
   console.log(
@@ -630,6 +693,8 @@ function startDirectGatewayFromPlist() {
     stdio: "inherit",
     env: qaEnv({
       ...(plist.EnvironmentVariables || {}),
+      OPENCLAW_HOME: gatewayStateDir,
+      OPENCLAW_STATE_DIR: gatewayStateDir,
       OPENCLAW_CONFIG_PATH: path.join(gatewayStateDir, "openclaw.json"),
       OPENCLAW_QA_DIRECT_GATEWAY: "1",
     }),
@@ -766,9 +831,11 @@ async function main() {
   syncDevClawdbotResources();
   const prepareOnly = String(process.env.KNAPSACK_QA_PREPARE_ONLY || "").trim() === "1";
   fs.mkdirSync(qaStateDir, { recursive: true });
+  seedQaDatabaseFromProd();
   seedQaProviderTokensFromProd();
   seedQaConfigFromProd();
   bootoutLaunchAgent();
+  killStaleVitePort();
   killStaleGateways();
   killStaleOpenClawChrome();
 
@@ -838,6 +905,7 @@ async function main() {
           OPENCLAW_HOME: qaStateDir,
           OPENCLAW_STATE_DIR: qaStateDir,
           OPENCLAW_CONFIG_PATH: path.join(qaStateDir, "openclaw.json"),
+          DATABASE_URL: qaDbPath,
         })
       : qaEnv();
     app = spawn(binary, [], {

--- a/src/src-tauri/resources/clawdbot/dist/server-startup-config-C-rNKEbY.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-startup-config-C-rNKEbY.js
@@ -10,6 +10,7 @@ import { a as getActiveSecretsRuntimeSnapshot, l as setPreparedSecretsRuntimeSna
 import { n as evaluateGatewayAuthSurfaceStates, t as GATEWAY_AUTH_SURFACE_PATHS } from "./runtime-gateway-auth-surfaces-C7es4SNw.js";
 import { i as assertGatewayAuthNotKnownWeak, n as mergeGatewayAuthConfig, r as mergeGatewayTailscaleConfig, t as ensureGatewayStartupAuth } from "./startup-auth-CWNnB8iD.js";
 import { a as prepareSecretsRuntimeFastPathSnapshot, o as resolveRefreshAgentDirs, i as mergeSecretsRuntimeEnv, n as collectCandidateAgentDirs, r as createEmptyRuntimeWebToolsMetadata } from "./runtime-fast-path-B08T2SHO.js";
+import { l as loadAuthProfileStoreWithoutExternalProfiles } from "./store-BMQkMM4l.js";
 import { o as coerceSecretRef } from "./types.secrets-DwPik3M8.js";
 import { isDeepStrictEqual } from "node:util";
 //#region src/gateway/server-startup-config.ts
@@ -55,10 +56,7 @@ function createDesktopManagedNoopSecretsSnapshot(config) {
 	const resolvedConfig = structuredClone(config);
 	const authStores = collectCandidateAgentDirs(resolvedConfig, runtimeEnv).map((agentDir) => ({
 		agentDir,
-		store: {
-			version: 1,
-			profiles: {}
-		}
+		store: loadAuthProfileStoreWithoutExternalProfiles(agentDir, { allowKeychainPrompt: false })
 	}));
 	return {
 		sourceConfig,

--- a/src/src-tauri/src/audio/transcribe.rs
+++ b/src/src-tauri/src/audio/transcribe.rs
@@ -206,10 +206,10 @@ async fn speech_to_text(
 pub async fn transcribe_audio(audio_file: &PathBuf, filename: String) -> Result<(), Error> {
   let provider = resolve_stt_provider()?;
   log::info!("[transcribe] Using {} for speech-to-text", provider.name);
-  
+
   let max_retries = 3;
   let mut current_retry = 0;
-  
+
   loop {
     match speech_to_text(&provider, audio_file, Some("en"), Some(0.5)).await {
       Ok(transcription) => {
@@ -223,22 +223,48 @@ pub async fn transcribe_audio(audio_file: &PathBuf, filename: String) -> Result<
         let transcripts_dir = knapsack_data_dir.join("transcripts");
         fs::create_dir_all(&transcripts_dir)?;
 
-    let transcript_path = transcripts_dir.join(&filename);
-      let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&transcript_path)?;
-      file.write_all(transcription.as_bytes())?;
-      file.write_all(b"\n ---END-CHUNK---")?;
-      file.write_all(b"\n")?;
-      log::debug!("WROTE TRANSCRIPT: {:?}", transcript_path);
-      return Ok(());
-    }
-    Err(e) => {
-      current_retry += 1;
-      let err_str = format!("{:?}", e);
+        let transcript_path = transcripts_dir.join(&filename);
+        let mut file = OpenOptions::new()
+          .create(true)
+          .append(true)
+          .open(&transcript_path)?;
+        file.write_all(transcription.as_bytes())?;
+        file.write_all(b"\n ---END-CHUNK---")?;
+        file.write_all(b"\n")?;
+        log::debug!("WROTE TRANSCRIPT: {:?}", transcript_path);
+        return Ok(());
+      }
+      Err(e) => {
+        current_retry += 1;
+        let err_str = format!("{:?}", e);
 
-      if current_retry >= max_retries {
+        if current_retry >= max_retries {
+          knap_log_error(
+            format!("Error transcribing with {}: {}", provider.name, err_str),
+            None,
+            None,
+          );
+          return Err(e);
+        }
+
+        let should_retry = err_str.contains("os error 10054")
+          || err_str.contains("os error 11001")
+          || err_str.contains("dns error")
+          || err_str.contains("forcibly closed")
+          || err_str.contains("connection error")
+          || err_str.contains("104");
+
+        if should_retry || current_retry < 2 {
+          log::warn!(
+            "Transcription failed, retrying ({}/{}). Error: {}",
+            current_retry,
+            max_retries,
+            err_str
+          );
+          tokio::time::sleep(tokio::time::Duration::from_secs(1 << current_retry)).await;
+          continue;
+        }
+
         knap_log_error(
           format!("Error transcribing with {}: {}", provider.name, err_str),
           None,
@@ -246,33 +272,7 @@ pub async fn transcribe_audio(audio_file: &PathBuf, filename: String) -> Result<
         );
         return Err(e);
       }
-
-      let should_retry = err_str.contains("os error 10054") 
-        || err_str.contains("os error 11001")
-        || err_str.contains("dns error")
-        || err_str.contains("forcibly closed")
-        || err_str.contains("connection error")
-        || err_str.contains("104");
-
-      if should_retry || current_retry < 2 {
-        log::warn!(
-          "Transcription failed, retrying ({}/{}). Error: {}",
-          current_retry,
-          max_retries,
-          err_str
-        );
-        tokio::time::sleep(tokio::time::Duration::from_secs(1 << current_retry)).await;
-        continue;
-      }
-
-      knap_log_error(
-        format!("Error transcribing with {}: {}", provider.name, err_str),
-        None,
-        None,
-      );
-      return Err(e);
     }
-  }
   }
 }
 

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -127,6 +127,14 @@ struct StoredTokens {
 }
 
 fn app_clawdbot_home(app_handle: &tauri::AppHandle) -> PathBuf {
+  if let Some(raw) =
+    std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("OPENCLAW_HOME"))
+  {
+    let path = PathBuf::from(raw);
+    if !path.as_os_str().is_empty() {
+      return path;
+    }
+  }
   app_handle
     .path_resolver()
     .app_data_dir()
@@ -849,6 +857,11 @@ fn should_retry_knapsack_before_fallback(err_lower: &str) -> bool {
     || err_lower.contains("fetch failed")
     || err_lower.contains("connection")
     || err_lower.contains("socket")
+    || err_lower.contains("econnreset")
+    || err_lower.contains("refused")
+    || err_lower.contains("temporar")
+    || err_lower.contains("try again")
+    || err_lower.contains("overloaded")
 }
 
 /// Pending emails awaiting user confirmation.  The key is a random token; the
@@ -1025,6 +1038,14 @@ fn provider_aggressive_compaction_limits(provider: &str) -> (usize, usize) {
   }
 }
 
+fn provider_context_recovery_limits(provider: &str) -> (usize, usize) {
+  match provider {
+    "ollama" => (4usize, 8_000usize),
+    "knapsack" => (6usize, 12_000usize),
+    _ => (6usize, 10_000usize),
+  }
+}
+
 fn summarize_compacted_message(
   message: &chat_agent::OaiMessage,
   max_chars: usize,
@@ -1197,9 +1218,17 @@ fn compact_messages_with_limits(
   let mut dropped: Vec<chat_agent::OaiMessage> = Vec::new();
   let mut selected_chars = 0usize;
   let mut seen_non_system = 0usize;
+  let system_budget = (max_total_chars / 3).clamp(1_024usize, 6_000usize);
+  let latest_non_system = messages
+    .iter()
+    .rev()
+    .find(|message| !matches!(message, chat_agent::OaiMessage::System { .. }))
+    .cloned();
 
   let system_message = match messages.first() {
-    Some(chat_agent::OaiMessage::System { .. }) => Some(messages[0].clone()),
+    Some(chat_agent::OaiMessage::System { .. }) => {
+      Some(shrink_message_to_budget(&messages[0], system_budget))
+    }
     _ => None,
   };
   if let Some(system) = system_message.clone() {
@@ -1245,28 +1274,61 @@ fn compact_messages_with_limits(
   }
   compacted.extend(selected);
 
-  while compacted.len()
-    > usize::from(
-      compacted
-        .first()
-        .map(|m| matches!(m, chat_agent::OaiMessage::System { .. }))
-        .unwrap_or(false),
-    )
-    && compacted.iter().map(estimate_message_chars).sum::<usize>() > max_total_chars
-  {
-    let remove_at = if compacted.len() > 2
-      && matches!(
-        compacted.get(1),
-        Some(chat_agent::OaiMessage::System { .. })
-      ) {
-      2
-    } else {
-      1
-    };
-    if remove_at >= compacted.len() {
-      break;
+  let compacted_non_system_count = compacted
+    .iter()
+    .filter(|message| !matches!(message, chat_agent::OaiMessage::System { .. }))
+    .count();
+  if non_system_messages > 0 && compacted_non_system_count == 0 {
+    if matches!(
+      compacted.get(1),
+      Some(chat_agent::OaiMessage::System { content }) if content.contains("Earlier conversation compacted")
+    ) {
+      compacted.remove(1);
     }
-    compacted.remove(remove_at);
+    if let Some(latest) = latest_non_system.as_ref() {
+      let rescue_budget = (max_total_chars / 4).clamp(768usize, 4_000usize);
+      compacted.push(shrink_message_to_budget(latest, rescue_budget));
+    }
+  }
+
+  while compacted.iter().map(estimate_message_chars).sum::<usize>() > max_total_chars {
+    let last_non_system_index = compacted
+      .iter()
+      .rposition(|message| !matches!(message, chat_agent::OaiMessage::System { .. }));
+    let removable_index = (1..compacted.len()).find(|idx| {
+      if Some(*idx) == last_non_system_index {
+        return false;
+      }
+      !matches!(
+        compacted.get(*idx),
+        Some(chat_agent::OaiMessage::System { .. })
+      )
+    });
+    if let Some(idx) = removable_index {
+      compacted.remove(idx);
+      continue;
+    }
+
+    if let Some(last_idx) = last_non_system_index {
+      let reduced_budget = (max_total_chars / 5).clamp(512usize, 2_000usize);
+      compacted[last_idx] = shrink_message_to_budget(&compacted[last_idx], reduced_budget);
+      let system_only = compacted.iter().enumerate().all(|(idx, message)| {
+        idx == last_idx || matches!(message, chat_agent::OaiMessage::System { .. })
+      });
+      if system_only
+        && compacted.iter().map(estimate_message_chars).sum::<usize>() > max_total_chars
+      {
+        if let Some(first) = compacted.first_mut() {
+          let tighter_system_budget = (max_total_chars / 6).clamp(512usize, 1_500usize);
+          *first = shrink_message_to_budget(first, tighter_system_budget);
+        }
+      } else {
+        break;
+      }
+      continue;
+    }
+
+    break;
   }
 
   compacted
@@ -1290,6 +1352,83 @@ fn aggressively_compact_messages_for_provider(
 ) -> Vec<chat_agent::OaiMessage> {
   let (max_non_system_messages, max_total_chars) = provider_aggressive_compaction_limits(provider);
   compact_messages_with_limits(messages, max_non_system_messages, max_total_chars)
+}
+
+fn build_context_recovery_messages(
+  messages: &[chat_agent::OaiMessage],
+  provider: &str,
+) -> Vec<chat_agent::OaiMessage> {
+  let (max_non_system_messages, max_total_chars) = provider_context_recovery_limits(provider);
+  let system_budget = (max_total_chars / 3).clamp(1_500usize, 4_000usize);
+  let summary_budget = (max_total_chars / 4).clamp(600usize, 2_500usize);
+  let tool_budget = (max_total_chars / 8).clamp(600usize, 1_500usize);
+  let user_budget = (max_total_chars / 5).clamp(1_000usize, 2_500usize);
+  let assistant_budget = (max_total_chars / 6).clamp(900usize, 2_000usize);
+  if messages.is_empty() {
+    return Vec::new();
+  }
+
+  let mut dropped: Vec<chat_agent::OaiMessage> = Vec::new();
+  let system_message = match messages.first() {
+    Some(chat_agent::OaiMessage::System { .. }) => {
+      Some(shrink_message_to_budget(&messages[0], system_budget))
+    }
+    _ => None,
+  };
+  let start_index = usize::from(system_message.is_some());
+  let non_system_messages = messages[start_index..].to_vec();
+  if non_system_messages.is_empty() {
+    return system_message.into_iter().collect();
+  }
+
+  let latest_message = non_system_messages.last().cloned();
+  let earlier_messages = &non_system_messages[..non_system_messages.len().saturating_sub(1)];
+  let recent_keep = max_non_system_messages.saturating_sub(1).min(3usize);
+  let split_index = earlier_messages.len().saturating_sub(recent_keep);
+  dropped.extend(earlier_messages[..split_index].iter().cloned());
+  let recent_messages = &earlier_messages[split_index..];
+
+  let mut rebuilt: Vec<chat_agent::OaiMessage> = Vec::new();
+  if let Some(system) = system_message {
+    rebuilt.push(system);
+  }
+  if let Some(summary) = build_compaction_summary(&dropped, summary_budget) {
+    rebuilt.push(summary);
+  }
+  for message in recent_messages {
+    let budget = match message {
+      chat_agent::OaiMessage::Tool { .. } => tool_budget,
+      chat_agent::OaiMessage::Assistant { .. } => assistant_budget,
+      chat_agent::OaiMessage::User { .. } => user_budget,
+      chat_agent::OaiMessage::System { .. } => system_budget,
+    };
+    rebuilt.push(shrink_message_to_budget(message, budget));
+  }
+  if let Some(message) = latest_message.as_ref() {
+    let budget = match message {
+      chat_agent::OaiMessage::Tool { .. } => tool_budget.max(1_200usize),
+      chat_agent::OaiMessage::Assistant { .. } => assistant_budget.max(1_500usize),
+      chat_agent::OaiMessage::User { .. } => user_budget.max(2_000usize),
+      chat_agent::OaiMessage::System { .. } => system_budget,
+    };
+    rebuilt.push(shrink_message_to_budget(message, budget));
+  }
+
+  while rebuilt.iter().map(estimate_message_chars).sum::<usize>() > max_total_chars {
+    let removable_index = (1..rebuilt.len().saturating_sub(1)).find(|idx| {
+      !matches!(
+        rebuilt.get(*idx),
+        Some(chat_agent::OaiMessage::System { .. })
+      )
+    });
+    if let Some(idx) = removable_index {
+      rebuilt.remove(idx);
+    } else {
+      break;
+    }
+  }
+
+  rebuilt
 }
 
 fn is_context_window_error(error_lower: &str) -> bool {
@@ -5276,7 +5415,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               &current_provider,
               &current_api_key,
               &current_model,
-              aggressive_messages,
+              aggressive_messages.clone(),
               tools.clone(),
               &current_ollama_base,
               !disable_fallback,
@@ -5307,7 +5446,85 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               "[clawd/chat] provider context limit hit but aggressive compaction could not shrink prompt further",
               sentry::Level::Warning,
             );
-          };
+          }
+
+          if recovered_resp.is_none() && is_context_window_error(&err_lower) {
+            let recovery_messages = build_context_recovery_messages(&messages, &current_provider);
+            let recovery_chars: usize = recovery_messages.iter().map(estimate_message_chars).sum();
+            let aggressive_chars: usize =
+              aggressive_messages.iter().map(estimate_message_chars).sum();
+            if recovery_chars < aggressive_chars {
+              eprintln!(
+                "[clawd/chat] provider={} still over context budget; retrying with emergency recovery compaction (chars {} -> {})",
+                current_provider, aggressive_chars, recovery_chars
+              );
+              sentry::with_scope(
+                |scope| {
+                  scope.set_tag("component", "clawd_chat");
+                  scope.set_tag("provider", current_provider.clone());
+                  scope.set_tag("model", current_model.clone());
+                  scope.set_extra("error", sentry::protocol::Value::from(err_str.clone()));
+                  scope.set_extra(
+                    "aggressive_message_count",
+                    sentry::protocol::Value::from(aggressive_messages.len() as i64),
+                  );
+                  scope.set_extra(
+                    "recovery_message_count",
+                    sentry::protocol::Value::from(recovery_messages.len() as i64),
+                  );
+                  scope.set_extra(
+                    "aggressive_chars",
+                    sentry::protocol::Value::from(aggressive_chars as i64),
+                  );
+                  scope.set_extra(
+                    "recovery_chars",
+                    sentry::protocol::Value::from(recovery_chars as i64),
+                  );
+                  sentry::capture_message(
+                    "[clawd/chat] provider context limit triggered emergency recovery compaction retry",
+                    sentry::Level::Warning,
+                  );
+                },
+                || {},
+              );
+
+              match call_provider(
+                &app_handle,
+                &current_provider,
+                &current_api_key,
+                &current_model,
+                recovery_messages,
+                tools.clone(),
+                &current_ollama_base,
+                !disable_fallback,
+              )
+              .await
+              {
+                Ok(r) => {
+                  eprintln!(
+                    "[clawd/chat] emergency recovery compaction retry succeeded for provider={}",
+                    current_provider
+                  );
+                  recovered_resp = Some(r);
+                }
+                Err(recovery_err) => {
+                  err_str = recovery_err.to_string();
+                  err_lower = err_str.to_lowercase();
+                  if is_context_window_error(&err_lower) {
+                    sentry::capture_message(
+                      "[clawd/chat] provider still rejected emergency recovery-compacted prompt",
+                      sentry::Level::Error,
+                    );
+                  }
+                }
+              }
+            } else {
+              sentry::capture_message(
+                "[clawd/chat] emergency recovery compaction could not shrink prompt further",
+                sentry::Level::Warning,
+              );
+            }
+          }
         }
 
         if recovered_resp.is_none()
@@ -5375,6 +5592,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             );
             err_lower = err_str.to_lowercase();
           }
+        } else if !should_attempt_fallback_for_provider_error(&err_lower) {
         } else if !should_attempt_fallback_for_provider_error(&err_lower) {
           return HttpResponse::InternalServerError().json(
             serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, err_str)}),
@@ -6250,8 +6468,10 @@ fn strip_html_tags(html: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::{
-    aggressively_compact_messages_for_provider, compact_messages_for_provider,
-    is_context_window_error, provider_compaction_limits,
+    aggressively_compact_messages_for_provider, build_context_recovery_messages,
+    compact_messages_for_provider, is_context_window_error,
+    is_transient_or_internal_provider_error, provider_compaction_limits,
+    provider_context_recovery_limits, should_attempt_fallback_for_provider_error,
   };
   use crate::clawd::chat_agent::OaiMessage;
 
@@ -6348,6 +6568,67 @@ mod tests {
   }
 
   #[test]
+  fn compact_messages_keeps_latest_user_when_system_prompt_is_huge() {
+    let (_, max_total_chars) = provider_compaction_limits("knapsack");
+    let messages = vec![
+      OaiMessage::System {
+        content: "system ".repeat(8_000),
+      },
+      user_message(format!("latest request {}", "x".repeat(max_total_chars))),
+    ];
+
+    let compacted = compact_messages_for_provider(&messages, "knapsack");
+
+    assert!(matches!(compacted.first(), Some(OaiMessage::System { .. })));
+    assert!(compacted.iter().any(|message| {
+      matches!(
+        message,
+        OaiMessage::User { content, .. } if content.contains("latest request")
+      )
+    }));
+    assert!(compacted
+      .iter()
+      .any(|message| !matches!(message, OaiMessage::System { .. })));
+  }
+
+  #[test]
+  fn recovery_compaction_shrinks_knapsack_prompt_further_for_single_provider_users() {
+    let (_, aggressive_limit) = super::provider_aggressive_compaction_limits("knapsack");
+    let (_, recovery_limit) = provider_context_recovery_limits("knapsack");
+    let messages = vec![
+      OaiMessage::System {
+        content: "system ".repeat(2_500),
+      },
+      user_message(format!("meeting context {}", "x".repeat(8_000))),
+      OaiMessage::Assistant {
+        content: Some("tooling".repeat(600)),
+        tool_calls: None,
+      },
+      OaiMessage::Tool {
+        tool_call_id: "tool-1".to_string(),
+        content: "y".repeat(10_000),
+      },
+      user_message(format!("latest request {}", "z".repeat(7_000))),
+    ];
+
+    let aggressive = aggressively_compact_messages_for_provider(&messages, "knapsack");
+    let recovery = build_context_recovery_messages(&messages, "knapsack");
+
+    let aggressive_chars: usize = aggressive.iter().map(super::estimate_message_chars).sum();
+    let recovery_chars: usize = recovery.iter().map(super::estimate_message_chars).sum();
+
+    assert!(aggressive_chars <= aggressive_limit);
+    assert!(recovery_chars <= recovery_limit);
+    assert!(recovery_chars < aggressive_chars);
+    assert!(recovery.iter().any(|message| {
+      matches!(
+        message,
+        OaiMessage::User { content, .. } if content.contains("latest request")
+      )
+    }));
+  }
+
+  #[test]
   fn context_window_error_detection_matches_user_visible_failures() {
     assert!(is_context_window_error(
       "message too large for this model".to_string().as_str()
@@ -6356,5 +6637,21 @@ mod tests {
       "maximum context length exceeded".to_string().as_str()
     ));
     assert!(!is_context_window_error("rate limit exceeded"));
+  }
+
+  #[test]
+  fn transient_provider_errors_are_fallback_eligible() {
+    assert!(is_transient_or_internal_provider_error(
+      "request timed out while waiting for provider"
+    ));
+    assert!(is_transient_or_internal_provider_error(
+      "fetch failed: connection reset by peer"
+    ));
+    assert!(should_attempt_fallback_for_provider_error(
+      "provider overloaded, please try again"
+    ));
+    assert!(!should_attempt_fallback_for_provider_error(
+      "invalid api key provided for provider"
+    ));
   }
 }

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -207,6 +207,162 @@ fn read_config_from_disk() -> Option<Value> {
   None
 }
 
+fn read_auth_profiles_from_disk() -> Option<Value> {
+  let mut candidates = Vec::new();
+  if let Ok(dir) = std::env::var("OPENCLAW_STATE_DIR") {
+    candidates.push(
+      std::path::PathBuf::from(dir)
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+  }
+  if let Ok(dir) = std::env::var("OPENCLAW_HOME") {
+    candidates.push(
+      std::path::PathBuf::from(dir)
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+  }
+  if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+    candidates.push(
+      std::path::PathBuf::from(&home)
+        .join("Library")
+        .join("Application Support")
+        .join("ai.knap.knapsack")
+        .join("clawdbot")
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+    candidates.push(
+      std::path::PathBuf::from(&home)
+        .join(".openclaw")
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+  }
+
+  for path in candidates {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+      continue;
+    };
+    let Ok(config) = serde_json::from_str::<Value>(&raw) else {
+      continue;
+    };
+    return Some(config);
+  }
+  None
+}
+
+fn provider_auth_profile_present(auth_profiles: &Value, provider: &str) -> bool {
+  auth_profiles
+    .get("profiles")
+    .and_then(|profiles| profiles.as_object())
+    .map(|profiles| {
+      profiles.iter().any(|(profile_id, profile)| {
+        profile_id.starts_with(&format!("{}:", provider))
+          || profile
+            .get("provider")
+            .and_then(|value| value.as_str())
+            .map(|value| value.eq_ignore_ascii_case(provider))
+            .unwrap_or(false)
+      })
+    })
+    .unwrap_or(false)
+}
+
+fn has_non_empty_env_key(var: &str) -> bool {
+  std::env::var(var)
+    .map(|value| !value.trim().is_empty())
+    .unwrap_or(false)
+}
+
+fn inference_auth_status() -> (bool, Option<String>) {
+  let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
+  let auth_profiles = read_auth_profiles_from_disk();
+  let provider_available = |provider: &str| match provider {
+    "knapsack" => true,
+    "ollama" => true,
+    "anthropic" => {
+      has_non_empty_env_key("ANTHROPIC_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "anthropic"))
+          .unwrap_or(false)
+    }
+    "openai" => {
+      has_non_empty_env_key("OPENAI_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "openai"))
+          .unwrap_or(false)
+    }
+    "groq" => {
+      has_non_empty_env_key("GROQ_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "groq"))
+          .unwrap_or(false)
+    }
+    "xai" => {
+      has_non_empty_env_key("XAI_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "xai"))
+          .unwrap_or(false)
+    }
+    "openrouter" => {
+      has_non_empty_env_key("OPENROUTER_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "openrouter"))
+          .unwrap_or(false)
+    }
+    "gemini" | "google" => {
+      has_non_empty_env_key("GEMINI_API_KEY")
+        || has_non_empty_env_key("GOOGLE_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "google"))
+          .unwrap_or(false)
+    }
+    "google-gemini-cli" => auth_profiles
+      .as_ref()
+      .map(|profiles| provider_auth_profile_present(profiles, "google-gemini-cli"))
+      .unwrap_or(false),
+    _ => false,
+  };
+
+  if provider_available(&active) {
+    return (true, Some(active));
+  }
+
+  for provider in [
+    "knapsack",
+    "ollama",
+    "anthropic",
+    "openai",
+    "groq",
+    "xai",
+    "google",
+    "openrouter",
+    "google-gemini-cli",
+  ] {
+    if provider_available(provider) {
+      return (true, Some(provider.to_string()));
+    }
+  }
+
+  (false, None)
+}
+
 fn configured_channels_from_disk() -> Vec<String> {
   let mut channels = read_config_from_disk()
     .and_then(|config| {
@@ -248,6 +404,29 @@ fn plugin_allow_from_disk() -> Vec<String> {
   plugins.sort();
   plugins.dedup();
   plugins
+}
+
+fn configured_model_from_disk() -> Option<String> {
+  let config = read_config_from_disk()?;
+  match config.pointer("/agents/defaults/model") {
+    Some(Value::String(model)) if !model.trim().is_empty() => Some(model.clone()),
+    Some(Value::Object(obj)) => obj
+      .get("primary")
+      .and_then(|value| value.as_str())
+      .map(str::trim)
+      .filter(|value| !value.is_empty())
+      .map(|value| value.to_string()),
+    _ => None,
+  }
+}
+
+fn gateway_config_rpc_fallback_ok(error: &str) -> bool {
+  let lower = error.to_ascii_lowercase();
+  (lower.contains("unknown method") && lower.contains("config.get"))
+    || lower.starts_with("timeout waiting for response")
+    || lower.starts_with("failed to send request")
+    || lower.contains("connection closed")
+    || lower.contains("channel closed")
 }
 
 fn plugin_allowed_in_config(plugin_id: &str) -> bool {
@@ -3381,37 +3560,14 @@ pub async fn channel_diagnostics() -> impl Responder {
   let mut issues = Vec::new();
   let mut repairs = Vec::new();
 
-  // Check LLM API key availability in the current process
-  let (has_api_key, api_key_provider) = {
-    if std::env::var("ANTHROPIC_API_KEY")
-      .map(|k| !k.trim().is_empty())
-      .unwrap_or(false)
-    {
-      (true, Some("anthropic".to_string()))
-    } else if std::env::var("OPENAI_API_KEY")
-      .map(|k| !k.trim().is_empty())
-      .unwrap_or(false)
-    {
-      (true, Some("openai".to_string()))
-    } else if std::env::var("GROQ_API_KEY")
-      .map(|k| !k.trim().is_empty())
-      .unwrap_or(false)
-    {
-      (true, Some("groq".to_string()))
-    } else if std::env::var("GEMINI_API_KEY")
-      .map(|k| !k.trim().is_empty())
-      .unwrap_or(false)
-    {
-      (true, Some("gemini".to_string()))
-    } else {
-      (false, None)
-    }
-  };
+  // Desktop builds often resolve inference auth from the managed auth-profile
+  // store, not from process env vars alone. Keep diagnostics aligned with the
+  // real runtime so Knapsack-only, Ollama, and auth-profile-backed providers
+  // don't show false "missing API key" failures.
+  let (has_api_key, api_key_provider) = inference_auth_status();
 
   if !has_api_key {
-    issues.push(
-      "No LLM API key found in environment (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)".to_string(),
-    );
+    issues.push("No usable inference provider auth found (Knapsack session, local Ollama, env key, or auth profile)".to_string());
   }
 
   // Fetch channel status from gateway
@@ -3597,10 +3753,7 @@ pub async fn channel_diagnostics() -> impl Responder {
       // plus browser/web/exec coverage, channel messages can look connected
       // while routed replies still fail.
       if !has_channel_reply_tools(&snapshot) {
-        issues.push(
-          "Channel reply tools are missing or incomplete — channel messages cannot use reply/web tools"
-            .to_string(),
-        );
+        let mut repaired_reply_tools = false;
         let re_snapshot = gateway_client::config_get(None).await;
         if let Ok(snap) = re_snapshot {
           let bh = extract_base_hash(&snap);
@@ -3626,11 +3779,23 @@ pub async fn channel_diagnostics() -> impl Responder {
           })
           .to_string();
           match gateway_client::config_patch(&sandbox_patch, &bh, None).await {
-            Ok(_) => repairs.push(
-              "Added channel reply tools with message + browser + web + exec coverage".to_string(),
-            ),
+            Ok(_) => {
+              repairs.push(
+                "Added channel reply tools with message + browser + web + exec coverage"
+                  .to_string(),
+              );
+              if let Ok(updated_snapshot) = gateway_client::config_get(None).await {
+                repaired_reply_tools = has_channel_reply_tools(&updated_snapshot);
+              }
+            }
             Err(e) => issues.push(format!("Failed to repair sandbox tools: {}", e)),
           }
+        }
+        if !repaired_reply_tools {
+          issues.push(
+            "Channel reply tools are missing or incomplete — channel messages cannot use reply/web tools"
+              .to_string(),
+          );
         }
       }
 
@@ -3704,13 +3869,25 @@ pub async fn channel_diagnostics() -> impl Responder {
       (hm, m, channels, plugin_allow)
     }
     Err(e) => {
-      issues.push(format!("Cannot fetch gateway config: {}", e));
       let configured_channels = configured_channels_from_disk();
       let plugin_allow = plugin_allow_from_disk();
-      if !configured_channels.is_empty() {
-        issues.push("Using disk config fallback for configured channels".to_string());
+      if gateway_config_rpc_fallback_ok(&e) {
+        let model = configured_model_from_disk().or_else(|| {
+          if has_api_key {
+            Some(resolve_default_model())
+          } else {
+            None
+          }
+        });
+        let has_model = model.is_some();
+        (has_model, model, configured_channels, plugin_allow)
+      } else {
+        issues.push(format!("Cannot fetch gateway config: {}", e));
+        if !configured_channels.is_empty() {
+          issues.push("Using disk config fallback for configured channels".to_string());
+        }
+        (false, None, configured_channels, plugin_allow)
       }
-      (false, None, configured_channels, plugin_allow)
     }
   };
 
@@ -5042,7 +5219,9 @@ pub async fn telegram_get_agent_bot_statuses() -> impl Responder {
 
 #[cfg(test)]
 mod reconnect_retry_tests {
-  use super::{build_enable_patch, is_connection_level_error, runtime_channel_active};
+  use super::{
+    build_enable_patch, inference_auth_status, is_connection_level_error, runtime_channel_active,
+  };
 
   #[test]
   fn connection_closed_is_retryable() {
@@ -5169,5 +5348,75 @@ mod reconnect_retry_tests {
 
     assert!(!runtime_channel_active(Some(&runtime), None));
     assert!(!runtime_channel_active(None, None));
+  }
+
+  #[test]
+  fn inference_auth_status_treats_knapsack_as_usable_without_env_keys() {
+    let original_active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").ok();
+    let original_state_dir = std::env::var("OPENCLAW_STATE_DIR").ok();
+    std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "knapsack");
+    std::env::remove_var("OPENCLAW_STATE_DIR");
+
+    let (has_auth, provider) = inference_auth_status();
+    assert!(has_auth);
+    assert_eq!(provider.as_deref(), Some("knapsack"));
+
+    if let Some(value) = original_active {
+      std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", value);
+    } else {
+      std::env::remove_var("KNAPSACK_ACTIVE_PROVIDER");
+    }
+    if let Some(value) = original_state_dir {
+      std::env::set_var("OPENCLAW_STATE_DIR", value);
+    } else {
+      std::env::remove_var("OPENCLAW_STATE_DIR");
+    }
+  }
+
+  #[test]
+  fn inference_auth_status_reads_google_cli_auth_from_profiles() {
+    let original_active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").ok();
+    let original_state_dir = std::env::var("OPENCLAW_STATE_DIR").ok();
+    let tmp = std::env::temp_dir().join(format!(
+      "channels-auth-status-{}-{}",
+      std::process::id(),
+      std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+    let agent_dir = tmp.join("agents").join("main").join("agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+      agent_dir.join("auth-profiles.json"),
+      serde_json::json!({
+        "profiles": {
+          "google-gemini-cli:default": {
+            "provider": "google-gemini-cli",
+            "type": "oauth"
+          }
+        }
+      })
+      .to_string(),
+    )
+    .unwrap();
+    std::env::set_var("OPENCLAW_STATE_DIR", &tmp);
+    std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "google-gemini-cli");
+
+    let (has_auth, provider) = inference_auth_status();
+    assert!(has_auth);
+    assert_eq!(provider.as_deref(), Some("google-gemini-cli"));
+
+    std::fs::remove_dir_all(&tmp).ok();
+    if let Some(value) = original_active {
+      std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", value);
+    } else {
+      std::env::remove_var("KNAPSACK_ACTIVE_PROVIDER");
+    }
+    if let Some(value) = original_state_dir {
+      std::env::set_var("OPENCLAW_STATE_DIR", value);
+    } else {
+      std::env::remove_var("OPENCLAW_STATE_DIR");
+    }
   }
 }

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -36,8 +36,20 @@ const BREAKER_TRIP_AFTER: u32 = 3;
 const BREAKER_COOLDOWN: Duration = Duration::from_secs(15);
 
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static LAST_BROWSER_RPC_SUCCESS_MS: AtomicU64 = AtomicU64::new(0);
 fn next_request_id() -> String {
   REQUEST_ID.fetch_add(1, Ordering::SeqCst).to_string()
+}
+
+fn now_epoch_ms() -> u64 {
+  std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+    .unwrap_or(0)
+}
+
+pub fn last_browser_rpc_success_ms() -> u64 {
+  LAST_BROWSER_RPC_SUCCESS_MS.load(Ordering::Relaxed)
 }
 
 #[derive(Serialize)]
@@ -914,6 +926,8 @@ fn ensure_browser_config_at(config_path: &std::path::Path) -> bool {
 /// so we don't repeatedly trigger restarts.
 static BROWSER_CONFIG_APPLIED: std::sync::atomic::AtomicBool =
   std::sync::atomic::AtomicBool::new(false);
+static BROWSER_CONFIG_RPC_UNSUPPORTED: std::sync::atomic::AtomicBool =
+  std::sync::atomic::AtomicBool::new(false);
 
 /// Push browser config to a running gateway via a **temporary** WebSocket
 /// Pick the best default LLM model based on which API key is available.
@@ -1087,6 +1101,16 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
   let primary_provider = primary.split('/').next().unwrap_or("").to_lowercase();
   let mut fallbacks = Vec::new();
 
+  // Anthropic first among paid fallbacks: in practice this is the most common
+  // "already configured and actually working" escape hatch on desktop builds.
+  // Without it, an OpenAI quota error can bounce through Groq/Google/OpenRouter
+  // auth failures even though a healthy Anthropic key is available.
+  if primary_provider != "anthropic" && has_key("ANTHROPIC_API_KEY") {
+    let model =
+      std::env::var("KNAPSACK_ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-opus-4-6".to_string());
+    fallbacks.push(format!("anthropic/{}", model));
+  }
+
   // Groq first: free, fast, and a good rate-limit escape hatch.
   if primary_provider != "groq" && has_key("GROQ_API_KEY") {
     let model = std::env::var("KNAPSACK_GROQ_MODEL")
@@ -1147,7 +1171,14 @@ pub fn build_model_config() -> serde_json::Value {
 
 /// connection.  config.patch triggers a SIGUSR1 restart on the gateway, so
 /// we use a throwaway connection and wait for the gateway to come back.
-async fn apply_runtime_browser_config(token: &str) {
+async fn apply_runtime_browser_config(token: &str) -> bool {
+  if BROWSER_CONFIG_RPC_UNSUPPORTED.load(Ordering::Relaxed) {
+    eprintln!(
+      "[gateway_client] Skipping runtime config.patch because this gateway build does not expose config.get"
+    );
+    return false;
+  }
+
   // Open a temporary WebSocket just for the config.patch exchange.
   let tmp_req = {
     let mut r = GATEWAY_WS_URL.into_client_request().expect("valid URL");
@@ -1159,7 +1190,7 @@ async fn apply_runtime_browser_config(token: &str) {
     Ok(Ok((ws, _))) => ws,
     _ => {
       eprintln!("[gateway_client] Could not open temporary WS for config.patch");
-      return;
+      return false;
     }
   };
 
@@ -1180,16 +1211,16 @@ async fn apply_runtime_browser_config(token: &str) {
     Ok(Ok(t)) => t,
     _ => {
       eprintln!("[gateway_client] Timeout/error waiting for challenge on tmp WS");
-      return;
+      return false;
     }
   };
 
   let event: EventFrame = match serde_json::from_str(&challenge_text) {
     Ok(e) => e,
-    Err(_) => return,
+    Err(_) => return false,
   };
   if event.event != "connect.challenge" {
-    return;
+    return false;
   }
 
   let connect_params = ConnectParams {
@@ -1223,7 +1254,7 @@ async fn apply_runtime_browser_config(token: &str) {
     .await
     .is_err()
   {
-    return;
+    return false;
   }
 
   // Wait for connect response.
@@ -1246,54 +1277,107 @@ async fn apply_runtime_browser_config(token: &str) {
     Err(_) => false,
   };
 
-  // Send config.get to get the baseHash.
-  let config_get_id = next_request_id();
-  let config_get_frame = RequestFrame {
-    frame_type: "req",
-    method: "config.get".to_string(),
-    id: config_get_id.clone(),
-    params: None,
-  };
-  if tmp_write
-    .send(Message::Text(
-      serde_json::to_string(&config_get_frame).unwrap(),
-    ))
-    .await
-    .is_err()
-  {
-    return;
-  }
+  // Send config.get to get the baseHash. During early gateway startup the
+  // control-plane registry can still be warming up, so retry a few times
+  // instead of treating a temporary unknown-method/timeout as a stable state.
+  let mut cfg_val: Option<Value> = None;
+  for (attempt_idx, wait_ms) in [0_u64, 250, 500, 1_000].into_iter().enumerate() {
+    let config_get_id = next_request_id();
+    let config_get_frame = RequestFrame {
+      frame_type: "req",
+      method: "config.get".to_string(),
+      id: config_get_id.clone(),
+      params: None,
+    };
+    if tmp_write
+      .send(Message::Text(
+        serde_json::to_string(&config_get_frame).unwrap(),
+      ))
+      .await
+      .is_err()
+    {
+      eprintln!("[gateway_client] Failed to send config.get on tmp WS");
+      return false;
+    }
 
-  // Read config.get response.
-  let cfg_val: Value = match tokio::time::timeout(Duration::from_secs(5), async {
-    loop {
-      match tmp_read.next().await {
-        Some(Ok(Message::Text(t))) => {
-          if let Ok(resp) = serde_json::from_str::<ResponseFrame>(&t) {
-            if resp.id == config_get_id && resp.ok {
-              break Ok(
-                resp
-                  .result
-                  .or(resp.data)
-                  .or(resp.payload)
-                  .unwrap_or(Value::Null),
-              );
-            } else if resp.id == config_get_id {
-              break Err("config.get failed");
+    let attempt_result = tokio::time::timeout(Duration::from_secs(5), async {
+      loop {
+        match tmp_read.next().await {
+          Some(Ok(Message::Text(t))) => {
+            if let Ok(resp) = serde_json::from_str::<ResponseFrame>(&t) {
+              if resp.id == config_get_id && resp.ok {
+                break Ok(
+                  resp
+                    .result
+                    .or(resp.data)
+                    .or(resp.payload)
+                    .unwrap_or(Value::Null),
+                );
+              } else if resp.id == config_get_id {
+                let error_text = resp
+                  .error
+                  .as_ref()
+                  .map(|value| value.to_string())
+                  .unwrap_or_else(|| "config.get failed".to_string());
+                break Err(error_text);
+              }
             }
           }
+          Some(Ok(Message::Close(_))) | None => break Err("connection closed".to_string()),
+          _ => continue,
         }
-        Some(Ok(Message::Close(_))) | None => break Err("connection closed"),
-        _ => continue,
+      }
+    })
+    .await;
+
+    match attempt_result {
+      Ok(Ok(value)) => {
+        cfg_val = Some(value);
+        break;
+      }
+      Ok(Err(error)) => {
+        let unknown_method = should_retry_unknown_method(&error, "config.get");
+        if unknown_method && attempt_idx + 1 >= 4 {
+          BROWSER_CONFIG_RPC_UNSUPPORTED.store(true, Ordering::Relaxed);
+        }
+        if unknown_method && attempt_idx + 1 < 4 {
+          eprintln!(
+            "[gateway_client] config.get unavailable during startup on tmp WS; retrying in {}ms (attempt {}/{})",
+            wait_ms,
+            attempt_idx + 1,
+            4
+          );
+          tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+          continue;
+        }
+        eprintln!(
+          "[gateway_client] config.get failed on tmp WS, skipping runtime patch: {}",
+          error
+        );
+        return false;
+      }
+      Err(_) => {
+        if attempt_idx + 1 < 4 {
+          eprintln!(
+            "[gateway_client] config.get timed out on tmp WS; retrying in {}ms (attempt {}/{})",
+            wait_ms,
+            attempt_idx + 1,
+            4
+          );
+          tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+          continue;
+        }
+        eprintln!("[gateway_client] config.get failed or timed out on tmp WS, skipping patch");
+        return false;
       }
     }
-  })
-  .await
-  {
-    Ok(Ok(v)) => v,
-    _ => {
-      eprintln!("[gateway_client] config.get failed or timed out on tmp WS, skipping patch");
-      return;
+  }
+
+  let cfg_val = match cfg_val {
+    Some(value) => value,
+    None => {
+      eprintln!("[gateway_client] config.get never succeeded on tmp WS, skipping patch");
+      return false;
     }
   };
 
@@ -1305,7 +1389,7 @@ async fn apply_runtime_browser_config(token: &str) {
 
   if base_hash.is_empty() {
     eprintln!("[gateway_client] config.get returned no hash, skipping runtime patch");
-    return;
+    return false;
   }
 
   // Send config.patch with browser + tools settings.
@@ -1418,7 +1502,7 @@ async fn apply_runtime_browser_config(token: &str) {
     .is_err()
   {
     eprintln!("[gateway_client] Failed to send config.patch — connection closed");
-    return;
+    return false;
   }
 
   // Read the config.patch response to detect rate-limiting or other rejection.
@@ -1481,7 +1565,7 @@ async fn apply_runtime_browser_config(token: &str) {
   if !patch_accepted {
     // Patch was rejected — gateway is NOT restarting.  No further action needed;
     // the already-correct disk config will be picked up on the next gateway restart.
-    return;
+    return false;
   }
 
   // Wait for the gateway to restart.  Poll until the port is listening again
@@ -1493,11 +1577,12 @@ async fn apply_runtime_browser_config(token: &str) {
       eprintln!("[gateway_client] Gateway is back up after config.patch");
       // Give it a moment to fully initialize.
       tokio::time::sleep(Duration::from_millis(500)).await;
-      return;
+      return true;
     }
     tokio::time::sleep(Duration::from_millis(wait_ms)).await;
   }
   eprintln!("[gateway_client] Gateway did not come back after config.patch within timeout");
+  false
 }
 
 async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String> {
@@ -1529,10 +1614,10 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
   // BROWSER_CONFIG_APPLIED prevents firing on every reconnect after a transient
   // WS drop.
   let need_runtime_patch = !BROWSER_CONFIG_APPLIED.load(Ordering::Relaxed)
+    && !BROWSER_CONFIG_RPC_UNSUPPORTED.load(Ordering::Relaxed)
     && (gateway_already_running || disk_config_changed);
 
   if need_runtime_patch {
-    BROWSER_CONFIG_APPLIED.store(true, Ordering::Relaxed);
     // Wait briefly for the gateway to be reachable if we just wrote the disk config.
     if disk_config_changed && !gateway_already_running {
       eprintln!(
@@ -1541,7 +1626,13 @@ async fn connect_and_handshake(token: &str) -> Result<Arc<GatewayClient>, String
     } else {
       eprintln!("[gateway_client] Applying config.patch RPC (gateway running, skipped disk write)");
     }
-    apply_runtime_browser_config(token).await;
+    if apply_runtime_browser_config(token).await {
+      BROWSER_CONFIG_APPLIED.store(true, Ordering::Relaxed);
+    } else {
+      eprintln!(
+        "[gateway_client] Runtime config.patch did not complete; leaving patch flag unset for retry"
+      );
+    }
   }
 
   ensure_gateway_best_effort(token).await;
@@ -2099,11 +2190,16 @@ fn should_retry_unknown_method(error: &str, method: &str) -> bool {
     .contains(&needle.to_ascii_lowercase())
 }
 
+fn is_unknown_requested_method(error: &str, method: &str) -> bool {
+  should_retry_unknown_method(error, method)
+}
+
 async fn gateway_request_pooled_inner(
   method: &str,
   params: Option<Value>,
   token: &str,
   allow_unknown_method_retry: bool,
+  allow_connection_retry: bool,
 ) -> Result<Value, String> {
   let client = get_or_connect(token).await?;
 
@@ -2198,6 +2294,25 @@ async fn gateway_request_pooled_inner(
   }
 
   drop(permit);
+  if is_connection_error && allow_connection_retry {
+    let gateway_still_healthy = gateway_ws_handshake_open(token, Duration::from_millis(1500)).await
+      || is_gateway_port_open().await;
+    if gateway_still_healthy {
+      eprintln!(
+        "[gateway_client] {} hit a stale pooled connection while gateway stayed healthy; reconnecting and retrying once",
+        method
+      );
+      invalidate_client();
+      return Box::pin(gateway_request_pooled_inner(
+        method,
+        retry_params.clone(),
+        token,
+        allow_unknown_method_retry,
+        false,
+      ))
+      .await;
+    }
+  }
   if allow_unknown_method_retry {
     if let Err(ref error) = out {
       if should_retry_unknown_method(error, method) {
@@ -2210,6 +2325,7 @@ async fn gateway_request_pooled_inner(
           method,
           retry_params,
           token,
+          false,
           false,
         ))
         .await;
@@ -2229,7 +2345,30 @@ pub async fn gateway_request_pooled(
   params: Option<Value>,
   token: &str,
 ) -> Result<Value, String> {
-  gateway_request_pooled_inner(method, params, token, true).await
+  gateway_request_pooled_inner(method, params, token, true, true).await
+}
+
+/// Make an optional request using the persistent gateway connection.
+///
+/// Some gateway builds legitimately do not expose newer RPC methods yet.
+/// Callers that can safely fall back locally should use this helper so an
+/// unsupported optional method does not trigger a noisy reconnect/retry cycle
+/// that looks like a stale connection or startup regression.
+pub async fn gateway_request_pooled_optional(
+  method: &str,
+  params: Option<Value>,
+  token: &str,
+) -> Result<Value, String> {
+  let out = gateway_request_pooled_inner(method, params, token, false, true).await;
+  if let Err(ref error) = out {
+    if is_unknown_requested_method(error, method) {
+      eprintln!(
+        "[gateway_client] {} is unsupported by the active gateway build; using caller fallback",
+        method
+      );
+    }
+  }
+  out
 }
 
 /// Make a two-phase request (like `agent`) using the persistent gateway
@@ -2529,7 +2668,10 @@ pub async fn browser_request(
     )
     .await
     {
-      Ok(Ok(result)) => return Ok(result),
+      Ok(Ok(result)) => {
+        LAST_BROWSER_RPC_SUCCESS_MS.store(now_epoch_ms(), Ordering::Relaxed);
+        return Ok(result);
+      }
       Ok(Err(e)) => {
         last_err = e;
         if attempt < backoffs.len() && is_transient_browser_error(&last_err) {
@@ -2762,6 +2904,25 @@ mod tests {
     std::env::remove_var("KNAPSACK_ACTIVE_PROVIDER");
   }
 
+  #[test]
+  fn fallback_models_include_anthropic_when_available() {
+    std::env::set_var("ANTHROPIC_API_KEY", "test-anthropic");
+    std::env::set_var("KNAPSACK_ANTHROPIC_MODEL", "claude-sonnet-4-5");
+    std::env::remove_var("GROQ_API_KEY");
+    std::env::remove_var("GEMINI_API_KEY");
+    std::env::remove_var("GOOGLE_API_KEY");
+    std::env::remove_var("OPENROUTER_API_KEY");
+
+    let fallbacks = collect_fallback_models("openai/gpt-5.5");
+    assert_eq!(
+      fallbacks.first().map(String::as_str),
+      Some("anthropic/claude-sonnet-4-5")
+    );
+
+    std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("KNAPSACK_ANTHROPIC_MODEL");
+  }
+
   // ── ensure_browser_config_at: no spurious change when already correct ───
   // A config that already satisfies every invariant must produce changed=false
   // so that a running gateway is not sent a redundant config.patch.
@@ -2980,6 +3141,14 @@ mod tests {
     assert!(!should_retry_unknown_method(
       "Request failed: Object {\"code\":\"INVALID_REQUEST\",\"message\":\"unknown method: status\"}",
       "config.get"
+    ));
+  }
+
+  #[test]
+  fn detects_unknown_requested_method_case_insensitively() {
+    assert!(is_unknown_requested_method(
+      "request failed: object {\"message\":\"Unknown Method: skills.status\"}",
+      "skills.status"
     ));
   }
 }

--- a/src/src-tauri/src/clawd/gateway_supervisor.rs
+++ b/src/src-tauri/src/clawd/gateway_supervisor.rs
@@ -501,6 +501,14 @@ pub async fn wait_for_gateway_ready(token: &str, max_wait_ms: u64) -> bool {
 /// circular imports if we later expand supervisor responsibilities.
 #[allow(dead_code)]
 pub fn app_clawdbot_home(app_handle: &tauri::AppHandle) -> PathBuf {
+  if let Some(raw) =
+    std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("OPENCLAW_HOME"))
+  {
+    let path = PathBuf::from(raw);
+    if !path.as_os_str().is_empty() {
+      return path;
+    }
+  }
   app_handle
     .path_resolver()
     .app_data_dir()

--- a/src/src-tauri/src/clawd/gateway_ws.rs
+++ b/src/src-tauri/src/clawd/gateway_ws.rs
@@ -147,16 +147,8 @@ fn gateway_token_candidates() -> Vec<PathBuf> {
   let home = std::env::var("HOME")
     .or_else(|_| std::env::var("USERPROFILE"))
     .unwrap_or_else(|_| ".".to_string());
-  candidates.push(
-    PathBuf::from(&home)
-      .join(".openclaw")
-      .join("openclaw.json"),
-  );
-  candidates.push(
-    PathBuf::from(&home)
-      .join(".clawdbot")
-      .join("clawdbot.json"),
-  );
+  candidates.push(PathBuf::from(&home).join(".openclaw").join("openclaw.json"));
+  candidates.push(PathBuf::from(&home).join(".clawdbot").join("clawdbot.json"));
 
   candidates
 }

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -291,6 +291,7 @@ const GATEWAY_TRANSIENT_FAILURE_GRACE_MS: u64 = 30_000;
 const BROWSER_START_NUDGE_COOLDOWN_MS: u64 = 45_000;
 const BROWSER_TRANSIENT_FAILURE_GRACE_MS: u64 = 15_000;
 const BROWSER_STARTUP_GRACE_MS: u64 = 20_000;
+const BROWSER_RECENT_RPC_SUCCESS_GRACE_MS: u64 = 15_000;
 
 fn now_epoch_ms() -> u64 {
   std::time::SystemTime::now()
@@ -3089,6 +3090,9 @@ fn read_log_tail_lines_bounded(
 }
 
 fn app_clawdbot_home(app_handle: &tauri::AppHandle) -> PathBuf {
+  if let Some(home) = default_clawdbot_home_from_env() {
+    return home;
+  }
   app_handle
     .path_resolver()
     .app_data_dir()
@@ -3287,6 +3291,67 @@ fn knapsack_email_from_tokens() -> Option<String> {
     .get("knapsack_email")
     .and_then(|email| email.as_str())
     .and_then(normalize_imessage_owner_identifier)
+}
+
+#[cfg(test)]
+mod clawdbot_home_env_tests {
+  use super::default_clawdbot_home_from_env;
+  use std::ffi::OsString;
+  use std::path::PathBuf;
+  use std::sync::{Mutex, OnceLock};
+
+  fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+  }
+
+  #[test]
+  fn default_clawdbot_home_prefers_explicit_state_dir() {
+    let _guard = env_lock().lock().unwrap();
+    let previous_state = std::env::var_os("OPENCLAW_STATE_DIR");
+    let previous_home = std::env::var_os("OPENCLAW_HOME");
+
+    std::env::set_var("OPENCLAW_STATE_DIR", "/tmp/knapsack-qa-state");
+    std::env::set_var("OPENCLAW_HOME", "/tmp/knapsack-qa-home");
+
+    assert_eq!(
+      default_clawdbot_home_from_env(),
+      Some(PathBuf::from("/tmp/knapsack-qa-state"))
+    );
+
+    match previous_state {
+      Some(value) => std::env::set_var("OPENCLAW_STATE_DIR", value),
+      None => std::env::remove_var("OPENCLAW_STATE_DIR"),
+    }
+    match previous_home {
+      Some(value) => std::env::set_var("OPENCLAW_HOME", value),
+      None => std::env::remove_var("OPENCLAW_HOME"),
+    }
+  }
+
+  #[test]
+  fn default_clawdbot_home_falls_back_to_openclaw_home() {
+    let _guard = env_lock().lock().unwrap();
+    let previous_state = std::env::var_os("OPENCLAW_STATE_DIR");
+    let previous_home = std::env::var_os("OPENCLAW_HOME");
+
+    std::env::remove_var("OPENCLAW_STATE_DIR");
+    std::env::set_var("OPENCLAW_HOME", "/tmp/knapsack-qa-home");
+
+    assert_eq!(
+      default_clawdbot_home_from_env(),
+      Some(PathBuf::from("/tmp/knapsack-qa-home"))
+    );
+
+    match previous_state {
+      Some(value) => std::env::set_var("OPENCLAW_STATE_DIR", value),
+      None => std::env::remove_var("OPENCLAW_STATE_DIR"),
+    }
+    match previous_home {
+      Some(value) => std::env::set_var("OPENCLAW_HOME", value),
+      None => std::env::remove_var("OPENCLAW_HOME"),
+    }
+  }
 }
 
 /// Safe default for iMessage DM access. Prefer the signed-in Knapsack email
@@ -3724,6 +3789,66 @@ fn sanitize_rejected_legacy_config_keys(cfg: &mut serde_json::Value) -> bool {
 
   patched |= remove_redaction_sentinels(cfg, "");
 
+  // Remove stale external plugin entries that the bundled desktop gateway
+  // does not ship and that routinely survive upgrades in disabled form.
+  // Leaving them in place is harmless to runtime, but it creates scary
+  // "plugin not found" warnings that bleed into diagnostics and erode trust.
+  const STALE_OPTIONAL_PLUGIN_IDS: &[&str] =
+    &["codex", "duckduckgo", "google", "groq", "openrouter"];
+
+  if let Some(allow) = cfg
+    .pointer_mut("/plugins/allow")
+    .and_then(|value| value.as_array_mut())
+  {
+    let before_len = allow.len();
+    allow.retain(|value| {
+      value
+        .as_str()
+        .map(|id| !STALE_OPTIONAL_PLUGIN_IDS.contains(&id))
+        .unwrap_or(true)
+    });
+    if allow.len() != before_len {
+      eprintln!("[clawd/service] Removed stale plugin ids from plugins.allow");
+      patched = true;
+    }
+  }
+
+  if let Some(entries) = cfg
+    .pointer_mut("/plugins/entries")
+    .and_then(|value| value.as_object_mut())
+  {
+    let stale_ids: Vec<String> = STALE_OPTIONAL_PLUGIN_IDS
+      .iter()
+      .filter_map(|id| entries.contains_key(*id).then_some((*id).to_string()))
+      .collect();
+    for id in stale_ids {
+      entries.remove(&id);
+      eprintln!(
+        "[clawd/service] Removed stale bundled-plugin config entry: plugins.entries.{}",
+        id
+      );
+      patched = true;
+    }
+  }
+
+  // The desktop bundle already provides browser-backed web search and no
+  // longer installs the old DuckDuckGo plugin. Remove the stale provider pin
+  // so the gateway can auto-detect the supported search path without warning.
+  if cfg
+    .pointer("/tools/web/search/provider")
+    .and_then(|value| value.as_str())
+    == Some("duckduckgo")
+  {
+    if let Some(search) = cfg
+      .pointer_mut("/tools/web/search")
+      .and_then(|value| value.as_object_mut())
+    {
+      search.remove("provider");
+      eprintln!("[clawd/service] Removed stale tools.web.search.provider=duckduckgo override");
+      patched = true;
+    }
+  }
+
   patched
 }
 
@@ -4077,6 +4202,12 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
       return;
     }
   };
+  if let Err(e) = sync_portable_api_key_auth_profiles(app_handle, &tokens) {
+    eprintln!(
+      "[clawd/service] Could not sync portable auth profiles from tokens.json: {}",
+      e
+    );
+  }
   if let Some(k) = &tokens.groq_api_key {
     let k = k.trim();
     if !k.is_empty() {
@@ -4247,6 +4378,373 @@ fn is_allowed_extra_env_var(name: &str) -> bool {
   )
 }
 
+fn sync_portable_api_key_auth_profiles(
+  app_handle: &tauri::AppHandle,
+  tokens: &StoredTokens,
+) -> Result<(), String> {
+  let agent_dir = app_clawdbot_home(app_handle)
+    .join("agents")
+    .join("main")
+    .join("agent");
+  ensure_dir(&agent_dir)?;
+  harden_dir_permissions(&agent_dir);
+  let auth_path = agent_dir.join("auth-profiles.json");
+
+  let mut root = match fs::read_to_string(&auth_path) {
+    Ok(content) => serde_json::from_str::<serde_json::Value>(&content).unwrap_or_else(|_| {
+      serde_json::json!({
+        "profiles": {}
+      })
+    }),
+    Err(_) => serde_json::json!({
+      "profiles": {}
+    }),
+  };
+
+  if !root.is_object() {
+    root = serde_json::json!({
+      "profiles": {}
+    });
+  }
+
+  let root_obj = root.as_object_mut().expect("root just forced to object");
+  if !root_obj
+    .get("profiles")
+    .map(|value| value.is_object())
+    .unwrap_or(false)
+  {
+    root_obj.insert("profiles".to_string(), serde_json::json!({}));
+  }
+
+  let profiles = root_obj
+    .get_mut("profiles")
+    .and_then(|value| value.as_object_mut())
+    .expect("profiles just forced to object");
+
+  let mut changed = false;
+  let mut removed_profile_ids = Vec::new();
+  let mut removed_provider_ids = Vec::new();
+
+  let managed_profiles = [
+    (
+      "openai",
+      "openai:default",
+      vec!["openai:default"],
+      tokens.openai_api_key.as_deref(),
+    ),
+    (
+      "anthropic",
+      "anthropic:default",
+      vec!["anthropic:default"],
+      tokens.anthropic_api_key.as_deref(),
+    ),
+    (
+      "google",
+      "google:default",
+      vec!["google:default", "gemini:default"],
+      tokens.gemini_api_key.as_deref(),
+    ),
+    (
+      "groq",
+      "groq:default",
+      vec!["groq:default"],
+      tokens.groq_api_key.as_deref(),
+    ),
+    (
+      "xai",
+      "xai:default",
+      vec!["xai:default"],
+      tokens.xai_api_key.as_deref(),
+    ),
+    (
+      "openrouter",
+      "openrouter:default",
+      vec!["openrouter:default"],
+      tokens.openrouter_api_key.as_deref(),
+    ),
+  ];
+
+  for (provider, canonical_id, managed_ids, maybe_key) in managed_profiles {
+    let normalized_key = maybe_key
+      .map(str::trim)
+      .filter(|value| !value.is_empty())
+      .map(str::to_string);
+
+    match normalized_key {
+      Some(key) => {
+        let desired = serde_json::json!({
+          "type": "api_key",
+          "provider": provider,
+          "key": key,
+        });
+        if profiles.get(canonical_id) != Some(&desired) {
+          profiles.insert(canonical_id.to_string(), desired);
+          changed = true;
+        }
+        for managed_id in managed_ids {
+          if managed_id != canonical_id && profiles.remove(managed_id).is_some() {
+            removed_profile_ids.push(managed_id.to_string());
+            changed = true;
+          }
+        }
+      }
+      None => {
+        for managed_id in managed_ids {
+          if profiles.remove(managed_id).is_some() {
+            removed_profile_ids.push(managed_id.to_string());
+            changed = true;
+          }
+        }
+        removed_provider_ids.push(provider.to_string());
+      }
+    }
+  }
+
+  if !removed_profile_ids.is_empty() {
+    if let Some(usage_stats) = root_obj
+      .get_mut("usageStats")
+      .and_then(|value| value.as_object_mut())
+    {
+      for profile_id in &removed_profile_ids {
+        if usage_stats.remove(profile_id).is_some() {
+          changed = true;
+        }
+      }
+      if usage_stats.is_empty() {
+        root_obj.remove("usageStats");
+        changed = true;
+      }
+    }
+
+    if let Some(last_good) = root_obj
+      .get_mut("lastGood")
+      .and_then(|value| value.as_object_mut())
+    {
+      for provider_id in &removed_provider_ids {
+        if last_good.remove(provider_id).is_some() {
+          changed = true;
+        }
+      }
+      if last_good.is_empty() {
+        root_obj.remove("lastGood");
+        changed = true;
+      }
+    }
+
+    if let Some(order) = root_obj
+      .get_mut("order")
+      .and_then(|value| value.as_object_mut())
+    {
+      for provider_id in &removed_provider_ids {
+        if order.remove(provider_id).is_some() {
+          changed = true;
+        }
+      }
+      if order.is_empty() {
+        root_obj.remove("order");
+        changed = true;
+      }
+    }
+  }
+
+  if changed {
+    fs::write(
+      &auth_path,
+      serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| format!("Failed writing {}: {}", auth_path.display(), e))?;
+    harden_file_permissions(&auth_path);
+  }
+
+  Ok(())
+}
+
+fn sync_portable_api_key_auth_config(
+  app_handle: &tauri::AppHandle,
+  tokens: &StoredTokens,
+) -> Result<(), String> {
+  let config_path = app_clawdbot_home(app_handle).join("openclaw.json");
+  if !config_path.exists() {
+    return Ok(());
+  }
+
+  let mut root = match fs::read_to_string(&config_path) {
+    Ok(content) => serde_json::from_str::<serde_json::Value>(&content)
+      .map_err(|e| format!("Failed parsing {}: {}", config_path.display(), e))?,
+    Err(e) => return Err(format!("Failed reading {}: {}", config_path.display(), e)),
+  };
+
+  if !root.is_object() {
+    root = serde_json::json!({});
+  }
+
+  let root_obj = root.as_object_mut().expect("root just forced to object");
+  if !root_obj
+    .get("auth")
+    .map(|value| value.is_object())
+    .unwrap_or(false)
+  {
+    root_obj.insert("auth".to_string(), serde_json::json!({}));
+  }
+
+  let auth = root_obj
+    .get_mut("auth")
+    .and_then(|value| value.as_object_mut())
+    .expect("auth just forced to object");
+
+  let mut profiles = auth
+    .get("profiles")
+    .and_then(|value| value.as_object())
+    .cloned()
+    .unwrap_or_default();
+  let mut order = auth
+    .get("order")
+    .and_then(|value| value.as_object())
+    .cloned()
+    .unwrap_or_default();
+
+  let mut changed = false;
+
+  let managed_profiles = [
+    (
+      "openai",
+      "openai:default",
+      vec!["openai:default"],
+      tokens.openai_api_key.as_deref(),
+    ),
+    (
+      "anthropic",
+      "anthropic:default",
+      vec!["anthropic:default"],
+      tokens.anthropic_api_key.as_deref(),
+    ),
+    (
+      "google",
+      "google:default",
+      vec!["google:default", "gemini:default"],
+      tokens.gemini_api_key.as_deref(),
+    ),
+    (
+      "groq",
+      "groq:default",
+      vec!["groq:default"],
+      tokens.groq_api_key.as_deref(),
+    ),
+    (
+      "xai",
+      "xai:default",
+      vec!["xai:default"],
+      tokens.xai_api_key.as_deref(),
+    ),
+    (
+      "openrouter",
+      "openrouter:default",
+      vec!["openrouter:default"],
+      tokens.openrouter_api_key.as_deref(),
+    ),
+  ];
+
+  for (provider, canonical_id, managed_ids, maybe_key) in managed_profiles {
+    let has_key = maybe_key
+      .map(str::trim)
+      .filter(|value| !value.is_empty())
+      .is_some();
+
+    if has_key {
+      let desired = serde_json::json!({
+        "provider": provider,
+        "mode": "api_key",
+      });
+      if profiles.get(canonical_id) != Some(&desired) {
+        profiles.insert(canonical_id.to_string(), desired);
+        changed = true;
+      }
+      for managed_id in &managed_ids {
+        if *managed_id != canonical_id && profiles.remove(*managed_id).is_some() {
+          changed = true;
+        }
+      }
+    } else {
+      for managed_id in &managed_ids {
+        if profiles.remove(*managed_id).is_some() {
+          changed = true;
+        }
+      }
+    }
+
+    let next_order = order
+      .get(provider)
+      .and_then(|value| value.as_array())
+      .map(|items| {
+        items
+          .iter()
+          .filter_map(|value| value.as_str().map(|text| text.to_string()))
+          .collect::<Vec<_>>()
+      })
+      .unwrap_or_default()
+      .into_iter()
+      .filter(|profile_id| {
+        !managed_ids
+          .iter()
+          .any(|managed_id| managed_id == &profile_id.as_str())
+      })
+      .collect::<Vec<_>>();
+
+    if has_key {
+      let mut reordered = vec![canonical_id.to_string()];
+      reordered.extend(next_order);
+      let desired = serde_json::Value::Array(
+        reordered
+          .iter()
+          .map(|profile_id| serde_json::Value::String(profile_id.clone()))
+          .collect(),
+      );
+      if order.get(provider) != Some(&desired) {
+        order.insert(provider.to_string(), desired);
+        changed = true;
+      }
+    } else if next_order.is_empty() {
+      if order.remove(provider).is_some() {
+        changed = true;
+      }
+    } else {
+      let desired = serde_json::Value::Array(
+        next_order
+          .iter()
+          .map(|profile_id| serde_json::Value::String(profile_id.clone()))
+          .collect(),
+      );
+      if order.get(provider) != Some(&desired) {
+        order.insert(provider.to_string(), desired);
+        changed = true;
+      }
+    }
+  }
+
+  if changed {
+    auth.insert(
+      "profiles".to_string(),
+      serde_json::Value::Object(profiles.clone()),
+    );
+    if order.is_empty() {
+      auth.remove("order");
+    } else {
+      auth.insert(
+        "order".to_string(),
+        serde_json::Value::Object(order.clone()),
+      );
+    }
+    fs::write(
+      &config_path,
+      serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| format!("Failed writing {}: {}", config_path.display(), e))?;
+    harden_file_permissions(&config_path);
+  }
+
+  Ok(())
+}
+
 fn save_tokens(app_handle: &tauri::AppHandle, tokens: &StoredTokens) -> Result<(), String> {
   let home = app_clawdbot_home(app_handle);
   ensure_dir(&home)?;
@@ -4258,6 +4756,8 @@ fn save_tokens(app_handle: &tauri::AppHandle, tokens: &StoredTokens) -> Result<(
   )
   .map_err(|e| format!("Failed writing {}: {}", path.display(), e))?;
   harden_file_permissions(&path);
+  sync_portable_api_key_auth_profiles(app_handle, tokens)?;
+  sync_portable_api_key_auth_config(app_handle, tokens)?;
   Ok(())
 }
 
@@ -5176,6 +5676,22 @@ fn gateway_recently_healthy(now_ms: u64, gateway_listening: bool) -> bool {
     && now_ms.saturating_sub(last_healthy_ms) < GATEWAY_TRANSIENT_FAILURE_GRACE_MS
 }
 
+fn is_transient_browser_probe_error(message: &str) -> bool {
+  let lower = message.to_ascii_lowercase();
+  lower.contains("channel closed")
+    || lower.contains("operation was canceled")
+    || lower.contains("received unexpected message from connection")
+    || lower.contains("connection reset")
+    || lower.contains("broken pipe")
+}
+
+fn is_noisy_browser_probe_error(message: &str) -> bool {
+  let lower = message.to_ascii_lowercase();
+  is_transient_browser_probe_error(message)
+    || lower.contains("timed out")
+    || lower.contains("deadline has elapsed")
+}
+
 async fn browser_control_status(
   gateway_token: &str,
   timeout: std::time::Duration,
@@ -5194,11 +5710,26 @@ async fn browser_control_status(
   let resp = match tokio::time::timeout(timeout, fut).await {
     Ok(Ok(resp)) => resp,
     Ok(Err(e)) => {
-      eprintln!("[clawd/service] browser control status probe failed: {}", e);
+      let err_text = e.to_string();
+      if is_transient_browser_probe_error(&err_text) {
+        log::debug!(
+          "[clawd/service] browser control status probe hit transient startup error: {}",
+          err_text
+        );
+        return BrowserControlProbe::Starting;
+      }
+      if is_noisy_browser_probe_error(&err_text) {
+        log::debug!(
+          "[clawd/service] browser control status probe hit short-lived startup error: {}",
+          err_text
+        );
+        return BrowserControlProbe::Down;
+      }
+      eprintln!("[clawd/service] browser control status probe failed: {}", err_text);
       return BrowserControlProbe::Down;
     }
     Err(_) => {
-      eprintln!(
+      log::debug!(
         "[clawd/service] browser control status probe timed out ({}ms)",
         timeout.as_millis()
       );
@@ -5217,11 +5748,26 @@ async fn browser_control_status(
   match resp.text().await {
     Ok(body) => parse_browser_control_status_body(&body),
     Err(e) => {
-      eprintln!(
-        "[clawd/service] browser control status probe failed to read response body: {}",
-        e
-      );
-      BrowserControlProbe::Down
+      let err_text = e.to_string();
+      if is_transient_browser_probe_error(&err_text) {
+        log::debug!(
+          "[clawd/service] browser control status probe body read hit transient startup error: {}",
+          err_text
+        );
+        BrowserControlProbe::Starting
+      } else if is_noisy_browser_probe_error(&err_text) {
+        log::debug!(
+          "[clawd/service] browser control status probe body read hit short-lived startup error: {}",
+          err_text
+        );
+        BrowserControlProbe::Down
+      } else {
+        eprintln!(
+          "[clawd/service] browser control status probe failed to read response body: {}",
+          err_text
+        );
+        BrowserControlProbe::Down
+      }
     }
   }
 }
@@ -5726,6 +6272,14 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         browser_probe = BrowserControlProbe::Starting;
       }
     }
+    if gateway_ok && browser_probe == BrowserControlProbe::Down {
+      let last_browser_rpc_success_ms = gateway_client::last_browser_rpc_success_ms();
+      if last_browser_rpc_success_ms != 0
+        && now_ms.saturating_sub(last_browser_rpc_success_ms) < BROWSER_RECENT_RPC_SUCCESS_GRACE_MS
+      {
+        browser_probe = BrowserControlProbe::Ready;
+      }
+    }
     if gateway_ok
       && browser_probe != BrowserControlProbe::Ready
       && browser_control_rpc_ready(
@@ -5922,6 +6476,12 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
                 eprintln!(
                   "[clawd/service] gateway busy: QA direct gateway event loop is temporarily stalled"
                 );
+              } else if runtime_deps_startup
+                || gateway_listening
+                || launch_grace_elapsed_ms.is_some()
+                || qa_direct_waiting_for_process
+              {
+                eprintln!("[clawd/service] gateway starting: QA direct gateway still warming up");
               } else {
                 eprintln!("[clawd/service] gateway down: QA direct gateway starting");
               }
@@ -8441,7 +9001,11 @@ fn ensure_node_binary_ready(node_path: &Path) -> Result<(), String> {
     .map_err(|e| format!("Failed to run Node.js at {}: {}", node_path.display(), e))?;
 
   let started = std::time::Instant::now();
-  let timeout = std::time::Duration::from_secs(3);
+  let timeout = if cfg!(debug_assertions) || qa_direct_gateway_mode() {
+    std::time::Duration::from_secs(10)
+  } else {
+    std::time::Duration::from_secs(3)
+  };
   loop {
     match child.try_wait() {
       Ok(Some(_)) => break,
@@ -8495,6 +9059,7 @@ async fn prepare_gateway_config(
 ) -> Result<ServiceSetup, String> {
   let prepare_started = std::time::Instant::now();
   let tokens = load_or_create_tokens(app_handle)?;
+  sync_portable_api_key_auth_profiles(app_handle, &tokens)?;
 
   fn first_existing(paths: &[PathBuf]) -> Option<PathBuf> {
     paths.iter().find(|p| p.exists()).cloned()
@@ -9520,6 +10085,8 @@ async fn prepare_gateway_config(
       }
     }
   }
+
+  sync_portable_api_key_auth_config(app_handle, &tokens)?;
   eprintln!(
     "[clawd/service] prepare_gateway_config: local config ready in {}ms",
     prepare_started.elapsed().as_millis()
@@ -9683,11 +10250,16 @@ async fn prepare_gateway_config(
     .join("plugin-runtime-deps")
     .to_string_lossy()
     .to_string();
+  let openclaw_config_path = PathBuf::from(&clawdbot_home_str)
+    .join("openclaw.json")
+    .to_string_lossy()
+    .to_string();
   let mut env = vec![
     ("PATH".to_string(), clawdbot_path),
     ("HOME".to_string(), user_home.clone()),
     ("OPENCLAW_HOME".to_string(), clawdbot_home_str.clone()),
     ("OPENCLAW_STATE_DIR".to_string(), clawdbot_home_str),
+    ("OPENCLAW_CONFIG_PATH".to_string(), openclaw_config_path),
     (
       "OPENCLAW_GATEWAY_TOKEN".to_string(),
       tokens.gateway_token.clone(),
@@ -9917,9 +10489,11 @@ async fn prepare_gateway_config(
     }
   }
   {
-    let home_str = app_clawdbot_home(app_handle).to_string_lossy().to_string();
+    let home = app_clawdbot_home(app_handle);
+    let home_str = home.to_string_lossy().to_string();
     std::env::set_var("OPENCLAW_HOME", &home_str);
     std::env::set_var("OPENCLAW_STATE_DIR", &home_str);
+    std::env::set_var("OPENCLAW_CONFIG_PATH", home.join("openclaw.json"));
   }
 
   // Set browser base_url
@@ -12007,7 +12581,7 @@ pub async fn skills_status(app_handle: web::Data<tauri::AppHandle>) -> impl Resp
   if let Ok(tokens) = load_or_create_tokens(&app_handle) {
     let gateway_result = tokio::time::timeout(
       std::time::Duration::from_secs(5),
-      super::gateway_client::gateway_request_pooled(
+      super::gateway_client::gateway_request_pooled_optional(
         "skills.status",
         Some(serde_json::json!({})),
         &tokens.gateway_token,
@@ -13981,6 +14555,51 @@ mod crash_classifier_tests {
   }
 
   #[test]
+  fn stale_disabled_plugin_entries_are_removed_from_config() {
+    let mut cfg = serde_json::json!({
+      "plugins": {
+        "allow": ["browser", "duckduckgo", "slack"],
+        "entries": {
+          "browser": { "enabled": true },
+          "duckduckgo": { "enabled": false },
+          "google": { "enabled": false },
+          "groq": { "enabled": false },
+          "openrouter": { "enabled": false },
+          "codex": { "enabled": false },
+          "slack": { "enabled": true }
+        }
+      },
+      "tools": {
+        "web": {
+          "search": {
+            "provider": "duckduckgo"
+          }
+        }
+      }
+    });
+
+    assert!(sanitize_rejected_legacy_config_keys(&mut cfg));
+    assert_eq!(
+      cfg
+        .pointer("/plugins/allow")
+        .and_then(|value| value.as_array())
+        .map(|arr| arr
+          .iter()
+          .filter_map(|value| value.as_str())
+          .collect::<Vec<_>>()),
+      Some(vec!["browser", "slack"])
+    );
+    assert!(cfg.pointer("/plugins/entries/duckduckgo").is_none());
+    assert!(cfg.pointer("/plugins/entries/google").is_none());
+    assert!(cfg.pointer("/plugins/entries/groq").is_none());
+    assert!(cfg.pointer("/plugins/entries/openrouter").is_none());
+    assert!(cfg.pointer("/plugins/entries/codex").is_none());
+    assert!(cfg.pointer("/plugins/entries/browser").is_some());
+    assert!(cfg.pointer("/plugins/entries/slack").is_some());
+    assert!(cfg.pointer("/tools/web/search/provider").is_none());
+  }
+
+  #[test]
   fn runtime_deps_staging_is_startup_progress_until_completion() {
     let staging =
       "2026-05-13T10:44:47 [gateway] [plugins] staging bundled runtime deps before gateway startup";
@@ -14244,7 +14863,10 @@ mod provider_key_tests {
 
 #[cfg(test)]
 mod service_status_message_tests {
-  use super::{mac_service_status_summary, parse_browser_control_status_body, BrowserControlProbe};
+  use super::{
+    is_noisy_browser_probe_error, is_transient_browser_probe_error, mac_service_status_summary,
+    parse_browser_control_status_body, BrowserControlProbe,
+  };
 
   #[test]
   fn qa_direct_startup_is_not_reported_as_not_running() {
@@ -14281,5 +14903,23 @@ mod service_status_message_tests {
       parse_browser_control_status_body("OK"),
       BrowserControlProbe::Ready
     );
+  }
+
+  #[test]
+  fn transient_browser_probe_errors_are_classified() {
+    assert!(is_transient_browser_probe_error("channel closed"));
+    assert!(is_transient_browser_probe_error(
+      "operation was canceled: received unexpected message from connection"
+    ));
+    assert!(!is_transient_browser_probe_error("connection refused"));
+  }
+
+  #[test]
+  fn short_lived_browser_probe_timeouts_are_treated_as_noisy_not_fatal() {
+    assert!(is_noisy_browser_probe_error(
+      "error sending request for url (http://127.0.0.1:18791/?profile=openclaw): operation timed out"
+    ));
+    assert!(is_noisy_browser_probe_error("deadline has elapsed"));
+    assert!(!is_noisy_browser_probe_error("connection refused"));
   }
 }

--- a/src/src-tauri/src/connections/api.rs
+++ b/src/src-tauri/src/connections/api.rs
@@ -236,11 +236,12 @@ async fn refresh_knapsack_api_token(path: web::Path<String>) -> impl Responder {
   let user_email = path.into_inner();
   let requested_email = user_email.trim().to_lowercase();
 
-  let token_env = std::env::var("KNAPSACK_USER_EMAIL").ok().map(|v| v.trim().to_lowercase());
-  if let (Some(email), Ok(access_token)) = (
-    token_env.as_deref(),
-    std::env::var("KNAPSACK_ACCESS_TOKEN"),
-  ) {
+  let token_env = std::env::var("KNAPSACK_USER_EMAIL")
+    .ok()
+    .map(|v| v.trim().to_lowercase());
+  if let (Some(email), Ok(access_token)) =
+    (token_env.as_deref(), std::env::var("KNAPSACK_ACCESS_TOKEN"))
+  {
     if email == requested_email && !access_token.trim().is_empty() {
       return HttpResponse::Ok().json(json!({
         "success": true,

--- a/src/src-tauri/src/connections/google/drive.rs
+++ b/src/src-tauri/src/connections/google/drive.rs
@@ -392,7 +392,9 @@ pub async fn fetch_drive(
       tasks.push(task);
     }
     for task in tasks {
-      task.await.unwrap();
+      if let Err(err) = task.await {
+        log::error!("[google-drive] worker task failed: {}", err);
+      }
     }
 
     let mut sliced_documents: Vec<HashMap<String, serde_json::Value>> = Vec::new();

--- a/src/src-tauri/src/connections/microsoft/auth.rs
+++ b/src/src-tauri/src/connections/microsoft/auth.rs
@@ -328,7 +328,7 @@ async fn refresh_access_token(
 pub async fn refresh_user_connection(
   user_connection: UserConnection,
   email: String,
-  ) -> Result<UserConnection, Error> {
+) -> Result<UserConnection, Error> {
   let refresh_response: RefreshResponse = match refresh_access_token(
     user_connection.refresh_token.clone().unwrap(),
     email.clone(),

--- a/src/src-tauri/src/db/db.rs
+++ b/src/src-tauri/src/db/db.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::connections::google::constants::{
@@ -36,9 +37,19 @@ const AFTER_CONNECT: &str = "PRAGMA busy_timeout=30000;
 PRAGMA journal_mode=WAL;
 PRAGMA synchronous=NORMAL;";
 
-fn create_pool() -> SqlitePool {
+pub fn resolve_db_path() -> PathBuf {
+  if let Some(raw) = std::env::var_os("DATABASE_URL") {
+    let configured = PathBuf::from(raw);
+    if !configured.as_os_str().is_empty() {
+      return configured;
+    }
+  }
   let home_dir = dirs::home_dir().expect("Couldn't get home_dir for platform.");
-  let db_pathbuf = home_dir.join(KNAPSACK_DB_FILENAME);
+  home_dir.join(KNAPSACK_DB_FILENAME)
+}
+
+fn create_pool() -> SqlitePool {
+  let db_pathbuf = resolve_db_path();
   let db_path = db_pathbuf.as_path();
 
   let manager = SqliteConnectionManager::file(db_path.to_str().unwrap())

--- a/src/src-tauri/src/db/diesel_setup.rs
+++ b/src/src-tauri/src/db/diesel_setup.rs
@@ -2,14 +2,13 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 
-use crate::db::db::KNAPSACK_DB_FILENAME;
+use crate::db::db::resolve_db_path;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 pub fn execute_migrations() -> Result<(), Box<dyn std::error::Error>> {
   log::debug!("--------------------- Executing migrations --------------------");
-  let home_dir = dirs::home_dir().expect("Could not determine the home directory");
-  let db_path = home_dir.join(KNAPSACK_DB_FILENAME);
+  let db_path = resolve_db_path();
 
   let db_url = db_path.to_str().ok_or("Invalid database path")?;
 

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -143,8 +143,7 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
     }
     "knapsack" => {
       if let Some(email) = &knapsack_email {
-        let model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
-          .unwrap_or_else(|_| "auto".to_string());
+        let model = std::env::var("KNAPSACK_KNAPSACK_MODEL").unwrap_or_else(|_| "auto".to_string());
         let model = {
           let model = model.trim();
           if let Some((provider, bare)) = model.split_once('/') {
@@ -335,7 +334,11 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
   if complexity == "haiku" {
     // Cross-provider routing: if OpenRouter is available and the current provider
     // is a paid one, route simple tasks to OpenRouter's free model instead.
-    if provider.name != "openrouter" && provider.name != "ollama" && provider.name != "groq" && provider.name != "knapsack" {
+    if provider.name != "openrouter"
+      && provider.name != "ollama"
+      && provider.name != "groq"
+      && provider.name != "knapsack"
+    {
       let openrouter_key = std::env::var("OPENROUTER_API_KEY")
         .ok()
         .filter(|k| !k.trim().is_empty());
@@ -372,7 +375,7 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
       "groq" => (provider.model.clone(), "Groq"),            // already cheap
       "knapsack" => (provider.model.clone(), "Knapsack"),
       "openrouter" => (provider.model.clone(), "OpenRouter"), // user chose this
-      "ollama" => (provider.model.clone(), "Ollama"),        // local, no cost
+      "ollama" => (provider.model.clone(), "Ollama"),         // local, no cost
       _ => (provider.model.clone(), "unchanged"),
     };
 
@@ -551,7 +554,10 @@ async fn resolve_knapsack_bearer_token(email: &str) -> Result<String, LLMError> 
       }
     }
     Err(err) => {
-      log::warn!("[knapsack_token] /refresh_token_api request failed: {}", err);
+      log::warn!(
+        "[knapsack_token] /refresh_token_api request failed: {}",
+        err
+      );
     }
   }
 
@@ -1069,8 +1075,8 @@ pub async fn multi_provider_completion(messages: Vec<LlmMessage>) -> Result<Stri
         .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
       let fb_gemini_model =
         std::env::var("KNAPSACK_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
-      let fb_knapsack_model = std::env::var("KNAPSACK_KNAPSACK_MODEL")
-        .unwrap_or_else(|_| "auto".to_string());
+      let fb_knapsack_model =
+        std::env::var("KNAPSACK_KNAPSACK_MODEL").unwrap_or_else(|_| "auto".to_string());
       let fb_knapsack_model = {
         let model = fb_knapsack_model.trim();
         if let Some((provider, bare)) = model.split_once('/') {
@@ -1096,8 +1102,7 @@ pub async fn multi_provider_completion(messages: Vec<LlmMessage>) -> Result<Stri
           } else {
             fb_knapsack_model.clone()
           },
-          option_env!("VITE_KN_API_SERVER")
-            .unwrap_or("https://api.knapsack.ai"),
+          option_env!("VITE_KN_API_SERVER").unwrap_or("https://api.knapsack.ai"),
           false,
         ),
         (

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -128,13 +128,10 @@ fn validate_bundled_ui_asset(app: &tauri::App, page: &str, label: &str) -> Optio
     format!("_up_/dist/{page}"),
   ];
   let found = candidate_paths.iter().find_map(|candidate| {
-    app
-      .path_resolver()
-      .resolve_resource(candidate)
-      .map(|path| {
-        log::info!("Resolved {label} UI asset: {:?}", path);
-        candidate.clone()
-      })
+    app.path_resolver().resolve_resource(candidate).map(|path| {
+      log::info!("Resolved {label} UI asset: {:?}", path);
+      candidate.clone()
+    })
   });
 
   if let Some(path) = &found {
@@ -164,9 +161,8 @@ pub fn release_type() -> Release {
 }
 
 #[cfg(target_os = "macos")]
-static KN_KEEP_AWAKE_PROCESS: Lazy<StdMutex<Option<std::process::Child>>> = Lazy::new(|| {
-  StdMutex::new(None)
-});
+static KN_KEEP_AWAKE_PROCESS: Lazy<StdMutex<Option<std::process::Child>>> =
+  Lazy::new(|| StdMutex::new(None));
 #[cfg(target_os = "windows")]
 static KN_KEEP_AWAKE_PROCESS: StdMutex<bool> = StdMutex::new(false);
 
@@ -235,8 +231,8 @@ mod keep_awake_macos {
 
 #[cfg(target_os = "windows")]
 mod keep_awake_windows {
-  use super::KN_KEEP_AWAKE_PROCESS;
   use super::StdMutex;
+  use super::KN_KEEP_AWAKE_PROCESS;
 
   const ES_CONTINUOUS: u32 = 0x80000000;
   const ES_SYSTEM_REQUIRED: u32 = 0x00000001;
@@ -1427,6 +1423,9 @@ fn create_data_dir() {
 
 // make the db path OS agnostic
 fn create_db_env_variable() {
+  if env::var_os("DATABASE_URL").is_some() {
+    return;
+  }
   let home_dir = dirs::home_dir().expect("Could not determine the home directory");
   let db_dir = home_dir.join(KNAPSACK_DB_FILENAME);
   let db_path = db_dir.as_path();


### PR DESCRIPTION
## Summary
- harden QA/dev runtime isolation and desktop-managed auth snapshot handling
- fix misleading channel/browser diagnostics during gateway startup and recovery
- improve gateway/browser/channel startup behavior and related fallback plumbing

## What I validated
- rebuilt and ran `npm run qa:dev` in `/private/tmp/knapsack_blockers_2026_06_18/src`
- verified `/api/clawd/service/health` settles to `gateway_ok=true` and `browser_ok=true`
- verified `/api/clawd/channels/diagnostics` returns `issues: []`
- verified dev startup logs now report QA-direct warmup as `gateway starting` instead of `gateway down`
- verified calendar endpoint returned `200` in the validated dev runs and the earlier `408` did not reproduce

## Notes
- this PR contains the broader blocker bundle from the clean dev worktree, including the validated follow-up fixes for desktop-managed auth detection and startup diagnostics
- local `.qa-dev-openclaw-state/` was intentionally excluded
