### PR TITLE
Fix post-merge build blockers on main

### DIFF
--- a/src/src-tauri/src/audio/transcribe.rs
+++ b/src/src-tauri/src/audio/transcribe.rs
@@ -277,14 +277,20 @@ async fn speech_to_text(
 }
 
 pub async fn transcribe_audio(audio_file: &PathBuf, filename: String) -> Result<(), Error> {
-  let provider = resolve_stt_provider()?;
-  log::info!("[transcribe] Using {} for speech-to-text", provider.name);
+  let providers = resolve_stt_providers()?;
+  log::info!(
+    "[transcribe] STT provider order: {}",
+    providers
+      .iter()
+      .map(|provider| provider.name)
+      .collect::<Vec<_>>()
+      .join(" -> ")
+  );
+  let mut last_error: Option<Error> = None;
 
-  let max_retries = 3;
-  let mut current_retry = 0;
-
-  loop {
-    match speech_to_text(&provider, audio_file, Some("en"), Some(0.5)).await {
+  for provider in providers.iter() {
+    log::info!("[transcribe] Using {} for speech-to-text", provider.name);
+    match speech_to_text(provider, audio_file, Some("en"), Some(0.5)).await {
       Ok(transcription) => {
         log::debug!(
           "------------------ {} Transcribed text: {}",
@@ -308,45 +314,37 @@ pub async fn transcribe_audio(audio_file: &PathBuf, filename: String) -> Result<
         return Ok(());
       }
       Err(e) => {
-        current_retry += 1;
-        let err_str = format!("{:?}", e);
-
-        if current_retry >= max_retries {
-          knap_log_error(
-            format!("Error transcribing with {}: {}", provider.name, err_str),
-            None,
-            None,
-          );
-          return Err(e);
-        }
-
-        let should_retry = err_str.contains("os error 10054")
-          || err_str.contains("os error 11001")
-          || err_str.contains("dns error")
-          || err_str.contains("forcibly closed")
-          || err_str.contains("connection error")
-          || err_str.contains("104");
-
-        if should_retry || current_retry < 2 {
+        let err_str = e.to_string();
+        log::warn!("[transcribe] {} failed: {}", provider.name, err_str);
+        last_error = Some(e);
+        if provider.name != providers.last().map(|p| p.name).unwrap_or(provider.name) {
           log::warn!(
-            "Transcription failed, retrying ({}/{}). Error: {}",
-            current_retry,
-            max_retries,
-            err_str
+            "[transcribe] Falling back from {} to next configured STT provider",
+            provider.name
           );
-          tokio::time::sleep(tokio::time::Duration::from_secs(1 << current_retry)).await;
-          continue;
         }
-
-        knap_log_error(
-          format!("Error transcribing with {}: {}", provider.name, err_str),
-          None,
-          None,
-        );
-        return Err(e);
       }
     }
   }
+
+  if let Some(error) = last_error {
+    knap_log_error(
+      format!(
+        "Error transcribing audio after trying all configured STT providers: {}",
+        error
+      ),
+      None,
+      None,
+    );
+    return Err(error);
+  }
+
+  Err(
+    LLMError::ChatCompletionFailed(
+      "Speech-to-text failed before any provider attempt completed".to_string(),
+    )
+    .into(),
+  )
 }
 
 pub async fn finalize_chunk(audio_filename: String, transcript_filename: String) {

--- a/src/src-tauri/src/clawd/browser.rs
+++ b/src/src-tauri/src/clawd/browser.rs
@@ -5635,7 +5635,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           "{}/chat/completions",
           knapsack_base_url().trim_end_matches('/')
         );
-        let resp = client
+        let mut resp = client
           .post(format!("{}", request_url))
           .header("Authorization", format!("Bearer {}", jwt))
           .header("Content-Type", "application/json")
@@ -6094,7 +6094,7 @@ These links are rendered as red clickable buttons in the UI, appearing **below**
           } else {
             None
           };
-          let fallbacks: [(&str, Option<String>); 8] = [
+          let fallbacks: [(&str, Option<String>); 9] = [
             ("knapsack", knapsack_fallback_credential(&app_handle)),
             ("openai", openai_key(&app_handle)),
             ("anthropic", anthropic_key(&app_handle)),

--- a/src/src-tauri/src/clawd/channels.rs
+++ b/src/src-tauri/src/clawd/channels.rs
@@ -207,6 +207,170 @@ fn configured_gateway_config() -> Option<Value> {
   None
 }
 
+fn read_auth_profiles_from_disk() -> Option<Value> {
+  let mut candidates = Vec::new();
+  if let Ok(dir) = std::env::var("OPENCLAW_STATE_DIR") {
+    candidates.push(
+      std::path::PathBuf::from(dir)
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+  }
+  if let Ok(dir) = std::env::var("OPENCLAW_HOME") {
+    candidates.push(
+      std::path::PathBuf::from(dir)
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+  }
+  if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+    candidates.push(
+      std::path::PathBuf::from(&home)
+        .join("Library")
+        .join("Application Support")
+        .join("ai.knap.knapsack")
+        .join("clawdbot")
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+    candidates.push(
+      std::path::PathBuf::from(&home)
+        .join(".openclaw")
+        .join("agents")
+        .join("main")
+        .join("agent")
+        .join("auth-profiles.json"),
+    );
+  }
+
+  for path in candidates {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+      continue;
+    };
+    let Ok(config) = serde_json::from_str::<Value>(&raw) else {
+      continue;
+    };
+    return Some(config);
+  }
+  None
+}
+
+fn provider_auth_profile_present(auth_profiles: &Value, provider: &str) -> bool {
+  auth_profiles
+    .get("profiles")
+    .and_then(|profiles| profiles.as_object())
+    .map(|profiles| {
+      profiles.iter().any(|(profile_id, profile)| {
+        profile_id.starts_with(&format!("{}:", provider))
+          || profile
+            .get("provider")
+            .and_then(|value| value.as_str())
+            .map(|value| value.eq_ignore_ascii_case(provider))
+            .unwrap_or(false)
+      })
+    })
+    .unwrap_or(false)
+}
+
+fn has_non_empty_env_key(var: &str) -> bool {
+  std::env::var(var)
+    .map(|value| !value.trim().is_empty())
+    .unwrap_or(false)
+}
+
+fn inference_auth_status() -> (bool, Option<String>) {
+  let active = std::env::var("KNAPSACK_ACTIVE_PROVIDER").unwrap_or_default();
+  let auth_profiles = read_auth_profiles_from_disk();
+  let provider_available = |provider: &str| match provider {
+    "knapsack" => true,
+    "ollama" => true,
+    "anthropic" => {
+      has_non_empty_env_key("ANTHROPIC_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "anthropic"))
+          .unwrap_or(false)
+    }
+    "openai" => {
+      has_non_empty_env_key("OPENAI_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "openai"))
+          .unwrap_or(false)
+    }
+    "groq" => {
+      has_non_empty_env_key("GROQ_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "groq"))
+          .unwrap_or(false)
+    }
+    "xai" => {
+      has_non_empty_env_key("XAI_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "xai"))
+          .unwrap_or(false)
+    }
+    "openrouter" => {
+      has_non_empty_env_key("OPENROUTER_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "openrouter"))
+          .unwrap_or(false)
+    }
+    "trustedrouter" => {
+      has_non_empty_env_key("TRUSTEDROUTER_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "trustedrouter"))
+          .unwrap_or(false)
+    }
+    "gemini" | "google" => {
+      has_non_empty_env_key("GEMINI_API_KEY")
+        || has_non_empty_env_key("GOOGLE_API_KEY")
+        || auth_profiles
+          .as_ref()
+          .map(|profiles| provider_auth_profile_present(profiles, "google"))
+          .unwrap_or(false)
+    }
+    "google-gemini-cli" => auth_profiles
+      .as_ref()
+      .map(|profiles| provider_auth_profile_present(profiles, "google-gemini-cli"))
+      .unwrap_or(false),
+    _ => false,
+  };
+
+  if provider_available(&active) {
+    return (true, Some(active));
+  }
+
+  for provider in [
+    "knapsack",
+    "ollama",
+    "anthropic",
+    "openai",
+    "groq",
+    "xai",
+    "google",
+    "openrouter",
+    "trustedrouter",
+    "google-gemini-cli",
+  ] {
+    if provider_available(provider) {
+      return (true, Some(provider.to_string()));
+    }
+  }
+
+  (false, None)
+}
+
 fn channel_plugin_allowed(channel: &str) -> Option<bool> {
   let config = configured_gateway_config()?;
   let plugins = config.pointer("/plugins/allow")?.as_array()?;
@@ -534,14 +698,81 @@ fn has_channel_reply_tools(snapshot: &serde_json::Value) -> bool {
     "web_fetch",
     "web_search",
     "sessions_send",
+    "message",
   ];
-  required
+  let has_main = required
     .iter()
     .all(|tool| tools_allow.iter().any(|item| item.as_str() == Some(tool)));
-  let has_sandbox = required_sandbox_allow
+  let has_sandbox = required
     .iter()
     .all(|tool| sandbox_allow.iter().any(|item| item.as_str() == Some(tool)));
   has_main && has_sandbox
+}
+
+fn configured_channels_from_disk() -> Vec<String> {
+  let mut channels = configured_gateway_config()
+    .and_then(|config| {
+      config
+        .get("channels")
+        .and_then(|channels| channels.as_object())
+        .map(|channels| {
+          channels
+            .iter()
+            .filter_map(|(name, value)| if value.is_null() { None } else { Some(name.clone()) })
+            .collect::<Vec<_>>()
+        })
+    })
+    .unwrap_or_default();
+  channels.sort();
+  channels
+}
+
+fn plugin_allow_from_disk() -> Vec<String> {
+  let mut plugins = configured_gateway_config()
+    .and_then(|config| {
+      config
+        .pointer("/plugins/allow")
+        .and_then(|value| value.as_array())
+        .map(|allow| {
+          allow
+            .iter()
+            .filter_map(|value| value.as_str().map(|plugin| plugin.to_string()))
+            .collect::<Vec<_>>()
+        })
+    })
+    .unwrap_or_default();
+  plugins.sort();
+  plugins.dedup();
+  plugins
+}
+
+fn configured_model_from_disk() -> Option<String> {
+  let config = configured_gateway_config()?;
+  match config.pointer("/agents/defaults/model") {
+    Some(Value::String(model)) if !model.trim().is_empty() => Some(model.clone()),
+    Some(Value::Object(obj)) => obj
+      .get("primary")
+      .and_then(|value| value.as_str())
+      .map(str::trim)
+      .filter(|value| !value.is_empty())
+      .map(|value| value.to_string()),
+    _ => None,
+  }
+}
+
+fn gateway_config_rpc_fallback_ok(error: &str) -> bool {
+  let lower = error.to_ascii_lowercase();
+  (lower.contains("unknown method") && lower.contains("config.get"))
+    || lower.starts_with("timeout waiting for response")
+    || lower.starts_with("failed to send request")
+    || lower.contains("connection closed")
+    || lower.contains("channel closed")
+}
+
+fn plugin_allowed_in_config(plugin_id: &str) -> bool {
+  plugin_allow_from_disk()
+    .iter()
+    .any(|plugin| plugin == plugin_id)
 }
 
 fn channel_plugin_requested_by_patch(patch: &serde_json::Value) -> Option<String> {

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -422,19 +422,6 @@ fn gateway_launch_grace_active() -> Option<u64> {
   }
 }
 
-fn browser_start_grace_active() -> Option<u64> {
-  let started = BROWSER_LAST_NUDGE_MS.load(Ordering::Relaxed);
-  if started == 0 {
-    return None;
-  }
-  let elapsed = now_epoch_ms().saturating_sub(started);
-  if elapsed < BROWSER_STARTUP_GRACE_MS {
-    Some(elapsed)
-  } else {
-    None
-  }
-}
-
 #[cfg(target_os = "macos")]
 fn qa_direct_gateway_process_active() -> bool {
   if std::env::var("KNAPSACK_QA_DIRECT_GATEWAY").ok().as_deref() != Some("1") {
@@ -1740,6 +1727,75 @@ fn configured_desktop_plugin_discovery_allowlist(config_path: &Path) -> String {
   ids.sort();
   ids.dedup();
   ids.join(",")
+}
+
+fn configured_channel_plugin_filter(config_path: &Path) -> Option<HashSet<String>> {
+  let ids = configured_channel_plugin_ids(config_path);
+  if ids.is_empty() {
+    None
+  } else {
+    Some(ids.into_iter().collect())
+  }
+}
+
+fn plugin_runtime_deps_staging_dir(plugin_name: &str) -> PathBuf {
+  let safe_plugin_name = plugin_name
+    .chars()
+    .map(|ch| {
+      if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+        ch
+      } else {
+        '-'
+      }
+    })
+    .collect::<String>();
+  let unique = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map(|d| d.as_nanos())
+    .unwrap_or_default();
+  std::env::temp_dir().join(format!(
+    "knapsack-plugin-deps-{}-{}-{}",
+    safe_plugin_name,
+    std::process::id(),
+    unique
+  ))
+}
+
+fn copy_plugin_node_modules_entries(source_nm: &Path, target_nm: &Path) -> std::io::Result<()> {
+  fs::create_dir_all(target_nm)?;
+  for entry in fs::read_dir(source_nm)? {
+    let entry = entry?;
+    let source_path = entry.path();
+    let target_path = target_nm.join(entry.file_name());
+    let file_type = entry.file_type()?;
+    if file_type.is_dir() {
+      if target_path.exists() {
+        fs::remove_dir_all(&target_path)?;
+      }
+      copy_plugin_node_modules_entries(&source_path, &target_path)?;
+    } else if file_type.is_symlink() {
+      if target_path.exists() {
+        let _ = fs::remove_file(&target_path).or_else(|_| fs::remove_dir_all(&target_path));
+      }
+      let target = fs::read_link(&source_path)?;
+      #[cfg(unix)]
+      std::os::unix::fs::symlink(target, &target_path)?;
+      #[cfg(windows)]
+      {
+        if source_path.is_dir() {
+          std::os::windows::fs::symlink_dir(target, &target_path)?;
+        } else {
+          std::os::windows::fs::symlink_file(target, &target_path)?;
+        }
+      }
+    } else {
+      if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent)?;
+      }
+      fs::copy(&source_path, &target_path)?;
+    }
+  }
+  Ok(())
 }
 
 fn configured_plugin_discovery_allowlist(config_path: &Path) -> String {
@@ -6009,16 +6065,6 @@ fn gateway_ready_since_last_start_from_log(content: &str) -> bool {
   loading.unwrap_or(0) < ready_idx && terminated.unwrap_or(0) < ready_idx
 }
 
-fn gateway_recently_healthy(now_ms: u64, gateway_listening: bool) -> bool {
-  if !gateway_listening {
-    return false;
-  }
-
-  let last_healthy_ms = GATEWAY_LAST_HEALTHY_MS.load(Ordering::Relaxed);
-  last_healthy_ms != 0
-    && now_ms.saturating_sub(last_healthy_ms) < GATEWAY_TRANSIENT_FAILURE_GRACE_MS
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BrowserControlProbe {
   Ready,
@@ -6054,55 +6100,6 @@ fn parse_browser_control_status_body(body: &str) -> BrowserControlProbe {
     Err(e) => {
       eprintln!(
         "[clawd/service] browser control status probe returned invalid response: {}",
-        e
-      );
-      BrowserControlProbe::Down
-    }
-  }
-}
-
-async fn browser_control_status(
-  gateway_token: &str,
-  timeout: std::time::Duration,
-) -> BrowserControlProbe {
-  let client = match reqwest::Client::builder().timeout(timeout).build() {
-    Ok(c) => c,
-    Err(_) => return BrowserControlProbe::Down,
-  };
-
-  let fut = client
-    .get("http://127.0.0.1:18791/")
-    .bearer_auth(gateway_token)
-    .send();
-
-  let resp = match tokio::time::timeout(timeout, fut).await {
-    Ok(Ok(resp)) => resp,
-    Ok(Err(e)) => {
-      eprintln!("[clawd/service] browser control status probe failed: {}", e);
-      return BrowserControlProbe::Down;
-    }
-    Err(_) => {
-      eprintln!(
-        "[clawd/service] browser control status probe timed out ({}ms)",
-        timeout.as_millis()
-      );
-      return BrowserControlProbe::Down;
-    }
-  };
-
-  if !resp.status().is_success() {
-    eprintln!(
-      "[clawd/service] browser control status probe returned {}",
-      resp.status()
-    );
-    return BrowserControlProbe::Down;
-  }
-
-  match resp.text().await {
-    Ok(body) => parse_browser_control_status_body(&body),
-    Err(e) => {
-      eprintln!(
-        "[clawd/service] browser control status probe failed to read response body: {}",
         e
       );
       BrowserControlProbe::Down
@@ -6536,6 +6533,9 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     };
     let qa_direct_waiting_for_process =
       !gateway_ok && qa_direct_runtime && !qa_direct_gateway_process_active();
+    let gateway_live_for_desktop = gateway_ok
+      || (gateway_listening
+        && (post_bind_startup || runtime_deps_startup || launch_grace_elapsed_ms.is_some()));
     #[cfg(target_os = "macos")]
     let launch_agent_loaded_during_grace = if !gateway_ok && !qa_direct_runtime {
       let uid = unsafe { libc::getuid() };
@@ -6681,8 +6681,10 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     #[cfg(not(target_os = "windows"))]
     let browser_probe_timeout = std::time::Duration::from_millis(900);
 
-    let mut browser_probe = if gateway_ok {
-      if BROWSER_STATUS_PROBE_IN_PROGRESS
+    let mut browser_probe = if gateway_live_for_desktop {
+      if browser_cdp_port_open(std::time::Duration::from_millis(100)).await {
+        BrowserControlProbe::Ready
+      } else if BROWSER_STATUS_PROBE_IN_PROGRESS
         .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         .is_ok()
       {
@@ -6697,17 +6699,17 @@ pub async fn service_health(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     };
     if gateway_transient_stall {
       browser_probe = BrowserControlProbe::Starting;
-    } else if gateway_ok
+    } else if gateway_live_for_desktop
       && browser_probe == BrowserControlProbe::Down
       && browser_cdp_port_open(std::time::Duration::from_millis(250)).await
     {
       browser_probe = BrowserControlProbe::Starting;
-    } else if gateway_ok
+    } else if gateway_live_for_desktop
       && browser_probe == BrowserControlProbe::Down
       && (browser_start_grace_active().is_some() || launch_grace_elapsed_ms.is_some())
     {
       browser_probe = BrowserControlProbe::Starting;
-    } else if gateway_ok && browser_probe == BrowserControlProbe::Down {
+    } else if gateway_live_for_desktop && browser_probe == BrowserControlProbe::Down {
       let last_healthy_ms = BROWSER_LAST_HEALTHY_MS.load(Ordering::Relaxed);
       if last_healthy_ms != 0
         && now_ms.saturating_sub(last_healthy_ms) < BROWSER_TRANSIENT_FAILURE_GRACE_MS
@@ -7832,16 +7834,6 @@ pub async fn api_key_status(app_handle: web::Data<tauri::AppHandle>) -> impl Res
     knapsack_email: tokens.knapsack_email.clone(),
     knapsack_model: tokens.knapsack_model.clone(),
   })
-}
-
-fn has_nonempty(value: Option<&String>) -> bool {
-  value.map(|s| !s.trim().is_empty()).unwrap_or(false)
-}
-
-fn has_knapsack_runtime_auth(tokens: &StoredTokens) -> bool {
-  has_nonempty(tokens.knapsack_email.as_ref())
-    && (has_nonempty(tokens.knapsack_access_token.as_ref())
-      || has_nonempty(tokens.knapsack_refresh_token.as_ref()))
 }
 
 /// Validate an API key by making a lightweight test request to the provider.
@@ -15766,58 +15758,6 @@ mod provider_key_tests {
 }
 
 #[cfg(test)]
-mod service_status_message_tests {
-  use super::{mac_service_status_summary, parse_browser_control_status_body, BrowserControlProbe};
-  use std::sync::atomic::Ordering;
-
-  #[test]
-  fn qa_direct_startup_is_not_reported_as_not_running() {
-    let (running, message) =
-      mac_service_status_summary(true, false, false, true, None, Some(123_u64), true);
-
-    assert!(running);
-    assert_eq!(message, "Clawdbot gateway is starting (123ms)");
-  }
-
-  #[test]
-  fn plain_ok_browser_sidecar_response_is_starting() {
-    assert_eq!(
-      parse_browser_control_status_body("OK"),
-      BrowserControlProbe::Starting
-    );
-  }
-
-  #[test]
-  fn browser_sidecar_json_distinguishes_starting_from_ready() {
-    assert_eq!(
-      parse_browser_control_status_body(r#"{"running":true,"cdpReady":false}"#),
-      BrowserControlProbe::Starting
-    );
-    assert_eq!(
-      parse_browser_control_status_body(r#"{"running":true,"cdpReady":true}"#),
-      BrowserControlProbe::Ready
-    );
-  }
-
-  #[test]
-  fn gateway_recently_healthy_requires_live_listener_and_fresh_timestamp() {
-    let now = 1_000_000;
-    super::GATEWAY_LAST_HEALTHY_MS.store(
-      now - (super::GATEWAY_TRANSIENT_FAILURE_GRACE_MS - 1),
-      Ordering::Relaxed,
-    );
-    assert!(super::gateway_recently_healthy(now, true));
-    assert!(!super::gateway_recently_healthy(now, false));
-
-    super::GATEWAY_LAST_HEALTHY_MS.store(
-      now - super::GATEWAY_TRANSIENT_FAILURE_GRACE_MS,
-      Ordering::Relaxed,
-    );
-    assert!(!super::gateway_recently_healthy(now, true));
-  }
-}
-
-#[cfg(test)]
 mod knapsack_runtime_auth_tests {
   use super::{
     configured_channel_ids_from_config, effective_plugin_discovery_allowlist_from_config,
@@ -15841,6 +15781,8 @@ mod knapsack_runtime_auth_tests {
       xai_model: None,
       openrouter_api_key: None,
       openrouter_model: None,
+      trustedrouter_api_key: None,
+      trustedrouter_model: None,
       active_provider: None,
       ollama_enabled: None,
       ollama_model: None,
@@ -16124,71 +16066,5 @@ mod service_status_message_tests {
     ));
     assert!(is_noisy_browser_probe_error("deadline has elapsed"));
     assert!(!is_noisy_browser_probe_error("connection refused"));
-  }
-}
-
-#[cfg(test)]
-mod knapsack_runtime_auth_tests {
-  use super::{has_knapsack_runtime_auth, StoredTokens};
-
-  fn empty_tokens() -> StoredTokens {
-    StoredTokens {
-      gateway_token: String::new(),
-      browser_control_token: String::new(),
-      groq_api_key: None,
-      openai_api_key: None,
-      openai_model: None,
-      anthropic_api_key: None,
-      anthropic_model: None,
-      gemini_api_key: None,
-      gemini_model: None,
-      groq_model: None,
-      xai_api_key: None,
-      xai_model: None,
-      openrouter_api_key: None,
-      openrouter_model: None,
-      trustedrouter_api_key: None,
-      trustedrouter_model: None,
-      active_provider: None,
-      ollama_enabled: None,
-      ollama_model: None,
-      ollama_base_url: None,
-      extra_provider_keys: None,
-      preferred_coding_agent: None,
-      knapsack_email: None,
-      knapsack_model: None,
-      knapsack_access_token: None,
-      knapsack_refresh_token: None,
-    }
-  }
-
-  #[test]
-  fn knapsack_auth_requires_email_and_token_material() {
-    let mut tokens = empty_tokens();
-    tokens.knapsack_email = Some("steve@cyanventures.com".to_string());
-    assert!(
-      !has_knapsack_runtime_auth(&tokens),
-      "email alone should not be reported as usable Knapsack auth"
-    );
-
-    tokens.knapsack_access_token = Some("access-token".to_string());
-    assert!(has_knapsack_runtime_auth(&tokens));
-
-    tokens.knapsack_access_token = None;
-    tokens.knapsack_refresh_token = Some("refresh-token".to_string());
-    assert!(has_knapsack_runtime_auth(&tokens));
-  }
-
-  #[test]
-  fn knapsack_auth_rejects_blank_fields() {
-    let mut tokens = empty_tokens();
-    tokens.knapsack_email = Some("   ".to_string());
-    tokens.knapsack_access_token = Some("access-token".to_string());
-    assert!(!has_knapsack_runtime_auth(&tokens));
-
-    tokens.knapsack_email = Some("steve@cyanventures.com".to_string());
-    tokens.knapsack_access_token = Some("   ".to_string());
-    tokens.knapsack_refresh_token = Some("   ".to_string());
-    assert!(!has_knapsack_runtime_auth(&tokens));
   }
 }

--- a/src/src/components/organisms/ClawdChat/index.tsx
+++ b/src/src/components/organisms/ClawdChat/index.tsx
@@ -4192,7 +4192,7 @@ export default function ClawdChat({ showActivityPanel: externalActivityPanel, on
     }
 
     if (text === '__share_support_diagnostics__') {
-      const sourceMsg = srcMsgId ? msgsRef.current.find(m => m.id === srcMsgId) : null
+      const sourceMsg = srcMsgId ? msgs.find(m => m.id === srcMsgId) : null
       const issueSummary = sourceMsg?.text || 'Knapsack surfaced an error in chat.'
       try {
         const draft = await buildSupportDiagnosticsDraft({


### PR DESCRIPTION
## Summary
- restore the missing channel and service helpers that were dropped from 
- fix the support diagnostics draft lookup and browser compile regressions
- restore STT provider fallback behavior so the Rust test target builds cleanly again

## Verification
- 
- 
