### PR TITLE
Fix QA dev launch agent cleanup

### DIFF
--- a/src/scripts/qa-dev-run.cjs
+++ b/src/scripts/qa-dev-run.cjs
@@ -34,6 +34,10 @@ const launchAgentPlist = path.join(
   "ai.knap.knapsack.clawdbot.plist",
 );
 const qaStateDir = path.join(projectDir, ".qa-dev-openclaw-state");
+const qaLaunchAgentBackupPath = path.join(
+  qaStateDir,
+  "launch-agent-backup.plist",
+);
 const prodStateDir = path.join(
   process.env.HOME || "",
   "Library",
@@ -402,6 +406,28 @@ function readLaunchAgentPlist() {
   return JSON.parse(result.stdout);
 }
 
+function launchAgentTargetsThisCheckout(plist) {
+  const entry = plist?.ProgramArguments?.[1] || "";
+  return entry.startsWith(
+    path.join(projectDir, "src-tauri", "resources", "clawdbot"),
+  );
+}
+
+function backupExistingLaunchAgentIfNeeded() {
+  if (process.platform !== "darwin") return;
+  try {
+    if (!fs.existsSync(launchAgentPlist)) return;
+    const plist = readLaunchAgentPlist();
+    if (launchAgentTargetsThisCheckout(plist)) return;
+    fs.mkdirSync(path.dirname(qaLaunchAgentBackupPath), { recursive: true });
+    fs.copyFileSync(launchAgentPlist, qaLaunchAgentBackupPath);
+  } catch (error) {
+    console.warn(
+      `[qa-dev-run] Could not back up existing LaunchAgent plist: ${error.message}`,
+    );
+  }
+}
+
 function defaultLiveGatewayStateDir() {
   return path.join(
     process.env.HOME || "",
@@ -461,6 +487,34 @@ function bootoutLaunchAgent() {
   spawnSync("launchctl", ["bootout", domain, launchAgentPlist], {
     stdio: "ignore",
   });
+}
+
+function removeQaLaunchAgentIfPresent() {
+  if (process.platform !== "darwin") return;
+  try {
+    if (!fs.existsSync(launchAgentPlist)) return;
+    const plist = readLaunchAgentPlist();
+    if (!launchAgentTargetsThisCheckout(plist)) return;
+    fs.rmSync(launchAgentPlist, { force: true });
+  } catch (error) {
+    console.warn(
+      `[qa-dev-run] Could not remove QA LaunchAgent plist: ${error.message}`,
+    );
+  }
+}
+
+function restoreLaunchAgentBackupIfPresent() {
+  if (process.platform !== "darwin") return;
+  try {
+    if (!fs.existsSync(qaLaunchAgentBackupPath)) return;
+    fs.mkdirSync(path.dirname(launchAgentPlist), { recursive: true });
+    fs.copyFileSync(qaLaunchAgentBackupPath, launchAgentPlist);
+    fs.rmSync(qaLaunchAgentBackupPath, { force: true });
+  } catch (error) {
+    console.warn(
+      `[qa-dev-run] Could not restore original LaunchAgent plist: ${error.message}`,
+    );
+  }
 }
 
 function killStaleGateways() {
@@ -881,6 +935,7 @@ function syncDevClawdbotResources() {
 
 async function main() {
   ensureRootNodeModules();
+  backupExistingLaunchAgentIfNeeded();
   runChecked(process.execPath, [path.join(projectDir, "scripts", "fix-rollup-native.cjs")]);
   runChecked(process.execPath, [
     path.join(projectDir, "scripts", "ensure-clawdbot-deps.cjs"),
@@ -924,8 +979,11 @@ async function main() {
     if (!vite.killed) vite.kill("SIGTERM");
     if (gateway && !gateway.killed) gateway.kill("SIGTERM");
     if (app && !app.killed) app.kill("SIGTERM");
+    bootoutLaunchAgent();
     killStaleGateways();
     killStaleOpenClawChrome();
+    removeQaLaunchAgentIfPresent();
+    restoreLaunchAgentBackupIfPresent();
   };
   process.on("SIGINT", () => {
     cleanup();

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -785,6 +785,28 @@ pub fn parse_oai_chat_resp(text: &str) -> anyhow::Result<OaiChatResp> {
   }
 }
 
+pub fn parse_json_value_with_escape_repair(text: &str) -> anyhow::Result<JsonValue> {
+  match serde_json::from_str::<JsonValue>(text) {
+    Ok(parsed) => Ok(parsed),
+    Err(original_err) => {
+      let repaired = repair_invalid_json_string_escapes(text);
+      if repaired == text {
+        return Err(original_err.into());
+      }
+      match serde_json::from_str::<JsonValue>(&repaired) {
+        Ok(parsed) => {
+          eprintln!(
+            "[chat_agent] repaired malformed JSON escapes in JSON response: {}",
+            original_err
+          );
+          Ok(parsed)
+        }
+        Err(_) => Err(original_err.into()),
+      }
+    }
+  }
+}
+
 fn repair_invalid_json_string_escapes(text: &str) -> String {
   fn is_hex(ch: char) -> bool {
     ch.is_ascii_hexdigit()
@@ -1057,7 +1079,7 @@ pub async fn anthropic_chat(
 
     if status.is_success() {
       // Parse Anthropic response → OAI format
-      let parsed: JsonValue = serde_json::from_str(&text)?;
+      let parsed = parse_json_value_with_escape_repair(&text)?;
 
       let mut reply_text = String::new();
       let mut tool_calls: Vec<OaiToolCall> = Vec::new();
@@ -1327,7 +1349,7 @@ pub async fn gemini_chat_with_retries(
     let text = res.text().await.unwrap_or_default();
 
     if status.is_success() {
-      let parsed: JsonValue = serde_json::from_str(&text)?;
+      let parsed = parse_json_value_with_escape_repair(&text)?;
 
       let mut reply_text = String::new();
       let mut tool_calls: Vec<OaiToolCall> = Vec::new();
@@ -1434,5 +1456,21 @@ mod tests {
     let parsed = parse_oai_chat_resp(raw).expect("response should be repaired");
     let content = parsed.choices[0].message.content.as_deref().unwrap_or("");
     assert_eq!(content, r#"draft \q now"#);
+  }
+
+  #[test]
+  fn repairs_truncated_unicode_escape_in_generic_json_value() {
+    let raw = r#"{"content":[{"type":"text","text":"bad \u12 path"}]}"#;
+    let parsed = parse_json_value_with_escape_repair(raw).expect("json should be repaired");
+    let text = parsed["content"][0]["text"].as_str().unwrap_or("");
+    assert_eq!(text, r#"bad \u12 path"#);
+  }
+
+  #[test]
+  fn repairs_invalid_backslash_escape_in_generic_json_value() {
+    let raw = r#"{"content":[{"type":"text","text":"draft \q now"}]}"#;
+    let parsed = parse_json_value_with_escape_repair(raw).expect("json should be repaired");
+    let text = parsed["content"][0]["text"].as_str().unwrap_or("");
+    assert_eq!(text, r#"draft \q now"#);
   }
 }


### PR DESCRIPTION
## Summary
- back up any existing Clawdbot LaunchAgent plist before qa:dev rewrites it
- remove the QA LaunchAgent plist during cleanup when it points at the QA checkout
- restore the original LaunchAgent plist after cleanup so QA runs do not contaminate the installed app

## Testing
- node --check src/scripts/qa-dev-run.cjs