### PR TITLE
Add inline support diagnostics email flow

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -4225,6 +4225,7 @@ pub async fn chat(
           &draft.subject,
           &draft.body_html,
           draft.thread_id.as_deref(),
+          None,
         )
         .await
         {

--- a/src/src-tauri/src/clawd/gmail.rs
+++ b/src/src-tauri/src/clawd/gmail.rs
@@ -1,5 +1,8 @@
 use actix_web::{get, web, HttpResponse, Responder};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{
+  engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+  Engine,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -31,6 +34,24 @@ pub struct UnreadImportantEmail {
 pub struct UnreadImportantResponse {
   pub success: bool,
   pub emails: Vec<UnreadImportantEmail>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmailAttachment {
+  pub filename: String,
+  pub mime_type: String,
+  pub content: String,
+  pub encoding: Option<String>,
+}
+
+fn wrap_base64_lines(encoded: &str) -> String {
+  encoded
+    .as_bytes()
+    .chunks(76)
+    .map(|chunk| String::from_utf8_lossy(chunk).to_string())
+    .collect::<Vec<_>>()
+    .join("\r\n")
 }
 
 /// A lightweight endpoint intended for Clawd integration: provide a bundle of
@@ -87,6 +108,7 @@ pub async fn send_gmail_email(
   subject: &str,
   body: &str,
   thread_id: Option<&str>,
+  attachments: Option<&[EmailAttachment]>,
 ) -> Result<String, String> {
   // 1. Get OAuth access token
   let scope = GOOGLE_GMAIL_SCOPE.to_string();
@@ -105,14 +127,23 @@ pub async fn send_gmail_email(
     format!("{} <{}>", user_name, user_email)
   };
 
-  let mut headers = vec![
-    "MIME-Version: 1.0".to_string(),
-    "Content-Type: text/html; charset=utf-8".to_string(),
+  let has_attachments = attachments.map(|items| !items.is_empty()).unwrap_or(false);
+  let boundary = format!("knapsack-boundary-{}", Uuid::new_v4());
+  let mut headers = vec!["MIME-Version: 1.0".to_string()];
+  if has_attachments {
+    headers.push(format!(
+      "Content-Type: multipart/mixed; boundary=\"{}\"",
+      boundary
+    ));
+  } else {
+    headers.push("Content-Type: text/html; charset=utf-8".to_string());
+  }
+  headers.extend([
     format!("Message-ID: {}", message_id),
     format!("Subject: {}", subject),
     format!("From: {}", full_sender),
     format!("To: {}", to),
-  ];
+  ]);
 
   if let Some(cc_val) = cc {
     if !cc_val.is_empty() {
@@ -122,7 +153,44 @@ pub async fn send_gmail_email(
 
   let html_body = format!("<div dir=\"ltr\">{}</div>", body);
 
-  let raw_message = format!("{}\r\n\r\n{}", headers.join("\r\n"), html_body);
+  let raw_message = if has_attachments {
+    let mut parts = vec![
+      format!("{}\r\n", headers.join("\r\n")),
+      format!("--{}\r\n", boundary),
+      "Content-Type: text/html; charset=utf-8\r\n".to_string(),
+      "Content-Transfer-Encoding: 7bit\r\n\r\n".to_string(),
+      format!("{}\r\n", html_body),
+    ];
+
+    if let Some(items) = attachments {
+      for attachment in items {
+        let bytes = if attachment.encoding.as_deref() == Some("base64") {
+          STANDARD
+            .decode(attachment.content.as_bytes())
+            .map_err(|e| format!("Invalid attachment base64: {}", e))?
+        } else {
+          attachment.content.as_bytes().to_vec()
+        };
+        let encoded_attachment = wrap_base64_lines(&STANDARD.encode(bytes));
+        parts.push(format!("--{}\r\n", boundary));
+        parts.push(format!(
+          "Content-Type: {}; name=\"{}\"\r\n",
+          attachment.mime_type, attachment.filename
+        ));
+        parts.push("Content-Transfer-Encoding: base64\r\n".to_string());
+        parts.push(format!(
+          "Content-Disposition: attachment; filename=\"{}\"\r\n\r\n",
+          attachment.filename
+        ));
+        parts.push(format!("{}\r\n", encoded_attachment));
+      }
+    }
+
+    parts.push(format!("--{}--", boundary));
+    parts.join("")
+  } else {
+    format!("{}\r\n\r\n{}", headers.join("\r\n"), html_body)
+  };
   let encoded = URL_SAFE_NO_PAD.encode(raw_message.as_bytes());
 
   // 3. Send via Gmail API

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -175,6 +175,7 @@ async fn kn_send_composed_email(
   thread_id: Option<String>,
   user_email: String,
   user_name: Option<String>,
+  attachments: Option<Vec<crate::clawd::gmail::EmailAttachment>>,
 ) -> Result<String, String> {
   let trimmed_to = to.trim().to_string();
   let trimmed_subject = subject.trim().to_string();
@@ -192,6 +193,7 @@ async fn kn_send_composed_email(
     &trimmed_subject,
     &trimmed_body,
     thread_id.as_deref(),
+    attachments.as_deref(),
   )
   .await
 }

--- a/src/src/components/molecules/EmailComposeDrawer/index.tsx
+++ b/src/src/components/molecules/EmailComposeDrawer/index.tsx
@@ -23,6 +23,7 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
   const [sending, setSending] = useState(false)
   const [sent, setSent] = useState(false)
   const [error, setError] = useState('')
+  const attachments = draft.attachments ?? []
 
   // Set initial body HTML (can't combine contentEditable + dangerouslySetInnerHTML)
   useEffect(() => {
@@ -64,6 +65,7 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
         threadId: draft.threadId,
         userEmail,
         userName,
+        attachments,
       })
       setSent(true)
       setTimeout(() => onDismiss(), 1500)
@@ -197,6 +199,33 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
 
       {/* Body — contentEditable for rich-text editing */}
       <div style={{ overflowY: 'auto', flex: 1, padding: '10px 16px' }}>
+        {attachments.length > 0 && (
+          <div style={{ marginBottom: 10 }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: '#64748b', marginBottom: 6 }}>
+              Attachments
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {attachments.map((attachment, index) => (
+                <span
+                  key={`${attachment.filename}-${index}`}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '4px 8px',
+                    borderRadius: 999,
+                    background: '#f8fafc',
+                    border: '1px solid #e2e8f0',
+                    color: '#475569',
+                    fontSize: 12,
+                  }}
+                >
+                  📎 {attachment.filename}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
         <div
           ref={bodyRef}
           contentEditable

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -20,6 +20,7 @@ import { TokenCostsView } from 'src/components/organisms/ActivityPanel'
 import { detectBuildIntent, extractProjectDescription } from 'src/utils/devIntentDetector'
 import { dispatchDevPopulate, dispatchOpenDevPanel } from 'src/utils/devModeEvents'
 import { getAgentMemory, saveAgentMemory } from 'src/automations/agentMemory'
+import { buildSupportDiagnosticsDraft } from 'src/utils/supportDiagnostics'
 
 // Prompt action prefix used by the AI to embed executable actions in messages.
 // Format in raw AI text: [Label](knapsack://prompt/Detailed instruction)
@@ -29,6 +30,14 @@ import { getAgentMemory, saveAgentMemory } from 'src/automations/agentMemory'
 // Instead we parse with balanced-parenthesis counting.
 
 type PromptAction = { label: string; prompt: string }
+
+const SHARE_SUPPORT_DIAGNOSTICS_ACTION =
+  '[Share diagnostics with Knapsack Support](knapsack://prompt/__share_support_diagnostics__)'
+
+function appendSupportDiagnosticsAction(message: string): string {
+  if (message.includes('__share_support_diagnostics__')) return message
+  return `${message}\n\n${SHARE_SUPPORT_DIAGNOSTICS_ACTION}`
+}
 
 // All recognized prompt link prefixes — the AI may use any of these forms
 const PROMPT_MARKERS = ['knapsack://prompt/', 'knapsack://prompt=', 'knapsack://prompt(']
@@ -1908,6 +1917,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     }
     return []
   })
+  const msgsRef = useRef<Msg[]>([])
+  useEffect(() => {
+    msgsRef.current = msgs
+  }, [msgs])
   const [chatFindOpen, setChatFindOpen] = useState(false)
   const [chatFindQuery, setChatFindQuery] = useState('')
   const [chatFindActiveIndex, setChatFindActiveIndex] = useState(0)
@@ -4015,6 +4028,33 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       return
     }
 
+    if (text === '__share_support_diagnostics__') {
+      const sourceMsg = srcMsgId ? msgsRef.current.find(m => m.id === srcMsgId) : null
+      const issueSummary = sourceMsg?.text || 'Knapsack surfaced an error in chat.'
+      try {
+        const draft = await buildSupportDiagnosticsDraft({
+          issueSummary,
+          activeModel: getActiveModelLabel(),
+        })
+        if (srcMsgId) {
+          setMsgs(prev => prev.map(m =>
+            m.id === srcMsgId
+              ? { ...m, confirmedActionPrompts: [...(m.confirmedActionPrompts ?? []), text] }
+              : m
+          ))
+        }
+        window.dispatchEvent(new CustomEvent('clawd-email-draft-ready', { detail: draft }))
+        pushAssistantRef.current?.(
+          'I drafted a support email with a sanitized diagnostics attachment addressed to **support@knap.ai**.',
+        )
+      } catch (error: any) {
+        pushAssistantRef.current?.(
+          `I couldn't prepare the diagnostics bundle: ${error?.message || String(error)}`,
+        )
+      }
+      return
+    }
+
     // Handle special "enable advanced and resend" action
     const advPrefix = '__enable_advanced_and_resend__'
     if (text.startsWith(advPrefix)) {
@@ -4771,7 +4811,9 @@ ${actualText}`
                   if (lowerReply.includes('rate limit') || lowerReply.includes('rate_limit') ||
                       lowerReply.includes('spending cap') || lowerReply.includes('no api key found') ||
                       lowerReply.includes('configure auth for this agent')) {
-                    displayText = friendlyError(displayText, getActiveModelLabel())
+                    displayText = appendSupportDiagnosticsAction(
+                      friendlyError(displayText, getActiveModelLabel()),
+                    )
                   }
                 }
                 setMsgs(prev => [
@@ -4847,7 +4889,11 @@ ${actualText}`
               // Persist a summary so future sessions have cross-session context.
               saveAgentMemory('knapsack-chat', out.reply)
             } else {
-              pushAssistant(friendlyError(out.message || out.error || 'No reply', activeModelAtSend))
+              pushAssistant(
+                appendSupportDiagnosticsAction(
+                  friendlyError(out.message || out.error || 'No reply', activeModelAtSend),
+                ),
+              )
             }
             succeeded = true
             break
@@ -4884,7 +4930,11 @@ ${actualText}`
         abortControllerRef.current = null
       }
     } catch (e: any) {
-      pushAssistant(friendlyError(e?.message || String(e), activeModelAtSend))
+      pushAssistant(
+        appendSupportDiagnosticsAction(
+          friendlyError(e?.message || String(e), activeModelAtSend),
+        ),
+      )
     } finally {
       // Safety net: always clear thinking state when request ends, even if inner
       // finally was skipped due to an error thrown between setting thinkingMessage

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -197,12 +197,20 @@ export interface EmailAction {
   rightAction: AutopilotActions
 }
 
+export interface ComposedEmailAttachment {
+  filename: string
+  mimeType: string
+  content: string
+  encoding?: 'utf8' | 'base64'
+}
+
 export interface ComposedEmailDraft {
   to: string
   cc?: string
   subject: string
   body: string
   threadId?: string
+  attachments?: ComposedEmailAttachment[]
 }
 
 export function useFeed(

--- a/src/src/utils/gmailService.ts
+++ b/src/src/utils/gmailService.ts
@@ -208,6 +208,7 @@ export const sendComposedEmail = async ({
   threadId,
   userEmail,
   userName,
+  attachments,
 }: {
   to: string
   cc?: string
@@ -216,6 +217,12 @@ export const sendComposedEmail = async ({
   threadId?: string
   userEmail: string
   userName?: string
+  attachments?: Array<{
+    filename: string
+    mimeType: string
+    content: string
+    encoding?: 'utf8' | 'base64'
+  }>
 }): Promise<void> => {
   try {
     await invoke('kn_send_composed_email', {
@@ -226,6 +233,7 @@ export const sendComposedEmail = async ({
       thread_id: threadId,
       user_email: userEmail,
       user_name: userName,
+      attachments,
     })
   } catch (error) {
     const message =

--- a/src/src/utils/supportDiagnostics.ts
+++ b/src/src/utils/supportDiagnostics.ts
@@ -1,0 +1,166 @@
+import { invoke } from '@tauri-apps/api/tauri'
+
+import { getAppVersion, getOSInfoString } from 'src/utils/app'
+import { KN_SERVER_HOST } from 'src/utils/constants'
+import type { ComposedEmailAttachment, ComposedEmailDraft } from 'src/hooks/feed/useFeed'
+
+type DiagnosticJson = Record<string, unknown> | null
+
+function redactSensitiveText(input: string): string {
+  return input
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[redacted-email]')
+    .replace(/(authorization["'=:\s]+bearer\s+)[A-Za-z0-9._\-+/=]+/gi, '$1[redacted-token]')
+    .replace(/((?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token)["'=:\s]+)([^"',\s}]+)/gi, '$1[redacted-secret]')
+    .replace(/\b(sk|rk|pk|ghp|xoxb|xoxp|xoxa|xapp)-[A-Za-z0-9._\-]{8,}\b/g, '[redacted-secret]')
+}
+
+function sanitizeLines(lines: string[]): string[] {
+  return lines
+    .map(line => redactSensitiveText(line))
+    .map(line => (line.length > 600 ? `${line.slice(0, 600)}…` : line))
+}
+
+async function safeJsonFetch(path: string, timeoutMs = 5000): Promise<DiagnosticJson> {
+  const controller = new AbortController()
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(`${KN_SERVER_HOST}${path}`, { signal: controller.signal })
+    if (!res.ok) {
+      return { ok: false, status: res.status, statusText: res.statusText }
+    }
+    const data = await res.json()
+    return JSON.parse(redactSensitiveText(JSON.stringify(data, null, 2)))
+  } catch (error: any) {
+    return { ok: false, error: error?.message || String(error) }
+  } finally {
+    window.clearTimeout(timer)
+  }
+}
+
+function buildDiagnosticText(params: {
+  issueSummary: string
+  activeModel: string
+  appVersion: string
+  osInfo: string
+  openclawVersion: string
+  generatedAt: string
+  errorLines: string[]
+  gatewayErrLines: string[]
+  gatewayOutLines: string[]
+  health: DiagnosticJson
+  status: DiagnosticJson
+  channels: DiagnosticJson
+}): string {
+  const {
+    issueSummary,
+    activeModel,
+    appVersion,
+    osInfo,
+    openclawVersion,
+    generatedAt,
+    errorLines,
+    gatewayErrLines,
+    gatewayOutLines,
+    health,
+    status,
+    channels,
+  } = params
+
+  return [
+    'Knapsack sanitized diagnostics bundle',
+    `Generated at: ${generatedAt}`,
+    `App version: ${appVersion}`,
+    `OpenClaw version: ${openclawVersion}`,
+    `OS: ${osInfo}`,
+    `Active model: ${activeModel || 'unknown'}`,
+    '',
+    'Issue summary:',
+    issueSummary,
+    '',
+    'Service health:',
+    JSON.stringify(health, null, 2),
+    '',
+    'Service status:',
+    JSON.stringify(status, null, 2),
+    '',
+    'Channel diagnostics:',
+    JSON.stringify(channels, null, 2),
+    '',
+    'Recent app error log lines:',
+    ...(errorLines.length > 0 ? errorLines : ['<none>']),
+    '',
+    'Recent gateway stderr log lines:',
+    ...(gatewayErrLines.length > 0 ? gatewayErrLines : ['<none>']),
+    '',
+    'Recent gateway stdout log lines:',
+    ...(gatewayOutLines.length > 0 ? gatewayOutLines : ['<none>']),
+    '',
+    'Privacy note:',
+    'This bundle is sanitized to exclude chat bodies, email bodies, document content, transcripts, and obvious secrets/tokens.',
+  ].join('\n')
+}
+
+export async function buildSupportDiagnosticsDraft(params: {
+  issueSummary: string
+  activeModel: string
+}): Promise<ComposedEmailDraft> {
+  const generatedAt = new Date().toISOString()
+  const [
+    appVersion,
+    osInfo,
+    openclawVersion,
+    errorLines,
+    gatewayErrLines,
+    gatewayOutLines,
+    health,
+    status,
+    channels,
+  ] = await Promise.all([
+    getAppVersion(),
+    getOSInfoString(),
+    invoke<string>('kn_get_openclaw_version').catch(() => 'unknown'),
+    invoke<string[]>('kn_read_logs', { logType: 'error', maxLines: 120 }).catch(() => []),
+    invoke<string[]>('kn_read_logs', { logType: 'clawdbot_err', maxLines: 120 }).catch(() => []),
+    invoke<string[]>('kn_read_logs', { logType: 'clawdbot_out', maxLines: 80 }).catch(() => []),
+    safeJsonFetch('/api/clawd/service/health'),
+    safeJsonFetch('/api/clawd/service/status'),
+    safeJsonFetch('/api/clawd/channels/diagnostics'),
+  ])
+
+  const sanitizedIssueSummary = redactSensitiveText(
+    params.issueSummary.replace(/\[Share diagnostics with Knapsack Support\]\(knapsack:\/\/prompt\/__share_support_diagnostics__\)/g, ''),
+  ).slice(0, 1200)
+  const attachmentText = buildDiagnosticText({
+    issueSummary: sanitizedIssueSummary,
+    activeModel: params.activeModel,
+    appVersion,
+    osInfo,
+    openclawVersion,
+    generatedAt,
+    errorLines: sanitizeLines(errorLines),
+    gatewayErrLines: sanitizeLines(gatewayErrLines),
+    gatewayOutLines: sanitizeLines(gatewayOutLines),
+    health,
+    status,
+    channels,
+  })
+
+  const attachment: ComposedEmailAttachment = {
+    filename: `knapsack-diagnostics-${generatedAt.replace(/:/g, '-')}.txt`,
+    mimeType: 'text/plain',
+    content: attachmentText,
+    encoding: 'utf8',
+  }
+
+  return {
+    to: 'support@knap.ai',
+    subject: `Knapsack diagnostics: ${params.activeModel || 'unknown-model'} - ${generatedAt.slice(0, 10)}`,
+    body: [
+      '<p>Hi Knapsack Support,</p>',
+      '<p>I ran into an issue in Knapsack and am sharing the attached sanitized diagnostics bundle for troubleshooting.</p>',
+      `<p><strong>Issue summary:</strong> ${sanitizedIssueSummary}</p>`,
+      '<p>Thank you.</p>',
+    ].join(''),
+    attachments: [attachment],
+  }
+}


### PR DESCRIPTION
## Summary
- add an inline chat action that drafts a support email when Knapsack surfaces a friendly error
- reuse the existing compose drawer and extend composed emails to support attachments
- attach a sanitized diagnostics bundle with recent logs and readiness snapshots for support@knap.ai

## Validation
- PATH="/Users/markheynen/knapsack_desktop/src/node_modules/.bin:$PATH" pnpm -C src exec tsc --noEmit
- cargo check --manifest-path src/src-tauri/Cargo.toml