### PR TITLE
Harden provider failover reporting and email draft sender handoff

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -793,6 +793,30 @@ fn emit_fallback_event(app_handle: &tauri::AppHandle, from: &str, to: &str, reas
   );
 }
 
+fn summarize_provider_error(err: &str) -> String {
+  let flattened = err.split_whitespace().collect::<Vec<_>>().join(" ");
+  let trimmed = flattened.trim();
+  const MAX_LEN: usize = 240;
+  if trimmed.len() <= MAX_LEN {
+    trimmed.to_string()
+  } else {
+    format!("{}...", &trimmed[..MAX_LEN])
+  }
+}
+
+fn fallback_failure_message(
+  configured_fallback_count: usize,
+  attempted_fallback_count: usize,
+) -> String {
+  if configured_fallback_count == 0 {
+    "Your active provider failed and no backup providers are configured in Settings. Please try again in a moment, or add another provider in Settings for automatic failover.".to_string()
+  } else if attempted_fallback_count == 0 {
+    "Your active provider failed and no eligible backup provider could be attempted with your current Settings. Please try again in a moment, or adjust Settings to allow another provider for automatic failover.".to_string()
+  } else {
+    "All AI providers are currently unavailable. Your active provider failed and no fallback provider could handle the request. Please try again in a moment, or add another provider in Settings for automatic failover.".to_string()
+  }
+}
+
 fn parse_retry_after_secs(text: &str, attempt: u32) -> f64 {
   let lower = text.to_lowercase();
   for pattern in ["try again in ", "retry in ", "wait "] {
@@ -4314,6 +4338,7 @@ pub async fn chat(
           "subject": subject,
           "body": body_html,
           "threadId": thread_id,
+          "senderEmail": user_email,
         }),
       );
 
@@ -5699,6 +5724,9 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
             ("ollama", ollama_key),
           ];
           let mut fallback_resp = None;
