### PR TITLE
Fix composed email invoke arg names

### DIFF
--- a/src/src/utils/gmailService.ts
+++ b/src/src/utils/gmailService.ts
@@ -230,8 +230,12 @@ export const sendComposedEmail = async ({
       cc,
       subject,
       body,
+      // Send both key styles so older and newer native handlers both bind correctly.
+      threadId,
       thread_id: threadId,
+      userEmail,
       user_email: userEmail,
+      userName,
       user_name: userName,
       attachments,
     })


### PR DESCRIPTION
## Summary
- send camelCase args to `kn_send_composed_email` so Tauri binds the required fields
- keep the legacy snake_case aliases in the payload for compatibility with any older receiver path
- fix the shipped 2.6.8 support-diagnostics compose failure Scout hit: `missing required key userEmail`

## Verification
- npm run build

## Root cause
The support-diagnostics compose drawer already had the sender-email fallback fix, but the actual invoke payload still sent `user_email` / `user_name`. The native command path expects camelCase keys, which matches the exact runtime error from Scout's screenshot.
