### PR TITLE
Bound Knapsack chat context before provider overflow

### DIFF
--- a/docs/chat-context-budgeting.md
+++ b/docs/chat-context-budgeting.md
@@ -1,0 +1,63 @@
+## Chat Context Budgeting
+
+### Goal
+
+Preserve Knapsack's autonomous/background behavior without allowing a single chat
+turn to overload the active provider context window.
+
+### Problem
+
+The chat stack currently allows several large context sources to accumulate into
+the foreground request:
+
+- prior user/assistant history
+- persistent memory notes
+- native email/calendar prefetched context
+- terminal output
+- attachment text extraction
+- gateway/shared-session history
+
+Even when each source is reasonable alone, the combined foreground payload can
+become large enough to trip provider limits or destabilize the request path.
+
+### Design Principles
+
+1. Background work should happen in separate working contexts.
+2. Foreground chat should receive compact findings, not raw source dumps.
+3. Every request path should have a deterministic inline-context budget.
+4. If a request still exceeds provider limits, compact before failing over to a
+   user-visible error.
+
+### Immediate Safeguards in This Patch
+
+1. **Bound memory notes before request send**
+   - keep fewer entries
+   - trim each summary
+   - enforce a total character cap
+
+2. **Bound frontend native context injection**
+   - clamp prefetched email/calendar context
+   - only include terminal context for prompts that are actually code or
+     terminal related
+   - clamp any terminal context that is included
+
+3. **Bound inline request text on both chat paths**
+   - clamp the assembled frontend text before it is sent
+   - clamp the gateway `agent-chat` inline text before it reaches the bundled
+     gateway
+   - clamp the direct `/api/clawd/chat` user-turn payload before it reaches the
+     provider loop
+
+4. **Preserve autonomy**
+   - the system still performs autonomous/background work
+   - the change only reduces how much raw material is replayed into the active
+     foreground turn
+
+### Follow-up Work
+
+The durable architecture should move further toward:
+
+- artifact handles instead of raw inline tool output
+- subtask-specific scratch contexts
+- retrieval-on-demand for email/calendar/browser results
+- token-budget preflight by source before every provider call

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -985,7 +985,12 @@ fn take_prefix_chars(value: &str, max_chars: usize) -> String {
   let mut chars = value.chars();
   let head: String = chars.by_ref().take(max_chars).collect();
   if chars.next().is_some() {
-    format!("{}...", head)
+    if max_chars <= 3 {
+      ".".repeat(max_chars)
+    } else {
+      let shortened: String = head.chars().take(max_chars - 3).collect();
+      format!("{}...", shortened)
+    }
   } else {
     head
   }
@@ -1044,6 +1049,49 @@ fn provider_context_recovery_limits(provider: &str) -> (usize, usize) {
     "knapsack" => (6usize, 12_000usize),
     _ => (6usize, 10_000usize),
   }
+}
+
+fn provider_inline_text_limit(provider: &str) -> usize {
+  match provider {
+    "ollama" => 6_000usize,
+    "knapsack" => 12_000usize,
+    _ => 8_000usize,
+  }
+}
+
+fn clamp_inline_text(text: &str, max_chars: usize, reason: &str) -> String {
+  if text.chars().count() <= max_chars {
+    return text.to_string();
+  }
+  format!(
+    "{}\n\n[{}; truncated from {} chars]",
+    take_prefix_chars(text, max_chars),
+    reason,
+    text.chars().count()
+  )
+}
+
+fn trim_memory_notes(memory_notes: &[String]) -> Vec<String> {
+  const MAX_MEMORY_NOTES: usize = 6;
+  const MAX_MEMORY_NOTE_CHARS: usize = 240;
+  const MAX_MEMORY_TOTAL_CHARS: usize = 1_800;
+
+  let mut kept: Vec<String> = Vec::new();
+  let mut total_chars = 0usize;
+  for note in memory_notes.iter().rev().take(MAX_MEMORY_NOTES) {
+    let trimmed = take_prefix_chars(note.trim(), MAX_MEMORY_NOTE_CHARS);
+    if trimmed.is_empty() {
+      continue;
+    }
+    let note_chars = trimmed.chars().count();
+    if !kept.is_empty() && total_chars + note_chars > MAX_MEMORY_TOTAL_CHARS {
+      continue;
+    }
+    total_chars += note_chars;
+    kept.push(trimmed);
+  }
+  kept.reverse();
+  kept
 }
 
 fn summarize_compacted_message(
@@ -2172,6 +2220,12 @@ pub async fn agent_chat(
     }
   }
 
