### PR TITLE
[codex] Fix Google OAuth exchange and Knapsack fallback retry

### DIFF
--- a/src/src-tauri/src/connections/google/auth.rs
+++ b/src/src-tauri/src/connections/google/auth.rs
@@ -438,9 +438,8 @@ async fn exchange_code_via_backend(code: String) -> Result<GoogleSigninResponse,
     let client = client.clone();
     async move {
       let response = client
-        .get(format!(
-          "{api_server}/api/authentication/google/signin/app?code={code}"
-        ))
+        .get(format!("{api_server}/api/authentication/google/signin/app"))
+        .query(&[("code", code.as_str())])
         .send()
         .await
         .map_err(FetchError::NetworkError)?;
@@ -450,10 +449,13 @@ async fn exchange_code_via_backend(code: String) -> Result<GoogleSigninResponse,
         StatusCode::UNAUTHORIZED => Err(FetchError::InvalidToken),
         StatusCode::TOO_MANY_REQUESTS => Err(FetchError::RateLimitExceeded),
         status if status.is_server_error() => Err(FetchError::ServerError(status)),
-        _ => Err(FetchError::UnknownError(format!(
-          "Unexpected status code: {:?}",
-          response.status()
-        ))),
+        status => {
+          let body = response.text().await.unwrap_or_default();
+          Err(FetchError::UnknownError(format!(
+            "Unexpected status code {} from google signin exchange: {}",
+            status, body
+          )))
+        }
       }
     }
   })

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -920,7 +920,7 @@ async fn knapsack_completion(
 ) -> Result<String, LLMError> {
   let email = &provider.api_key;
   let client = reqwest::Client::new();
-  let token = resolve_knapsack_bearer_token(email).await?;
+  let mut token = resolve_knapsack_bearer_token(email).await?;
 
   let conversation: Vec<serde_json::Value> = messages
     .iter()
@@ -939,7 +939,7 @@ async fn knapsack_completion(
     "model": &provider.model,
   });
 
-  let resp = client
+  let mut resp = client
     .post(format!("{}/chat/completions", &provider.base_url))
     .header("Authorization", format!("Bearer {}", token))
     .header("Content-Type", "application/json")
@@ -950,7 +950,29 @@ async fn knapsack_completion(
       LLMError::ChatCompletionFailed(format!("Knapsack inference request failed: {}", e))
     })?;
 
-  let status = resp.status();
+  let mut status = resp.status();
+  if status == reqwest::StatusCode::UNAUTHORIZED {
+    log::warn!(
+      "[notes] Knapsack bearer token was unauthorized; refreshing once before surfacing sign-in failure"
+    );
+    std::env::remove_var("KNAPSACK_ACCESS_TOKEN");
+    token = resolve_knapsack_bearer_token(email).await?;
+    resp = client
+      .post(format!("{}/chat/completions", &provider.base_url))
+      .header("Authorization", format!("Bearer {}", token))
+      .header("Content-Type", "application/json")
+      .json(&body)
+      .send()
+      .await
+      .map_err(|e| {
+        LLMError::ChatCompletionFailed(format!(
+          "Knapsack inference retry after refresh failed: {}",
+          e
+        ))
+      })?;
+    status = resp.status();
+  }
+
   if !status.is_success() {
     let text = resp.text().await.unwrap_or_default();
     if status == reqwest::StatusCode::UNAUTHORIZED {


### PR DESCRIPTION
## What changed
- fixed the Google OAuth desktop completion exchange to send the auth code as a properly encoded query parameter
- improved the Google sign-in exchange error so backend 400 responses include the response body in logs
- made Knapsack meeting-notes fallback refresh and retry once on 401 before surfacing a sign-in failure

## Why this changed
Caitlin's June 23 desktop logs showed two concrete issues during meeting prep:
1. Google Drive add-account OAuth returned to the desktop app successfully, but `/api/knapsack/google/complete/signin` failed with a backend 400/desktop 500
2. when OpenAI hit 429s, fallback sometimes tried Knapsack and failed immediately with `Knapsack session expired — please sign in again`, even though other Knapsack call paths already refresh-and-retry on 401

## Root cause
- the Google backend exchange URL was constructed by interpolating the OAuth code directly into the URL string instead of using proper query encoding
- the meeting-notes Knapsack completion path did not mirror the existing refresh-and-retry behavior used in the browser-side Knapsack completion path

## User impact
- reduces failed Google Drive account linking during meeting prep enrichment
- makes provider fallback more resilient when a cached Knapsack bearer token has gone stale

## Validation
- `cargo check --manifest-path /tmp/knapsack_fix_caitlin_logs/src/src-tauri/Cargo.toml`
- reviewed Caitlin's June 23 logs against the patched paths
