### PR TITLE
Improve search fallback when DuckDuckGo challenges

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -6123,10 +6123,11 @@ pub async fn screenshot(
 // results, and return them as structured JSON.
 //
 // Priority order for web search (enforced by channel_diagnostics):
-//   1. Brave API  (BRAVE_API_KEY present)
+//   1. Brave/API-backed provider  (explicitly configured)
 //   2. Browser CDP  (this endpoint, requires browser_ok)
-//   3. DuckDuckGo provider  (key-free HTTP fallback, browser unavailable)
-//   4. API key prompt  (all else failed)
+//   3. Optional DuckDuckGo HTTP fallback  (explicitly tolerated last resort)
+//   4. Google News RSS fallback  (news-oriented fallback)
+//   5. API key prompt / browser guidance  (all else failed)
 
 #[derive(Debug, Deserialize)]
 pub struct BrowserSearchQuery {
@@ -6437,6 +6438,14 @@ fn parse_google_news_rss(xml: &str, max_results: usize) -> Vec<BrowserSearchResu
   results
 }
 
+fn is_ddg_bot_challenge_html(html: &str) -> bool {
+  let lower = html.to_ascii_lowercase();
+  lower.contains("g-recaptcha")
+    || lower.contains("are you a human")
+    || lower.contains("id=\"challenge-form\"")
+    || lower.contains("name=\"challenge\"")
+}
+
 /// Browser-based web search via CDP (DuckDuckGo Lite).
 ///
 /// `GET /api/clawd/browser/search?q=<query>[&count=5][&chrome=true]`
@@ -6585,6 +6594,57 @@ pub async fn browser_search(
   match http_client.get(&ddg_url).send().await {
     Ok(resp) => match resp.text().await {
       Ok(html) => {
+        if is_ddg_bot_challenge_html(&html) {
+          let news_url = format!(
+            "https://news.google.com/rss/search?q={}&hl=en-US&gl=US&ceid=US:en",
+            encoded_q
+          );
+          log::warn!(
+            "[browser_search] DDG HTTP fallback hit a bot challenge; trying Google News RSS fallback"
+          );
+          return match http_client.get(&news_url).send().await {
+            Ok(news_resp) => match news_resp.text().await {
+              Ok(xml) => {
+                let results = parse_google_news_rss(&xml, max_results);
+                HttpResponse::Ok().json(BrowserSearchResponse {
+                  success: !results.is_empty(),
+                  message: if results.is_empty() {
+                    Some(
+                      "DuckDuckGo returned a bot challenge and Google News RSS did not return usable results"
+                        .to_string(),
+                    )
+                  } else {
+                    Some(
+                      "DuckDuckGo returned a bot challenge; using Google News RSS fallback results"
+                        .to_string(),
+                    )
+                  },
+                  results,
+                  provider: "google-news-rss".to_string(),
+                })
+              }
+              Err(e) => HttpResponse::Ok().json(BrowserSearchResponse {
+                success: false,
+                message: Some(format!(
+                  "DuckDuckGo returned a bot challenge and Google News RSS response could not be read: {}",
+                  e
+                )),
+                results: vec![],
+                provider: "google-news-rss".to_string(),
+              }),
+            },
+            Err(e) => HttpResponse::Ok().json(BrowserSearchResponse {
+              success: false,
+              message: Some(format!(
+                "DuckDuckGo returned a bot challenge and Google News RSS fallback failed: {}",
+                e
+              )),
+              results: vec![],
+              provider: "none".to_string(),
+            }),
+          };
+        }
+
         let mut results = parse_ddg_lite_html(&html, max_results.saturating_add(5));
         if results.is_empty() {
           let plain = strip_html_tags(&html);
@@ -6936,5 +6996,15 @@ mod tests {
     assert!(clamped.contains("Trimmed for test"));
     assert!(clamped.contains("truncated from"));
     assert!(clamped.starts_with("prefix "));
+  }
+
+  #[test]
+  fn detects_ddg_bot_challenge_markup() {
+    assert!(super::is_ddg_bot_challenge_html(
+      r#"<html><form id="challenge-form"><div>Are you a human?</div></form></html>"#
+    ));
+    assert!(!super::is_ddg_bot_challenge_html(
+      "<html><body><a href=\"https://example.com\">Example</a></body></html>"
+    ));
   }
 }

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -2586,7 +2586,12 @@ fn default_channel_status_params() -> Value {
 /// Get channel status from the gateway (pooled).
 pub async fn get_channel_status(token: Option<&str>) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  call_channel_method("channels.status", Some(default_channel_status_params()), Some(&t)).await
+  call_channel_method(
+    "channels.status",
+    Some(default_channel_status_params()),
+    Some(&t),
+  )
+  .await
 }
 
 /// Call a channel method on the gateway (pooled).
@@ -2880,6 +2885,34 @@ mod tests {
     let cfg = json!({"agents": {"defaults": {}}});
     // Must return "" (empty), NOT "null" or some other non-empty sentinel
     assert_eq!(read_model_from_config(&cfg), "");
+  }
+
+  #[test]
+  fn browser_config_does_not_auto_pin_duckduckgo_provider() {
+    let cfg_json = json!({
+      "tools": {
+        "deny": ["canvas", "nodes", "cron", "gateway"],
+        "allow": ["browser", "web_fetch", "web_search", "group:web"]
+      }
+    });
+    let f = write_config(&serde_json::to_string(&cfg_json).unwrap());
+    let changed = ensure_browser_config_at(f.path());
+    assert!(
+      changed,
+      "baseline browser/tool invariants should still be patched"
+    );
+
+    let updated: Value = serde_json::from_str(&std::fs::read_to_string(f.path()).unwrap()).unwrap();
+    assert_eq!(
+      updated.pointer("/tools/web/search/provider"),
+      None,
+      "search provider should remain unset when no API-backed provider is configured"
+    );
+    assert_eq!(
+      updated.pointer("/plugins/entries/duckduckgo"),
+      None,
+      "DuckDuckGo should not be force-enabled as an implicit default"
+    );
   }
 
   #[test]

--- a/src/src-tauri/src/clawd/tools_md_content.txt
+++ b/src/src-tauri/src/clawd/tools_md_content.txt
@@ -81,7 +81,7 @@ If `web_search` fails or returns an error (e.g. missing API key, quota exceeded,
 
 The user should NEVER see an error about missing API keys or be asked to configure search providers. You have a real browser — use it. There is always a way to search the web.
 
-**CRITICAL:** When the user says "look online", "search for", "find out about", "what's the latest on" — this means find the information, READ the results, and SUMMARIZE the findings back to the user. Do NOT just open a browser to a search page and tell them to look.
+**CRITICAL:** When no explicit `web_search` provider is configured, prefer the **browser** tool first for general web research instead of assuming the key-free provider path is reliable. When the user says "look online", "search for", "find out about", "what's the latest on" — this means find the information, READ the results, and SUMMARIZE the findings back to the user. Do NOT just open a browser to a search page and tell them to look.
 
 ## Web Fetch
 
@@ -134,7 +134,7 @@ When the user asks you to check email, check calendar, book flights, research pr
 - "Check flight prices" → Use browser/web_search to actually look up prices and present findings — NEVER give the user instructions on how to search themselves
 
 **Tool selection guide:**
-- Use **web_search** → to find information, news, answers (fastest for research and news). If it fails, fall back to browser.
+- Use **web_search** → to find information, news, answers when a provider is configured. If it fails or no provider is configured, fall back to browser immediately.
 - Use **web_fetch** → to read a specific URL's content (articles, docs, APIs)
 - Use **browser** → for interactive tasks requiring login (email, calendar, web apps), forms, JavaScript-heavy pages, multi-step flows, AND as a fallback for web search
 - For connected Google Docs/Sheets/Drive files, prefer the **local Knapsack Drive APIs** before browser automation. Do not claim Sheets are unreadable unless the local Drive export endpoint fails too.


### PR DESCRIPTION
## Summary
- detect DuckDuckGo bot-challenge HTML in the browser search fallback path
- fall back to Google News RSS instead of surfacing provider-unavailable style failures
- steer browser-first search guidance away from implicitly relying on DuckDuckGo

## Testing
- cargo test --manifest-path src/src-tauri/Cargo.toml detects_ddg_bot_challenge_markup
- cargo test --manifest-path src/src-tauri/Cargo.toml browser_config_does_not_auto_pin_duckduckgo_provider
- npm run qa:dev in a fresh worktree, then verified health/status on ports 1420, 8897, 18789, and 18791