+  text_with_attachments = clamp_inline_text(
+    &text_with_attachments,
+    12_000usize,
+    "Additional inline context omitted before sending to the shared gateway session",
+  );
+
   // Try gateway agent-chat if port is open
   let gateway_reply = if gateway_client::is_gateway_port_open().await {
     eprintln!(
@@ -2627,6 +2681,7 @@ pub async fn chat(
         .collect()
     })
     .unwrap_or_default();
+  let memory_notes = trim_memory_notes(&memory_notes);
 
   let chrome = body.get("chrome").and_then(|v| v.as_bool());
   let profile = clawd_profile(chrome);
@@ -2758,6 +2813,11 @@ pub async fn chat(
       }
     },
   };
+  let full_text = clamp_inline_text(
+    &full_text,
+    provider_inline_text_limit(&provider),
+    "Additional inline request context omitted to fit the foreground provider budget",
+  );
 
   // Browser control requests go through the gateway's `browser.request` RPC
   // method — no direct HTTP client needed.
@@ -6653,5 +6713,33 @@ mod tests {
     assert!(!should_attempt_fallback_for_provider_error(
       "invalid api key provided for provider"
     ));
+  }
+
+  #[test]
+  fn trim_memory_notes_limits_count_and_total_size() {
+    let notes = (0..10)
+      .map(|idx| format!("note-{idx}: {}", "x".repeat(400)))
+      .collect::<Vec<_>>();
+
+    let trimmed = super::trim_memory_notes(&notes);
+
+    assert!(trimmed.len() <= 6);
+    assert!(trimmed.iter().all(|note: &String| note.chars().count() <= 240));
+    let total_chars: usize = trimmed
+      .iter()
+      .map(|note: &String| note.chars().count())
+      .sum();
+    assert!(total_chars <= 1_800);
+    assert!(trimmed.last().unwrap().contains("note-9"));
+  }
+
+  #[test]
+  fn clamp_inline_text_adds_notice_when_over_budget() {
+    let original = format!("prefix {}", "x".repeat(20_000));
+    let clamped = super::clamp_inline_text(&original, 1_000, "Trimmed for test");
+
+    assert!(clamped.contains("Trimmed for test"));
+    assert!(clamped.contains("truncated from"));
+    assert!(clamped.starts_with("prefix "));
   }
 }

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -811,6 +811,74 @@ function formatMaybeJson(text: string, maxChars = 8000): string {
 const SMART_PROMPT = 'Check my email and calendar and tell me what I should focus on today'
 const NO_AUTH_PROMPT = 'Search the web for the latest AI news and give me a summary'
 const BUILD_WEBSITE_PROMPT = `Build a personal website about me`
+const MAX_NATIVE_PREFETCH_CONTEXT_CHARS = 6000
+const MAX_TERMINAL_CONTEXT_CHARS = 1800
+const MAX_TERMINAL_CONTEXT_LINES = 12
+const MAX_MEMORY_NOTE_ENTRIES = 6
+const MAX_MEMORY_NOTE_CHARS = 240
+const MAX_MEMORY_NOTE_TOTAL_CHARS = 1800
+const MAX_INLINE_CHAT_CONTEXT_CHARS = 12000
+
+function truncateWithNotice(text: string, maxChars: number, notice: string): string {
+  if (text.length <= maxChars) return text
+  return `${text.slice(0, maxChars)}\n\n[${notice}; truncated from ${text.length} chars]`
+}
+
+function trimMemoryNotes(entries: Array<{ timestamp: string; summary: string }>): Array<{ timestamp: string; summary: string }> {
+  const trimmed = entries
+    .slice(-MAX_MEMORY_NOTE_ENTRIES)
+    .map(entry => ({
+      timestamp: entry.timestamp,
+      summary: (entry.summary || '').trim().slice(0, MAX_MEMORY_NOTE_CHARS),
+    }))
+    .filter(entry => entry.summary.length > 0)
+
+  const kept: Array<{ timestamp: string; summary: string }> = []
+  let totalChars = 0
+  for (const entry of trimmed.reverse()) {
+    const nextChars = entry.summary.length
+    if (kept.length > 0 && totalChars + nextChars > MAX_MEMORY_NOTE_TOTAL_CHARS) continue
+    kept.push(entry)
+    totalChars += nextChars
+  }
+  return kept.reverse()
+}
+
+function shouldIncludeTerminalContext(text: string, advancedMode: boolean, developerMode: boolean): boolean {
+  if (developerMode) return true
+  if (!advancedMode) return false
+  const lower = text.toLowerCase()
+  return [
+    'terminal',
+    'command',
+    'shell',
+    'log',
+    'error',
+    'stack trace',
+    'build',
+    'compile',
+    'test',
+    'debug',
+    'bug',
+    'npm',
+    'node',
+    'python',
+    'rust',
+    'cargo',
+    'git',
+    'repo',
+    'repository',
+    'code',
+  ].some(keyword => lower.includes(keyword))
+}
+
+function capInlineChatContext(text: string): string {
+  return truncateWithNotice(
+    text,
+    MAX_INLINE_CHAT_CONTEXT_CHARS,
+    'Additional inline context omitted to keep the request within the model budget',
+  )
+}
 
 // Check for freshly onboarded agents and build a personalized intro prompt
 function getOnboardingAgentsPrompt(): { prompt: string; agents: { name: string; emoji: string; personality: string }[] } | null {
@@ -995,7 +1063,11 @@ async function fetchEmailCalendarContext(): Promise<string> {
     console.warn('[ClawdChat] Failed to pre-fetch upcoming meetings:', err)
   }
 
-  return contextParts.join('\n')
+  return truncateWithNotice(
+    contextParts.join('\n'),
+    MAX_NATIVE_PREFETCH_CONTEXT_CHARS,
+    'Native email/calendar context trimmed for foreground chat',
+  )
 }
 
 function shouldPrefetchNativeEmailCalendarContext(text: string): boolean {
@@ -4518,7 +4590,7 @@ ${actualText}`
 
         // Auto-include recent terminal output as context so the AI can see
         // what the user is working on without requiring copy-paste
-        if (!isSmartPrompt) {
+        if (!isSmartPrompt && shouldIncludeTerminalContext(text, advancedMode, developerMode)) {
           try {
             const termRes = await fetch(apiUrl('/api/clawd/terminal/output?max_lines=30'))
             if (termRes.ok) {
@@ -4528,10 +4600,15 @@ ${actualText}`
                 if (entries.length > 0) {
                   let termContext = '\n\n---\n[Terminal context — recent output from built-in terminal]\n'
                   for (const [sid, lines] of entries) {
-                    termContext += `[Session: ${sid}]\n${lines.join('\n')}\n`
+                    const recentLines = lines.slice(-MAX_TERMINAL_CONTEXT_LINES)
+                    termContext += `[Session: ${sid}]\n${recentLines.join('\n')}\n`
                   }
                   termContext += '---'
-                  actualText += termContext
+                  actualText += truncateWithNotice(
+                    termContext,
+                    MAX_TERMINAL_CONTEXT_CHARS,
+                    'Terminal context trimmed for foreground chat',
+                  )
                 }
               }
             }
