### PR TITLE
Fix browser download export corruption

### DIFF
--- a/src/src-tauri/resources/clawdbot/dist/pw-ai-BAGe7T5A.js
+++ b/src/src-tauri/resources/clawdbot/dist/pw-ai-BAGe7T5A.js
@@ -16,6 +16,9 @@ import { t as isSelectableCdpBrowserTarget } from "./cdp-target-filter-CaIsrb0G.
 import { createRequire } from "node:module";
 import path from "node:path";
 import crypto from "node:crypto";
+const fs = createRequire(import.meta.url)("node:fs/promises");
+const fsNative = createRequire(import.meta.url)("node:fs");
+const { pipeline } = createRequire(import.meta.url)("node:stream/promises");
 //#region extensions/browser/src/browser/output-atomic.ts
 async function writeViaSiblingTempPath(params) {
 	await ensureOutputDirectory(params.rootDir);
@@ -1247,6 +1250,22 @@ function createPageDownloadWaiter(page, timeoutMs) {
 		}
 	};
 }
+async function resolveDownloadArtifactPath(download) {
+	let lastError = null;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			const realizedPath = await download.path?.();
+			if (realizedPath) return realizedPath;
+		} catch (err) {
+			lastError = err;
+		}
+		const failure = await download.failure?.().catch(() => null);
+		if (failure) throw new Error(`download failed: ${failure}`);
+		await new Promise((resolve) => setTimeout(resolve, 100 * (attempt + 1)));
+	}
+	if (lastError) throw lastError;
+	return null;
+}
 async function saveDownloadPayload(download, outPath, rootDir) {
 	const suggested = download.suggestedFilename?.() || "download.bin";
 	const requestedPath = outPath?.trim();
@@ -1254,7 +1273,23 @@ async function saveDownloadPayload(download, outPath, rootDir) {
 		rootDir,
 		path: path.resolve(requestedPath || buildTempDownloadPath(suggested)),
 		write: async (tempPath) => {
-			await download.saveAs?.(tempPath);
+			const realizedPath = await resolveDownloadArtifactPath(download).catch(() => null);
+			if (realizedPath) return await fs.copyFile(realizedPath, tempPath);
+			if (typeof download.createReadStream === "function") {
+				const stream = await download.createReadStream();
+				if (stream) {
+					await pipeline(stream, fsNative.createWriteStream(tempPath));
+					return;
+				}
+			}
+			try {
+				await download.saveAs?.(tempPath);
+			} catch (err) {
+				if (!String(err).includes("ENOENT")) throw err;
+				const retriedPath = await resolveDownloadArtifactPath(download);
+				if (!retriedPath) throw err;
+				await fs.copyFile(retriedPath, tempPath);
+			}
 		}
 	});
 	return {


### PR DESCRIPTION
## Summary
- fix the managed browser download export path when Playwright temp artifacts are not ready yet
- prefer the realized download artifact path or `createReadStream()` before falling back to `download.saveAs()`
- retry `ENOENT` saveAs failures by resolving the artifact path and copying it directly

## Root cause
I reproduced the failure against the bundled OpenClaw browser CLI using a deterministic blob download in the managed Chrome profile.

The failing path was not Chrome corrupting bytes on disk directly. The failure happened when Knapsack/OpenClaw tried to export the Playwright download artifact into the guarded output path:

`download.saveAs: ENOENT: no such file or directory, copyfile '/var/.../playwright-artifacts-.../...'
 -> '/var/.../fs-safe-output-.../.fs-safe-output-...-original.bin.part'`

That means the browser-control layer was trying to copy from a Playwright temp artifact before that artifact was reliably available on the managed-CDP path.

## Fix
- wait for a realized download artifact path when available
- if Playwright exposes a download stream, pipe that into the output file directly
- only use `download.saveAs()` as a fallback
- if fallback `saveAs()` still hits `ENOENT`, resolve the artifact path again and copy it directly

## Verification
- Reproduced the original `download.saveAs ... ENOENT` failure locally through the bundled `openclaw browser download` path.
- Verified independently that the same managed-CDP download succeeds via `download.createReadStream()` and preserves the original 65,536-byte payload exactly.

## Notes
- This is a bundled `clawdbot/dist` fix because that is the checked-in runtime surface used by Knapsack here.