+          let mut configured_fallbacks: Vec<String> = Vec::new();
+          let mut attempted_fallbacks: Vec<String> = Vec::new();
+          let mut failed_fallbacks: Vec<String> = Vec::new();
           for (fb_provider, fb_key_opt) in &fallbacks {
             if *fb_provider == current_provider.as_str() {
               continue;
@@ -5711,6 +5739,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
               continue;
             }
             if let Some(fb_key) = fb_key_opt {
+              configured_fallbacks.push((*fb_provider).to_string());
               let fb_model = match *fb_provider {
                 "knapsack" => knapsack_model(&app_handle),
                 "anthropic" => super::service::get_anthropic_model(&app_handle),
@@ -5725,6 +5754,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
                 "[clawd/chat] Trying fallback provider={} model={}",
                 fb_provider, fb_model
               );
+              attempted_fallbacks.push(format!("{}/{}", fb_provider, fb_model));
               match call_provider(
                 &app_handle,
                 fb_provider,
@@ -5747,6 +5777,12 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
                   break;
                 }
                 Err(fb_err) => {
+                  failed_fallbacks.push(format!(
+                    "{}/{}: {}",
+                    fb_provider,
+                    fb_model,
+                    summarize_provider_error(&fb_err.to_string())
+                  ));
                   eprintln!(
                     "[clawd/chat] Fallback {} also failed: {}",
                     fb_provider, fb_err
@@ -5758,9 +5794,61 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           match fallback_resp {
             Some(r) => r,
             None => {
-              return HttpResponse::Ok().json(
-                serde_json::json!({"ok": false, "message": format!("All AI providers are currently unavailable. Your active provider failed and no fallback provider could handle the request. Please try again in a moment, or add another provider in Settings for automatic failover.")}),
+              let failure_message =
+                fallback_failure_message(configured_fallbacks.len(), attempted_fallbacks.len());
+              sentry::with_scope(
+                |scope| {
+                  scope.set_tag("component", "clawd_chat");
+                  scope.set_tag("provider", current_provider.clone());
+                  scope.set_tag("model", current_model.clone());
+                  scope.set_tag("failure_type", "provider_failover_exhausted");
+                  scope.set_extra(
+                    "primary_error",
+                    sentry::protocol::Value::from(summarize_provider_error(&err_str)),
+                  );
+                  scope.set_extra(
+                    "configured_fallbacks",
+                    sentry::protocol::Value::from(
+                      configured_fallbacks
+                        .iter()
+                        .cloned()
+                        .map(sentry::protocol::Value::from)
+                        .collect::<Vec<_>>(),
+                    ),
+                  );
+                  scope.set_extra(
+                    "attempted_fallbacks",
+                    sentry::protocol::Value::from(
+                      attempted_fallbacks
+                        .iter()
+                        .cloned()
+                        .map(sentry::protocol::Value::from)
+                        .collect::<Vec<_>>(),
+                    ),
+                  );
+                  scope.set_extra(
+                    "failed_fallbacks",
+                    sentry::protocol::Value::from(
+                      failed_fallbacks
+                        .iter()
+                        .cloned()
+                        .map(sentry::protocol::Value::from)
+                        .collect::<Vec<_>>(),
+                    ),
+                  );
+                  scope.set_extra(
+                    "paid_fallback_disabled",
+                    sentry::protocol::Value::from(disable_paid),
+                  );
+                  sentry::capture_message(
+                    "[clawd/chat] provider failover exhausted",
+                    sentry::Level::Error,
+                  );
+                },
+                || {},
               );
+              return HttpResponse::Ok()
+                .json(serde_json::json!({"ok": false, "message": failure_message}));
             }
           }
         }
@@ -6538,7 +6626,7 @@ fn strip_html_tags(html: &str) -> String {
 mod tests {
   use super::{
     aggressively_compact_messages_for_provider, build_context_recovery_messages,
-    compact_messages_for_provider, is_context_window_error,
+    compact_messages_for_provider, fallback_failure_message, is_context_window_error,
     is_transient_or_internal_provider_error, provider_compaction_limits,
     provider_context_recovery_limits, should_attempt_fallback_for_provider_error,
   };
@@ -6725,6 +6813,19 @@ mod tests {
   }
 
   #[test]
+  fn fallback_failure_message_is_specific_when_no_backup_provider_exists() {
+    let message = fallback_failure_message(0, 0);
+    assert!(message.contains("no backup providers are configured"));
+    assert!(!message.contains("All AI providers are currently unavailable"));
+  }
+
+  #[test]
+  fn fallback_failure_message_uses_global_outage_copy_when_backups_were_attempted() {
+    let message = fallback_failure_message(2, 2);
+    assert!(message.contains("All AI providers are currently unavailable"));
+  }
+
+  #[test]
   fn trim_memory_notes_limits_count_and_total_size() {
     let notes = (0..10)
       .map(|idx| format!("note-{idx}: {}", "x".repeat(400)))
@@ -6733,7 +6834,9 @@ mod tests {
     let trimmed = super::trim_memory_notes(&notes);
 
     assert!(trimmed.len() <= 6);
-    assert!(trimmed.iter().all(|note: &String| note.chars().count() <= 240));
+    assert!(trimmed
+      .iter()
+      .all(|note: &String| note.chars().count() <= 240));
     let total_chars: usize = trimmed
       .iter()
       .map(|note: &String| note.chars().count())

--- a/src/src/components/molecules/EmailComposeDrawer/index.tsx
+++ b/src/src/components/molecules/EmailComposeDrawer/index.tsx
@@ -24,6 +24,7 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
   const [sent, setSent] = useState(false)
   const [error, setError] = useState('')
   const attachments = draft.attachments ?? []
+  const senderEmail = draft.senderEmail?.trim() || userEmail.trim()
 
   // Set initial body HTML (can't combine contentEditable + dangerouslySetInnerHTML)
   useEffect(() => {
@@ -54,6 +55,10 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
   }, [ccInput, ccList, handleAddCc, handleRemoveCc])
 
   const handleSend = useCallback(async () => {
+    if (!senderEmail) {
+      setError('No connected sender email was found for this draft. Reconnect Gmail and try again.')
+      return
+    }
     setSending(true)
     setError('')
     try {
@@ -63,7 +68,7 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
         subject,
         body: bodyRef.current?.innerHTML || draft.body,
         threadId: draft.threadId,
-        userEmail,
+        userEmail: senderEmail,
         userName,
         attachments,
       })
@@ -74,7 +79,7 @@ const EmailComposeDrawer = ({ draft, userEmail, userName, onDismiss }: EmailComp
     } finally {
       setSending(false)
     }
-  }, [to, subject, ccList, draft, userEmail, userName, onDismiss])
+  }, [to, subject, ccList, draft, senderEmail, userName, onDismiss])
 
   const fieldRowStyle: React.CSSProperties = {
     display: 'flex',

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -2858,7 +2858,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
 
   // Check whether the currently selected model supports vision (image attachments)
   const currentModelSupportsVision = useCallback((): { supported: boolean; modelName: string; visionModels: string[] } => {
-    if (selectedProvider === 'knapsack') {
+    if (confirmedProvider === 'knapsack') {
       const currentId = selectedKnapsackModel || 'auto'
       return {
         supported: true,
@@ -2866,28 +2866,28 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         visionModels: [],
       }
     }
-    const allModels = selectedProvider === 'openai' ? OPENAI_MODELS
-      : selectedProvider === 'anthropic' ? ANTHROPIC_MODELS
-      : selectedProvider === 'gemini' ? GEMINI_MODELS
-      : selectedProvider === 'groq' ? GROQ_MODELS
-      : selectedProvider === 'xai' ? XAI_MODELS
-      : selectedProvider === 'openrouter' ? OPENROUTER_MODELS
+    const allModels = confirmedProvider === 'openai' ? OPENAI_MODELS
+      : confirmedProvider === 'anthropic' ? ANTHROPIC_MODELS
+      : confirmedProvider === 'gemini' ? GEMINI_MODELS
+      : confirmedProvider === 'groq' ? GROQ_MODELS
+      : confirmedProvider === 'xai' ? XAI_MODELS
+      : confirmedProvider === 'openrouter' ? OPENROUTER_MODELS
       : []
-    const currentId = selectedProvider === 'openai' ? selectedModel
-      : selectedProvider === 'anthropic' ? selectedAnthropicModel
-      : selectedProvider === 'gemini' ? selectedGeminiModel
-      : selectedProvider === 'groq' ? selectedGroqModel
-      : selectedProvider === 'xai' ? selectedXaiModel
-      : selectedProvider === 'openrouter' ? selectedOpenRouterModel
+    const currentId = confirmedProvider === 'openai' ? selectedModel
+      : confirmedProvider === 'anthropic' ? selectedAnthropicModel
+      : confirmedProvider === 'gemini' ? selectedGeminiModel
+      : confirmedProvider === 'groq' ? selectedGroqModel
+      : confirmedProvider === 'xai' ? selectedXaiModel
+      : confirmedProvider === 'openrouter' ? selectedOpenRouterModel
       : ''
     const current = allModels.find(m => m.id === currentId)
     // Ollama: we don't know model capabilities, assume supported
-    if (selectedProvider === 'ollama') return { supported: true, modelName: '', visionModels: [] }
+    if (confirmedProvider === 'ollama') return { supported: true, modelName: '', visionModels: [] }
     const modelName = current?.name || currentId
     const supported = current?.vision ?? false
     const visionModels = allModels.filter(m => m.vision).map(m => m.name)
     return { supported, modelName, visionModels }
-  }, [selectedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel])
+  }, [confirmedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel])
 
   // File upload handlers
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -3372,6 +3372,62 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     }
   }, [])
 
+  const syncProviderSelectionFromBackend = useCallback(async () => {
+    try {
+      const keyStatus = await apiGet<ApiKeyStatus>('/api/clawd/service/api-key-status')
+      const activeProvider = keyStatus.active_provider as Provider | undefined
+      if (activeProvider) {
+        setSelectedProvider(activeProvider)
+        setConfirmedProvider(activeProvider)
+        localStorage.setItem(ACTIVE_PROVIDER_STORAGE, activeProvider)
+      }
+
+      if (keyStatus.model && activeProvider) {
+        const backendModel = keyStatus.model
+        if (activeProvider === 'openai') {
+          const normalized = normalizeOpenAIModelSelection(backendModel)
+          setSelectedModel(normalized)
+          localStorage.setItem(OPENAI_MODEL_STORAGE, normalized)
+        } else if (activeProvider === 'anthropic') {
+          setSelectedAnthropicModel(backendModel)
+          localStorage.setItem(ANTHROPIC_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'gemini') {
+          setSelectedGeminiModel(backendModel)
+          localStorage.setItem(GEMINI_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'groq') {
+          setSelectedGroqModel(backendModel)
+          localStorage.setItem(GROQ_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'xai') {
+          setSelectedXaiModel(backendModel)
+          localStorage.setItem(XAI_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'openrouter') {
+          setSelectedOpenRouterModel(backendModel)
+          localStorage.setItem(OPENROUTER_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'ollama') {
+          setSelectedOllamaModel(backendModel)
+          localStorage.setItem(OLLAMA_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'knapsack') {
+          const normalizedKnapsackModel = KNAPSACK_MODELS.some(model => model.id === backendModel) ? backendModel : 'auto'
+          setSelectedKnapsackModel(normalizedKnapsackModel)
+          localStorage.setItem(KNAPSACK_MODEL_STORAGE, normalizedKnapsackModel)
+        }
+      }
+
+      if (keyStatus.ollama_enabled && keyStatus.ollama_model) {
+        setSelectedOllamaModel(keyStatus.ollama_model)
+        localStorage.setItem(OLLAMA_MODEL_STORAGE, keyStatus.ollama_model)
+      }
+
+      if (keyStatus.knapsack_model) {
+        const normalizedKnapsackModel = KNAPSACK_MODELS.some(model => model.id === keyStatus.knapsack_model) ? keyStatus.knapsack_model : 'auto'
+        setSelectedKnapsackModel(normalizedKnapsackModel)
+        localStorage.setItem(KNAPSACK_MODEL_STORAGE, normalizedKnapsackModel)
+      }
+    } catch {
+      // Keep the optimistic local selection if backend sync is temporarily unavailable.
+    }
+  }, [])
+
   // Ollama uses a separate save flow (ollama/configure endpoint, no API key)
   const saveOllamaProvider = useCallback(async () => {
     if (!selectedOllamaModel) return
@@ -3382,8 +3438,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         model: selectedOllamaModel,
       })
       localStorage.setItem(OLLAMA_MODEL_STORAGE, selectedOllamaModel)
+      setSelectedProvider('ollama')
       setConfirmedProvider('ollama')
       localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'ollama')
+      await syncProviderSelectionFromBackend()
       setShowKeyPrompt(false)
       setHasCompletedOnboarding(true)
       localStorage.setItem(ONBOARDING_VERSION_STORAGE, APP_VERSION)
@@ -3399,7 +3457,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [selectedOllamaModel])
+  }, [selectedOllamaModel, syncProviderSelectionFromBackend])
 
   const saveApiKey = useCallback(async () => {
     if (selectedProvider === 'ollama') { saveOllamaProvider(); return }
@@ -3437,8 +3495,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       } else if (selectedProvider === 'knapsack') {
         localStorage.setItem(KNAPSACK_MODEL_STORAGE, selectedKnapsackModel)
       }
+      setSelectedProvider(selectedProvider)
       setConfirmedProvider(selectedProvider)
       localStorage.setItem(ACTIVE_PROVIDER_STORAGE, selectedProvider)
+      await syncProviderSelectionFromBackend()
       setShowKeyPrompt(false)
       setEditingProviderKey(false)
       setHasCompletedOnboarding(true)
@@ -3479,7 +3539,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel, selectedOllamaModel, selectedProvider, saveOllamaProvider])
+  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel, selectedOllamaModel, selectedProvider, saveOllamaProvider, syncProviderSelectionFromBackend])
 
   // Switch to a provider that already has a saved key (no new key needed)
   const switchProviderModel = useCallback(async (providerId: Provider, alreadyActive = false) => {
@@ -3519,7 +3579,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(KNAPSACK_MODEL_STORAGE, selectedKnapsackModel)
       }
       setSelectedProvider(providerId)
+      setConfirmedProvider(providerId)
       localStorage.setItem(ACTIVE_PROVIDER_STORAGE, providerId)
+      await syncProviderSelectionFromBackend()
       setShowKeyPrompt(false)
       try {
         await apiPost('/api/clawd/service/enable', { enabled: true })
@@ -3549,7 +3611,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel])
+  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel, saveOllamaProvider, syncProviderSelectionFromBackend])
 
   useEffect(() => {
     const init = async () => {
@@ -4292,22 +4354,23 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     // Snapshot the active model label from React state at request time so error
     // messages reflect the model that was actually selected when sent, not the
     // model in localStorage (which can lag behind UI state changes).
+    const providerAtSend = confirmedProvider
     const activeModelAtSend = (() => {
-      if (selectedProvider === 'knapsack') return `knapsack/${selectedKnapsackModel}`
-      const m = selectedProvider === 'ollama'
+      if (providerAtSend === 'knapsack') return `knapsack/${selectedKnapsackModel}`
+      const m = providerAtSend === 'ollama'
         ? selectedOllamaModel
-        : selectedProvider === 'anthropic'
+        : providerAtSend === 'anthropic'
         ? selectedAnthropicModel
-        : selectedProvider === 'gemini'
+        : providerAtSend === 'gemini'
         ? selectedGeminiModel
-        : selectedProvider === 'groq'
+        : providerAtSend === 'groq'
         ? selectedGroqModel
-        : selectedProvider === 'xai'
+        : providerAtSend === 'xai'
         ? selectedXaiModel
-        : selectedProvider === 'openrouter'
+        : providerAtSend === 'openrouter'
         ? selectedOpenRouterModel
         : selectedModel
-      return m ? `${selectedProvider}/${m}` : selectedProvider
+      return m ? `${providerAtSend}/${m}` : providerAtSend
     })()
     const selectedModelForProvider = activeModelAtSend.includes('/')
       ? activeModelAtSend.split('/').slice(1).join('/')
@@ -4723,7 +4786,7 @@ ${actualText}`
 
         // Build request with optional attachments
         const requestBody: Record<string, any> = {
-          provider: selectedProvider,
+          provider: providerAtSend,
           model: selectedModelForProvider,
           text: actualText || 'Please analyze the attached files.',
           sessionId: 'ui',
@@ -4772,7 +4835,7 @@ ${actualText}`
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              provider: selectedProvider,
+              provider: providerAtSend,
               model: selectedModelForProvider,
               text: requestBody.text,
               advancedMode,
@@ -7406,6 +7469,7 @@ ${actualText}`
                                 setSelectedProvider('knapsack')
                                 setConfirmedProvider('knapsack')
                                 localStorage.setItem(ACTIVE_PROVIDER_STORAGE, 'knapsack')
+                                await syncProviderSelectionFromBackend()
                                 setSavedProviderKeys(prev => ({ ...prev, knapsack: true }))
                                 pushAssistant(`Switched to Knapsack (${KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel}).`)
                               } catch {}
@@ -7484,6 +7548,7 @@ ${actualText}`
                                   if (isConfirmedActive) {
                                     try {
                                       await apiPost('/api/clawd/service/set-api-key', { provider: p.id, model: newModel })
+                                      await syncProviderSelectionFromBackend()
                                       const modelName = models.find(m => m.id === newModel)?.name || newModel
                                       pushAssistant(`Switched to ${modelName}.`)
                                     } catch {}

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -4636,6 +4636,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         const isSmartPrompt = text === SMART_PROMPT
         const isBuildWebsitePrompt = text === BUILD_WEBSITE_PROMPT
         let actualText = text
+        let usedNativeEmailCalendarContext = false
 
         // For the build website prompt, inject user info so the AI can auto-populate
         // the website without asking the user a bunch of questions.
@@ -4648,6 +4649,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
             const context = await fetchEmailCalendarContext()
             if (context) {
               actualText = INITIAL_BRIEFING_INSTRUCTIONS + context
+              usedNativeEmailCalendarContext = true
             } else {
               // No data available — fall back to letting the agent browse
               actualText = `${text}\n\nAfter checking my email and calendar, recommend 5 specific things I should do based on what you find.`
@@ -4662,6 +4664,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           try {
             const context = await fetchEmailCalendarContext()
             if (context) {
+              usedNativeEmailCalendarContext = true
               actualText = `${text}
 
 Use the native Knapsack email/calendar context below first. Only use browser automation if the native context is missing something required to answer accurately.
@@ -4749,7 +4752,7 @@ ${actualText}`
         // Keep the frontend timeout longer than the backend request budget.
         // If the shared gateway session is slow or poisoned, the backend falls
         // back to direct chat so desktop users still get a timely answer.
-        let useDirectChat = false
+        let useDirectChat = usedNativeEmailCalendarContext
 
         if (!useDirectChat) {
         const agentTimeout = AbortController.prototype ? new AbortController() : null

--- a/src/src/hooks/feed/useFeed.tsx
+++ b/src/src/hooks/feed/useFeed.tsx
@@ -210,6 +210,7 @@ export interface ComposedEmailDraft {
   subject: string
   body: string
   threadId?: string
+  senderEmail?: string
   attachments?: ComposedEmailAttachment[]
 }
 


### PR DESCRIPTION
## Summary
- add Sentry reporting and clearer copy when provider failover is exhausted
- avoid misleading "all providers unavailable" copy when no backup provider is configured
- preserve sender email on AI-composed drafts so send does not fail when profile email is missing
- prefer direct desktop chat when native email/calendar context has already been prefetched

## Validation
- `cargo test fallback_failure_message_is_specific_when_no_backup_provider_exists --manifest-path src/src-tauri/Cargo.toml`
- `npm run build`
