### PR TITLE
fix: make recording indicator stop button reach main window

### DIFF
--- a/src/src/components/molecules/RecordingIndicator/index.tsx
+++ b/src/src/components/molecules/RecordingIndicator/index.tsx
@@ -51,7 +51,12 @@ function RecordingIndicator() {
 
   const handleStop = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
-    emit('stop-recording-from-indicator')
+    invoke('emit_event', {
+      event: 'stop-recording-from-indicator',
+      payload: {},
+    }).catch(() => {
+      emit('stop-recording-from-indicator')
+    })
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- route the floating recording indicator stop action through the existing Tauri `emit_event` bridge to the main window
- keep the prior frontend event emit as a fallback
- preserve the fix as a narrow single-file change

## Validation
- `npm exec -- tsc --noEmit` from `/Users/markheynen/knapsack_desktop/src`
- verified diff is limited to `RecordingIndicator/index.tsx`

## Notes
- this addresses the case where the floating pill is clicked from a separate Tauri window and the meeting screen-local listener does not receive the event reliably