### PR TITLE
Fix Drive and Sheets agent routing

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4713,12 +4713,13 @@ Examples:
 
 ## Quick Access to Common Services
 - If the user's prompt is only asking about their emails, inbox, schedule, meetings, or calendar, and the prompt already includes native Knapsack email/calendar context, answer from that context first instead of opening the browser.
+- If the user pasted or referenced a connected Google Docs / Sheets / Drive URL, fetch it through the local Knapsack Drive endpoint first so you can read the exported text/CSV directly before opening the browser.
 - Only use browser navigation for Gmail/Calendar/Drive when the user explicitly asks to use the web UI or when the native context/tooling cannot answer the request.
 - "check my email" / "Gmail" → prefer native email context first; only navigate("https://mail.google.com") if native context is unavailable or insufficient
 - "search for X" → navigate("https://www.google.com/search?q=X")  (only the search query goes in the URL)
 - "calendar" → prefer native calendar context first; only navigate("https://calendar.google.com") if native context is unavailable or insufficient
 - "tasks" / "Google Tasks" → navigate("https://tasks.google.com")
-- "drive" / "docs" → prefer native Drive context when provided; otherwise navigate("https://drive.google.com")
+- "drive" / "docs" / "sheets" → prefer native Drive context and `http://127.0.0.1:8897/api/knapsack/connections/google/drive/file_text?email=<connected_google_email>&id_or_url=<urlencoded drive or sheets url>` when possible; otherwise navigate("https://drive.google.com")
 - "LinkedIn" → navigate("https://www.linkedin.com")
 - "Twitter" / "X" → navigate("https://x.com")
 - "GitHub" → navigate("https://github.com")

--- a/src/src-tauri/src/clawd/tools_md_content.txt
+++ b/src/src-tauri/src/clawd/tools_md_content.txt
@@ -106,11 +106,28 @@ When the user asks you to check email, check calendar, book flights, research pr
 6. You are authorized by the user to access their accounts. The browser is already logged in.
 7. For multi-step tasks (e.g., searching for flights), execute ALL steps yourself: navigate, fill forms, search, read results, and present findings.
 
+**Native Knapsack local APIs to prefer before opening a logged-in web app:**
+- Calendar events:
+  - `http://127.0.0.1:8897/api/knapsack/recent_calendar_events`
+  - `http://127.0.0.1:8897/api/knapsack/calendar_event?id=<event_id>`
+- Email context:
+  - `http://127.0.0.1:8897/api/knapsack/search_emails_by_addresses?addresses=<comma-separated-emails>`
+  - `http://127.0.0.1:8897/api/knapsack/email_thread/<document_id>`
+- Google Drive / Docs / Sheets:
+  - `http://127.0.0.1:8897/api/knapsack/connections/google/drive/ids_by_email?email=<user_email,other_email>`
+  - `http://127.0.0.1:8897/api/knapsack/document_infos` (POST with drive document ids/types when you already know the ids)
+  - `http://127.0.0.1:8897/api/knapsack/connections/google/drive/file_text?email=<connected_google_email>&id_or_url=<urlencoded drive or sheets url>`
+    - This endpoint accepts a raw Google Drive file id OR a full Google Docs/Sheets/Drive URL.
+    - For Google Sheets it exports CSV text. For Google Docs it exports plain text.
+    - Use this FIRST when the user asks you to read or extract data from a connected Google Sheet or Drive document.
+
 **Examples of what to do:**
-- "Check my email" → Use browser to navigate to Gmail, snapshot the inbox, read and summarize unread messages
-- "What's on my calendar?" → Use browser to navigate to Google Calendar, snapshot, read and list upcoming events
+- "Check my email" → First use the local Knapsack email APIs when the question is about already-synced mail; use the browser only if the needed message is not in local results
+- "What's on my calendar?" → First use `web_fetch` on the local Knapsack calendar API, then summarize the upcoming events
 - "Look up the latest news on X" → Use `web_search` to find articles, then `web_fetch` to read them, then summarize the key points
 - "Any important emails?" → Use browser to navigate to Gmail, snapshot, scan for urgent items and summarize
