### PR TITLE
Fix support email sender selection

### DIFF
--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -36,7 +36,12 @@ import { listen } from '@tauri-apps/api/event'
 import { getReleaseType } from 'src/api/app_info'
 import { safeInvoke } from 'src/utils/tauriIpcBridge'
 
-import { ConnectionKeys, googleConnections, microsoftConnections } from '../../../api/connections'
+import {
+  ConnectionKeys,
+  getGoogleGmailConnections,
+  googleConnections,
+  microsoftConnections,
+} from '../../../api/connections'
 import { getFeedbacks } from '../../../api/threads'
 import { setHasOnboarded } from '../../../pages/onboarding'
 import { openGoogleAuthScreen } from '../../../utils/permissions/google'
@@ -202,7 +207,13 @@ function Home({
       // When email is not connected the AI falls back to browser automation instead.
       if (!feed.loggedEmailAutopilot) return
       const detail = (e as CustomEvent).detail
-      feed.setComposedEmailDraft(detail)
+      const gmailSenderEmail = getGoogleGmailConnections(connections)
+        .map(connection => connection.calendarAccountEmail?.trim())
+        .find(Boolean)
+      feed.setComposedEmailDraft({
+        ...detail,
+        senderEmail: detail?.senderEmail || gmailSenderEmail || userEmail,
+      })
       setCurrentTab(TabChoices.Openclaw)
     }
     const handleFocusChat = () => setCurrentTab(TabChoices.Openclaw)
@@ -218,7 +229,7 @@ function Home({
       window.removeEventListener('clawd-focus-chat', handleFocusChat)
       window.removeEventListener('clawd-open-meeting', handleOpenMeeting)
     }
-  }, [feed.loggedEmailAutopilot, feed.setComposedEmailDraft])
+  }, [connections, feed.loggedEmailAutopilot, feed.setComposedEmailDraft, userEmail])
 
   useEffect(() => {
     document.documentElement.style.backgroundColor = 'rgba(5, 5, 5, 0.0)'


### PR DESCRIPTION
### Motivation
- AI-generated support email drafts could open the compose drawer with no valid `senderEmail` even when a Gmail account was connected, causing send failures.

### Description
- Import `getGoogleGmailConnections` and derive a connected Gmail account email from `connections` in `Home.tsx`.
- When handling the `clawd-email-draft-ready` event, populate the draft's `senderEmail` with the explicit draft sender if present, otherwise the first connected Gmail account, and finally fall back to the signed-in `userEmail` using `feed.setComposedEmailDraft`.
- Update the effect dependency list to include `connections` and `userEmail` so the selected sender reflects the latest connection state.

### Testing
- Ran `git diff --check`, which passed without issues.
- Ran `npm run build`, which was blocked by a network/DNS error while downloading Node.js from `nodejs.org`.
- Ran `npx tsc --noEmit`, which failed due to missing local type dependencies (e.g. `@emotion/react`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b72333c2c83219d0ed72769924cbe)