### PR TITLE
Fix deferred channel startup readiness

### DIFF
--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -392,6 +392,55 @@ function readLaunchAgentPlist() {
   return JSON.parse(result.stdout);
 }
 
+function defaultLiveGatewayStateDir() {
+  return path.join(
+    process.env.HOME || "",
+    "Library",
+    "Application Support",
+    "ai.knap.knapsack",
+    "clawdbot",
+  );
+}
+
+function syncQaGatewayState() {
+  let sourceStateDir = null;
+  try {
+    if (fs.existsSync(launchAgentPlist)) {
+      const plist = readLaunchAgentPlist();
+      sourceStateDir =
+        plist.EnvironmentVariables?.OPENCLAW_STATE_DIR ||
+        plist.EnvironmentVariables?.OPENCLAW_HOME ||
+        null;
+    }
+  } catch {
+    // Fall back to the standard live state directory below.
+  }
+  sourceStateDir = sourceStateDir || defaultLiveGatewayStateDir();
+  if (!sourceStateDir || sourceStateDir === qaStateDir || !fs.existsSync(sourceStateDir)) {
+    return;
+  }
+
+  fs.mkdirSync(qaStateDir, { recursive: true });
+  for (const fileName of ["openclaw.json", "tokens.json", "clawdbot.json", "paired.json"]) {
+    const sourcePath = path.join(sourceStateDir, fileName);
+    if (!fs.existsSync(sourcePath)) continue;
+    fs.copyFileSync(sourcePath, path.join(qaStateDir, fileName));
+  }
+
+  const sourceDevicesDir = path.join(sourceStateDir, "devices");
+  const targetDevicesDir = path.join(qaStateDir, "devices");
+  if (fs.existsSync(sourceDevicesDir)) {
+    fs.mkdirSync(targetDevicesDir, { recursive: true });
+    for (const entry of fs.readdirSync(sourceDevicesDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      fs.copyFileSync(
+        path.join(sourceDevicesDir, entry.name),
+        path.join(targetDevicesDir, entry.name),
+      );
+    }
+  }
+}
+
 function bootoutLaunchAgent() {
   if (process.platform !== "darwin") return;
   const uid = process.getuid?.();
@@ -831,6 +880,7 @@ async function main() {
   syncDevClawdbotResources();
   const prepareOnly = String(process.env.KNAPSACK_QA_PREPARE_ONLY || "").trim() === "1";
   fs.mkdirSync(qaStateDir, { recursive: true });
+  syncQaGatewayState();
   seedQaDatabaseFromProd();
   seedQaProviderTokensFromProd();
   seedQaConfigFromProd();

--- a/src/src-tauri/resources/clawdbot/dist/server-methods-90LGtoqF.js
+++ b/src/src-tauri/resources/clawdbot/dist/server-methods-90LGtoqF.js
@@ -2843,6 +2843,19 @@ function resolveChannelsStatusTimeoutMs(params) {
 	if (typeof params.timeoutMsRaw !== "number" || !Number.isFinite(params.timeoutMsRaw)) return fallback;
 	return Math.min(Math.max(1e3, params.timeoutMsRaw), CHANNEL_STATUS_MAX_TIMEOUT_MS);
 }
+function normalizeGatewayRuntimeConfig(candidate) {
+	if (!candidate || typeof candidate !== "object") return candidate;
+	if (candidate.channels && typeof candidate.channels === "object") return candidate;
+	if (candidate.config && typeof candidate.config === "object") return candidate.config;
+	if (candidate.runtimeConfig && typeof candidate.runtimeConfig === "object") return candidate.runtimeConfig;
+	return candidate;
+}
+function resolveChannelRuntimeConfig(context) {
+	return applyPluginAutoEnable({
+		config: normalizeGatewayRuntimeConfig(getActiveSecretsRuntimeSnapshot()?.config ?? context.getRuntimeConfig()),
+		env: process.env
+	}).config;
+}
 function resolveRuntimeAccountSnapshot(params) {
 	const direct = params.runtime.channelAccounts[params.channelId]?.[params.accountId];
 	if (direct) return direct;
@@ -2915,10 +2928,7 @@ const channelsHandlers = {
 		});
 		const rawChannel = params.channel;
 		const requestedChannel = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : void 0;
-		const cfg = applyPluginAutoEnable({
-			config: context.getRuntimeConfig(),
-			env: process.env
-		}).config;
+		const cfg = resolveChannelRuntimeConfig(context);
 		const runtime = context.getRuntimeSnapshot();
 		const plugins = listChannelPlugins();
 		const selectedPlugins = requestedChannel ? plugins.filter((plugin) => plugin.id === requestedChannel) : plugins;
@@ -3119,10 +3129,7 @@ const channelsHandlers = {
 			return;
 		}
 		try {
-			const cfg = applyPluginAutoEnable({
-				config: context.getRuntimeConfig(),
-				env: process.env
-			}).config;
+			const cfg = resolveChannelRuntimeConfig(context);
 			respond(true, await startChannelAccount({
 				channelId,
 				accountId: params.accountId,

--- a/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
+++ b/src/src-tauri/resources/clawdbot/dist/server.impl-BCpatfdp.js
@@ -2022,23 +2022,68 @@ async function startGatewayServer(port = 18789, opts = {}) {
 		log.info(`http server listening (desktop-managed early-bind; 0 plugins; ${elapsedSeconds}s)`);
 		startDesktopBrowserControlPlaceholder(log);
 	}
-	if (desktopManagedFastStartup) {
-		startupTrace.mark("runtime.channels.deferred");
-	} else {
-		const { createChannelManager } = await startupTrace.measure("runtime.channels.import", () => import("./server-channels-CRUeVkRN.js"));
-		Object.assign(channelManager, createChannelManager({
-			getRuntimeConfig: () => applyPluginAutoEnable({
-				config: getRuntimeConfig(),
-				env: process.env
-			}).config,
-			channelLogs,
-			channelRuntimeEnvs,
-			resolveChannelRuntime: getChannelRuntime,
-			resolveStartupChannelRuntime: getStartupChannelRuntime,
-			getPluginHttpRouteRegistry: () => pluginRegistry,
-			startupTrace
-		}));
-	}
+	const { createChannelManager } = await startupTrace.measure("runtime.channels.import", () => import("./server-channels-CRUeVkRN.js"));
+	const normalizeGatewayRuntimeConfig = (candidate) => {
+		if (!candidate || typeof candidate !== "object") return candidate;
+		if (candidate.channels && typeof candidate.channels === "object") return candidate;
+		if (candidate.config && typeof candidate.config === "object") return candidate.config;
+		if (candidate.runtimeConfig && typeof candidate.runtimeConfig === "object") return candidate.runtimeConfig;
+		return candidate;
+	};
+	const resolveChannelManagerConfig = () => {
+		const liveBase = normalizeGatewayRuntimeConfig(getActiveSecretsRuntimeSnapshot()?.config ?? getRuntimeConfig());
+		const live = applyPluginAutoEnable({
+			config: liveBase,
+			env: process.env
+		}).config;
+		const startup = applyPluginAutoEnable({
+			config: cfgAtStart,
+			env: process.env
+		}).config;
+		const startupChannels = startup?.channels && typeof startup.channels === "object" ? startup.channels : {};
+		const liveChannels = live?.channels && typeof live.channels === "object" ? live.channels : {};
+		const startupChannelIds = Object.keys(startupChannels);
+		if (startupChannelIds.length === 0) return live;
+		const mergedChannels = {
+			...startupChannels,
+			...liveChannels
+		};
+		for (const channelId of startupChannelIds) {
+			const startupChannel = startupChannels[channelId];
+			const liveChannel = liveChannels[channelId];
+			if (!startupChannel || typeof startupChannel !== "object") continue;
+			if (!liveChannel || typeof liveChannel !== "object") {
+				mergedChannels[channelId] = startupChannel;
+				continue;
+			}
+			const startupAccounts = startupChannel.accounts && typeof startupChannel.accounts === "object" ? Object.keys(startupChannel.accounts) : [];
+			const liveAccounts = liveChannel.accounts && typeof liveChannel.accounts === "object" ? Object.keys(liveChannel.accounts) : [];
+			const startupSecrets = ["botToken", "appToken", "userToken", "signingSecret", "accessToken", "token", "apiKey", "phoneNumber"].some((key) => typeof startupChannel[key] === "string" && startupChannel[key].trim().length > 0);
+			const liveSecrets = ["botToken", "appToken", "userToken", "signingSecret", "accessToken", "token", "apiKey", "phoneNumber"].some((key) => typeof liveChannel[key] === "string" && liveChannel[key].trim().length > 0);
+			if (liveAccounts.length > 0 || startupAccounts.length === 0 && liveSecrets) continue;
+			mergedChannels[channelId] = {
+				...startupChannel,
+				...liveChannel,
+				accounts: liveAccounts.length > 0 ? liveChannel.accounts : startupChannel.accounts
+			};
+		}
+		return {
+			...startup,
+			...live,
+			channels: mergedChannels,
+			plugins: live?.plugins ?? startup.plugins
+		};
+	};
+	if (desktopManagedFastStartup) startupTrace.mark("runtime.channels.deferred");
+	Object.assign(channelManager, createChannelManager({
+		getRuntimeConfig: resolveChannelManagerConfig,
+		channelLogs,
+		channelRuntimeEnvs,
+		resolveChannelRuntime: getChannelRuntime,
+		resolveStartupChannelRuntime: getStartupChannelRuntime,
+		getPluginHttpRouteRegistry: () => pluginRegistry,
+		startupTrace
+	}));
 	const { a: incrementPresenceVersion, i: getPresenceVersion, n: getHealthCache, o: refreshGatewayHealthSnapshot, r: getHealthVersion } = await startupTrace.measure("runtime.health-state.import", () => loadHealthStateModule());
 	({ getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } = channelManager);
 	const { createGatewayNodeSessionRuntime } = await import("./server-node-session-runtime-C2gow8hU.js");
@@ -2268,6 +2313,16 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			runtimeState.gatewayMethods.splice(0, runtimeState.gatewayMethods.length, ...listAttachedGatewayMethods());
 			pinActivePluginHttpRouteRegistry(pluginRegistry);
 			pinActivePluginChannelRegistry(pluginRegistry);
+		};
+		const activateDesktopCoreMethods = async (reason) => {
+			try {
+				const { coreGatewayHandlers: loadedCoreGatewayHandlers } = await loadCoreMethodsModule();
+				coreGatewayHandlers = loadedCoreGatewayHandlers;
+				attachedGatewayMethodRegistry = buildAttachedGatewayMethodRegistry(pluginRegistry);
+				runtimeState.gatewayMethods.splice(0, runtimeState.gatewayMethods.length, ...listAttachedGatewayMethods());
+			} catch (err) {
+				log.warn(`desktop-managed core gateway methods failed to load after ${reason}: ${String(err)}`);
+			}
 		};
 		const refreshAttachedGatewayDiscovery = async (nextPluginRegistry) => {
 			if (minimalTestGateway) return;
@@ -2500,13 +2555,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			if (!desktopManagedEarlyBound) log.info(`http server listening (desktop-managed fast-bind; 0 plugins; ${elapsedSeconds}s)`);
 			startDesktopBrowserControlPlaceholder(log);
 			setTimeout(() => {
-				loadCoreMethodsModule().then(({ coreGatewayHandlers: loadedCoreGatewayHandlers }) => {
-					coreGatewayHandlers = loadedCoreGatewayHandlers;
-					attachedGatewayMethodRegistry = buildAttachedGatewayMethodRegistry(pluginRegistry);
-					runtimeState.gatewayMethods.splice(0, runtimeState.gatewayMethods.length, ...listAttachedGatewayMethods());
-				}).catch((err) => {
-					log.warn(`desktop-managed core gateway methods failed to load after listen: ${String(err)}`);
-				});
+				activateDesktopCoreMethods("listen timeout");
 			}, 45e3).unref?.();
 		}
 		const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
@@ -2592,6 +2641,7 @@ async function startGatewayServer(port = 18789, opts = {}) {
 			},
 			onStartupPluginsLoaded: async (loaded) => {
 				replaceAttachedPluginRuntime(loaded);
+				if (desktopManagedGateway) await activateDesktopCoreMethods("startup plugins");
 				startupPendingReason = "startup-sidecars";
 				await refreshAttachedGatewayDiscovery(loaded.pluginRegistry);
 			},

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -2586,7 +2586,7 @@ fn default_channel_status_params() -> Value {
 /// Get channel status from the gateway (pooled).
 pub async fn get_channel_status(token: Option<&str>) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  gateway_request_pooled("channels.status", Some(default_channel_status_params()), &t).await
+  call_channel_method("channels.status", Some(default_channel_status_params()), Some(&t)).await
 }
 
 /// Call a channel method on the gateway (pooled).


### PR DESCRIPTION
## Summary
- create the real channel manager even during desktop fast startup so deferred Slack and Telegram startup can finish after gateway readiness
- make channel status and diagnostics trust runtime account snapshots after readiness instead of stale summary text
- stop noisy web-search fallback repairs and suppress benign browser probe errors during startup handoff

## QA
- `npm run qa:dev`
- verified `http://127.0.0.1:8897/api/clawd/service/health` => gateway/browser healthy
- verified `/api/clawd/channels/generic/slack/status` => linked true after readiness
- verified `/api/clawd/channels/telegram/status` converges to linked true after readiness
- verified `/api/clawd/channels/diagnostics` reports Slack and Telegram active via runtime snapshot without deferred false positives