### PR TITLE
Fix dev QA bootstrap on fresh main

### DIFF
--- a/src/scripts/ensure-clawdbot-deps.cjs
+++ b/src/scripts/ensure-clawdbot-deps.cjs
@@ -20,7 +20,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 // Source (checked-in) clawdbot dir
 const SOURCE_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources', 'clawdbot');
@@ -28,17 +28,57 @@ const SOURCE_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'resources',
 const TARGET_CLAWDBOT_DIR = path.join(__dirname, '..', 'src-tauri', 'target', 'debug', 'resources', 'clawdbot');
 const FORCE_EXTENSION_LOCAL_DEPS = new Set(['slack', 'telegram', 'whatsapp']);
 
+function resolveNpmCli() {
+  const candidates = [];
+  if (process.env.npm_execpath) candidates.push(process.env.npm_execpath);
+  candidates.push(
+    path.join(path.dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.join(path.dirname(process.execPath), '..', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  );
+  if (process.platform === 'win32') {
+    const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+    candidates.push(
+      path.join(programFiles, 'nodejs', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    );
+  }
+  return candidates.find((candidate) => candidate && fs.existsSync(candidate)) || null;
+}
+
+function runNpm(args, options = {}) {
+  const npmCli = resolveNpmCli();
+  let result;
+  if (npmCli) {
+    result = spawnSync(process.execPath, [npmCli, ...args], {
+      cwd: options.cwd,
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+  } else {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    result = spawnSync(npmCommand, args, {
+      cwd: options.cwd,
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+  }
+  if (result.status !== 0) {
+    throw new Error(`npm ${args.join(' ')} failed with status ${result.status}`);
+  }
+}
+
 function runNpmInstall(cwd, label) {
   // Prefer `npm ci` when a lockfile is present — it does a clean install from the
   // lockfile and catches version mismatches that `npm install` silently ignores.
   // Falls back to `npm install` when no lockfile exists (e.g. target debug dir).
   const hasLockfile = fs.existsSync(path.join(cwd, 'npm-shrinkwrap.json'))
     || fs.existsSync(path.join(cwd, 'package-lock.json'));
-  const cmd = hasLockfile
-    ? 'npm ci --ignore-scripts --no-audit --no-fund'
-    : 'npm install --omit=dev --ignore-scripts --no-audit --no-fund';
   console.log(`[ensure-clawdbot-deps] ${hasLockfile ? 'npm ci' : 'npm install'} in ${label}...`);
-  execSync(cmd, { cwd, stdio: 'inherit' });
+  runNpm(
+    hasLockfile
+      ? ['ci', '--ignore-scripts', '--no-audit', '--no-fund']
+      : ['install', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund'],
+    { cwd },
+  );
 }
 
 function runtimeDependencySpecs(pkg) {
@@ -53,12 +93,12 @@ function runtimeDependencySpecs(pkg) {
 
 function runPluginRuntimeDepsInstall(cwd, label, specs) {
   if (!specs.length) return;
-  const quotedSpecs = specs.map((spec) => JSON.stringify(spec)).join(' ');
   const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'knapsack-plugin-deps-'));
-  const cmd = `npm install ${quotedSpecs} --no-save --omit=dev --ignore-scripts --no-audit --no-fund`;
   console.log(`[ensure-clawdbot-deps] npm install targeted runtime deps for ${label}: ${specs.join(', ')}`);
   try {
-    execSync(cmd, { cwd: stagingDir, stdio: 'inherit' });
+    runNpm(['install', ...specs, '--no-save', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund'], {
+      cwd: stagingDir,
+    });
     const sourceNm = path.join(stagingDir, 'node_modules');
     const targetNm = path.join(cwd, 'node_modules');
     fs.mkdirSync(targetNm, { recursive: true });

--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -80,6 +80,22 @@ function npmCommand() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
+function resolveNpmCli() {
+  const candidates = [];
+  if (process.env.npm_execpath) candidates.push(process.env.npm_execpath);
+  candidates.push(
+    path.join(path.dirname(process.execPath), "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+    path.join(path.dirname(process.execPath), "..", "node_modules", "npm", "bin", "npm-cli.js"),
+  );
+  if (process.platform === "win32") {
+    const programFiles = process.env.ProgramFiles || "C:\\Program Files";
+    candidates.push(
+      path.join(programFiles, "nodejs", "node_modules", "npm", "bin", "npm-cli.js"),
+    );
+  }
+  return candidates.find((candidate) => candidate && fs.existsSync(candidate)) || null;
+}
+
 function qaEnv(extra = {}) {
   const env = {
     ...process.env,
@@ -132,6 +148,11 @@ function rootNodeModulesReady() {
 function ensureRootNodeModules() {
   if (rootNodeModulesReady()) return;
   console.log("[qa-dev-run] root node_modules missing; running npm install");
+  const npmCli = resolveNpmCli();
+  if (npmCli) {
+    runChecked(process.execPath, [npmCli, "install"], { cwd: projectDir });
+    return;
+  }
   runChecked(npmCommand(), ["install"], { cwd: projectDir });
 }
 
@@ -914,6 +935,11 @@ async function main() {
     });
   }
 
+  if (prepareOnly) {
+    process.exit(0);
+    return;
+  }
+
   const vite = spawnVite();
   let gateway = null;
   let shuttingDown = false;
@@ -951,7 +977,10 @@ async function main() {
     });
   };
 
-  await waitForUrl("http://127.0.0.1:1420/");
+  await waitForUrl(
+    "http://127.0.0.1:1420/",
+    Number(process.env.KNAPSACK_QA_VITE_READY_TIMEOUT_MS || 90_000),
+  );
   bootoutLaunchAgent();
   killStaleGateways();
   killStaleOpenClawChrome();
@@ -984,12 +1013,6 @@ async function main() {
         "[qa-dev-run] Continuing without managed direct gateway start; app bootstrap path was not local",
       );
     }
-  }
-
-  if (prepareOnly) {
-    cleanup();
-    process.exit(0);
-    return;
   }
 
   app.on("exit", (code, signal) => {

--- a/src/scripts/qa-loop-runner.cjs
+++ b/src/scripts/qa-loop-runner.cjs
@@ -956,7 +956,7 @@ function prepareDevRuntime(env) {
     },
     encoding: "utf8",
     windowsHide: true,
-    timeout: Number(process.env.KNAPSACK_QA_PREPARE_TIMEOUT_MS || 180_000),
+    timeout: Number(process.env.KNAPSACK_QA_PREPARE_TIMEOUT_MS || 1_800_000),
   });
   const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
   if (output) {
@@ -1753,6 +1753,12 @@ async function createMockMeeting() {
     },
   });
   if (!stop.ok) {
+    const noRecordingInProgress =
+      (typeof stop.body === "string" && stop.body.toLowerCase().includes("no recording in progress"))
+      || (typeof stop.body?.error === "string" && stop.body.error.toLowerCase().includes("no recording in progress"));
+    if (stop.status === 400 && noRecordingInProgress) {
+      return { ok: true };
+    }
     return {
       ok: false,
       detail: `stop_recording failed (${stop.status}) ${normalizeResult(stop.body)}`,


### PR DESCRIPTION
## Summary
Fix the dev QA bootstrap path on fresh `main` checkouts.

## What changed
- run helper npm installs through the active Node runtime when possible
- let prepare-only dev QA stop after dependency/build prep instead of booting Vite/app
- increase dev prepare timeout for fresh debug builds
- widen the Vite readiness timeout for fresh checkouts
- treat `stop_recording: No recording in progress` as a benign mock-meeting auto-stop case

## Validation
- Ran dev QA loop on latest `main`
- Result: PASSED
- Startup to active+stable: 7890ms
- Gemini chat: ok, 1331ms
- Mock meeting: ok
- Browser control / feed / automations checks: ok