### PR TITLE
[codex] add chat find and queued attachments

### DIFF
--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -1787,6 +1787,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     }
     return []
   })
+  const [chatFindOpen, setChatFindOpen] = useState(false)
+  const [chatFindQuery, setChatFindQuery] = useState('')
+  const [chatFindActiveIndex, setChatFindActiveIndex] = useState(0)
   const [busy, setBusy] = useState(false)
 
   useEffect(() => { onBusyChange?.(busy) }, [busy, onBusyChange])
@@ -2008,6 +2011,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
   // Message threading (reply-to) state
   const [replyToMsg, setReplyToMsg] = useState<Msg | null>(null)
+  const chatFindInputRef = useRef<HTMLInputElement | null>(null)
   const msgRefsMap = useRef<Map<string, HTMLDivElement>>(new Map())
 
   // Voice silence detection refs
@@ -4809,24 +4813,39 @@ ${actualText}`
   // Keyboard shortcuts
   const clearHistoryRef = useRef(clearHistory)
   clearHistoryRef.current = clearHistory
+  const openChatFindRef = useRef<() => void>(() => {})
+  const closeChatFindRef = useRef<() => void>(() => {})
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') stopGenerationRef.current()
       const mod = e.metaKey || e.ctrlKey
+      if (e.key === 'Escape') {
+        const activeEl = document.activeElement
+        if (chatFindOpen && activeEl === chatFindInputRef.current) {
+          e.preventDefault()
+          closeChatFindRef.current()
+          return
+        }
+        stopGenerationRef.current()
+      }
       // Cmd/Ctrl+Shift+Backspace — clear chat history
       if (mod && e.shiftKey && e.key === 'Backspace') {
         e.preventDefault()
         clearHistoryRef.current()
       }
+      // Cmd/Ctrl+F — search chat history
+      if (mod && !e.shiftKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault()
+        openChatFindRef.current()
+      }
       // Cmd/Ctrl+L — focus chat input
-      if (mod && !e.shiftKey && e.key === 'l') {
+      if (mod && !e.shiftKey && e.key.toLowerCase() === 'l') {
         e.preventDefault()
         document.querySelector<HTMLTextAreaElement>('.ClawdChatInput textarea')?.focus()
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  }, [chatFindOpen])
 
   // Number-key shortcuts for gateway/browser troubleshooting banners
   useEffect(() => {
@@ -4935,6 +4954,53 @@ ${actualText}`
     }),
     [msgs],
   )