+- "Read this spreadsheet" → Call the local `drive/file_text` endpoint with the connected Google account and the spreadsheet URL, then inspect the returned CSV/text before using the browser
+- "Find the New York row in this Google Sheet and tell me columns H-K" → Use the local `drive/file_text` endpoint first, search the CSV/text for `New York`, then only fall back to browser if the native export is unavailable
 - "Research Y for me" → Use `web_search` to find sources, `web_fetch` to read them, synthesize into a briefing
 - "Find flights on aa.com" → Use browser to navigate to aa.com, fill in the search form, search, read results, and present the options
 - "Book a restaurant" → Use browser to navigate to OpenTable/Resy, search for availability, and present options
@@ -120,6 +137,7 @@ When the user asks you to check email, check calendar, book flights, research pr
 - Use **web_search** → to find information, news, answers (fastest for research and news). If it fails, fall back to browser.
 - Use **web_fetch** → to read a specific URL's content (articles, docs, APIs)
 - Use **browser** → for interactive tasks requiring login (email, calendar, web apps), forms, JavaScript-heavy pages, multi-step flows, AND as a fallback for web search
+- For connected Google Docs/Sheets/Drive files, prefer the **local Knapsack Drive APIs** before browser automation. Do not claim Sheets are unreadable unless the local Drive export endpoint fails too.
 
 **Quick access URLs (for browser tool):**
 - Gmail: https://mail.google.com

