### PR TITLE
Fix malformed gateway replies, Slack disconnect recovery, and checkbox overflow

### DIFF
--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -2216,6 +2216,34 @@ fn is_degraded_gateway_capability_reply(reply: &str) -> bool {
   .any(|needle| lower.contains(needle))
 }
 
+fn gateway_run_failed(status: &str) -> bool {
+  matches!(
+    status.trim().to_ascii_lowercase().as_str(),
+    "failed" | "error" | "errored" | "cancelled" | "canceled" | "timed_out" | "timeout"
+  )
+}
+
+fn is_gateway_execution_failure_reply(reply: &str) -> bool {
+  let lower = reply.trim().to_lowercase().replace('`', "");
+  if lower.is_empty() {
+    return false;
+  }
+
+  [
+    "json deserialize error",
+    "unexpected end of hex escape",
+    "invalid args",
+    "missing required key",
+    "cannot find module",
+    "permission denied",
+    "command not found",
+    "message failed",
+    "tool call validation failed",
+  ]
+  .iter()
+  .any(|needle| lower.contains(needle))
+}
+
 /// Send a chat message through the gateway's agent pipeline.
 /// Read recent terminal output from the built-in terminal sessions.
 /// Used by the chat agent's `read_terminal` tool so the AI can see what's
@@ -2383,7 +2411,20 @@ pub async fn agent_chat(
               .parse::<u16>()
               .map(|c| (300..=599).contains(&c))
               .unwrap_or(false);
-          if is_http_error {
+          if gateway_run_failed(status) {
+            eprintln!(
+              "[clawd/agent-chat] Gateway run ended with status={}, falling back to direct chat. Summary: {:?}",
+              status,
+              &reply[..reply.len().min(200)]
+            );
+            None
+          } else if is_gateway_execution_failure_reply(trimmed) {
+            eprintln!(
+              "[clawd/agent-chat] Gateway returned execution failure reply, falling back to direct chat: {:?}",
+              &trimmed[..trimmed.len().min(200)]
+            );
+            None
+          } else if is_http_error {
             eprintln!(
               "[clawd/agent-chat] Gateway returned HTTP error reply: {:?}, falling back to direct chat",
               &trimmed[..trimmed.len().min(100)]

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -2110,8 +2110,9 @@ async fn disconnect_channel(channel: &str, account_id: &str) -> HttpResponse {
 
     match gateway_client::config_get(None).await {
       Ok(config_snapshot) => {
-        let base_hash = extract_base_hash(&config_snapshot);
-        match gateway_client::config_patch(&patch, &base_hash, None).await {
+        let patch_json = patch.clone();
+        let build_patch = |_snapshot: &serde_json::Value| patch_json.clone();
+        match config_patch_with_reconnect(&config_snapshot, build_patch).await {
           Ok(_) => {
             gateway_client::invalidate();
             return HttpResponse::Ok().json(GenericResponse {
@@ -2217,7 +2218,7 @@ pub async fn generic_channel_status(
       configured: false,
       linked: Some(false),
       provider: None,
-      message: Some("Channel is not configured in this build".to_string()),
+      message: None,
       account: None,
     });
   }
@@ -3286,7 +3287,6 @@ pub async fn channel_allowlist_update(
   let config_result = gateway_client::config_get(None).await;
   match config_result {
     Ok(config_snapshot) => {
-      let base_hash = extract_base_hash(&config_snapshot);
       let uses_nested_dm = matches!(channel.as_str(), "discord" | "slack" | "googlechat");
 
       let mut patch_inner = serde_json::Map::new();
@@ -3348,9 +3348,10 @@ pub async fn channel_allowlist_update(
           }
       });
 
-      match gateway_client::config_patch(&serde_json::to_string(&patch).unwrap(), &base_hash, None)
-        .await
-      {
+      let patch_json = serde_json::to_string(&patch).unwrap();
+      let build_patch = |_snapshot: &serde_json::Value| patch_json.clone();
+
+      match config_patch_with_reconnect(&config_snapshot, build_patch).await {
         Ok(_) => HttpResponse::Ok().json(GenericResponse {
           success: true,
           message: Some("Allowlist updated".to_string()),

--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -1431,7 +1431,7 @@ pub async fn gemini_chat_with_retries(
 }
 
 pub fn parse_args_map(args: &str) -> HashMap<String, JsonValue> {
-  serde_json::from_str::<JsonValue>(args)
+  parse_json_value_with_escape_repair(args)
     .ok()
     .and_then(|v| v.as_object().cloned())
     .map(|m| m.into_iter().map(|(k, v)| (k, v)).collect())
@@ -1472,5 +1472,18 @@ mod tests {
     let parsed = parse_json_value_with_escape_repair(raw).expect("json should be repaired");
     let text = parsed["content"][0]["text"].as_str().unwrap_or("");
     assert_eq!(text, r#"draft \q now"#);
+  }
+
+  #[test]
+  fn repairs_invalid_tool_argument_escapes() {
+    let parsed = parse_args_map(r#"{"path":"C:\users\amit\u12tmp","note":"draft \q now"}"#);
+    assert_eq!(
+      parsed.get("path").and_then(|v| v.as_str()),
+      Some(r#"C:\users\amit\u12tmp"#)
+    );
+    assert_eq!(
+      parsed.get("note").and_then(|v| v.as_str()),
+      Some(r#"draft \q now"#)
+    );
   }
 }

--- a/src/src/components/atoms/input-checkbox/index.tsx
+++ b/src/src/components/atoms/input-checkbox/index.tsx
@@ -24,15 +24,15 @@ const InputCheckbox = React.forwardRef<HTMLInputElement, IInputCheckboxProps>(
   ): JSX.Element => {
     return (
       <div
-        className={cn('flex flex-no-wrap gap-2 text-white items-center w-full cursor-pointer', className)}
+        className={cn('flex gap-2 text-white items-start w-full cursor-pointer', className)}
         onClick={onClick}
       >
         <CheckboxImage
           initialChecked={checked}
           isNewCheckboxUI={isNewCheckboxUI}
         />
-        <label className="cursor-pointer">
-          <span className="text-sm leading-6 text-nowrap text-black">{children}</span>
+        <label className="cursor-pointer min-w-0 flex-1">
+          <span className="text-sm leading-6 text-black break-words whitespace-normal">{children}</span>
         </label>
       </div>
     )


### PR DESCRIPTION
## Summary
- repair malformed JSON escape handling in provider responses and tool arguments so Amit-style gateway replies fall back cleanly instead of surfacing deserialize errors
- make generic channel status/disconnect flows consult live runtime state and retry config patches so Slack disconnect and allowlist updates survive transient gateway reconnects
- let checkbox labels wrap correctly in update settings

## Validation
- cargo check --manifest-path src/src-tauri/Cargo.toml --message-format short
- cargo test repairs_invalid_tool_argument_escapes --manifest-path src/src-tauri/Cargo.toml -- --exact