### PR TITLE
fix: extract full UUID from notarytool submit output

### DIFF
--- a/src/scripts/sign-and-notarize.sh
+++ b/src/scripts/sign-and-notarize.sh
@@ -360,7 +360,10 @@ if [ "$DO_NOTARIZE" = true ]; then
     fi
 
     # Fallback for non-JSON text output (including older notarytool formats).
-    submission_id=$(printf '%s\n' "$raw_output" | grep -Eio '(^|[[:space:]])(id|request[-_ ]?id|request[-_ ]?uuid)\s*[:=]\s*[a-zA-Z0-9-]{10,}' | head -n1 | sed -E 's/.*([a-zA-Z0-9-]{10,})$/\1/' || true)
+    # Strip everything up to and including the first : or = so the greedy .* in
+    # sed cannot consume part of the UUID (old bug: s/.*([a-zA-Z0-9-]{10,})$/\1/
+    # captured only the minimum 10 chars, e.g. "00b9e90128" instead of the full UUID).
+    submission_id=$(printf '%s\n' "$raw_output" | grep -Eio '(^|[[:space:]])(id|request[-_ ]?id|request[-_ ]?uuid)\s*[:=]\s*[a-zA-Z0-9-]{10,}' | head -n1 | sed -E 's/^[^:=]*[:=][[:space:]]*//' || true)
     if [ -n "$submission_id" ]; then
       printf '%s\n' "$submission_id"
       return 0


### PR DESCRIPTION
## Summary

- Fixes a greedy `sed` regex in `extract_notary_submission_id()` that captured only the last 10 characters of the UUID instead of the full 36-character value (e.g. `00b9e90128` instead of `0534c2d6-bb9b-4b39-a0eb-a900b9e90128`)
- All 120 notarytool polls returned `<network error>` because they were querying Apple with an invalid submission ID
- Changed `sed -E 's/.*([a-zA-Z0-9-]{10,})$/\1/'` → `sed -E 's/^[^:=]*[:=][[:space:]]*//'` which strips the key/separator prefix and leaves the full UUID intact
- This is the sole cause of every release failure since June 23 (runs 169–174)

## Test plan

- [ ] CI passes (macOS notarization is directly tested by the build-macos job — a green run confirms the fix)
- [ ] Merge and trigger release workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEiHz8v9to5ed7MghkMjRa)_