### PR TITLE
Show all connected Google accounts in Settings

### DIFF
--- a/src/src-tauri/src/connections/api.rs
+++ b/src/src-tauri/src/connections/api.rs
@@ -29,6 +29,7 @@ pub struct UserConnectionResponse {
   #[serde(flatten)]
   user_connection: UserConnection,
   synced_since: Option<u64>,
+  owner_email: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -41,6 +42,7 @@ pub struct GetConnectionsResponse {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetConnectionsParams {
   email: String,
+  all_users: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -165,11 +167,24 @@ async fn get_connections(req: HttpRequest) -> impl Responder {
     Ok(s) => Some(s),
     Err(_) => None,
   };
-  match UserConnection::find_by_user_email(params.email.clone()) {
-    Ok(connections) => {
-      let connection_responses: Vec<UserConnectionResponse> = connections
-        .into_iter()
-        .map(|connection| {
+  let include_all_users = params.all_users.unwrap_or(false);
+  let owner_emails = if include_all_users {
+    match User::find_all_with_email() {
+      Ok(users) => users.into_iter().map(|user| user.email).collect::<Vec<_>>(),
+      Err(error) => {
+        log::warn!("Failed retrieving local users: {:?}", error);
+        vec![params.email.clone()]
+      }
+    }
+  } else {
+    vec![params.email.clone()]
+  };
+
+  let mut connection_responses = Vec::new();
+  for owner_email in owner_emails {
+    match UserConnection::find_by_user_email(owner_email.clone()) {
+      Ok(connections) => {
+        for connection in connections {
           let mut connection_synced_since = None;
           if let Some(sync_dates) = &synced_since {
             if let Some(conn) = &connection.connection {
@@ -183,28 +198,37 @@ async fn get_connections(req: HttpRequest) -> impl Responder {
             }
           }
 
-          UserConnectionResponse {
+          connection_responses.push(UserConnectionResponse {
             user_connection: connection,
             synced_since: connection_synced_since,
-          }
-        })
-        .collect();
+            owner_email: owner_email.clone(),
+          });
+        }
+      }
+      Err(error) => {
+        log::warn!(
+          "Failed retrieving user connections for {}: {:?}",
+          owner_email,
+          error
+        );
+      }
+    }
+  }
 
-      let response = GetConnectionsResponse {
-        connections: Some(connection_responses),
-        success: true,
-        message: None,
-      };
-      HttpResponse::Ok().json(response)
-    }
-    Err(_) => {
-      log::error!("Failed retrieving user connections");
-      HttpResponse::BadRequest().json(GetConnectionsResponse {
-        success: false,
-        connections: None,
-        message: Some("Failed to retrieve user connections".to_string()),
-      })
-    }
+  if connection_responses.is_empty() {
+    log::error!("Failed retrieving user connections");
+    HttpResponse::BadRequest().json(GetConnectionsResponse {
+      success: false,
+      connections: None,
+      message: Some("Failed to retrieve user connections".to_string()),
+    })
+  } else {
+    let response = GetConnectionsResponse {
+      connections: Some(connection_responses),
+      success: true,
+      message: None,
+    };
+    HttpResponse::Ok().json(response)
   }
 }
 

--- a/src/src-tauri/src/db/models/user.rs
+++ b/src/src-tauri/src/db/models/user.rs
@@ -12,6 +12,21 @@ pub struct User {
 }
 
 impl User {
+  pub fn find_all_with_email() -> Result<Vec<User>> {
+    let connection = get_db_conn();
+    let mut stmt =
+      connection.prepare("SELECT id, email, uuid FROM users WHERE email != '' ORDER BY id DESC")?;
+    let rows = stmt.query_map([], |row| {
+      Ok(User {
+        id: row.get(0)?,
+        email: row.get(1)?,
+        uuid: row.get(2)?,
+      })
+    })?;
+
+    rows.collect()
+  }
+
   pub fn find_by_email(email: String) -> Result<User> {
     let connection = get_db_conn();
     let mut stmt = connection.prepare("SELECT id, email, uuid FROM users WHERE email = ?1")?;

--- a/src/src/api/connections.tsx
+++ b/src/src/api/connections.tsx
@@ -38,6 +38,8 @@ export type Connection = {
   /** Set for google_calendar_read connections — the Google account email whose
    *  calendar this connection syncs.  Empty string for all other types. */
   calendarAccountEmail?: string
+  /** The local Knapsack profile email that owns this connection. */
+  ownerEmail?: string
 }
 
 /** Record key used for a Google Calendar connection given its account email. */
@@ -221,8 +223,16 @@ export function getGoogleConnectionKeysFromScopes(scopes: string[]): ConnectionK
   return keys
 }
 
-export async function getConnections(email: string): Promise<Record<string, Connection>> {
-  const response = await fetch(`${KN_API_CONNECTIONS}?email=${email}`, {
+export async function getConnections(
+  email: string,
+  options?: { includeAllUsers?: boolean },
+): Promise<Record<string, Connection>> {
+  const query = new URLSearchParams({ email })
+  if (options?.includeAllUsers) {
+    query.set('all_users', 'true')
+  }
+
+  const response = await fetch(`${KN_API_CONNECTIONS}?${query.toString()}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -245,10 +255,12 @@ export async function getConnections(email: string): Promise<Record<string, Conn
         lastSynced?: number
         syncedSince?: number
         calendarAccountEmail?: string
+        ownerEmail?: string
       },
     ) => {
       const scope = userConnection.connection.scope
       const calendarAccountEmail = userConnection.calendarAccountEmail || ''
+      const ownerEmail = userConnection.ownerEmail || email
       // Calendar, Drive, and Gmail connections are keyed as "scope|accountEmail"
       // so that multiple linked accounts can coexist in the same record.
       const multiAccountScopes = new Set([
@@ -258,8 +270,10 @@ export async function getConnections(email: string): Promise<Record<string, Conn
       ])
       const recordKey =
         multiAccountScopes.has(scope as ConnectionKeys) && calendarAccountEmail
-          ? `${scope}|${calendarAccountEmail}`
-          : scope
+          ? `${scope}|${calendarAccountEmail}${options?.includeAllUsers ? `|${ownerEmail}` : ''}`
+          : options?.includeAllUsers
+            ? `${scope}|${ownerEmail}`
+            : scope
 
       return {
         ...acc,
@@ -274,6 +288,7 @@ export async function getConnections(email: string): Promise<Record<string, Conn
             ? new Date(userConnection.syncedSince * 1000)
             : null,
           calendarAccountEmail,
+          ownerEmail,
         } as Connection,
       }
     },

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -5,6 +5,7 @@ import {
   Connection,
   ConnectionKeys,
   connectionsMap,
+  getConnections,
   getGoogleCalendarConnections,
   getGoogleDriveConnections,
   getGoogleGmailConnections,
@@ -251,6 +252,7 @@ export const SettingsDialog = ({
   profile,
   onProviderSignInClick,
 }: SettingsDialogProps) => {
+  const [settingsConnections, setSettingsConnections] = useState<Record<string, Connection>>(connections)
   const [sendPushNotificationsIsChecked, setSendPushNotificationsIsChecked] = useState<boolean>(false)
   const [saveTranscripts, setSaveTranscripts] = useState<boolean>(true)
   const [meetingChatEnabled, setMeetingChatEnabled] = useState<boolean>(true)
@@ -291,14 +293,30 @@ export const SettingsDialog = ({
   const [ollamaBusy, setOllamaBusy] = useState(false)
   const [selectedOllamaModel, setSelectedOllamaModel] = useState('')
   const [backendPrimaryEmail, setBackendPrimaryEmail] = useState('')
+  const displayConnections =
+    isOpen && Object.keys(settingsConnections).length > 0 ? settingsConnections : connections
   const googlePrimaryEmail =
     email ||
     profile?.email ||
     backendPrimaryEmail ||
-    getGoogleDriveConnections(connections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
-    getGoogleGmailConnections(connections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
-    getGoogleCalendarConnections(connections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
+    getGoogleDriveConnections(displayConnections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
+    getGoogleGmailConnections(displayConnections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
+    getGoogleCalendarConnections(displayConnections).find(item => item.calendarAccountEmail)?.calendarAccountEmail ||
     ''
+
+  const loadSettingsConnections = useCallback(async () => {
+    if (!googlePrimaryEmail) return
+    try {
+      const updatedConnections = await getConnections(googlePrimaryEmail, { includeAllUsers: true })
+      setSettingsConnections(updatedConnections)
+    } catch (error: any) {
+      logError(new Error('Failed to load all settings connections'), {
+        additionalInfo: 'Settings connections aggregate',
+        error: error?.message || String(error),
+      })
+      setSettingsConnections(connections)
+    }
+  }, [connections, googlePrimaryEmail])
 
   const requireGooglePrimaryEmail = useCallback((flow: string) => {
     if (googlePrimaryEmail) return googlePrimaryEmail
@@ -337,6 +355,15 @@ export const SettingsDialog = ({
     [googlePrimaryEmail],
   )
 
+  const getGoogleOwnerSuffix = useCallback((item: Connection) => {
+    if (!item.ownerEmail || item.ownerEmail === item.calendarAccountEmail) return ''
+    return ` via ${item.ownerEmail}`
+  }, [])
+
+  useEffect(() => {
+    setSettingsConnections(connections)
+  }, [connections])
+
   useEffect(() => {
     if (!isOpen || email || profile?.email || backendPrimaryEmail) return
 
@@ -352,6 +379,11 @@ export const SettingsDialog = ({
         })
       })
   }, [backendPrimaryEmail, email, isOpen, profile?.email])
+
+  useEffect(() => {
+    if (!isOpen) return
+    void loadSettingsConnections()
+  }, [isOpen, loadSettingsConnections])
 
   useEffect(() => {
     if(profile && profile.provider){
@@ -460,8 +492,9 @@ export const SettingsDialog = ({
         setIsFilesEnabled(false)
       }
       fetchConnections(email)
+      await loadSettingsConnections()
     },
-    [deleteConnection, email, fetchConnections],
+    [deleteConnection, email, fetchConnections, loadSettingsConnections],
   )
 
   const handleShowNotificationLeadTimeChange = (min: string) => {
@@ -1185,13 +1218,13 @@ export const SettingsDialog = ({
               ))}
 
             {/* Google Drive — one row per linked account */}
-            {getGoogleDriveConnections(connections).map(item => (
+            {getGoogleDriveConnections(displayConnections).map(item => (
               <div
                 className="flex justify-between h-[36px] items-center"
-                key={`drive-${item.id}-${item.calendarAccountEmail}`}
+                key={`drive-${item.id}-${item.calendarAccountEmail}-${item.ownerEmail}`}
               >
                 <Typography>
-                  Drive, {getGoogleAccountLabel(item)}
+                  Drive, {getGoogleAccountLabel(item)}{getGoogleOwnerSuffix(item)}
                 </Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
@@ -1203,13 +1236,13 @@ export const SettingsDialog = ({
             ))}
 
             {/* Google Gmail — one row per linked account */}
-            {getGoogleGmailConnections(connections).map(item => (
+            {getGoogleGmailConnections(displayConnections).map(item => (
               <div
                 className="flex justify-between h-[36px] items-center"
-                key={`gmail-${item.id}-${item.calendarAccountEmail}`}
+                key={`gmail-${item.id}-${item.calendarAccountEmail}-${item.ownerEmail}`}
               >
                 <Typography>
-                  Gmail, {getGoogleAccountLabel(item)}
+                  Gmail, {getGoogleAccountLabel(item)}{getGoogleOwnerSuffix(item)}
                 </Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
@@ -1221,13 +1254,13 @@ export const SettingsDialog = ({
             ))}
 
             {/* Google Calendar — one row per linked account */}
-            {getGoogleCalendarConnections(connections).map(item => (
+            {getGoogleCalendarConnections(displayConnections).map(item => (
               <div
                 className="flex justify-between h-[36px] items-center"
-                key={`cal-${item.id}-${item.calendarAccountEmail}`}
+                key={`cal-${item.id}-${item.calendarAccountEmail}-${item.ownerEmail}`}
               >
                 <Typography>
-                  Calendar, {getGoogleAccountLabel(item)}
+                  Calendar, {getGoogleAccountLabel(item)}{getGoogleOwnerSuffix(item)}
                 </Typography>
                 <Typography
                   className={`cursor-pointer ${styles.link}`}
@@ -1288,7 +1321,7 @@ export const SettingsDialog = ({
                   className={`cursor-pointer ${styles.link}`}
                   onClick={handleAddGoogleDrive}
                 >
-                  {getGoogleDriveConnections(connections).length > 0 ? 'Add another' : 'Add'}
+                  {getGoogleDriveConnections(displayConnections).length > 0 ? 'Add another' : 'Add'}
                 </Typography>
               </div>
             )}
@@ -1301,7 +1334,7 @@ export const SettingsDialog = ({
                   className={`cursor-pointer ${styles.link}`}
                   onClick={handleAddGoogleGmail}
                 >
-                  {getGoogleGmailConnections(connections).length > 0 ? 'Add another' : 'Add'}
+                  {getGoogleGmailConnections(displayConnections).length > 0 ? 'Add another' : 'Add'}
                 </Typography>
               </div>
             )}
@@ -1314,7 +1347,7 @@ export const SettingsDialog = ({
                   className={`cursor-pointer ${styles.link}`}
                   onClick={handleAddGoogleCalendar}
                 >
-                  {getGoogleCalendarConnections(connections).length > 0
+                  {getGoogleCalendarConnections(displayConnections).length > 0
                     ? 'Add another'
                     : 'Add'}
                 </Typography>


### PR DESCRIPTION
## Summary
- load Google connections across all local Knapsack profiles when Settings opens
- label Settings rows with the connected Google account and owning profile when they differ
- keep the broader app connection state unchanged so this stays a UI-scoped fix

## Validation
- `cargo fmt --manifest-path src/src-tauri/Cargo.toml`
- `cargo check -p knapsack --manifest-path src/src-tauri/Cargo.toml`
- `npm ci`
- `npm run build`