### PR TITLE
[codex] add slack option to onboarding

### DIFF
--- a/src/src/api/channels.ts
+++ b/src/src/api/channels.ts
@@ -1,6 +1,9 @@
+import { getApiToken } from 'src/api/connections'
+
 /** API helpers for messaging channel endpoints (WhatsApp, iMessage). */
 
 const API_BASE = 'http://127.0.0.1:8897'
+const REMOTE_API_BASE = import.meta.env.VITE_KN_API_SERVER || 'https://api.knapsack.ai'
 const WHATSAPP_BUNDLED = false
 
 export interface ChannelStatus {
@@ -57,6 +60,31 @@ async function post<T>(path: string, body?: unknown, timeoutMs = 30_000): Promis
   } finally {
     clearTimeout(timer)
   }
+}
+
+async function remoteRequest<T>(
+  userEmail: string,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const token = await getApiToken(userEmail)
+  const headers = new Headers(init?.headers || {})
+  if (!headers.has('Content-Type') && init?.body !== undefined) {
+    headers.set('Content-Type', 'application/json')
+  }
+  headers.set('Authorization', `Bearer ${token}`)
+
+  const res = await fetch(`${REMOTE_API_BASE}${path}`, {
+    ...init,
+    headers,
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(text || `HTTP ${res.status}`)
+  }
+
+  return (await res.json()) as T
 }
 
 // ── WhatsApp ─────────────────────────────────────────────────
@@ -257,6 +285,58 @@ export interface SendMessageResponse {
 /** Send a message to a user through a connected channel (WhatsApp, iMessage, or Telegram). */
 export const sendChannelMessage = (channel: string, to: string, message: string) =>
   post<SendMessageResponse>('/api/clawd/channels/send', { channel, to, message })
+
+// ── Hosted Slack OAuth (web backend) ───────────────────────
+
+export interface HostedSlackInstallSessionResponse {
+  session_id: string
+  authorize_url: string
+  expires_in: number
+  onboarding_recommended_default_employees?: Array<Record<string, string>>
+}
+
+export interface HostedSlackInstallRedeemResponse {
+  status: string
+  linked: boolean
+  slack_team_id?: string | null
+  slack_team_name?: string | null
+  slack_user_id?: string | null
+  slack_dm_channel_id?: string | null
+  slack_bot_name?: string | null
+  granted_scopes?: string[]
+  onboarding_recommended_default_employees?: Array<Record<string, string>>
+  error?: string | null
+}
+
+export interface HostedLinkStatusResponse {
+  linked: boolean
+  display_label?: string | null
+  external_chat_id?: string | null
+}
+
+export const createHostedSlackInstallSession = (userEmail: string) =>
+  remoteRequest<HostedSlackInstallSessionResponse>(
+    userEmail,
+    '/api/messaging/channels/slack/install-sessions',
+    { method: 'POST', body: JSON.stringify({}) },
+  )
+
+export const redeemHostedSlackInstallSession = (userEmail: string, sessionId: string) =>
+  remoteRequest<HostedSlackInstallRedeemResponse>(
+    userEmail,
+    `/api/messaging/channels/slack/install-sessions/${encodeURIComponent(sessionId)}`,
+    { method: 'GET' },
+  )
+
+export const getHostedSlackLinkStatus = (userEmail: string) =>
+  remoteRequest<HostedLinkStatusResponse>(userEmail, '/api/messaging/channels/slack/link/status', {
+    method: 'GET',
+  })
+
+export const disconnectHostedSlackLink = (userEmail: string) =>
+  remoteRequest<{ ok?: boolean }>(userEmail, '/api/messaging/channels/slack/link', {
+    method: 'DELETE',
+  })
 
 // ── Allowlist Management ─────────────────────────────────────
 

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -6577,7 +6577,7 @@ ${actualText}`
                   </div>
                   {!channelStatus.genericChannels.slack?.configured && (
                     <div className="ClawdChannelGuide">
-                      <div className="ClawdChannelGuideTitle">Connect Slack</div>
+                      <div className="ClawdChannelGuideTitle">Connect Scout on Slack</div>
                       <div style={{ fontSize: 12, color: '#64748b', marginBottom: 8 }}>
                         Slack requires both a <strong>Bot Token</strong> and an <strong>App-Level Token</strong>.
                       </div>
@@ -6587,11 +6587,11 @@ ${actualText}`
                           type="button"
                           onClick={() => handleSendWithText(SLACK_GUIDED_SETUP_PROMPT)}
                         >
-                          Set up Slack with Knapsack
+                          Set up Scout with Knapsack
                         </button>
                       </div>
                       <div className="ClawdChannelGuideNote ClawdChannelGuideNote--compact">
-                        Knapsack will open the Slack app setup flow in your browser, apply the required App Home, Messages tab, Socket Mode, and scope settings, and then bring back the tokens you need.
+                        Knapsack will open the Slack app setup flow in your browser, apply the required App Home, Messages tab, Socket Mode, and scope settings, and then bring back the tokens you need. If you later connect Scout to Gmail, Calendar, or Drive, we recommend dedicated Scout accounts instead of your personal accounts.
                       </div>
                       {(() => {
                         const botTrimmed = slackBotToken.trim()

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -5,10 +5,11 @@ import cn from 'classnames'
 
 import {
   configureAgentBot,
-  configureGenericChannel,
-  disconnectGenericChannel,
+  createHostedSlackInstallSession,
+  disconnectHostedSlackLink,
   getAgentBotStatuses,
-  getGenericChannelStatus,
+  getHostedSlackLinkStatus,
+  redeemHostedSlackInstallSession,
 } from 'src/api/channels'
 
 import styles from './styles.module.scss'
@@ -27,16 +28,24 @@ function defaultBotState(): BotState {
   return { phase: 'idle', username: '', errorMessage: '' }
 }
 
-type SlackPhase = 'idle' | 'entering_tokens' | 'connecting' | 'done' | 'skipped' | 'error'
+type SlackPhase = 'idle' | 'starting' | 'waiting' | 'done' | 'skipped' | 'error'
 
 interface SlackState {
   phase: SlackPhase
   workspaceLabel: string
   errorMessage: string
+  sessionId?: string
+  botLabel?: string
 }
 
 function defaultSlackState(): SlackState {
-  return { phase: 'idle', workspaceLabel: '', errorMessage: '' }
+  return {
+    phase: 'idle',
+    workspaceLabel: '',
+    errorMessage: '',
+    sessionId: undefined,
+    botLabel: '',
+  }
 }
 
 export interface AgentTelegramEntry {
@@ -53,6 +62,8 @@ export type TelegramAccountsScreenProps = {
   agents: AgentTelegramEntry[]
   /** Derived from the user's email/profile to generate unique bot usernames. */
   userSlug?: string
+  /** Signed-in account email used for hosted Slack OAuth. */
+  accountEmail?: string | null
   onComplete: (index: number) => void
   onSkip: (index: number) => void
 }
@@ -95,73 +106,108 @@ function CopyButton({ text }: { text: string }) {
 function SlackWorkspaceCard({
   state,
   onChange,
+  accountEmail,
 }: {
   state: SlackState
   onChange: (patch: Partial<SlackState>) => void
+  accountEmail?: string
 }) {
-  const [botTokenInput, setBotTokenInput] = useState('')
-  const [appTokenInput, setAppTokenInput] = useState('')
-
   const handleSetUp = async () => {
-    onChange({ phase: 'entering_tokens', errorMessage: '' })
-    try {
-      await openUrl('https://api.slack.com/apps')
-    } catch {
-      /* ignore */
-    }
-  }
-
-  const handleConnect = async () => {
-    const botToken = botTokenInput.trim()
-    const appToken = appTokenInput.trim()
-    if (!botToken || !appToken) return
-
-    onChange({ phase: 'connecting', errorMessage: '' })
-    try {
-      const resp = await configureGenericChannel('slack', { botToken, appToken })
-      if (!resp.success) {
-        onChange({
-          phase: 'entering_tokens',
-          errorMessage: resp.message ?? 'Slack connection failed - check both tokens and try again.',
-        })
-        return
-      }
-
-      const status = await getGenericChannelStatus('slack').catch(() => null)
+    if (!accountEmail) {
       onChange({
-        phase: 'done',
-        workspaceLabel: status?.account ?? 'Slack workspace connected',
-        errorMessage: '',
+        phase: 'error',
+        errorMessage: 'Connect Google or Microsoft first so Knapsack can link Slack to your account.',
       })
-      setBotTokenInput('')
-      setAppTokenInput('')
+      return
+    }
+
+    onChange({ phase: 'starting', errorMessage: '', sessionId: undefined })
+    try {
+      const session = await createHostedSlackInstallSession(accountEmail)
+      onChange({
+        phase: 'waiting',
+        errorMessage: '',
+        sessionId: session.session_id,
+      })
+      await openUrl(session.authorize_url)
     } catch {
       onChange({
-        phase: 'entering_tokens',
-        errorMessage: 'Slack connection failed - check both tokens and try again.',
+        phase: 'error',
+        errorMessage: 'Could not start Slack setup right now. Please try again.',
+        sessionId: undefined,
       })
     }
   }
 
   const handleDisconnect = async () => {
+    if (!accountEmail) return
     onChange({ errorMessage: '' })
     try {
-      await disconnectGenericChannel('slack')
-      onChange({ phase: 'idle', workspaceLabel: '', errorMessage: '' })
+      await disconnectHostedSlackLink(accountEmail)
+      onChange({
+        phase: 'idle',
+        workspaceLabel: '',
+        errorMessage: '',
+        sessionId: undefined,
+        botLabel: '',
+      })
     } catch {
       onChange({ errorMessage: 'Could not disconnect Slack right now.' })
     }
   }
 
-  const botTrimmed = botTokenInput.trim()
-  const appTrimmed = appTokenInput.trim()
-  const botValid = !botTrimmed || botTrimmed.startsWith('xoxb-')
-  const appValid = !appTrimmed || appTrimmed.startsWith('xapp-')
-  const canConnect = !!botTrimmed && !!appTrimmed && botValid && appValid
   const isDone = state.phase === 'done'
-  const isEntering = state.phase === 'entering_tokens'
-  const isConnecting = state.phase === 'connecting'
+  const isStarting = state.phase === 'starting'
+  const isWaiting = state.phase === 'waiting'
   const isSkipped = state.phase === 'skipped'
+
+  useEffect(() => {
+    if (!accountEmail || state.phase !== 'waiting' || !state.sessionId) return
+
+    let cancelled = false
+    const poll = async () => {
+      try {
+        const status = await redeemHostedSlackInstallSession(accountEmail, state.sessionId!)
+        if (cancelled) return
+
+        if (status.linked || status.status === 'complete') {
+          onChange({
+            phase: 'done',
+            workspaceLabel: status.slack_team_name ?? 'Slack workspace connected',
+            botLabel: status.slack_bot_name ?? 'Slack bot ready',
+            errorMessage: '',
+            sessionId: undefined,
+          })
+          return
+        }
+
+        if (status.status === 'error') {
+          onChange({
+            phase: 'error',
+            errorMessage: status.error || 'Slack setup did not complete. Please try again.',
+            sessionId: undefined,
+          })
+        }
+      } catch (error: any) {
+        if (cancelled) return
+        const message = String(error?.message || '')
+        if (message.includes('404')) {
+          onChange({
+            phase: 'error',
+            errorMessage: 'This Slack setup link expired. Start again from Knapsack.',
+            sessionId: undefined,
+          })
+        }
+      }
+    }
+
+    poll()
+    const id = setInterval(poll, 2000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [accountEmail, onChange, state.phase, state.sessionId])
 
   return (
     <div
@@ -202,7 +248,7 @@ function SlackWorkspaceCard({
               onClick={handleSetUp}
               className="text-sm text-[#913631] font-medium hover:underline font-InterTight whitespace-nowrap"
             >
-              Set up -&gt;
+              Connect in Slack -&gt;
             </button>
           )}
 
@@ -215,14 +261,10 @@ function SlackWorkspaceCard({
             </button>
           )}
 
-          {(isEntering || isConnecting) && (
+          {(isStarting || isWaiting) && (
             <button
               className="text-xs text-gray-400 hover:text-gray-600 underline font-InterTight"
-              onClick={() => {
-                setBotTokenInput('')
-                setAppTokenInput('')
-                onChange({ phase: 'skipped', errorMessage: '' })
-              }}
+              onClick={() => onChange({ phase: 'skipped', errorMessage: '', sessionId: undefined })}
             >
               Skip
             </button>
@@ -239,65 +281,47 @@ function SlackWorkspaceCard({
         </div>
       </div>
 
-      {(isEntering || isConnecting) && (
+      {(isStarting || isWaiting) && (
         <div className="mt-3 space-y-3">
           <div className="bg-gray-50 rounded-xl p-3 space-y-2.5">
             <p className="text-xs font-medium text-gray-600 font-InterTight">
-              Create a Slack app at <span className="font-semibold">api.slack.com/apps</span>, then paste:
+              We&apos;ll open Slack in your browser so you can install the workspace app and come
+              right back here when you&apos;re done.
             </p>
             <ul className="list-disc pl-5 text-xs text-gray-500 font-InterTight space-y-1">
-              <li>Bot token from OAuth &amp; Permissions (<span className="font-mono">xoxb-...</span>)</li>
-              <li>App-level token with <span className="font-mono">connections:write</span> (<span className="font-mono">xapp-...</span>)</li>
+              <li>Approve the Slack install in your browser</li>
+              <li>Return to Knapsack Desktop after Slack says the connection is complete</li>
             </ul>
           </div>
 
-          <div>
-            <p className="text-xs text-gray-500 font-InterTight mb-1.5">
-              Paste both Slack tokens:
+          <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2">
+            <p className="text-xs text-gray-500 font-InterTight">
+              {isStarting ? 'Opening Slack install...' : 'Waiting for Slack approval...'}
             </p>
-            {state.errorMessage && (
-              <p className="text-xs text-red-500 font-InterTight mb-1.5">{state.errorMessage}</p>
-            )}
-            <div className="space-y-2">
-              <input
-                type="text"
-                placeholder="Bot token (xoxb-...)"
-                value={botTokenInput}
-                onChange={e => setBotTokenInput(e.target.value)}
-                disabled={isConnecting}
-                className={cn(
-                  'w-full text-xs border rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50',
-                  botTrimmed && !botValid ? 'border-red-400' : 'border-gray-200',
-                )}
-              />
-              {botTrimmed && !botValid && (
-                <p className="text-xs text-red-500 font-InterTight">Bot token must start with <code>xoxb-</code>.</p>
-              )}
-              <input
-                type="text"
-                placeholder="App token (xapp-...)"
-                value={appTokenInput}
-                onChange={e => setAppTokenInput(e.target.value)}
-                disabled={isConnecting}
-                className={cn(
-                  'w-full text-xs border rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50',
-                  appTrimmed && !appValid ? 'border-red-400' : 'border-gray-200',
-                )}
-              />
-              {appTrimmed && !appValid && (
-                <p className="text-xs text-red-500 font-InterTight">App token must start with <code>xapp-</code>.</p>
-              )}
-              <div className="flex justify-end">
-                <button
-                  onClick={handleConnect}
-                  disabled={isConnecting || !canConnect}
-                  className="text-xs font-medium font-InterTight px-3 py-2 rounded-lg bg-[#913631] text-white hover:bg-[#7a2d29] disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
-                >
-                  {isConnecting ? 'Connecting...' : 'Connect Slack'}
-                </button>
-              </div>
-            </div>
+            <button
+              onClick={handleSetUp}
+              disabled={isStarting}
+              className="text-xs font-medium font-InterTight px-3 py-1.5 rounded-lg bg-[#913631] text-white hover:bg-[#7a2d29] disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+            >
+              Open Slack
+            </button>
           </div>
+        </div>
+      )}
+
+      {isDone && state.botLabel && (
+        <p className="mt-3 text-xs text-green-700 font-InterTight">{state.botLabel}</p>
+      )}
+
+      {state.phase === 'error' && (
+        <div className="mt-3 flex items-center justify-between rounded-xl border border-red-200 bg-red-50 px-3 py-2">
+          <p className="text-xs text-red-600 font-InterTight">{state.errorMessage}</p>
+          <button
+            onClick={handleSetUp}
+            className="text-xs font-medium font-InterTight text-[#913631] hover:underline whitespace-nowrap"
+          >
+            Try again
+          </button>
         </div>
       )}
     </div>
@@ -480,6 +504,7 @@ export function TelegramAccountsScreen({
   currentSlideOutScreen,
   agents,
   userSlug = 'user',
+  accountEmail,
   onComplete,
   onSkip,
 }: TelegramAccountsScreenProps) {
@@ -507,17 +532,20 @@ export function TelegramAccountsScreen({
   useEffect(() => {
     if (currentSlideInScreen === index && !loaded.current) {
       loaded.current = true
-      getGenericChannelStatus('slack')
-        .then(status => {
-          if (status?.configured) {
-            setSlackState({
-              phase: 'done',
-              workspaceLabel: status.account ?? 'Slack workspace connected',
-              errorMessage: '',
-            })
-          }
-        })
-        .catch(() => {}) // non-fatal
+      if (accountEmail) {
+        getHostedSlackLinkStatus(accountEmail)
+          .then(status => {
+            if (status?.linked) {
+              setSlackState({
+                phase: 'done',
+                workspaceLabel: status.display_label ?? 'Slack workspace connected',
+                errorMessage: '',
+                botLabel: '',
+              })
+            }
+          })
+          .catch(() => {}) // non-fatal
+      }
 
       getAgentBotStatuses()
         .then(statuses => {
@@ -578,6 +606,7 @@ export function TelegramAccountsScreen({
       <div className="w-full space-y-3 max-h-[55vh] overflow-y-auto pr-1">
         <SlackWorkspaceCard
           state={slackState}
+          accountEmail={accountEmail ?? undefined}
           onChange={patch => setSlackState(prev => ({ ...prev, ...patch }))}
         />
 

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -226,7 +226,7 @@ function SlackWorkspaceCard({
             </svg>
           </div>
           <div>
-            <p className="text-sm font-semibold text-gray-900 font-InterTight">Slack workspace</p>
+            <p className="text-sm font-semibold text-gray-900 font-InterTight">📋 Scout on Slack</p>
             <p className="text-xs text-gray-400 font-InterTight">
               Most teams start here instead of creating individual Telegram bots.
             </p>
@@ -248,7 +248,7 @@ function SlackWorkspaceCard({
               onClick={handleSetUp}
               className="text-sm text-[#913631] font-medium hover:underline font-InterTight whitespace-nowrap"
             >
-              Connect in Slack -&gt;
+              Set up Scout -&gt;
             </button>
           )}
 
@@ -596,10 +596,10 @@ export function TelegramAccountsScreen({
           Give your team a voice
         </h2>
         <p className="mt-3 text-gray-500 text-base font-InterTight leading-relaxed">
-          Most teams choose one place to start. Connect Slack for your workspace,
-          or set up Telegram bots for individual agents. Click{' '}
-          <span className="font-medium text-gray-700">Set up -&gt;</span> and
-          we&apos;ll walk you through whichever path you pick.
+          Most teams choose one place to start. Set up Scout in Slack for your
+          workspace, or set up Telegram bots for individual agents. If you later
+          connect Gmail, Calendar, or Drive for Scout, we recommend using
+          dedicated Scout accounts instead of your personal inbox or calendar.
         </p>
       </div>
 

--- a/src/src/pages/onboarding/TelegramAccountsScreen.tsx
+++ b/src/src/pages/onboarding/TelegramAccountsScreen.tsx
@@ -5,7 +5,10 @@ import cn from 'classnames'
 
 import {
   configureAgentBot,
+  configureGenericChannel,
+  disconnectGenericChannel,
   getAgentBotStatuses,
+  getGenericChannelStatus,
 } from 'src/api/channels'
 
 import styles from './styles.module.scss'
@@ -22,6 +25,18 @@ interface BotState {
 
 function defaultBotState(): BotState {
   return { phase: 'idle', username: '', errorMessage: '' }
+}
+
+type SlackPhase = 'idle' | 'entering_tokens' | 'connecting' | 'done' | 'skipped' | 'error'
+
+interface SlackState {
+  phase: SlackPhase
+  workspaceLabel: string
+  errorMessage: string
+}
+
+function defaultSlackState(): SlackState {
+  return { phase: 'idle', workspaceLabel: '', errorMessage: '' }
 }
 
 export interface AgentTelegramEntry {
@@ -74,6 +89,218 @@ function CopyButton({ text }: { text: string }) {
     >
       {copied ? '✓ Copied' : 'Copy'}
     </button>
+  )
+}
+
+function SlackWorkspaceCard({
+  state,
+  onChange,
+}: {
+  state: SlackState
+  onChange: (patch: Partial<SlackState>) => void
+}) {
+  const [botTokenInput, setBotTokenInput] = useState('')
+  const [appTokenInput, setAppTokenInput] = useState('')
+
+  const handleSetUp = async () => {
+    onChange({ phase: 'entering_tokens', errorMessage: '' })
+    try {
+      await openUrl('https://api.slack.com/apps')
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const handleConnect = async () => {
+    const botToken = botTokenInput.trim()
+    const appToken = appTokenInput.trim()
+    if (!botToken || !appToken) return
+
+    onChange({ phase: 'connecting', errorMessage: '' })
+    try {
+      const resp = await configureGenericChannel('slack', { botToken, appToken })
+      if (!resp.success) {
+        onChange({
+          phase: 'entering_tokens',
+          errorMessage: resp.message ?? 'Slack connection failed - check both tokens and try again.',
+        })
+        return
+      }
+
+      const status = await getGenericChannelStatus('slack').catch(() => null)
+      onChange({
+        phase: 'done',
+        workspaceLabel: status?.account ?? 'Slack workspace connected',
+        errorMessage: '',
+      })
+      setBotTokenInput('')
+      setAppTokenInput('')
+    } catch {
+      onChange({
+        phase: 'entering_tokens',
+        errorMessage: 'Slack connection failed - check both tokens and try again.',
+      })
+    }
+  }
+
+  const handleDisconnect = async () => {
+    onChange({ errorMessage: '' })
+    try {
+      await disconnectGenericChannel('slack')
+      onChange({ phase: 'idle', workspaceLabel: '', errorMessage: '' })
+    } catch {
+      onChange({ errorMessage: 'Could not disconnect Slack right now.' })
+    }
+  }
+
+  const botTrimmed = botTokenInput.trim()
+  const appTrimmed = appTokenInput.trim()
+  const botValid = !botTrimmed || botTrimmed.startsWith('xoxb-')
+  const appValid = !appTrimmed || appTrimmed.startsWith('xapp-')
+  const canConnect = !!botTrimmed && !!appTrimmed && botValid && appValid
+  const isDone = state.phase === 'done'
+  const isEntering = state.phase === 'entering_tokens'
+  const isConnecting = state.phase === 'connecting'
+  const isSkipped = state.phase === 'skipped'
+
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4 transition-all',
+        isDone && 'border-green-400 bg-green-50',
+        isSkipped && 'opacity-50 border-gray-200 bg-white',
+        !isDone && !isSkipped && 'border-gray-200 bg-white',
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#f4f4f5] text-[#611f69]">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
+            </svg>
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-gray-900 font-InterTight">Slack workspace</p>
+            <p className="text-xs text-gray-400 font-InterTight">
+              Most teams start here instead of creating individual Telegram bots.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {isDone && (
+            <span className="text-green-600 text-xs font-medium font-InterTight flex items-center gap-1">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              {state.workspaceLabel || 'Connected'}
+            </span>
+          )}
+
+          {state.phase === 'idle' && (
+            <button
+              onClick={handleSetUp}
+              className="text-sm text-[#913631] font-medium hover:underline font-InterTight whitespace-nowrap"
+            >
+              Set up -&gt;
+            </button>
+          )}
+
+          {isDone && (
+            <button
+              className="text-xs text-gray-500 hover:text-gray-700 underline font-InterTight"
+              onClick={handleDisconnect}
+            >
+              Disconnect
+            </button>
+          )}
+
+          {(isEntering || isConnecting) && (
+            <button
+              className="text-xs text-gray-400 hover:text-gray-600 underline font-InterTight"
+              onClick={() => {
+                setBotTokenInput('')
+                setAppTokenInput('')
+                onChange({ phase: 'skipped', errorMessage: '' })
+              }}
+            >
+              Skip
+            </button>
+          )}
+
+          {isSkipped && (
+            <button
+              className="text-xs text-gray-400 hover:text-gray-600 underline font-InterTight"
+              onClick={() => onChange({ phase: 'idle', errorMessage: '' })}
+            >
+              Undo
+            </button>
+          )}
+        </div>
+      </div>
+
+      {(isEntering || isConnecting) && (
+        <div className="mt-3 space-y-3">
+          <div className="bg-gray-50 rounded-xl p-3 space-y-2.5">
+            <p className="text-xs font-medium text-gray-600 font-InterTight">
+              Create a Slack app at <span className="font-semibold">api.slack.com/apps</span>, then paste:
+            </p>
+            <ul className="list-disc pl-5 text-xs text-gray-500 font-InterTight space-y-1">
+              <li>Bot token from OAuth &amp; Permissions (<span className="font-mono">xoxb-...</span>)</li>
+              <li>App-level token with <span className="font-mono">connections:write</span> (<span className="font-mono">xapp-...</span>)</li>
+            </ul>
+          </div>
+
+          <div>
+            <p className="text-xs text-gray-500 font-InterTight mb-1.5">
+              Paste both Slack tokens:
+            </p>
+            {state.errorMessage && (
+              <p className="text-xs text-red-500 font-InterTight mb-1.5">{state.errorMessage}</p>
+            )}
+            <div className="space-y-2">
+              <input
+                type="text"
+                placeholder="Bot token (xoxb-...)"
+                value={botTokenInput}
+                onChange={e => setBotTokenInput(e.target.value)}
+                disabled={isConnecting}
+                className={cn(
+                  'w-full text-xs border rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50',
+                  botTrimmed && !botValid ? 'border-red-400' : 'border-gray-200',
+                )}
+              />
+              {botTrimmed && !botValid && (
+                <p className="text-xs text-red-500 font-InterTight">Bot token must start with <code>xoxb-</code>.</p>
+              )}
+              <input
+                type="text"
+                placeholder="App token (xapp-...)"
+                value={appTokenInput}
+                onChange={e => setAppTokenInput(e.target.value)}
+                disabled={isConnecting}
+                className={cn(
+                  'w-full text-xs border rounded-lg px-3 py-2 font-mono font-InterTight focus:outline-none focus:border-[#913631] disabled:opacity-50',
+                  appTrimmed && !appValid ? 'border-red-400' : 'border-gray-200',
+                )}
+              />
+              {appTrimmed && !appValid && (
+                <p className="text-xs text-red-500 font-InterTight">App token must start with <code>xapp-</code>.</p>
+              )}
+              <div className="flex justify-end">
+                <button
+                  onClick={handleConnect}
+                  disabled={isConnecting || !canConnect}
+                  className="text-xs font-medium font-InterTight px-3 py-2 rounded-lg bg-[#913631] text-white hover:bg-[#7a2d29] disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+                >
+                  {isConnecting ? 'Connecting...' : 'Connect Slack'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -259,6 +486,7 @@ export function TelegramAccountsScreen({
   // Chief of Staff is always the first row, not part of the agents array
   const [chiefState, setChiefState] = useState<BotState>(defaultBotState)
   const [agentStates, setAgentStates] = useState<BotState[]>(() => agents.map(() => defaultBotState()))
+  const [slackState, setSlackState] = useState<SlackState>(defaultSlackState)
 
   const updateAgent = useCallback(
     (i: number, patch: Partial<BotState>) =>
@@ -279,6 +507,18 @@ export function TelegramAccountsScreen({
   useEffect(() => {
     if (currentSlideInScreen === index && !loaded.current) {
       loaded.current = true
+      getGenericChannelStatus('slack')
+        .then(status => {
+          if (status?.configured) {
+            setSlackState({
+              phase: 'done',
+              workspaceLabel: status.account ?? 'Slack workspace connected',
+              errorMessage: '',
+            })
+          }
+        })
+        .catch(() => {}) // non-fatal
+
       getAgentBotStatuses()
         .then(statuses => {
           const byId = new Map(statuses.map(s => [s.agent_id, s]))
@@ -304,6 +544,7 @@ export function TelegramAccountsScreen({
   }, [currentSlideInScreen, index, agents])
 
   const doneCount =
+    (slackState.phase === 'done' ? 1 : 0) +
     (chiefState.phase === 'done' ? 1 : 0) +
     agentStates.filter(s => s.phase === 'done').length
 
@@ -327,13 +568,19 @@ export function TelegramAccountsScreen({
           Give your team a voice
         </h2>
         <p className="mt-3 text-gray-500 text-base font-InterTight leading-relaxed">
-          Each agent gets its own Telegram bot. Click{' '}
-          <span className="font-medium text-gray-700">Set up →</span> — we'll
-          open BotFather and show you exactly what to type. Takes about 30 seconds per bot.
+          Most teams choose one place to start. Connect Slack for your workspace,
+          or set up Telegram bots for individual agents. Click{' '}
+          <span className="font-medium text-gray-700">Set up -&gt;</span> and
+          we&apos;ll walk you through whichever path you pick.
         </p>
       </div>
 
       <div className="w-full space-y-3 max-h-[55vh] overflow-y-auto pr-1">
+        <SlackWorkspaceCard
+          state={slackState}
+          onChange={patch => setSlackState(prev => ({ ...prev, ...patch }))}
+        />
+
         {/* Chief of Staff — always first */}
         <AgentBotCard
           emoji="🎩"

--- a/src/src/pages/onboarding/index.tsx
+++ b/src/src/pages/onboarding/index.tsx
@@ -485,6 +485,7 @@ export const Onboarding = ({ updateProfile }: OnboardingProps) => {
       onAgentPickerSkip={handleAgentPickerSkip}
       activatedAgents={activatedAgents}
       userSlug={userEmail ? userEmail.split('@')[0].toLowerCase().replace(/[^a-z0-9]/g, '_').slice(0, 12) : 'user'}
+      accountEmail={userEmail}
       onTelegramAccountsComplete={handleTelegramAccountsComplete}
       onTelegramAccountsSkip={handleTelegramAccountsSkip}
       //onAudioGrantClick={onClickGrantAudioPermission}

--- a/src/src/pages/onboarding/template.tsx
+++ b/src/src/pages/onboarding/template.tsx
@@ -405,6 +405,7 @@ type OnboardingTemplateProps = {
   onAgentPickerSkip: (index: number) => void
   activatedAgents: AgentTelegramEntry[]
   userSlug: string
+  accountEmail?: string | null
   onTelegramAccountsComplete: (index: number) => void
   onTelegramAccountsSkip: (index: number) => void
   // onAudioGrantClick: (index: number) => void
@@ -432,6 +433,7 @@ export const OnboardingTemplate = ({
   onAgentPickerSkip,
   activatedAgents,
   userSlug,
+  accountEmail,
   onTelegramAccountsComplete,
   onTelegramAccountsSkip,
   // onAudioGrantClick,
@@ -493,6 +495,7 @@ export const OnboardingTemplate = ({
           index={5}
           agents={activatedAgents}
           userSlug={userSlug}
+          accountEmail={accountEmail}
           onComplete={onTelegramAccountsComplete}
           onSkip={onTelegramAccountsSkip}
         />


### PR DESCRIPTION
## What changed
- add a Slack workspace option to onboarding alongside the existing Telegram bot setup
- preload existing Slack connection status when the onboarding screen opens
- update the onboarding copy so it frames Slack and Telegram as two ways to start, with Slack as the more common team-first option

## Why
The current onboarding implies Telegram-first setup for every team. In practice, many teams will choose one messaging surface to start with, and Slack is often the simpler first step.

## User impact
New users can connect a Slack workspace directly from onboarding instead of discovering Slack later in settings. The screen now better matches how people actually choose to onboard messaging.

## Validation
- `tsc --noEmit -p /tmp/knapsack_slack_onboarding_pr/src/tsconfig.json` using the repo's installed frontend dependencies
