### PR TITLE
Add TrustedRouter provider option

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: src
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            npm exec -- tauri build --target universal-apple-darwin --bundles app updater --ci
+            npm exec -- tauri build --target universal-apple-darwin --bundles app --ci
           else
             npm exec -- tauri build --target universal-apple-darwin --ci
           fi

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -105,6 +105,11 @@ struct StoredTokens {
   openrouter_api_key: Option<String>,
   #[serde(default)]
   openrouter_model: Option<String>,
+  // TrustedRouter support
+  #[serde(default)]
+  trustedrouter_api_key: Option<String>,
+  #[serde(default)]
+  trustedrouter_model: Option<String>,
   #[serde(default)]
   active_provider: Option<String>,
   // Ollama (local LLM) support
@@ -193,6 +198,8 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     xai_model: None,
     openrouter_api_key: None,
     openrouter_model: None,
+    trustedrouter_api_key: None,
+    trustedrouter_model: None,
     active_provider: None,
     ollama_enabled: None,
     ollama_model: None,
@@ -571,6 +578,20 @@ fn openrouter_key(app_handle: &tauri::AppHandle) -> Option<String> {
     .filter(|s| !s.is_empty())
 }
 
+fn trustedrouter_key(app_handle: &tauri::AppHandle) -> Option<String> {
+  if let Ok(k) = std::env::var("TRUSTEDROUTER_API_KEY") {
+    let k = k.trim().to_string();
+    if !k.is_empty() {
+      return Some(k);
+    }
+  }
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.trustedrouter_api_key)
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
 fn knapsack_access_token(app_handle: &tauri::AppHandle) -> Option<String> {
   if let Ok(k) = std::env::var("KNAPSACK_ACCESS_TOKEN") {
     let k = k.trim().to_string();
@@ -701,6 +722,9 @@ fn normalize_provider_model(provider: &str, model: &str) -> String {
   let model = model.trim();
   if model.is_empty() {
     return String::new();
+  }
+  if provider.eq_ignore_ascii_case("openrouter") || provider.eq_ignore_ascii_case("trustedrouter") {
+    return model.to_string();
   }
   if let Some((prefix, bare)) = model.split_once('/') {
     if prefix.eq_ignore_ascii_case(provider) {
@@ -2807,7 +2831,15 @@ pub async fn chat(
   if requested_provider.is_some()
     && !matches!(
       provider.as_str(),
-      "openai" | "anthropic" | "gemini" | "groq" | "xai" | "openrouter" | "ollama" | "knapsack"
+      "openai"
+        | "anthropic"
+        | "gemini"
+        | "groq"
+        | "xai"
+        | "openrouter"
+        | "trustedrouter"
+        | "ollama"
+        | "knapsack"
     )
   {
     return HttpResponse::BadRequest().json(serde_json::json!({
@@ -2878,6 +2910,13 @@ pub async fn chat(
           "message": "OpenRouter API key is not set. Add it in Settings and Save, then re-enable."
         }))
       }
+    },
+    "trustedrouter" => match trustedrouter_key(&app_handle) {
+      Some(k) => k,
+      None => return HttpResponse::BadRequest().json(serde_json::json!({
+        "ok": false,
+        "message": "TrustedRouter API key is not set. Add it in Settings and Save, then re-enable."
+      })),
     },
     _ => match openai_key(&app_handle) {
       Some(k) => k,
@@ -5277,6 +5316,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       "xai" => super::service::get_xai_model(&app_handle),
       "ollama" => ollama_model(&app_handle),
       "openrouter" => super::service::get_openrouter_model(&app_handle),
+      "trustedrouter" => super::service::get_trustedrouter_model(&app_handle),
       _ => super::service::get_openai_model(&app_handle),
     },
   };
@@ -5311,6 +5351,16 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
       "openrouter" => {
         chat_agent::openai_compatible_chat(key, model, "https://openrouter.ai/api/v1", msgs, tls)
           .await
+      }
+      "trustedrouter" => {
+        chat_agent::openai_compatible_chat(
+          key,
+          model,
+          "https://api.trustedrouter.com/v1",
+          msgs,
+          tls,
+        )
+        .await
       }
       "knapsack" => {
         let email = knapsack_user_email(app_handle).ok_or_else(|| {
@@ -5779,7 +5829,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
         if let Some(r) = recovered_resp {
           r
         } else {
-          // Try fallback providers in order: OpenAI → Anthropic → Gemini → Groq → xAI → OpenRouter → Ollama
+          // Try fallback providers in order: Knapsack → OpenAI → Anthropic → Gemini → Groq → xAI → TrustedRouter → OpenRouter → Ollama
           if disable_fallback {
             return HttpResponse::Ok().json(
               serde_json::json!({"ok": false, "message": format!("{} error: {}", current_provider, err_str)}),
@@ -5796,13 +5846,14 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           } else {
             None
           };
-          let fallbacks: [(&str, Option<String>); 8] = [
+          let fallbacks: [(&str, Option<String>); 9] = [
             ("knapsack", knapsack_fallback_credential(&app_handle)),
             ("openai", openai_key(&app_handle)),
             ("anthropic", anthropic_key(&app_handle)),
             ("gemini", gemini_key(&app_handle)),
             ("groq", groq_key(&app_handle)),
             ("xai", xai_key(&app_handle)),
+            ("trustedrouter", trustedrouter_key(&app_handle)),
             ("openrouter", openrouter_key(&app_handle)),
             ("ollama", ollama_key),
           ];
@@ -5831,6 +5882,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
                 "xai" => super::service::get_xai_model(&app_handle),
                 "ollama" => ollama_model(&app_handle),
                 "openrouter" => super::service::get_openrouter_model(&app_handle),
+                "trustedrouter" => super::service::get_trustedrouter_model(&app_handle),
                 _ => super::service::get_openai_model(&app_handle),
               };
               eprintln!(

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -325,6 +325,13 @@ fn inference_auth_status() -> (bool, Option<String>) {
           .map(|profiles| provider_auth_profile_present(profiles, "openrouter"))
           .unwrap_or(false)
     }
+    "trustedrouter" => {
+      has_non_empty_env_key("TRUSTEDROUTER_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "trustedrouter"))
+          .unwrap_or(false)
+    }
     "gemini" | "google" => {
       has_non_empty_env_key("GEMINI_API_KEY")
         || has_non_empty_env_key("GOOGLE_API_KEY")

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -970,6 +970,11 @@ pub fn resolve_default_model() -> String {
         .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
       return format!("openrouter/{}", model);
     }
+    "trustedrouter" => {
+      let model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
+        .unwrap_or_else(|_| "trustedrouter/auto".to_string());
+      return format!("trustedrouter/{}", model);
+    }
     "ollama" => {
       let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
       return format!("ollama/{}", model);
@@ -1017,7 +1022,7 @@ pub fn resolve_default_model() -> String {
   // so paid fallbacks are not silently selected when the CLI model is unavailable.
   let active_is_free = matches!(
     active.as_str(),
-    "groq" | "xai" | "gemini" | "ollama" | "openrouter" | "google-gemini-cli"
+    "groq" | "xai" | "gemini" | "ollama" | "openrouter" | "trustedrouter" | "google-gemini-cli"
   );
 
   if !disable_paid || !active_is_free {
@@ -1074,6 +1079,11 @@ pub fn resolve_default_model() -> String {
     let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
       .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
     return format!("openrouter/{}", model);
+  }
+  if has_key("TRUSTEDROUTER_API_KEY") {
+    let model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
+      .unwrap_or_else(|_| "trustedrouter/auto".to_string());
+    return format!("trustedrouter/{}", model);
   }
   if has_key("OLLAMA_API_KEY") {
     let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
@@ -1139,6 +1149,12 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
     let model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
       .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
     fallbacks.push(format!("openrouter/{}", model));
+  }
+
+  if primary_provider != "trustedrouter" && has_key("TRUSTEDROUTER_API_KEY") {
+    let model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
+      .unwrap_or_else(|_| "trustedrouter/auto".to_string());
+    fallbacks.push(format!("trustedrouter/{}", model));
   }
 
   fallbacks
@@ -2586,7 +2602,12 @@ fn default_channel_status_params() -> Value {
 /// Get channel status from the gateway (pooled).
 pub async fn get_channel_status(token: Option<&str>) -> Result<Value, String> {
   let t = resolve_token(token)?;
-  call_channel_method("channels.status", Some(default_channel_status_params()), Some(&t)).await
+  call_channel_method(
+    "channels.status",
+    Some(default_channel_status_params()),
+    Some(&t),
+  )
+  .await
 }
 
 /// Call a channel method on the gateway (pooled).

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -64,6 +64,7 @@ fn regenerate_macos_plist_with_current_env(plist_path: &std::path::Path) -> bool
     "GROQ_API_KEY",
     "XAI_API_KEY",
     "OPENROUTER_API_KEY",
+    "TRUSTEDROUTER_API_KEY",
     "OLLAMA_API_KEY",
     "OLLAMA_HOST",
     "KNAPSACK_ACTIVE_PROVIDER",
@@ -73,6 +74,7 @@ fn regenerate_macos_plist_with_current_env(plist_path: &std::path::Path) -> bool
     "KNAPSACK_GROQ_MODEL",
     "KNAPSACK_XAI_MODEL",
     "KNAPSACK_OPENROUTER_MODEL",
+    "KNAPSACK_TRUSTEDROUTER_MODEL",
     "KNAPSACK_OLLAMA_MODEL",
   ];
 
@@ -3959,8 +3961,13 @@ struct StoredTokens {
   openrouter_api_key: Option<String>,
   #[serde(default)]
   openrouter_model: Option<String>,
+  // TrustedRouter support (OpenAI-compatible attested router)
+  #[serde(default)]
+  trustedrouter_api_key: Option<String>,
+  #[serde(default)]
+  trustedrouter_model: Option<String>,
 
-  /// Which provider is currently selected: "openai", "anthropic", "gemini", "groq", "xai", "openrouter", "ollama"
+  /// Which provider is currently selected: "openai", "anthropic", "gemini", "groq", "xai", "openrouter", "trustedrouter", "ollama"
   #[serde(default)]
   active_provider: Option<String>,
 
@@ -4169,7 +4176,9 @@ fn load_or_create_tokens(app_handle: &tauri::AppHandle) -> Result<StoredTokens, 
     xai_model: None, // Defaults to grok-code-fast-1
     openrouter_api_key: None,
     openrouter_model: None, // Defaults to meta-llama/llama-3.3-70b-instruct:free
-    active_provider: None,  // Defaults to openai
+    trustedrouter_api_key: None,
+    trustedrouter_model: None, // Defaults to trustedrouter/auto
+    active_provider: None,     // Defaults to openai
     ollama_enabled: None,
     ollama_model: None,
     ollama_base_url: None,
@@ -4299,6 +4308,24 @@ pub fn propagate_llm_keys_to_env(app_handle: &tauri::AppHandle) {
     let m = m.trim();
     if !m.is_empty() {
       std::env::set_var("KNAPSACK_OPENROUTER_MODEL", m);
+    }
+  }
+  if let Some(k) = tokens.trustedrouter_api_key.clone() {
+    let k_trimmed = k.trim().to_string();
+    if !k_trimmed.is_empty() {
+      if validate_api_key_format(&k_trimmed).is_ok() {
+        std::env::set_var("TRUSTEDROUTER_API_KEY", &k_trimmed);
+      } else {
+        eprintln!("[clawd/service] WARNING: stored TRUSTEDROUTER_API_KEY looks malformed (len={}), clearing from storage. Please re-enter your key in Settings.", k_trimmed.len());
+        tokens.trustedrouter_api_key = None;
+        let _ = save_tokens(app_handle, &tokens);
+      }
+    }
+  }
+  if let Some(m) = &tokens.trustedrouter_model {
+    let m = m.trim();
+    if !m.is_empty() {
+      std::env::set_var("KNAPSACK_TRUSTEDROUTER_MODEL", m);
     }
   }
   // Propagate Ollama settings so OpenClaw subprocess picks them up
@@ -4827,6 +4854,14 @@ pub fn get_openrouter_model(app_handle: &tauri::AppHandle) -> String {
     .ok()
     .and_then(|t| t.openrouter_model)
     .unwrap_or_else(|| "meta-llama/llama-3.3-70b-instruct:free".to_string())
+}
+
+/// Get the configured TrustedRouter model (defaults to trustedrouter/auto if not set)
+pub fn get_trustedrouter_model(app_handle: &tauri::AppHandle) -> String {
+  load_or_create_tokens(app_handle)
+    .ok()
+    .and_then(|t| t.trustedrouter_model)
+    .unwrap_or_else(|| "trustedrouter/auto".to_string())
 }
 
 fn resource_path(app_handle: &tauri::AppHandle, rel: &str) -> PathBuf {
@@ -5725,7 +5760,10 @@ async fn browser_control_status(
         );
         return BrowserControlProbe::Down;
       }
-      eprintln!("[clawd/service] browser control status probe failed: {}", err_text);
+      eprintln!(
+        "[clawd/service] browser control status probe failed: {}",
+        err_text
+      );
       return BrowserControlProbe::Down;
     }
     Err(_) => {
@@ -7153,6 +7191,7 @@ pub struct ApiKeyStatusResponse {
   pub has_groq_key: bool,
   pub has_xai_key: bool,
   pub has_openrouter_key: bool,
+  pub has_trustedrouter_key: bool,
   pub has_gemini_cli_key: bool,
   pub openai_key_hint: Option<String>,
   pub anthropic_key_hint: Option<String>,
@@ -7160,6 +7199,7 @@ pub struct ApiKeyStatusResponse {
   pub groq_key_hint: Option<String>,
   pub xai_key_hint: Option<String>,
   pub openrouter_key_hint: Option<String>,
+  pub trustedrouter_key_hint: Option<String>,
   pub gemini_cli_email: Option<String>,
   // Ollama (local LLM) status
   pub ollama_enabled: bool,
@@ -7202,6 +7242,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         has_groq_key: false,
         has_xai_key: false,
         has_openrouter_key: false,
+        has_trustedrouter_key: false,
         has_gemini_cli_key: false,
         openai_key_hint: None,
         anthropic_key_hint: None,
@@ -7209,6 +7250,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
         groq_key_hint: None,
         xai_key_hint: None,
         openrouter_key_hint: None,
+        trustedrouter_key_hint: None,
         gemini_cli_email: None,
         ollama_enabled: false,
         ollama_model: None,
@@ -7252,6 +7294,11 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     .as_ref()
     .map(|k| !k.trim().is_empty())
     .unwrap_or(false);
+  let has_trustedrouter = tokens
+    .trustedrouter_api_key
+    .as_ref()
+    .map(|k| !k.trim().is_empty())
+    .unwrap_or(false);
   let ollama_enabled = tokens.ollama_enabled.unwrap_or(false);
   let (has_gemini_cli, gemini_cli_email) = read_gemini_cli_auth(&app_handle);
   let has_knapsack = has_knapsack_runtime_auth(&tokens);
@@ -7261,6 +7308,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     || has_groq
     || has_xai
     || has_openrouter
+    || has_trustedrouter
     || ollama_enabled
     || has_gemini_cli
     || has_knapsack;
@@ -7276,6 +7324,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     "groq" => tokens.groq_model.clone(),
     "xai" => tokens.xai_model.clone(),
     "openrouter" => tokens.openrouter_model.clone(),
+    "trustedrouter" => tokens.trustedrouter_model.clone(),
     "ollama" => tokens
       .ollama_model
       .clone()
@@ -7314,6 +7363,11 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     .map(|k| mask_key(k));
   let openrouter_hint = tokens
     .openrouter_api_key
+    .as_ref()
+    .filter(|k| !k.trim().is_empty())
+    .map(|k| mask_key(k));
+  let trustedrouter_hint = tokens
+    .trustedrouter_api_key
     .as_ref()
     .filter(|k| !k.trim().is_empty())
     .map(|k| mask_key(k));
@@ -7357,6 +7411,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     has_groq_key: has_groq,
     has_xai_key: has_xai,
     has_openrouter_key: has_openrouter,
+    has_trustedrouter_key: has_trustedrouter,
     has_gemini_cli_key: has_gemini_cli,
     openai_key_hint: openai_hint,
     anthropic_key_hint: anthropic_hint,
@@ -7364,6 +7419,7 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     groq_key_hint: groq_hint,
     xai_key_hint: xai_hint,
     openrouter_key_hint: openrouter_hint,
+    trustedrouter_key_hint: trustedrouter_hint,
     gemini_cli_email,
     ollama_enabled,
     ollama_model: tokens.ollama_model.clone(),
@@ -7480,6 +7536,14 @@ pub async fn validate_api_key(payload: web::Json<ValidateApiKeyRequest>) -> impl
         .send()
         .await
     }
+    "trustedrouter" => {
+      // TrustedRouter: OpenAI-compatible models endpoint.
+      client
+        .get("https://api.trustedrouter.com/v1/models")
+        .bearer_auth(&key)
+        .send()
+        .await
+    }
     "huggingface" => {
       // Hugging Face: validate with whoami endpoint
       client
@@ -7556,13 +7620,13 @@ fn validate_api_key_format(key: &str) -> Result<(), String> {
   Ok(())
 }
 
-/// Set API key for any provider (OpenAI, Anthropic, Gemini, or extra providers)
+/// Set API key for any provider (OpenAI, Anthropic, Gemini, OpenRouter, TrustedRouter, or extra providers)
 #[derive(Debug, Deserialize)]
 pub struct SetApiKeyRequest {
   #[serde(default)]
   pub key: String,
   pub model: Option<String>,
-  /// "openai" (default), "anthropic", "gemini", "groq", "minimax", "zai", "huggingface"
+  /// "openai" (default), "anthropic", "gemini", "groq", "openrouter", "trustedrouter", "minimax", "zai", "huggingface"
   pub provider: Option<String>,
   /// For extra providers: the environment variable name to store the key under.
   /// e.g. "MINIMAX_API_KEY", "ZAI_API_KEY", "HF_TOKEN"
@@ -7692,6 +7756,10 @@ pub async fn set_api_key(
         .openrouter_api_key
         .as_ref()
         .map_or(false, |k| !k.is_empty()),
+      "trustedrouter" => tokens
+        .trustedrouter_api_key
+        .as_ref()
+        .map_or(false, |k| !k.is_empty()),
       "ollama" => true,
       "knapsack" => tokens
         .knapsack_email
@@ -7727,6 +7795,9 @@ pub async fn set_api_key(
         "openrouter" => {
           tokens.openrouter_model = Some(model.trim().to_string());
         }
+        "trustedrouter" => {
+          tokens.trustedrouter_model = Some(model.trim().to_string());
+        }
         "ollama" => {
           tokens.ollama_model = Some(model.trim().to_string());
         }
@@ -7744,6 +7815,7 @@ pub async fn set_api_key(
       "groq" => "Groq",
       "xai" => "Grok (xAI)",
       "openrouter" => "OpenRouter",
+      "trustedrouter" => "TrustedRouter",
       "ollama" => "Ollama",
       "knapsack" => "Knapsack",
       _ => "OpenAI",
@@ -7780,6 +7852,14 @@ pub async fn set_api_key(
         std::env::set_var("OPENROUTER_API_KEY", k);
       } else if !k.is_empty() {
         eprintln!("[clawd/service] WARNING: stored OPENROUTER_API_KEY looks malformed, skipping propagation. Please re-enter your key in Settings.");
+      }
+    }
+    if let Some(k) = &tokens.trustedrouter_api_key {
+      let k = k.trim();
+      if !k.is_empty() && validate_api_key_format(k).is_ok() {
+        std::env::set_var("TRUSTEDROUTER_API_KEY", k);
+      } else if !k.is_empty() {
+        eprintln!("[clawd/service] WARNING: stored TRUSTEDROUTER_API_KEY looks malformed, skipping propagation. Please re-enter your key in Settings.");
       }
     }
     // Ollama env vars: only set when Ollama is the active provider.
@@ -7952,6 +8032,14 @@ pub async fn set_api_key(
       }
       "OpenRouter"
     }
+    "trustedrouter" => {
+      tokens.trustedrouter_api_key = Some(key);
+      tokens.active_provider = Some("trustedrouter".to_string());
+      if let Some(model) = &payload.model {
+        tokens.trustedrouter_model = Some(model.trim().to_string());
+      }
+      "TrustedRouter"
+    }
     "ollama" => {
       // Ollama doesn't need a real API key — just enable it and store settings
       tokens.ollama_enabled = Some(true);
@@ -8055,6 +8143,18 @@ pub async fn set_api_key(
       eprintln!("[clawd/service] WARNING: stored OPENROUTER_API_KEY looks malformed (len={}), skipping propagation. Please re-enter your key in Settings.", k.len());
     }
   }
+  if let Some(k) = &tokens.trustedrouter_api_key {
+    let k = k.trim();
+    if !k.is_empty() && validate_api_key_format(k).is_ok() {
+      eprintln!(
+        "[clawd/service] set-api-key: propagating TRUSTEDROUTER_API_KEY len={}",
+        k.len()
+      );
+      std::env::set_var("TRUSTEDROUTER_API_KEY", k);
+    } else if !k.is_empty() {
+      eprintln!("[clawd/service] WARNING: stored TRUSTEDROUTER_API_KEY looks malformed (len={}), skipping propagation. Please re-enter your key in Settings.", k.len());
+    }
+  }
   if let Some(p) = &tokens.active_provider {
     std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", p);
   }
@@ -8075,6 +8175,9 @@ pub async fn set_api_key(
   }
   if let Some(m) = &tokens.openrouter_model {
     std::env::set_var("KNAPSACK_OPENROUTER_MODEL", m);
+  }
+  if let Some(m) = &tokens.trustedrouter_model {
+    std::env::set_var("KNAPSACK_TRUSTEDROUTER_MODEL", m);
   }
   // Propagate Ollama settings — only when Ollama is the active provider.
   // When switching away, clear the env vars so the gateway won't discover
@@ -8787,6 +8890,7 @@ pub struct GetApiKeyResponse {
   pub groq_model: Option<String>,
   pub xai_model: Option<String>,
   pub openrouter_model: Option<String>,
+  pub trustedrouter_model: Option<String>,
 }
 
 #[get("/api/clawd/service/get-api-key")]
@@ -8809,6 +8913,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
         groq_model: None,
         xai_model: None,
         openrouter_model: None,
+        trustedrouter_model: None,
       })
     }
   };
@@ -8835,6 +8940,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
     "groq" => tokens.groq_model.clone(),
     "xai" => tokens.xai_model.clone(),
     "openrouter" => tokens.openrouter_model.clone(),
+    "trustedrouter" => tokens.trustedrouter_model.clone(),
     "ollama" => tokens
       .ollama_model
       .or_else(|| Some("llama3.1:latest".to_string())),
@@ -8857,6 +8963,7 @@ pub async fn get_api_key(app_handle: web::Data<tauri::AppHandle>) -> impl Respon
     groq_model: tokens.groq_model.clone(),
     xai_model: tokens.xai_model.clone(),
     openrouter_model: tokens.openrouter_model.clone(),
+    trustedrouter_model: tokens.trustedrouter_model.clone(),
   })
 }
 
@@ -8936,6 +9043,7 @@ fn any_provider_key_available() -> bool {
     "GROQ_API_KEY",
     "XAI_API_KEY",
     "OPENROUTER_API_KEY",
+    "TRUSTEDROUTER_API_KEY",
     "OLLAMA_API_KEY",
   ];
   VARS.iter().any(|v| {
@@ -8963,6 +9071,7 @@ fn model_ref_has_key(model_ref: &str) -> bool {
     "groq" => has("GROQ_API_KEY"),
     "xai" => has("XAI_API_KEY"),
     "openrouter" => has("OPENROUTER_API_KEY"),
+    "trustedrouter" => has("TRUSTEDROUTER_API_KEY"),
     "ollama" => has("OLLAMA_API_KEY"),
     _ => true,
   }
@@ -10446,6 +10555,14 @@ async fn prepare_gateway_config(
       env.push(("OPENROUTER_API_KEY".to_string(), k));
     }
   }
+  // Propagate TrustedRouter key
+  if let Some(k) = tokens.trustedrouter_api_key.clone() {
+    let k = k.trim().to_string();
+    if !k.is_empty() {
+      std::env::set_var("TRUSTEDROUTER_API_KEY", &k);
+      env.push(("TRUSTEDROUTER_API_KEY".to_string(), k));
+    }
+  }
 
   // Propagate active provider and model overrides so the gateway uses the
   // correct provider/model the user selected in the UI.
@@ -10473,6 +10590,9 @@ async fn prepare_gateway_config(
   }
   if let Some(m) = tokens.openrouter_model.clone() {
     env.push(("KNAPSACK_OPENROUTER_MODEL".to_string(), m));
+  }
+  if let Some(m) = tokens.trustedrouter_model.clone() {
+    env.push(("KNAPSACK_TRUSTEDROUTER_MODEL".to_string(), m));
   }
 
   if let Some(extra) = &tokens.extra_provider_keys {
@@ -14950,6 +15070,8 @@ mod knapsack_runtime_auth_tests {
       xai_model: None,
       openrouter_api_key: None,
       openrouter_model: None,
+      trustedrouter_api_key: None,
+      trustedrouter_model: None,
       active_provider: None,
       ollama_enabled: None,
       ollama_model: None,

--- a/src/src-tauri/src/heartbeat/engine.rs
+++ b/src/src-tauri/src/heartbeat/engine.rs
@@ -612,6 +612,9 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
   let openrouter_key = std::env::var("OPENROUTER_API_KEY")
     .ok()
     .filter(|k| !k.trim().is_empty());
+  let trustedrouter_key = std::env::var("TRUSTEDROUTER_API_KEY")
+    .ok()
+    .filter(|k| !k.trim().is_empty());
 
   // First: try the user's active provider with its CHEAPEST model
   match active.as_str() {
@@ -660,6 +663,15 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
         is_anthropic: false,
       });
     }
+    "trustedrouter" if trustedrouter_key.is_some() => {
+      return Ok(HeartbeatProvider {
+        name: "trustedrouter".into(),
+        api_key: trustedrouter_key.unwrap(),
+        model: "trustedrouter/fast".into(),
+        base_url: "https://api.trustedrouter.com/v1".into(),
+        is_anthropic: false,
+      });
+    }
     _ => {}
   }
 
@@ -670,7 +682,7 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
   );
   let active_is_free = matches!(
     active.as_str(),
-    "groq" | "gemini" | "ollama" | "openrouter" | ""
+    "groq" | "gemini" | "ollama" | "openrouter" | "trustedrouter" | ""
   );
 
   if let Some(key) = groq_key {
@@ -697,6 +709,15 @@ fn resolve_heartbeat_provider() -> Result<HeartbeatProvider, String> {
       api_key: key,
       model: "meta-llama/llama-3.3-70b-instruct:free".into(),
       base_url: "https://openrouter.ai/api/v1".into(),
+      is_anthropic: false,
+    });
+  }
+  if let Some(key) = trustedrouter_key {
+    return Ok(HeartbeatProvider {
+      name: "trustedrouter".into(),
+      api_key: key,
+      model: "trustedrouter/fast".into(),
+      base_url: "https://api.trustedrouter.com/v1".into(),
       is_anthropic: false,
     });
   }

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -38,7 +38,7 @@ struct CompletionUsage {
 
 /// Resolved LLM provider info for meeting notes completion.
 struct ResolvedProvider {
-  name: String, // "openai", "anthropic", "gemini", "groq", "openrouter", "knapsack"
+  name: String, // "openai", "anthropic", "gemini", "groq", "openrouter", "trustedrouter", "knapsack"
   api_key: String,
   model: String,
   base_url: String,   // e.g. "https://api.openai.com/v1"
@@ -46,7 +46,7 @@ struct ResolvedProvider {
 }
 
 /// Try to resolve the best available LLM provider from env vars.
-/// Priority: active_provider setting → OpenAI → Anthropic → Gemini → Groq → OpenRouter → Knapsack
+/// Priority: active_provider setting → OpenAI → Anthropic → Gemini → Groq → TrustedRouter → OpenRouter → Knapsack
 fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
   let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
   let openai_key = std::env::var("OPENAI_API_KEY")
@@ -63,6 +63,9 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
     .ok()
     .filter(|k| !k.trim().is_empty());
   let openrouter_key = std::env::var("OPENROUTER_API_KEY")
+    .ok()
+    .filter(|k| !k.trim().is_empty());
+  let trustedrouter_key = std::env::var("TRUSTEDROUTER_API_KEY")
     .ok()
     .filter(|k| !k.trim().is_empty());
   let ollama_key = std::env::var("OLLAMA_API_KEY")
@@ -141,6 +144,18 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
         is_anthropic: false,
       });
     }
+    "trustedrouter" if trustedrouter_key.is_some() => {
+      let trustedrouter_model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
+        .unwrap_or_else(|_| "trustedrouter/auto".to_string());
+      let key = trustedrouter_key.unwrap();
+      return Ok(ResolvedProvider {
+        name: "trustedrouter".into(),
+        api_key: key,
+        model: trustedrouter_model,
+        base_url: "https://api.trustedrouter.com/v1".into(),
+        is_anthropic: false,
+      });
+    }
     "knapsack" => {
       if let Some(email) = &knapsack_email {
         let model = std::env::var("KNAPSACK_KNAPSACK_MODEL").unwrap_or_else(|_| "auto".to_string());
@@ -195,7 +210,7 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
     .unwrap_or(true);
   let active_is_free = matches!(
     active.as_str(),
-    "groq" | "gemini" | "ollama" | "openrouter" | "knapsack"
+    "groq" | "gemini" | "ollama" | "openrouter" | "trustedrouter" | "knapsack"
   );
 
   if !disable_paid || !active_is_free {
@@ -284,6 +299,17 @@ fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
       is_anthropic: false,
     });
   }
+  if let Some(key) = trustedrouter_key {
+    let trustedrouter_model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
+      .unwrap_or_else(|_| "trustedrouter/auto".to_string());
+    return Ok(ResolvedProvider {
+      name: "trustedrouter".into(),
+      api_key: key,
+      model: trustedrouter_model,
+      base_url: "https://api.trustedrouter.com/v1".into(),
+      is_anthropic: false,
+    });
+  }
   if let Some(key) = openrouter_key {
     let openrouter_model = std::env::var("KNAPSACK_OPENROUTER_MODEL")
       .unwrap_or_else(|_| "meta-llama/llama-3.3-70b-instruct:free".to_string());
@@ -337,6 +363,7 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
     if provider.name != "openrouter"
       && provider.name != "ollama"
       && provider.name != "groq"
+      && provider.name != "trustedrouter"
       && provider.name != "knapsack"
     {
       let openrouter_key = std::env::var("OPENROUTER_API_KEY")
@@ -374,6 +401,7 @@ fn apply_model_routing(provider: &mut ResolvedProvider, prompt: &str) {
       "gemini" => ("gemini-3.5-flash".to_string(), "Flash"), // already cheap
       "groq" => (provider.model.clone(), "Groq"),            // already cheap
       "knapsack" => (provider.model.clone(), "Knapsack"),
+      "trustedrouter" => (provider.model.clone(), "TrustedRouter"),
       "openrouter" => (provider.model.clone(), "OpenRouter"), // user chose this
       "ollama" => (provider.model.clone(), "Ollama"),         // local, no cost
       _ => (provider.model.clone(), "unchanged"),

--- a/src/src/components/SigninButton.tsx
+++ b/src/src/components/SigninButton.tsx
@@ -4,7 +4,7 @@ import './SigninButton.scss'
 type SigninButtonProps = {
   className?: string
   onGoogleSignIn: () => void
-  onProviderSignIn: (provider: 'openai' | 'anthropic' | 'openrouter') => void
+  onProviderSignIn: (provider: 'openai' | 'anthropic' | 'openrouter' | 'trustedrouter') => void
 }
 
 export const SigninButton: React.FC<SigninButtonProps> = ({
@@ -109,6 +109,19 @@ export const SigninButton: React.FC<SigninButtonProps> = ({
             <div className="signin-dropdown-text">
               <span className="signin-dropdown-name">OpenRouter</span>
               <span className="signin-dropdown-desc">Free &amp; paid models</span>
+            </div>
+          </button>
+
+          <button
+            className="signin-dropdown-item"
+            onClick={() => { setOpen(false); onProviderSignIn('trustedrouter') }}
+          >
+            <div className="signin-dropdown-icon">
+              <span style={{ fontSize: 11, fontWeight: 700, color: '#2563eb' }}>TR</span>
+            </div>
+            <div className="signin-dropdown-text">
+              <span className="signin-dropdown-name">TrustedRouter</span>
+              <span className="signin-dropdown-desc">Attested OpenAI-compatible routing</span>
             </div>
           </button>
         </div>

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -180,6 +180,7 @@ function getActiveModelLabel(): string {
     knapsack: KNAPSACK_MODEL_STORAGE,
     groq: 'moltbot_groq_model',
     openrouter: 'moltbot_openrouter_model',
+    trustedrouter: 'moltbot_trustedrouter_model',
     ollama: 'moltbot_ollama_model',
     xai: 'moltbot_xai_model',
   }
@@ -398,6 +399,7 @@ type ApiKeyStatus = {
   has_groq_key?: boolean
   has_xai_key?: boolean
   has_openrouter_key?: boolean
+  has_trustedrouter_key?: boolean
   has_knapsack?: boolean
   knapsack_email?: string
   knapsack_model?: string
@@ -407,6 +409,7 @@ type ApiKeyStatus = {
   groq_key_hint?: string
   xai_key_hint?: string
   openrouter_key_hint?: string
+  trustedrouter_key_hint?: string
   ollama_enabled?: boolean
   ollama_model?: string
   ollama_base_url?: string
@@ -430,7 +433,7 @@ type SkillInfo = {
   homepage?: string // URL for skill detail page (from gateway)
 }
 
-type Provider = 'knapsack' | 'openai' | 'anthropic' | 'gemini' | 'groq' | 'xai' | 'openrouter' | 'ollama'
+type Provider = 'knapsack' | 'openai' | 'anthropic' | 'gemini' | 'groq' | 'xai' | 'openrouter' | 'trustedrouter' | 'ollama'
 
 type ProviderOption = {
   id: Provider
@@ -453,6 +456,7 @@ const PROVIDERS: ProviderOption[] = [
   { id: 'groq', name: 'Groq', description: 'GPT-OSS, Llama 4, Kimi K2 — ultra-fast', keyPrefix: 'gsk_', helpUrl: 'https://console.groq.com/keys' },
   { id: 'xai', name: 'Grok (xAI)', description: 'Grok 4.20, Grok 4 Fast, Grok Code Fast', keyPrefix: 'xai-', helpUrl: 'https://console.x.ai/' },
   { id: 'openrouter', name: 'OpenRouter', description: 'Free & paid models from many providers', keyPrefix: 'sk-or-', helpUrl: 'https://openrouter.ai/keys' },
+  { id: 'trustedrouter', name: 'TrustedRouter', description: 'OpenAI-compatible attested routing through TrustedRouter', keyPrefix: 'sk-tr-', helpUrl: 'https://trustedrouter.com/console/api-keys' },
   { id: 'ollama', name: 'Ollama', description: 'Local models — free, private, no API key', keyPrefix: '', helpUrl: 'https://ollama.com' },
 ]
 
@@ -542,6 +546,17 @@ const OPENROUTER_MODELS: OpenRouterModelOption[] = [
   { id: 'openai/gpt-5.5', name: 'GPT-5.5 (Paid)', description: 'Paid, OpenAI newest frontier via OpenRouter', vision: true },
 ]
 
+const TRUSTEDROUTER_MODELS: OpenRouterModelOption[] = [
+  { id: 'trustedrouter/auto', name: 'Auto', description: 'TrustedRouter selects the best healthy route for each request', vision: true },
+  { id: 'trustedrouter/zdr', name: 'Zero Data Retention', description: 'Routes through providers with zero-retention policies where available', vision: true },
+  { id: 'trustedrouter/e2e', name: 'End-to-End Encrypted', description: 'Routes to end-to-end encrypted provider paths where available', vision: true },
+  { id: 'trustedrouter/fast', name: 'Fast', description: 'Low-latency route for quick agent loops' },
+  { id: 'trustedrouter/synth', name: 'Synth', description: 'Panel synthesis across multiple open models' },
+  { id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6', description: 'Balanced coding and reasoning via TrustedRouter', vision: true },
+  { id: 'zai/glm-5.2', name: 'GLM 5.2', description: 'Strong open model for coding and agentic work' },
+  { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code', description: 'Open model optimized for coding workflows' },
+]
+
 // Recommended models to offer for download when Ollama has none installed
 type OllamaModelSuggestion = { id: string; name: string; description: string; size: string }
 const OLLAMA_SUGGESTED_MODELS: OllamaModelSuggestion[] = [
@@ -625,6 +640,7 @@ const GEMINI_MODEL_STORAGE = 'moltbot_gemini_model'
 const GROQ_MODEL_STORAGE = 'moltbot_groq_model'
 const XAI_MODEL_STORAGE = 'moltbot_xai_model'
 const OPENROUTER_MODEL_STORAGE = 'moltbot_openrouter_model'
+const TRUSTEDROUTER_MODEL_STORAGE = 'moltbot_trustedrouter_model'
 const OLLAMA_MODEL_STORAGE = 'moltbot_ollama_model'
 const TONE_STORAGE = 'moltbot_tone'
 const VOICE_MODE_STORAGE = 'moltbot_voice_mode'
@@ -1966,6 +1982,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
   const [selectedOpenRouterModel, setSelectedOpenRouterModel] = useState<string>(() => {
     return localStorage.getItem(OPENROUTER_MODEL_STORAGE) || 'meta-llama/llama-3.3-70b-instruct:free'
   })
+  const [selectedTrustedRouterModel, setSelectedTrustedRouterModel] = useState<string>(() => {
+    return localStorage.getItem(TRUSTEDROUTER_MODEL_STORAGE) || 'trustedrouter/auto'
+  })
   const [selectedOllamaModel, setSelectedOllamaModel] = useState<string>(() => {
     return localStorage.getItem(OLLAMA_MODEL_STORAGE) || ''
   })
@@ -2333,6 +2352,12 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
               setSelectedOpenRouterModel(backendModel)
               localStorage.setItem(OPENROUTER_MODEL_STORAGE, backendModel)
             }
+          } else if (activeProvider === 'trustedrouter') {
+            const localModel = localStorage.getItem(TRUSTEDROUTER_MODEL_STORAGE)
+            if (!localModel) {
+              setSelectedTrustedRouterModel(backendModel)
+              localStorage.setItem(TRUSTEDROUTER_MODEL_STORAGE, backendModel)
+            }
           } else if (activeProvider === 'ollama') {
             const localModel = localStorage.getItem(OLLAMA_MODEL_STORAGE)
             if (!localModel) {
@@ -2360,6 +2385,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           groq: keyStatus.groq_key_hint,
           xai: keyStatus.xai_key_hint,
           openrouter: keyStatus.openrouter_key_hint,
+          trustedrouter: keyStatus.trustedrouter_key_hint,
         })
         // Track which providers have saved keys
         setSavedProviderKeys({
@@ -2370,6 +2396,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           groq: !!keyStatus.has_groq_key,
           xai: !!keyStatus.has_xai_key,
           openrouter: !!keyStatus.has_openrouter_key,
+          trustedrouter: !!keyStatus.has_trustedrouter_key,
         })
         if (keyStatus.knapsack_email) {
           setKnapsackEmail(keyStatus.knapsack_email)
@@ -2410,6 +2437,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
             groq_model?: string
             xai_model?: string
             openrouter_model?: string
+            trustedrouter_model?: string
           }>('/api/clawd/service/get-api-key')
           if (fullKeys.anthropic_model) {
             setSelectedAnthropicModel(fullKeys.anthropic_model)
@@ -2430,6 +2458,10 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           if (fullKeys.openrouter_model) {
             setSelectedOpenRouterModel(fullKeys.openrouter_model)
             localStorage.setItem(OPENROUTER_MODEL_STORAGE, fullKeys.openrouter_model)
+          }
+          if (fullKeys.trustedrouter_model) {
+            setSelectedTrustedRouterModel(fullKeys.trustedrouter_model)
+            localStorage.setItem(TRUSTEDROUTER_MODEL_STORAGE, fullKeys.trustedrouter_model)
           }
         } catch { /* ignore */ }
         // If this version was already onboarded, skip the prompt
@@ -2872,6 +2904,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       : confirmedProvider === 'groq' ? GROQ_MODELS
       : confirmedProvider === 'xai' ? XAI_MODELS
       : confirmedProvider === 'openrouter' ? OPENROUTER_MODELS
+      : confirmedProvider === 'trustedrouter' ? TRUSTEDROUTER_MODELS
       : []
     const currentId = confirmedProvider === 'openai' ? selectedModel
       : confirmedProvider === 'anthropic' ? selectedAnthropicModel
@@ -2879,6 +2912,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
       : confirmedProvider === 'groq' ? selectedGroqModel
       : confirmedProvider === 'xai' ? selectedXaiModel
       : confirmedProvider === 'openrouter' ? selectedOpenRouterModel
+      : confirmedProvider === 'trustedrouter' ? selectedTrustedRouterModel
       : ''
     const current = allModels.find(m => m.id === currentId)
     // Ollama: we don't know model capabilities, assume supported
@@ -2887,7 +2921,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     const supported = current?.vision ?? false
     const visionModels = allModels.filter(m => m.vision).map(m => m.name)
     return { supported, modelName, visionModels }
-  }, [confirmedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel])
+  }, [confirmedProvider, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedTrustedRouterModel, selectedKnapsackModel])
 
   // File upload handlers
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -3403,6 +3437,9 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         } else if (activeProvider === 'openrouter') {
           setSelectedOpenRouterModel(backendModel)
           localStorage.setItem(OPENROUTER_MODEL_STORAGE, backendModel)
+        } else if (activeProvider === 'trustedrouter') {
+          setSelectedTrustedRouterModel(backendModel)
+          localStorage.setItem(TRUSTEDROUTER_MODEL_STORAGE, backendModel)
         } else if (activeProvider === 'ollama') {
           setSelectedOllamaModel(backendModel)
           localStorage.setItem(OLLAMA_MODEL_STORAGE, backendModel)
@@ -3471,6 +3508,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : selectedProvider === 'groq' ? selectedGroqModel
         : selectedProvider === 'xai' ? selectedXaiModel
         : selectedProvider === 'openrouter' ? selectedOpenRouterModel
+        : selectedProvider === 'trustedrouter' ? selectedTrustedRouterModel
         : selectedProvider === 'knapsack' ? selectedKnapsackModel
         : undefined
       await apiPost('/api/clawd/service/set-api-key', {
@@ -3492,6 +3530,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(XAI_MODEL_STORAGE, selectedXaiModel)
       } else if (selectedProvider === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
+      } else if (selectedProvider === 'trustedrouter') {
+        localStorage.setItem(TRUSTEDROUTER_MODEL_STORAGE, selectedTrustedRouterModel)
       } else if (selectedProvider === 'knapsack') {
         localStorage.setItem(KNAPSACK_MODEL_STORAGE, selectedKnapsackModel)
       }
@@ -3523,6 +3563,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
           modelName = XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel
         } else if (selectedProvider === 'openrouter') {
           modelName = OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel
+        } else if (selectedProvider === 'trustedrouter') {
+          modelName = TRUSTEDROUTER_MODELS.find(m => m.id === selectedTrustedRouterModel)?.name || selectedTrustedRouterModel
         } else if (selectedProvider === 'knapsack') {
           modelName = KNAPSACK_MODELS.find(m => m.id === selectedKnapsackModel)?.name || selectedKnapsackModel
         } else {
@@ -3539,7 +3581,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel, selectedOllamaModel, selectedProvider, saveOllamaProvider, syncProviderSelectionFromBackend])
+  }, [apiKey, selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedTrustedRouterModel, selectedKnapsackModel, selectedOllamaModel, selectedProvider, saveOllamaProvider, syncProviderSelectionFromBackend])
 
   // Switch to a provider that already has a saved key (no new key needed)
   const switchProviderModel = useCallback(async (providerId: Provider, alreadyActive = false) => {
@@ -3556,6 +3598,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : providerId === 'groq' ? selectedGroqModel
         : providerId === 'xai' ? selectedXaiModel
         : providerId === 'openrouter' ? selectedOpenRouterModel
+        : providerId === 'trustedrouter' ? selectedTrustedRouterModel
         : providerId === 'knapsack' ? selectedKnapsackModel
         : undefined
       await apiPost('/api/clawd/service/set-api-key', {
@@ -3575,6 +3618,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         localStorage.setItem(XAI_MODEL_STORAGE, selectedXaiModel)
       } else if (providerId === 'openrouter') {
         localStorage.setItem(OPENROUTER_MODEL_STORAGE, selectedOpenRouterModel)
+      } else if (providerId === 'trustedrouter') {
+        localStorage.setItem(TRUSTEDROUTER_MODEL_STORAGE, selectedTrustedRouterModel)
       } else if (providerId === 'knapsack') {
         localStorage.setItem(KNAPSACK_MODEL_STORAGE, selectedKnapsackModel)
       }
@@ -3593,6 +3638,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : providerId === 'gemini' ? GEMINI_MODELS
         : providerId === 'xai' ? XAI_MODELS
         : providerId === 'knapsack' ? KNAPSACK_MODELS
+        : providerId === 'trustedrouter' ? TRUSTEDROUTER_MODELS
         : providerId === 'openrouter' ? OPENROUTER_MODELS
         : GROQ_MODELS
       const mv = providerId === 'openai' ? selectedModel
@@ -3600,6 +3646,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         : providerId === 'gemini' ? selectedGeminiModel
         : providerId === 'xai' ? selectedXaiModel
         : providerId === 'knapsack' ? selectedKnapsackModel
+        : providerId === 'trustedrouter' ? selectedTrustedRouterModel
         : providerId === 'openrouter' ? selectedOpenRouterModel
         : selectedGroqModel
       const modelName = models.find(m => m.id === mv)?.name || mv
@@ -3611,7 +3658,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     } finally {
       setSavingKey(false)
     }
-  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedKnapsackModel, saveOllamaProvider, syncProviderSelectionFromBackend])
+  }, [selectedModel, selectedAnthropicModel, selectedGeminiModel, selectedGroqModel, selectedXaiModel, selectedOpenRouterModel, selectedTrustedRouterModel, selectedKnapsackModel, saveOllamaProvider, syncProviderSelectionFromBackend])
 
   useEffect(() => {
     const init = async () => {
@@ -4369,6 +4416,8 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
         ? selectedXaiModel
         : providerAtSend === 'openrouter'
         ? selectedOpenRouterModel
+        : providerAtSend === 'trustedrouter'
+        ? selectedTrustedRouterModel
         : selectedModel
       return m ? `${providerAtSend}/${m}` : providerAtSend
     })()
@@ -5312,6 +5361,7 @@ ${actualText}`
               : confirmedProvider === 'xai' ? (XAI_MODELS.find(m => m.id === selectedXaiModel)?.name || selectedXaiModel || 'Grok')
               : confirmedProvider === 'ollama' ? (selectedOllamaModel || 'Ollama')
               : confirmedProvider === 'openrouter' ? (OPENROUTER_MODELS.find(m => m.id === selectedOpenRouterModel)?.name || selectedOpenRouterModel || 'OpenRouter')
+              : confirmedProvider === 'trustedrouter' ? (TRUSTEDROUTER_MODELS.find(m => m.id === selectedTrustedRouterModel)?.name || selectedTrustedRouterModel || 'TrustedRouter')
               : confirmedProvider === 'knapsack' ? 'Knapsack'
               : (OPENAI_MODELS.find(m => m.id === selectedModel)?.name || selectedModel || 'OpenAI')}
           </button>
@@ -7496,18 +7546,21 @@ ${actualText}`
                   : p.id === 'gemini' ? GEMINI_MODELS
                   : p.id === 'xai' ? XAI_MODELS
                   : p.id === 'openrouter' ? OPENROUTER_MODELS
+                  : p.id === 'trustedrouter' ? TRUSTEDROUTER_MODELS
                   : GROQ_MODELS
                 const modelValue = p.id === 'openai' ? selectedModel
                   : p.id === 'anthropic' ? selectedAnthropicModel
                   : p.id === 'gemini' ? selectedGeminiModel
                   : p.id === 'xai' ? selectedXaiModel
                   : p.id === 'openrouter' ? selectedOpenRouterModel
+                  : p.id === 'trustedrouter' ? selectedTrustedRouterModel
                   : selectedGroqModel
                 const setModelValue = p.id === 'openai' ? setSelectedModel
                   : p.id === 'anthropic' ? setSelectedAnthropicModel
                   : p.id === 'gemini' ? setSelectedGeminiModel
                   : p.id === 'xai' ? setSelectedXaiModel
                   : p.id === 'openrouter' ? setSelectedOpenRouterModel
+                  : p.id === 'trustedrouter' ? setSelectedTrustedRouterModel
                   : setSelectedGroqModel
 
                 return (
@@ -7543,6 +7596,7 @@ ${actualText}`
                                     : p.id === 'gemini' ? GEMINI_MODEL_STORAGE
                                     : p.id === 'xai' ? XAI_MODEL_STORAGE
                                     : p.id === 'openrouter' ? OPENROUTER_MODEL_STORAGE
+                                    : p.id === 'trustedrouter' ? TRUSTEDROUTER_MODEL_STORAGE
                                     : GROQ_MODEL_STORAGE
                                   localStorage.setItem(storageKey, newModel)
                                   if (isConfirmedActive) {

--- a/src/src/components/templates/Home/Home.tsx
+++ b/src/src/components/templates/Home/Home.tsx
@@ -98,7 +98,7 @@ function Home({
   const [useLocalLLM, setUseLocalLLM] = useState<boolean>(false)
   const [isSettingsDialogOpened, setIsSettingsDialogOpened] = useState(false)
   const [isProviderSignInDialogOpened, setIsProviderSignInDialogOpened] = useState(false)
-  const [providerSignInInitialProvider, setProviderSignInInitialProvider] = useState<'knapsack' | 'openai' | 'anthropic' | 'openrouter' | undefined>(undefined)
+  const [providerSignInInitialProvider, setProviderSignInInitialProvider] = useState<'knapsack' | 'openai' | 'anthropic' | 'openrouter' | 'trustedrouter' | undefined>(undefined)
   const [openProviderPanelTrigger, setOpenProviderPanelTrigger] = useState(0)
   const [connectionsDropdownOpened, setConnectionsDropdownOpened] = useState(false)
   const [showAutomationLabModal, setShowAutomationLabModal] = useState(false)
@@ -331,7 +331,7 @@ function Home({
     }
   }
 
-  const handleOpenProviderSignIn = useCallback((provider?: 'knapsack' | 'openai' | 'anthropic' | 'openrouter') => {
+  const handleOpenProviderSignIn = useCallback((provider?: 'knapsack' | 'openai' | 'anthropic' | 'openrouter' | 'trustedrouter') => {
     // Close settings dialog and open the ClawdChat provider sidebar instead
     setIsSettingsDialogOpened(false)
     setProviderSignInInitialProvider(provider)

--- a/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
+++ b/src/src/components/templates/Home/components/ProviderSignInDialog/index.tsx
@@ -13,7 +13,7 @@ import styles from './styles.module.scss'
 
 const API_BASE = 'http://127.0.0.1:8897'
 
-type Provider = 'knapsack' | 'openai' | 'anthropic' | 'openrouter' | 'gemini'
+type Provider = 'knapsack' | 'openai' | 'anthropic' | 'openrouter' | 'trustedrouter' | 'gemini'
 
 type ProviderConfig = {
   id: Provider
@@ -96,6 +96,22 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
     defaultModel: 'qwen/qwen3-coder-480b-a35b-instruct:free',
   },
   {
+    id: 'trustedrouter',
+    name: 'TrustedRouter',
+    description: 'Attested OpenAI-compatible routing through TrustedRouter',
+    keyPrefix: 'sk-tr-',
+    helpUrl: 'https://trustedrouter.com/console/api-keys',
+    helpLabel: 'trustedrouter.com/console/api-keys',
+    models: [
+      { id: 'trustedrouter/auto', name: 'Auto', description: 'TrustedRouter selects the best healthy route for each request' },
+      { id: 'trustedrouter/zdr', name: 'Zero Data Retention', description: 'Routes through zero-retention providers where available' },
+      { id: 'trustedrouter/e2e', name: 'End-to-End Encrypted', description: 'Routes to end-to-end encrypted provider paths where available' },
+      { id: 'trustedrouter/fast', name: 'Fast', description: 'Low-latency route for quick agent loops' },
+      { id: 'trustedrouter/synth', name: 'Synth', description: 'Panel synthesis across multiple open models' },
+    ],
+    defaultModel: 'trustedrouter/auto',
+  },
+  {
     id: 'gemini',
     name: 'Gemini',
     description: 'Gemini 2.5 Pro, 2.5 Flash — sign in with Google',
@@ -163,11 +179,13 @@ type ApiKeyStatusResponse = {
   has_openai_key?: boolean
   has_anthropic_key?: boolean
   has_openrouter_key?: boolean
+  has_trustedrouter_key?: boolean
   has_gemini_key?: boolean
   has_gemini_cli_key?: boolean
   openai_key_hint?: string
   anthropic_key_hint?: string
   openrouter_key_hint?: string
+  trustedrouter_key_hint?: string
   gemini_key_hint?: string
   gemini_cli_email?: string
   extra_providers?: ExtraProviderStatusItem[]
@@ -227,6 +245,7 @@ export const ProviderSignInDialog = ({
     if (provider === 'openai') return keyStatus.openai_key_hint
     if (provider === 'anthropic') return keyStatus.anthropic_key_hint
     if (provider === 'openrouter') return keyStatus.openrouter_key_hint
+    if (provider === 'trustedrouter') return keyStatus.trustedrouter_key_hint
     if (provider === 'gemini') return keyStatus.gemini_key_hint
     return undefined
   }
@@ -335,6 +354,7 @@ export const ProviderSignInDialog = ({
           const statusData: ApiKeyStatusResponse = await statusRes.json()
           const connected =
             provider === 'openrouter' ? statusData.has_openrouter_key :
+            provider === 'trustedrouter' ? statusData.has_trustedrouter_key :
             provider === 'openai' ? statusData.has_openai_key :
             provider === 'anthropic' ? statusData.has_anthropic_key : false
 
@@ -478,7 +498,7 @@ export const ProviderSignInDialog = ({
         setSelectedProvider('knapsack')
         const config = PROVIDER_CONFIGS.find(p => p.id === 'knapsack')!
         setSelectedModel(data.knapsack_model || config.defaultModel)
-      } else if (data.active_provider === 'openai' || data.active_provider === 'anthropic' || data.active_provider === 'openrouter' || data.active_provider === 'gemini') {
+      } else if (data.active_provider === 'openai' || data.active_provider === 'anthropic' || data.active_provider === 'openrouter' || data.active_provider === 'trustedrouter' || data.active_provider === 'gemini') {
         setSelectedProvider(data.active_provider as Provider)
         const config = PROVIDER_CONFIGS.find(p => p.id === data.active_provider)!
         setSelectedModel(data.model || config.defaultModel)
@@ -608,6 +628,7 @@ export const ProviderSignInDialog = ({
     if (provider === 'openai') return !!keyStatus.has_openai_key
     if (provider === 'anthropic') return !!keyStatus.has_anthropic_key
     if (provider === 'openrouter') return !!keyStatus.has_openrouter_key
+    if (provider === 'trustedrouter') return !!keyStatus.has_trustedrouter_key
     if (provider === 'gemini') return !!keyStatus.has_gemini_key || !!keyStatus.has_gemini_cli_key
     return false
   }
@@ -763,6 +784,9 @@ export const ProviderSignInDialog = ({
                     <path d="M4 4h6v6H4V4zm10 0h6v6h-6V4zM4 14h6v6H4v-6zm10 0h6v6h-6v-6z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" fill="none"/>
                     <path d="M10 7h4M7 10v4M17 10v4M10 17h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
                   </svg>
+                )}
+                {config.id === 'trustedrouter' && (
+                  <span style={{ fontSize: 12, fontWeight: 700, color: 'currentColor' }}>TR</span>
                 )}
                 {config.id === 'gemini' && (
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/src/components/templates/Home/components/SettingsDialog/index.tsx
+++ b/src/src/components/templates/Home/components/SettingsDialog/index.tsx
@@ -65,7 +65,7 @@ type SettingsDialogProps = {
   fetchConnections: (email: string) => void
   deleteConnection: (id: number) => void
   profile: Profile | undefined
-  onProviderSignInClick?: (provider?: 'knapsack' | 'openai' | 'anthropic' | 'openrouter') => void
+  onProviderSignInClick?: (provider?: 'knapsack' | 'openai' | 'anthropic' | 'openrouter' | 'trustedrouter') => void
 }
 
 const PERMISSION_LIST_GOOGLE_CONNECTIONS = new Set([
@@ -267,6 +267,7 @@ export const SettingsDialog = ({
     has_openai_key?: boolean
     has_anthropic_key?: boolean
     has_openrouter_key?: boolean
+    has_trustedrouter_key?: boolean
     has_gemini_cli_key?: boolean
     has_knapsack?: boolean
     knapsack_email?: string
@@ -409,6 +410,7 @@ export const SettingsDialog = ({
           has_openai_key: data.has_openai_key,
           has_anthropic_key: data.has_anthropic_key,
           has_openrouter_key: data.has_openrouter_key,
+          has_trustedrouter_key: data.has_trustedrouter_key,
           has_gemini_cli_key: data.has_gemini_cli_key,
           has_knapsack: data.has_knapsack,
           knapsack_email: data.knapsack_email,
@@ -785,6 +787,27 @@ export const SettingsDialog = ({
                   onClick={() => { handleClose(); onProviderSignInClick?.('openrouter') }}
                 >
                   {providerStatus?.has_openrouter_key ? 'Change' : 'Sign in'}
+                </button>
+              </div>
+            </ProviderAccordion>
+
+            {/* TrustedRouter */}
+            <ProviderAccordion
+              title="TrustedRouter"
+              isActive={providerStatus?.active_provider === 'trustedrouter'}
+              isConnected={!!providerStatus?.has_trustedrouter_key}
+              expanded={expandedProvider === 'trustedrouter'}
+              onToggle={() => toggleProvider('trustedrouter')}
+            >
+              <div className={styles.providerActions}>
+                <span className={styles.providerStatus}>
+                  {providerStatus?.has_trustedrouter_key ? 'API key configured' : 'No API key set'}
+                </span>
+                <button
+                  className={styles.providerActionLink}
+                  onClick={() => { handleClose(); onProviderSignInClick?.('trustedrouter') }}
+                >
+                  {providerStatus?.has_trustedrouter_key ? 'Change' : 'Sign in'}
                 </button>
               </div>
             </ProviderAccordion>


### PR DESCRIPTION
## Summary

Adds TrustedRouter as an AI provider option alongside OpenRouter and the existing direct providers.

## What changed

- Adds TrustedRouter to provider setup, settings, and chat provider selection UI.
- Stores and restores `TRUSTEDROUTER_API_KEY` and `KNAPSACK_TRUSTEDROUTER_MODEL`.
- Validates TrustedRouter API keys through `https://api.trustedrouter.com/v1/models`.
- Routes chat, meeting completion, heartbeat, gateway defaults, and fallbacks through the OpenAI-compatible TrustedRouter API at `https://api.trustedrouter.com/v1`.
- Includes common TrustedRouter model aliases such as `trustedrouter/auto`, `trustedrouter/zdr`, `trustedrouter/e2e`, `trustedrouter/fast`, and `trustedrouter/synth`.

## Testing

- `npm ci`
- `cd src/src-tauri && cargo fmt --check`
- `cd src && VITE_KN_API_SERVER=https://api.knapsack.ai VITE_GOOGLE_CLIENT_ID=dummy npm run build`
- `cd src/src-tauri && VITE_KN_API_SERVER=https://api.knapsack.ai VITE_GOOGLE_CLIENT_ID=dummy cargo check`

`cargo check` passes with existing project warnings.