@@ -4545,6 +4622,8 @@ ${actualText}`
           const quotedText = currentReplyTo.text.slice(0, 500).replace(/\n/g, '\n> ')
           actualText = `> ${quotedText}\n\n${actualText}`
         }
+
+        actualText = capInlineChatContext(actualText)
 
         // Build request with optional attachments
         const requestBody: Record<string, any> = {
@@ -4560,7 +4639,7 @@ ${actualText}`
           developerMode, // When true, enables Sentry scanning, error log analysis, and auto-PR creation
           userEmail: userEmail || '', // For direct email sending via send_email tool
           userName: userName || '', // Sender display name for emails
-          memoryNotes: getAgentMemory('knapsack-chat'), // Persistent cross-session context
+          memoryNotes: trimMemoryNotes(getAgentMemory('knapsack-chat')), // Persistent cross-session context
         }
 
         // Add attachments if present


### PR DESCRIPTION
## Summary
- add a chat context budgeting spec for preserving autonomous/background work without replaying too much raw context into the foreground turn
- clamp inline chat context in the frontend, including native email/calendar prefetch, terminal context, and persisted memory notes
- clamp inline text and memory notes again in the Rust chat paths, including the shared gateway `agent-chat` route

## Why
We are seeing real prod `v2.5.8` "Message too large" failures across multiple providers, which points to foreground request assembly bloat rather than a single bad model. This patch keeps the autonomous/background behavior, but budgets how much raw material can be replayed into the active chat request.

## Validation
- `cargo check --manifest-path src/src-tauri/Cargo.toml`
- `cargo test clamp_inline_text_adds_notice_when_over_budget --manifest-path src/src-tauri/Cargo.toml`
- `cargo test trim_memory_notes_limits_count_and_total_size --manifest-path src/src-tauri/Cargo.toml` was in progress during validation, and the underlying truncation bug it exposed was fixed by making `take_prefix_chars` honor the requested cap including the ellipsis
- `npm run build` from this sparse worktree is still blocked by local frontend dependency resolution (`tsc` / module availability), which appears environmental rather than caused by these changes

## Notes
- This is intentionally a bounded-context fix, not a reduction in autonomy.
- Follow-up architecture should move further toward subtask scratch contexts and artifact handles instead of replaying raw tool outputs.