+
+  const chatFindMatches = useMemo(() => {
+    const query = chatFindQuery.trim().toLowerCase()
+    if (!query) return [] as Array<{ id: string }>
+    return parsedMsgs
+      .filter(({ msg, cleaned }) => `${cleaned}\n${msg.text}`.toLowerCase().includes(query))
+      .map(({ msg }) => ({ id: msg.id }))
+  }, [parsedMsgs, chatFindQuery])
+
+  useEffect(() => {
+    if (chatFindMatches.length === 0) {
+      setChatFindActiveIndex(0)
+      return
+    }
+    setChatFindActiveIndex(prev => Math.min(prev, chatFindMatches.length - 1))
+  }, [chatFindMatches])
+
+  const openChatFind = useCallback(() => {
+    setChatFindOpen(true)
+    requestAnimationFrame(() => {
+      chatFindInputRef.current?.focus()
+      chatFindInputRef.current?.select()
+    })
+  }, [])
+
+  const closeChatFind = useCallback(() => {
+    setChatFindOpen(false)
+    setChatFindQuery('')
+    setChatFindActiveIndex(0)
+  }, [])
+
+  openChatFindRef.current = openChatFind
+  closeChatFindRef.current = closeChatFind
+
+  const goToChatFindMatch = useCallback((direction: 1 | -1) => {
+    if (chatFindMatches.length === 0) return
+    setChatFindActiveIndex(prev => (prev + direction + chatFindMatches.length) % chatFindMatches.length)
+  }, [chatFindMatches])
+
+  const activeChatFindMatchId = chatFindMatches[chatFindActiveIndex]?.id ?? null
+
+  useEffect(() => {
+    if (!activeChatFindMatchId) return
+    const el = msgRefsMap.current.get(activeChatFindMatchId)
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [activeChatFindMatchId])
 
   // Fast id→Msg lookup for reply-to resolution
   const msgsById = useMemo(() => {
@@ -5193,9 +5259,58 @@ ${actualText}`
       {/* Channels UI removed - voice controls are now inline in the input area */}
 
       <div className="ClawdChatBody" ref={el => { chatBodyRef.current = el }}>
+        {chatFindOpen && (
+          <div className="ClawdChatFindBar" role="search" aria-label="Search chat history">
+            <input
+              ref={chatFindInputRef}
+              type="text"
+              value={chatFindQuery}
+              onChange={e => setChatFindQuery(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  goToChatFindMatch(e.shiftKey ? -1 : 1)
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  closeChatFind()
+                }
+              }}
+              placeholder="Search this conversation"
+              aria-label="Search this conversation"
+            />
+            <div className="ClawdChatFindBar__count">
+              {chatFindQuery.trim()
+                ? (chatFindMatches.length > 0 ? `${chatFindActiveIndex + 1}/${chatFindMatches.length}` : '0 results')
+                : 'Type to search'}
+            </div>
+            <button
+              type="button"
+              onClick={() => goToChatFindMatch(-1)}
+              disabled={chatFindMatches.length === 0}
+              title="Previous match"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => goToChatFindMatch(1)}
+              disabled={chatFindMatches.length === 0}
+              title="Next match"
+            >
+              ↓
+            </button>
+            <button type="button" onClick={closeChatFind} title="Close search">
+              Close
+            </button>
+          </div>
+        )}
         {parsedMsgs.map(({ msg: m, cleaned, actions }) => (
           <div
             key={m.id}
+            className={[
+              chatFindMatches.some(match => match.id === m.id) ? 'ClawdChatMatch' : '',
+              activeChatFindMatchId === m.id ? 'ClawdChatMatch--active' : '',
+            ].filter(Boolean).join(' ')}
             ref={el => {
               if (el) msgRefsMap.current.set(m.id, el)
               else msgRefsMap.current.delete(m.id)

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -327,6 +327,8 @@ function friendlyError(raw: string, activeModel?: string): string {
 }
 
 type Role = 'system' | 'user' | 'assistant'
+type Attachment = { name: string; type: string; content: string; preview?: string }
+type QueuedDraft = { text: string; attachments: Attachment[] }
 
 type Msg = {
   id: string
@@ -1171,9 +1173,9 @@ type ChatInputBarProps = {
   isRecording: boolean
   isTranscribing: boolean
   voiceEnabled: boolean
-  attachedFiles: Array<{ name: string; type: string; content: string; preview?: string }>
+  attachedFiles: Attachment[]
   onSend: (text: string) => void
-  onQueue: (text: string) => void
+  onQueue: (text: string, attachments?: Attachment[]) => void
   onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
   onRemoveFile: (index: number) => void
   onStartRecording: () => void
@@ -1500,7 +1502,6 @@ const ChatInputBar = memo(function ChatInputBar(props: ChatInputBarProps) {
         <button
           className="ClawdFileBtn"
           onClick={() => fileInputRef.current?.click()}
-          disabled={busy}
           title="Attach files or images"
         >
           📎
@@ -1524,8 +1525,8 @@ const ChatInputBar = memo(function ChatInputBar(props: ChatInputBarProps) {
                 e.preventDefault()
                 if (busy) {
                   // Queue the message to send after current request completes
-                  if (input.trim()) {
-                    onQueue(input.trim())
+                  if (input.trim() || attachedFiles.length > 0) {
+                    onQueue(input.trim(), attachedFiles)
                     setInput('')
                     autoResize()
                   }
@@ -1562,10 +1563,10 @@ const ChatInputBar = memo(function ChatInputBar(props: ChatInputBarProps) {
               ⏹️ Stop
             </button>
             <button
-              disabled={!input.trim()}
+              disabled={!input.trim() && attachedFiles.length === 0}
               onClick={() => {
-                if (input.trim()) {
-                  onQueue(input.trim())
+                if (input.trim() || attachedFiles.length > 0) {
+                  onQueue(input.trim(), attachedFiles)
                   setInput('')
                   autoResize()
                 }
@@ -1795,9 +1796,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   useEffect(() => { onBusyChange?.(busy) }, [busy, onBusyChange])
 
   // Queued messages — when user presses Enter while busy, queue messages to send after each request completes
-  const queuedMessagesRef = useRef<string[]>([])
+  const queuedMessagesRef = useRef<QueuedDraft[]>([])
   const [hasQueuedMessage, setHasQueuedMessage] = useState(false)
-  const [queuedMessageTexts, setQueuedMessageTexts] = useState<string[]>([])
+  const [queuedMessages, setQueuedMessages] = useState<QueuedDraft[]>([])
   const [editingQueuedIndex, setEditingQueuedIndex] = useState<number | null>(null)
   const [editingQueuedText, setEditingQueuedText] = useState('')
 
@@ -2000,7 +2001,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [selectedOutputDevice, _setSelectedOutputDevice] = useState<string>('')
 
   // File upload state
-  const [attachedFiles, setAttachedFiles] = useState<Array<{ name: string; type: string; content: string; preview?: string }>>([])
+  const [attachedFiles, setAttachedFiles] = useState<Attachment[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const dragCounter = useRef(0)
 
@@ -2020,7 +2021,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const analyserRef = useRef<AnalyserNode | null>(null)
 
   // Refs for callbacks that need to be called from other callbacks (avoids circular dependency)
-  const doSendRef = useRef<((text: string) => Promise<void>) | null>(null)
+  const doSendRef = useRef<((text: string, attachmentOverride?: Attachment[]) => Promise<void>) | null>(null)
   const pushAssistantRef = useRef<((text: string) => void) | null>(null)
   const handleSendWithTextRef = useRef<((text: string) => Promise<void>) | null>(null)
 
@@ -3637,7 +3638,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         setShowScrollButton(true)
       }
     }
-  }, [msgs, thinkingMessage, queuedMessageTexts])
+  }, [msgs, thinkingMessage, queuedMessages])
 
   const scrollToBottom = useCallback(() => {
     if (chatBodyRef.current) {
@@ -3761,7 +3762,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   // handleSendWithText queues automatically if the chat is busy mid-inference.
   const busyRef = useRef(false)
   busyRef.current = busy
-  const queueMessageRef = useRef<(text: string) => void>(() => {})
+  const queueMessageRef = useRef<(text: string, attachments?: Attachment[]) => void>(() => {})
   useEffect(() => {
     const handler = (e: Event) => {
       const text = (e as CustomEvent<string>).detail
@@ -4057,7 +4058,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     localStorage.setItem(VOICE_MODE_STORAGE, String(newValue))
   }, [voiceEnabled, stopCurrentAudio])
 
-  const doSend = async (text: string) => {
+  const doSend = async (text: string, attachmentOverride?: Attachment[]) => {
 
     // Cancel any pending "Run in Terminal" auto-follow-up since the user
     // (or another trigger) is already sending a message.
@@ -4095,8 +4096,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     setReplyToMsg(null)
 
     // Capture current attachments and clear them
-    const currentAttachments = [...attachedFiles]
-    setAttachedFiles([])
+    const currentAttachments = attachmentOverride ? [...attachmentOverride] : [...attachedFiles]
+    if (!attachmentOverride) setAttachedFiles([])
 
     // Show user message with attachment indicators
     const attachmentSummary = currentAttachments.length > 0
@@ -4787,10 +4788,16 @@ ${actualText}`
   const stableStopGeneration = useCallback(() => { stopGenerationRef.current() }, [])
 
   // Queue a message to send after the current request completes
-  const stableQueueMessage = useCallback((text: string) => {
-    queuedMessagesRef.current = [...queuedMessagesRef.current, text]
+  const stableQueueMessage = useCallback((text: string, attachments: Attachment[] = []) => {
+    const nextDraft: QueuedDraft = { text, attachments: [...attachments] }
+    queuedMessagesRef.current = [...queuedMessagesRef.current, nextDraft]
     setHasQueuedMessage(true)
-    setQueuedMessageTexts(prev => [...prev, text])
+    setQueuedMessages(prev => [...prev, nextDraft])
+    if (attachments.length > 0) {
+      setAttachedFiles(prev =>
+        prev.filter(file => !attachments.some(att => att.name === file.name && att.content === file.content))
+      )
+    }
   }, [])
   // Keep queueMessageRef updated so handleSendWithText can queue mid-inference
   queueMessageRef.current = stableQueueMessage
@@ -4801,10 +4808,10 @@ ${actualText}`
     if (prevBusyRef.current && !busy && queuedMessagesRef.current.length > 0) {
       const [next, ...rest] = queuedMessagesRef.current
       queuedMessagesRef.current = rest
-      setQueuedMessageTexts(rest)
+      setQueuedMessages(rest)
       setHasQueuedMessage(rest.length > 0)
       // Short delay to let UI settle before sending next message
-      const timer = setTimeout(() => doSendRef.current?.(next), 150)
+      const timer = setTimeout(() => doSendRef.current?.(next.text, next.attachments), 150)
       return () => clearTimeout(timer)
     }
     prevBusyRef.current = busy
@@ -5493,7 +5500,7 @@ ${actualText}`
             </div>
           </div>
         )}
-        {queuedMessageTexts.map((qText, i) => (
+        {queuedMessages.map((queued, i) => (
           <div key={`queued-${i}`} className="ClawdMsg ClawdMsg-user ClawdMsg-queued">
             {editingQueuedIndex === i ? (
               <div className="ClawdQueuedEdit">
@@ -5507,9 +5514,9 @@ ${actualText}`
                       const trimmed = editingQueuedText.trim()
                       if (trimmed) {
                         const updated = [...queuedMessagesRef.current]
-                        updated[i] = trimmed
+                        updated[i] = { ...updated[i], text: trimmed }
                         queuedMessagesRef.current = updated
-                        setQueuedMessageTexts(updated)
+                        setQueuedMessages(updated)
                       }
                       setEditingQueuedIndex(null)
                     } else if (e.key === 'Escape') {
@@ -5525,9 +5532,9 @@ ${actualText}`
                       const trimmed = editingQueuedText.trim()
                       if (trimmed) {
                         const updated = [...queuedMessagesRef.current]
-                        updated[i] = trimmed
+                        updated[i] = { ...updated[i], text: trimmed }
                         queuedMessagesRef.current = updated
-                        setQueuedMessageTexts(updated)
+                        setQueuedMessages(updated)
                       }
                       setEditingQueuedIndex(null)
                     }}
@@ -5544,18 +5551,25 @@ ${actualText}`
               </div>
             ) : (
               <div className="ClawdBubble">
-                <ReactMarkdown remarkPlugins={mdPlugins} components={mdComponents}>{qText}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={mdPlugins} components={mdComponents}>
+                  {queued.text || (queued.attachments.length > 0 ? 'Please analyze the attached files.' : '')}
+                </ReactMarkdown>
+                {queued.attachments.length > 0 && (
+                  <div className="ClawdQueuedAttachmentSummary">
+                    Attached: {queued.attachments.map(file => file.name).join(', ')}
+                  </div>
+                )}
               </div>
             )}
             <div className="ClawdQueuedFooter">
-              <span className="ClawdQueuedLabel">Queued{queuedMessageTexts.length > 1 ? ` (${i + 1} of ${queuedMessageTexts.length})` : ''}</span>
+              <span className="ClawdQueuedLabel">Queued{queuedMessages.length > 1 ? ` (${i + 1} of ${queuedMessages.length})` : ''}</span>
               {editingQueuedIndex !== i && (
                 <div className="ClawdQueuedActions">
                   <button
                     className="ClawdQueuedActions__btn"
                     title="Edit queued message"
                     onClick={() => {
-                      setEditingQueuedText(qText)
+                      setEditingQueuedText(queued.text)
                       setEditingQueuedIndex(i)
                     }}
                   >
@@ -5567,7 +5581,7 @@ ${actualText}`
                     onClick={() => {
                       const updated = queuedMessagesRef.current.filter((_, idx) => idx !== i)
                       queuedMessagesRef.current = updated
-                      setQueuedMessageTexts(updated)
+                      setQueuedMessages(updated)
                       setHasQueuedMessage(updated.length > 0)
                     }}
                   >

--- a/src/src/components/organisms/ClawdChat/style.scss
+++ b/src/src/components/organisms/ClawdChat/style.scss
@@ -295,6 +295,68 @@
   }
 }
 
+.ClawdChatFindBar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(8px);
+
+  input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
+    font-size: 13px;
+    outline: none;
+
+    &:focus {
+      border-color: rgba(59, 130, 246, 0.45);
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+    }
+  }
+
+  button {
+    flex-shrink: 0;
+    padding: 7px 10px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
+    background: #fff;
+    font-size: 12px;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.ClawdChatFindBar__count {
+  flex-shrink: 0;
+  min-width: 68px;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 12px;
+  text-align: right;
+}
+
+.ClawdChatMatch {
+  border-radius: 12px;
+}
+
+.ClawdChatMatch--active {
+  outline: 2px solid rgba(59, 130, 246, 0.28);
+  outline-offset: 4px;
+}
+
 .ClawdScrollToBottom {
   position: absolute;
   bottom: 80px;

--- a/src/src/components/organisms/ClawdChat/style.scss
+++ b/src/src/components/organisms/ClawdChat/style.scss
@@ -533,6 +533,12 @@
   flex: 1;
 }
 
+.ClawdQueuedAttachmentSummary {
+  margin-top: 8px;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.58);
+}
+
 .ClawdQueuedActions {
   display: flex;
   gap: 4px;


### PR DESCRIPTION
## What changed
- add `Cmd/Ctrl+F` chat-history search inside Knapsack Chat
- add next/previous match navigation and active-match scrolling/highlighting
- allow file attachments to be added while a response is in flight
- queue attachments together with queued drafts so queued doc analysis survives the wait

## Why
The chat surface already had keyboard shortcuts for clear/focus, but no in-conversation find. Also, queued messages were text-only, so attaching a document during an in-flight response was blocked and would have been dropped even if the paperclip were enabled.

## User impact
- users can search the current chat transcript without relying on browser find
- users can attach a PDF/doc/text file while Knapsack is responding and queue that draft normally

## Validation
- `npm run build` from `src/`
