### PR TITLE
Fix follow-up email drafts and compose send path

### DIFF
--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -167,6 +167,36 @@ static KN_KEEP_AWAKE_PROCESS: Lazy<StdMutex<Option<std::process::Child>>> =
 static KN_KEEP_AWAKE_PROCESS: StdMutex<bool> = StdMutex::new(false);
 
 #[tauri::command]
+async fn kn_send_composed_email(
+  to: String,
+  cc: Option<String>,
+  subject: String,
+  body: String,
+  thread_id: Option<String>,
+  user_email: String,
+  user_name: Option<String>,
+) -> Result<String, String> {
+  let trimmed_to = to.trim().to_string();
+  let trimmed_subject = subject.trim().to_string();
+  let trimmed_body = body.trim().to_string();
+
+  if trimmed_to.is_empty() || trimmed_subject.is_empty() || trimmed_body.is_empty() {
+    return Err("To, subject, and body are required".to_string());
+  }
+
+  crate::clawd::gmail::send_gmail_email(
+    &user_email,
+    user_name.as_deref().unwrap_or(""),
+    &trimmed_to,
+    cc.as_deref(),
+    &trimmed_subject,
+    &trimmed_body,
+    thread_id.as_deref(),
+  )
+  .await
+}
+
+#[tauri::command]
 fn kn_set_keep_awake(enabled: bool) -> Result<(), String> {
   #[cfg(target_os = "macos")]
   {
@@ -1951,6 +1981,7 @@ async fn main() {
       kn_get_log_path,
       kn_get_openclaw_version,
       kn_set_keep_awake,
+      kn_send_composed_email,
       kn_execute_command,
       kn_openclaw_configure_channels_cmd,
       kn_spawn_streaming_command,

--- a/src/src/components/organisms/CenterWorkspace/index.tsx
+++ b/src/src/components/organisms/CenterWorkspace/index.tsx
@@ -32,6 +32,7 @@ import { RecordingContextProps } from '../MeetingNotesMode/RecordingContext'
 import Mic from '/assets/images/icons/mic-white.svg'
 import { EmailAutopilot } from 'src/components/molecules/EmailAutopilot'
 import { logError } from 'src/utils/errorHandling'
+import { buildFollowUpEmailBody } from 'src/utils/emails'
 import EmailCategoryTabs from '../EmailCategoryTabs'
 import SettingsButton from 'src/components/atoms/settings-button'
 
@@ -366,18 +367,24 @@ const CenterWorkspace: React.FC<CenterWorkspaceProps> = ({
                       onLibraryWorkspaceOpen={onLibraryWorkspaceOpen}
                       userEmail={userEmail}
                       userName={userName}
-                      onEmailClick={(_notesMarkdown, meeting) => {
+                      onEmailClick={(notesMarkdown, meeting) => {
                         const participants = meeting?.participants ?? []
+                        const primaryRecipient = participants.find(
+                          p => p.email && p.email !== userEmail,
+                        )
                         const toEmails = participants
                           .filter(p => p.email && p.email !== userEmail)
                           .map(p => p.email)
                           .join(', ')
                         const subject = meeting?.title
-                          ? `Great to chat — ${meeting.title}`
-                          : 'Great to chat'
-                        const body = `<p>Hi,</p><p>Great connecting today${meeting?.title ? ` about <strong>${meeting.title}</strong>` : ''}. Thanks again for the conversation — it was a productive meeting.</p><p>What we agreed on:
-<br>- Next steps are captured in my notes.
-<br>- I’ll follow up if anything else pops up.</p><p>If you want a tighter version for this thread, I can help with that too.</p><p>Talk soon,<br>${userName || ''}</p>`
+                          ? `Follow up: ${meeting.title}`
+                          : 'Meeting Follow Up'
+                        const body = buildFollowUpEmailBody(
+                          notesMarkdown,
+                          meeting?.title,
+                          userName,
+                          primaryRecipient?.name || primaryRecipient?.email,
+                        )
                         feed.setComposedEmailDraft({ to: toEmails, subject, body })
                       }}
                     />

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -677,12 +677,20 @@ function Home({
                   }}
                   onEmailClick={(notesMarkdown, meeting) => {
                     const participants = meeting?.participants ?? []
+                    const primaryRecipient = participants.find(
+                      p => p.email && p.email !== userEmail,
+                    )
                     const toEmails = participants
                       .filter(p => p.email && p.email !== userEmail)
                       .map(p => p.email)
                       .join(', ')
                     const subject = meeting?.title ? `Follow up: ${meeting.title}` : 'Meeting Follow Up'
-                    const body = buildFollowUpEmailBody(notesMarkdown, meeting?.title, userName)
+                    const body = buildFollowUpEmailBody(
+                      notesMarkdown,
+                      meeting?.title,
+                      userName,
+                      primaryRecipient?.name || primaryRecipient?.email,
+                    )
                     feed.setComposedEmailDraft({ to: toEmails, subject, body })
                   }}
                 />

--- a/src/src/utils/emails.tsx
+++ b/src/src/utils/emails.tsx
@@ -66,42 +66,126 @@ export function extractExternalEmails(myEmail: string, emailList: string[]): str
   })
 }
 
+function cleanMeetingLine(line: string): string {
+  return line
+    .replace(/^[-*]\s*/, '')
+    .replace(/^-\s*\[[ xX]\]\s*/, '')
+    .replace(/^action item[s]?:\s*/i, '')
+    .replace(/^action:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function ensureSentence(text: string): string {
+  const trimmed = text.trim()
+  if (!trimmed) return ''
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`
+}
+
+function extractSection(lines: string[], heading: RegExp): string[] {
+  const startIndex = lines.findIndex(line => heading.test(line.trim()))
+  if (startIndex === -1) return []
+  const out: string[] = []
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i].trim()
+    if (!line) continue
+    if (/^##\s+/.test(line)) break
+    out.push(line)
+  }
+  return out
+}
+
+function extractHighlights(lines: string[]): string[] {
+  const sectionLines = extractSection(lines, /^##\s+Highlights/i)
+  return sectionLines
+    .filter(line => /^[-*]\s+/.test(line))
+    .map(cleanMeetingLine)
+    .filter(Boolean)
+    .slice(0, 3)
+}
+
+function extractActionItems(lines: string[]): string[] {
+  const explicitSection = extractSection(lines, /^##\s+Action Items/i)
+  const sectionMatches = explicitSection
+    .filter(line => /^[-*]\s+/.test(line))
+    .map(cleanMeetingLine)
+    .filter(Boolean)
+
+  if (sectionMatches.length > 0) {
+    return sectionMatches
+  }
+
+  return lines
+    .filter(line => /^-\s*\[[ xX]\]/.test(line) || /^action item[s]?:/i.test(line) || /^action:/i.test(line))
+    .map(cleanMeetingLine)
+    .filter(Boolean)
+}
+
+function extractSummaryParagraph(lines: string[]): string | undefined {
+  const summaryIndex = lines.findIndex(line => /^#\s+Summary/i.test(line.trim()))
+  if (summaryIndex === -1) return
+  const summaryLines: string[] = []
+  for (let i = summaryIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i].trim()
+    if (!line) continue
+    if (/^##\s+/.test(line) || /^#\s+Meeting Notes/i.test(line)) break
+    if (/^[-*]\s+/.test(line)) continue
+    summaryLines.push(line)
+    if (summaryLines.join(' ').length > 240) break
+  }
+  const summary = ensureSentence(summaryLines.join(' ').replace(/\s+/g, ' ').trim())
+  return summary || undefined
+}
+
+function firstName(nameOrEmail?: string): string | undefined {
+  const value = nameOrEmail?.trim()
+  if (!value) return
+  const beforeEmail = value.split('<')[0].trim()
+  const candidate = beforeEmail || value.split('@')[0].trim()
+  const token = candidate.split(/\s+/)[0]?.trim()
+  return token || undefined
+}
+
 /**
- * Build a conversational meeting follow-up email from raw meeting notes markdown.
- * Extracts action items and key decisions, then writes them as plain prose rather
- * than pasting the full structured notes dump.
+ * Build a short, conversational meeting follow-up email from meeting notes.
+ * We intentionally avoid dumping raw task lists into the draft.
  */
-export function buildFollowUpEmailBody(notesMarkdown: string, meetingTitle?: string, userName?: string): string {
-  const lines = notesMarkdown.split('\n').map(l => l.trim()).filter(Boolean)
+export function buildFollowUpEmailBody(
+  notesMarkdown: string,
+  meetingTitle?: string,
+  userName?: string,
+  recipientName?: string,
+): string {
+  const lines = notesMarkdown.split('\n')
+  const summary = extractSummaryParagraph(lines)
+  const highlights = extractHighlights(lines)
+  const actionItems = extractActionItems(lines)
 
-  // Pull out action items (lines with checkboxes or starting with "Action:")
-  const actionItems = lines.filter(l =>
-    /^-\s*\[[ xX]\]/.test(l) || /^action item[s]?:/i.test(l) || /^action:/i.test(l)
-  ).map(l => l.replace(/^-\s*\[[ xX]\]\s*/, '').replace(/^action item[s]?:\s*/i, '').replace(/^action:\s*/i, ''))
-
-  // Pull out key decisions / outcomes
-  const decisions = lines.filter(l =>
-    /^(?:decision|outcome|agreed|next step)[s]?:/i.test(l)
-  ).map(l => l.replace(/^[^:]+:\s*/i, ''))
-
-  const greeting = `<p>Hi,</p>`
-  const intro = `<p>Great meeting${meetingTitle ? ` about ${meetingTitle}` : ''} — thanks for your time!</p>`
+  const greetingName = firstName(recipientName)
+  const greeting = `<p>Hi${greetingName ? ` ${escHtml(greetingName)}` : ''},</p>`
+  const intro = `<p>Great meeting today${meetingTitle ? ` about <strong>${escHtml(meetingTitle)}</strong>` : ''}. Thanks again for your time.</p>`
 
   let body = greeting + intro
 
-  if (actionItems.length > 0) {
-    body += `<p>Here's what we agreed on:</p><ul style="margin:4px 0;padding-left:20px">`
-    actionItems.forEach(item => { body += `<li>${escHtml(item)}</li>` })
-    body += `</ul>`
-  } else if (decisions.length > 0) {
-    body += `<p>Key takeaways:</p><ul style="margin:4px 0;padding-left:20px">`
-    decisions.forEach(d => { body += `<li>${escHtml(d)}</li>` })
-    body += `</ul>`
-  } else {
-    body += `<p>Happy to share a quick summary if useful — just let me know.</p>`
+  if (summary) {
+    body += `<p>${escHtml(summary)}</p>`
   }
 
-  body += `<p>Let me know if you have any questions or if anything needs adjusting.</p>`
+  if (highlights.length > 0) {
+    body += `<p>A few quick takeaways from our conversation:</p><ul style="margin:4px 0;padding-left:20px">`
+    highlights.forEach(item => {
+      body += `<li>${escHtml(ensureSentence(item))}</li>`
+    })
+    body += `</ul>`
+  }
+
+  if (actionItems.length > 0) {
+    body += `<p>I’ll follow up on the next steps we discussed and keep you posted on progress.</p>`
+  } else if (highlights.length === 0 && !summary) {
+    body += `<p>I’m happy to send over anything else that would be helpful from our conversation.</p>`
+  }
+
+  body += `<p>Please let me know if there’s anything you’d like me to prioritize or clarify.</p>`
   body += `<p>Best,<br>${escHtml(userName || '')}</p>`
   return body
 }

--- a/src/src/utils/gmailService.ts
+++ b/src/src/utils/gmailService.ts
@@ -1,4 +1,5 @@
 import { Base64 } from 'js-base64'
+import { invoke } from '@tauri-apps/api/tauri'
 import { ConnectionKeys, getAccessToken } from 'src/api/connections'
 import { DisplayEmail } from 'src/hooks/feed/useFeed'
 
@@ -216,45 +217,23 @@ export const sendComposedEmail = async ({
   userEmail: string
   userName?: string
 }): Promise<void> => {
-  const accessToken = await getAccessToken(userEmail, ConnectionKeys.GOOGLE_GMAIL)
-  const fullSender = userName ? `${userName} <${userEmail}>` : userEmail
-  const newMessageId = `<${Date.now()}.${Math.random().toString(36).substring(2)}@gmail.com>`
-
-  const emailLines = [
-    'MIME-Version: 1.0',
-    'Content-Type: text/html; charset=utf-8',
-    `Message-ID: ${newMessageId}`,
-    `Subject: ${subject}`,
-    `From: ${fullSender}`,
-    `To: ${to}`,
-  ]
-  if (cc) emailLines.push(`CC: ${cc}`)
-
-  if (threadId) {
-    const originalMessageId = await getOriginalMessageId(threadId, accessToken)
-    if (originalMessageId) {
-      emailLines.push(`In-Reply-To: ${originalMessageId.split(' ').pop()}`)
-      emailLines.push(`References: ${originalMessageId}`)
-    }
-  }
-
-  emailLines.push('', body)
-
-  const encodedEmail = Base64.encodeURI(emailLines.join('\r\n'))
-  const payload: Record<string, unknown> = { raw: encodedEmail }
-  if (threadId) payload.threadId = threadId
-
-  const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  })
-
-  if (!response.ok) {
-    const errorData = await response.json()
-    throw new Error(`Gmail API error: ${errorData.error?.message || 'Unknown error'}`)
+  try {
+    await invoke('kn_send_composed_email', {
+      to,
+      cc,
+      subject,
+      body,
+      thread_id: threadId,
+      user_email: userEmail,
+      user_name: userName,
+    })
+  } catch (error) {
+    const message =
+      typeof error === 'string'
+        ? error
+        : error instanceof Error
+          ? error.message
+          : 'Failed to send email'
+    throw new Error(message)
   }
 }


### PR DESCRIPTION
## Summary
- route manual follow-up drafts through the shared follow-up email builder instead of the stale local template
- make the follow-up builder produce shorter, more conversational drafts from notes instead of dumping raw action items
- send composed emails through the existing Tauri Gmail helper so the draft drawer uses the same backend path as the working agent flow

## Validation
- `cargo check --manifest-path src/src-tauri/Cargo.toml`

## Root cause
The app had drifted into two separate paths here:
1. meeting follow-up drafts in the UI were still being built from older local templates/helpers, so the copy got awkward and overly internal
2. the compose drawer was sending directly from the frontend to Gmail, instead of using the backend Gmail helper already used elsewhere, which is why the drawer could surface `Load failed` even when other Gmail-powered flows still worked
