### PR TITLE
Prevent overlapping channel status polls

### DIFF
--- a/src/src/hooks/channels/useChannelStatus.ts
+++ b/src/src/hooks/channels/useChannelStatus.ts
@@ -137,6 +137,11 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
   // We do this once per session so we can restore the bot username
   // and verify the saved token is still valid on app relaunch.
   const tgValidatedRef = useRef(false)
+  // Prevent overlapping poll cycles from piling up local HTTP requests when
+  // the backend is slow or timing out. Coalesce extra refresh requests into a
+  // single follow-up pass instead of running them concurrently.
+  const refreshInFlightRef = useRef(false)
+  const refreshQueuedRef = useRef(false)
 
   // Use refs to track current channel states for smart-polling decisions.
   // This avoids putting state variables in `refresh`'s dependency array,
@@ -151,7 +156,7 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
   const genericChannelsRef = useRef(genericChannels)
   genericChannelsRef.current = genericChannels
 
-  const refresh = useCallback(async () => {
+  const runRefreshCycle = useCallback(async () => {
     // Only show loading indicator on the very first fetch, not background polls.
     // Toggling loading on every poll caused 2 extra parent re-renders per cycle.
     const isFirstLoad = prevJsonRef.current._initialized !== 'true'
@@ -379,6 +384,23 @@ export function useChannelStatus(enabled = true, intervalMs = 15_000) {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const refresh = useCallback(async () => {
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true
+      return
+    }
+
+    refreshInFlightRef.current = true
+    try {
+      do {
+        refreshQueuedRef.current = false
+        await runRefreshCycle()
+      } while (refreshQueuedRef.current)
+    } finally {
+      refreshInFlightRef.current = false
+    }
+  }, [runRefreshCycle])
 
   // Always do a single initial fetch so hasAnyChannel / showChannelBanner
   // are populated on mount even when polling is disabled.


### PR DESCRIPTION
## Summary
- prevent overlapping `useChannelStatus` refresh cycles from running concurrently
- coalesce extra refresh requests into one follow-up pass when a poll is already in flight
- reduce local request pileups when channel-status checks are slow or timing out

## Root cause
Scout's logs do not show a real Gemini context overflow. They show backend overload and file descriptor exhaustion instead:

- `Too many open files (os error 24)` repeated many times
- `r2d2 - unable to open database file`
- earlier channel-status timeouts such as `slack_status gateway error: Timed out reading channel status` and `telegram_status gateway error: Timed out reading channel status`

The frontend hook was polling on an interval with an async refresh function and no in-flight guard. If a refresh took longer than the polling interval, the next cycle could start before the prior one finished, fanning out more local HTTP requests and making the overload worse.

## Verification
- `npm run build`

## Related
- PR #565 fixes the misleading "Message too large" classification for generic load failures
