### PR TITLE
Fix Slack DM routing to use real DM channels

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/extensions/slack/dist/send-Bpc-Eks7.js
+++ b/src/src-tauri/resources/clawdbot/dist/extensions/slack/dist/send-Bpc-Eks7.js
@@ -492,8 +492,7 @@ function isSlackUserRecipient(recipient) {
 	return recipient.kind === "user" || /^U[A-Z0-9]+$/i.test(recipient.id);
 }
 function resolveDirectUserPostChannelId(params) {
-	if (!isSlackUserRecipient(params.recipient) || params.hasMedia || params.threadTs) return;
-	return params.recipient.id;
+	return;
 }
 function resolvePostedMessageChannelId(response, fallback) {
 	return (typeof response.channel === "string" ? normalizeOptionalString(response.channel) : null) ?? fallback;


### PR DESCRIPTION
## Summary
- stop posting Slack user-targeted messages directly to raw user IDs
- always resolve a real DM channel via the existing conversations.open path
- avoid messages landing in App Home history instead of the user's DM sidebar

## Validation
- node --check src/src-tauri/resources/clawdbot/dist/extensions/slack/dist/send-Bpc-Eks7.js