### PR TITLE
Fix release version baseline and tag guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,11 @@ jobs:
             git commit -m "release: $TAG"
           fi
           git rebase origin/main
-          git push origin HEAD:main
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
             echo "ERROR: tag $TAG already exists on origin; refusing to reuse it for a new release commit."
             exit 1
           fi
+          git push origin HEAD:main
           git tag "$TAG"
           git push origin "refs/tags/$TAG"
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knapsack",
-  "version": "2.4.5",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knapsack",
-      "version": "2.4.5",
+      "version": "2.7.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@amplitude/analytics-browser": "^1.3.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knapsack",
   "private": true,
-  "version": "2.4.5",
+  "version": "2.7.2",
   "license": "AGPL-3.0",
   "type": "module",
   "scripts": {

--- a/src/scripts/bump-version.cjs
+++ b/src/scripts/bump-version.cjs
@@ -2,16 +2,19 @@
 /**
  * bump-version.cjs — Bumps the version across all config files.
  *
- * Versioning scheme: 0.9.6 → 0.9.7 → 0.9.8 → 0.9.9 → 1.0.0
- *
  * Usage:
- *   node scripts/bump-version.cjs           # bump: 0.9.6 → 0.9.7, or 0.9.9 → 1.0.0
- *   node scripts/bump-version.cjs 0.9.8     # set exact version
+ *   node scripts/bump-version.cjs           # bump patch/minor/major rollover
+ *   node scripts/bump-version.cjs 2.7.3     # set exact version
  *
  * Updates: package.json, package-lock.json, src-tauri/tauri.conf.json
+ *
+ * When release tags have advanced beyond the checked-in version files, this
+ * script uses the higher tagged release as the bump baseline so release
+ * automation cannot accidentally roll back to an older version line.
  */
 const fs = require('fs');
 const path = require('path');
+const childProcess = require('child_process');
 
 const projectDir = path.resolve(__dirname, '..');
 const files = {
@@ -22,7 +25,50 @@ const files = {
 
 const pkg = JSON.parse(fs.readFileSync(files.pkg, 'utf8'));
 const currentVersion = pkg.version;
-const [major, minor, patch] = currentVersion.split('.').map(Number);
+
+function parseVersion(version) {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Invalid semver version: ${version}`);
+  }
+  return version.split('.').map(Number);
+}
+
+function compareVersions(a, b) {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i] !== right[i]) return left[i] - right[i];
+  }
+  return 0;
+}
+
+function latestTaggedReleaseVersion() {
+  try {
+    const output = childProcess
+      .execSync('git tag --list "v*" --sort=-v:refname', {
+        cwd: projectDir,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      .toString()
+      .trim();
+    const taggedVersions = output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((tag) => tag.replace(/^v/, ''))
+      .filter((version) => /^\d+\.\d+\.\d+$/.test(version));
+    return taggedVersions[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+const latestTagVersion = latestTaggedReleaseVersion();
+const baseVersion =
+  latestTagVersion && compareVersions(latestTagVersion, currentVersion) > 0
+    ? latestTagVersion
+    : currentVersion;
+const [major, minor, patch] = parseVersion(baseVersion);
 
 const arg = process.argv[2];
 let newVersion;
@@ -47,6 +93,12 @@ if (arg && /^\d+\.\d+\.\d+$/.test(arg)) {
 if (newVersion === currentVersion) {
   console.log(`[bump-version] Already at v${currentVersion} — nothing to do.`);
   process.exit(0);
+}
+
+if (baseVersion !== currentVersion) {
+  console.log(
+    `[bump-version] Using tagged release v${baseVersion} as bump baseline because package.json is at v${currentVersion}.`,
+  );
 }
 
 console.log(`[bump-version] ${currentVersion} → ${newVersion}`);

--- a/src/src-tauri/Cargo.toml
+++ b/src/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "knapsack"
-version = "2.4.4"
+version = "2.7.2"
 description = "Knapsack"
 authors = ["you"]
 license = "AGPL-3.0"

--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "package": {
     "productName": "Knapsack",
-    "version": "2.4.5"
+    "version": "2.7.2"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
## Summary
- restore the checked-in app version baseline to the current released line
- make bump-version use the latest existing release tag when repo version files lag behind
- verify the target release tag before the workflow pushes main so stale versions cannot mutate main again

## Testing
- node src/scripts/sync-version.cjs
- temporary git harness: node src/scripts/bump-version.cjs with package.json at 2.4.5 and tag v2.7.2 -> 2.7.3