--- a/src/src-tauri/src/connections/google/drive.rs
+++ b/src/src-tauri/src/connections/google/drive.rs
@@ -17,6 +17,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
+use url::Url;
 
 use crate::constants::EMBEDDING_BATCH_SIZE;
 use crate::db::models::{
@@ -40,6 +41,12 @@ pub struct FetchGoogleDriveResponse {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct FetchGoogleDriveParams {
   email: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FetchGoogleDriveFileTextParams {
+  email: String,
+  id_or_url: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -152,6 +159,82 @@ struct FetchGoogleDriveFileResponse {
   success: bool,
   error: Option<String>,
   paths: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize)]
+struct FetchGoogleDriveFileTextResponse {
+  success: bool,
+  error: Option<String>,
+  file_id: Option<String>,
+  name: Option<String>,
+  mime_type: Option<String>,
+  content: Option<String>,
+  truncated: bool,
+}
+
+fn resolve_google_drive_file_id(id_or_url: &str) -> Option<String> {
+  let trimmed = id_or_url.trim();
+  if trimmed.is_empty() {
+    return None;
+  }
+  if !trimmed.contains("://") {
+    return Some(trimmed.to_string());
+  }
+
+  let parsed = Url::parse(trimmed).ok()?;
+
+  if let Some(id) = parsed
+    .query_pairs()
+    .find_map(|(key, value)| (key == "id").then(|| value.into_owned()))
+  {
+    if !id.is_empty() {
+      return Some(id);
+    }
+  }
+
+  let segments = parsed.path_segments()?.collect::<Vec<_>>();
+  for pair in segments.windows(2) {
+    if pair[0] == "d" && !pair[1].is_empty() {
+      return Some(pair[1].to_string());
+    }
+  }
+
+  if segments.len() >= 2 && segments[0] == "folders" && !segments[1].is_empty() {
+    return Some(segments[1].to_string());
+  }
+
+  None
+}
+
+#[cfg(test)]
+mod tests {
+  use super::resolve_google_drive_file_id;
+
+  #[test]
+  fn extracts_drive_ids_from_google_urls_and_plain_ids() {
+    assert_eq!(
+      resolve_google_drive_file_id("1AbCdEfGhIjKlMnOpQrStUvWxYz"),
+      Some("1AbCdEfGhIjKlMnOpQrStUvWxYz".to_string())
+    );
+    assert_eq!(
+      resolve_google_drive_file_id(
+        "https://docs.google.com/spreadsheets/d/1sheetIdExample123/edit#gid=0"
+      ),
+      Some("1sheetIdExample123".to_string())
+    );
+    assert_eq!(
+      resolve_google_drive_file_id(
+        "https://drive.google.com/file/d/1fileIdExample456/view?usp=sharing"
+      ),
+      Some("1fileIdExample456".to_string())
+    );
+    assert_eq!(
+      resolve_google_drive_file_id(
+        "https://drive.google.com/open?id=1queryParamId789"
+      ),
+      Some("1queryParamId789".to_string())
+    );
+  }
 }
 
 pub async fn embed_drive_document(
@@ -633,6 +716,65 @@ async fn fetch_google_drive_files(
   //     .await;
   // }
   Ok(HttpResponse::Ok().json(json!({ "success": true,  "data": documents })))
+}
+
+#[get("/api/knapsack/connections/google/drive/file_text")]
+async fn fetch_google_drive_file_text(
+  req: HttpRequest,
+) -> Result<HttpResponse, error::Error> {
+  let params =
+    actix_web::web::Query::<FetchGoogleDriveFileTextParams>::from_query(req.query_string())
+      .map_err(|e| error::ErrorBadRequest(e.to_string()))?;
+
+  let file_id = resolve_google_drive_file_id(&params.id_or_url)
+    .ok_or_else(|| error::ErrorBadRequest("Could not extract a Google Drive file id"))?;
+
+  let user_connection = UserConnection::find_by_user_email_and_scope(
+    params.email.clone(),
+    String::from(GOOGLE_DRIVE_SCOPE),
+  )
+  .map_err(|e| error::ErrorBadRequest(format!("Drive connection not found: {:?}", e)))?;
+
+  let access_token = refresh_connection_token(params.email.clone(), user_connection.clone())
+    .await
+    .map_err(|e| error::ErrorInternalServerError(format!("Failed to refresh Drive token: {:?}", e)))?;
+
+  let hub = DriveHub::new(get_https_client(), access_token);
+  let (_response, file) = hub
+    .files()
+    .get(&file_id)
+    .param("fields", "id,name,mimeType")
+    .doit()
+    .await
+    .map_err(|e| error::ErrorBadRequest(format!("Failed to fetch Drive file metadata: {:?}", e)))?;
+
+  let mime_type = file.mime_type.clone().unwrap_or_else(|| "text/plain".to_string());
+  let home_dir = dirs::home_dir().expect("Couldn't get home_dir for platform.");
+  let temp_dir = home_dir.join("knapsack_temp");
+  fs::create_dir_all(temp_dir.clone())?;
+
+  let chunks = get_drive_file_content(mime_type.clone(), file_id.clone(), temp_dir, hub.clone())
+    .await
+    .ok_or_else(|| error::ErrorBadRequest("Failed to export or download Drive file content"))?;
+
+  let combined = chunks.join("\n");
+  let max_chars = 200_000;
+  let truncated = combined.chars().count() > max_chars;
+  let content = if truncated {
+    combined.chars().take(max_chars).collect::<String>()
+  } else {
+    combined
+  };
+
+  Ok(HttpResponse::Ok().json(FetchGoogleDriveFileTextResponse {
+    success: true,
+    error: None,
+    file_id: Some(file_id),
+    name: file.name.clone(),
+    mime_type: Some(mime_type),
+    content: Some(content),
+    truncated,
+  }))
 }
 
 #[get("/api/knapsack/google/drive/mimeTypes")]

--- a/src/src-tauri/src/server/actix.rs
+++ b/src/src-tauri/src/server/actix.rs
@@ -261,6 +261,7 @@ pub async fn start_server<'a>(
       .service(connections::google::profile::fetch_google_profile_api)
       .service(connections::google::drive::fetch_google_drive_api)
       .service(connections::google::drive::fetch_google_drive_files)
+      .service(connections::google::drive::fetch_google_drive_file_text)
       .service(connections::google::drive::fetch_google_drive_mime_types)
       .service(connections::google::drive::fetch_google_drive_documents_ids_shared_by_users)
       .service(connections::google::calendar::fetch_google_calendar_api)


### PR DESCRIPTION
## Summary
- add a native Drive file text export endpoint that accepts a Drive file id or pasted Google Docs/Sheets URL
- teach the Knapsack chat agent to prefer native Drive exports before browser automation for connected Docs and Sheets
- keep browser fallback available only when the native Drive export path fails

## Validation
- cargo check --manifest-path src/src-tauri/Cargo.toml
