### PR TITLE
Fix Slack reply runtime reference error

### DIFF
--- a/src/scripts/verify-clawdbot-bundle.cjs
+++ b/src/scripts/verify-clawdbot-bundle.cjs
@@ -165,6 +165,7 @@ function extensionDependencyExists(extensionDir, dependencyName) {
 }
 
 const distDir = path.join(CLAWDBOT_DIR, 'dist');
+const getReplyChunkPath = path.join(distDir, 'get-reply-DOTqK3jN.js');
 const relativeImportRegexes = [
   /(?:^|[;\n]\s*)import\s+(?:[^"';]+?\s+from\s+)?["'](\.{1,2}\/[^"']+)["']/g,
   /(?:^|[;\n]\s*)export\s+[^"';]+?\s+from\s+["'](\.{1,2}\/[^"']+)["']/g,
@@ -195,6 +196,26 @@ for (const jsFile of walkFiles(distDir)) {
     }
   }
 }
+
+function verifyScopedReplyRuntimeFlags() {
+  if (!fs.existsSync(getReplyChunkPath)) return;
+  const content = fs.readFileSync(getReplyChunkPath, 'utf8');
+  if (!content.includes('suppressSlackChannelReasoningAndVerbose')) return;
+
+  const resolverWiresFlag = /resolveReplyDirectives\(params\)\s*\{\s*const\s*\{[\s\S]*?suppressSlackChannelReasoningAndVerbose\s*=\s*false/m.test(content);
+  if (!resolverWiresFlag) {
+    console.error('[verify-clawdbot] CRITICAL: get-reply chunk references suppressSlackChannelReasoningAndVerbose without wiring it into resolveReplyDirectives(params)');
+    errors++;
+  }
+
+  const mainReplyFlowPassesFlag = /resolveReplyDirectives\(\{[\s\S]*?hasResolvedHeartbeatModelOverride,\s*suppressSlackChannelReasoningAndVerbose,\s*typing/m.test(content);
+  if (!mainReplyFlowPassesFlag) {
+    console.error('[verify-clawdbot] CRITICAL: get-reply chunk does not pass suppressSlackChannelReasoningAndVerbose into the main resolveReplyDirectives() call');
+    errors++;
+  }
+}
+
+verifyScopedReplyRuntimeFlags();
 
 // Verify bundled extensions have required plugin metadata
 const extensionsDir = path.join(CLAWDBOT_DIR, 'dist', 'extensions');

--- a/src/src-tauri/resources/clawdbot/dist/get-reply-DOTqK3jN.js
+++ b/src/src-tauri/resources/clawdbot/dist/get-reply-DOTqK3jN.js
@@ -952,7 +952,7 @@ function resolveDirectiveCommandText(params) {
 	};
 }
 async function resolveReplyDirectives(params) {
-	const { ctx, cfg, agentId, agentCfg, agentDir, workspaceDir, sessionCtx, sessionEntry, sessionStore, sessionKey, storePath, sessionScope, groupResolution, isGroup, triggerBodyNormalized, resetTriggered, commandAuthorized, defaultProvider, defaultModel, primaryProvider, primaryModel, provider: initialProvider, model: initialModel, hasOneTurnModelOverride, skipStoredModelOverride, hasResolvedHeartbeatModelOverride, typing, opts, skillFilter } = params;
+	const { ctx, cfg, agentId, agentCfg, agentDir, workspaceDir, sessionCtx, sessionEntry, sessionStore, sessionKey, storePath, sessionScope, groupResolution, isGroup, triggerBodyNormalized, resetTriggered, commandAuthorized, defaultProvider, defaultModel, primaryProvider, primaryModel, provider: initialProvider, model: initialModel, hasOneTurnModelOverride, skipStoredModelOverride, hasResolvedHeartbeatModelOverride, typing, opts, skillFilter, suppressSlackChannelReasoningAndVerbose = false } = params;
 	const agentEntry = listAgentEntries(cfg).find((entry) => normalizeAgentId(entry.id) === normalizeAgentId(agentId));
 	const targetSessionEntry = sessionStore[sessionKey] ?? sessionEntry;
 	let provider = initialProvider;
@@ -1741,6 +1741,7 @@ async function maybeResolveNativeSlashCommandFastReply(params) {
 		provider: params.provider,
 		model: params.model,
 		hasResolvedHeartbeatModelOverride: false,
+		suppressSlackChannelReasoningAndVerbose: false,
 		typing: params.typing,
 		opts: params.opts,
 		skillFilter: params.skillFilter
@@ -4501,6 +4502,7 @@ async function getReplyFromConfig(ctx, opts, configOverride) {
 		model,
 		hasOneTurnModelOverride: hasAppliedImageModelOverride,
 		hasResolvedHeartbeatModelOverride,
+		suppressSlackChannelReasoningAndVerbose,
 		typing,
 		opts: resolvedOpts,
 		skillFilter: mergedSkillFilter

--- a/src/src-tauri/resources/clawdbot/dist/plugin-sdk/src/auto-reply/reply/get-reply-directives.d.ts
+++ b/src/src-tauri/resources/clawdbot/dist/plugin-sdk/src/auto-reply/reply/get-reply-directives.d.ts
@@ -90,6 +90,7 @@ export declare function resolveReplyDirectives(params: {
     hasOneTurnModelOverride?: boolean;
     skipStoredModelOverride?: boolean;
     hasResolvedHeartbeatModelOverride: boolean;
+    suppressSlackChannelReasoningAndVerbose?: boolean;
     typing: TypingController;
     opts?: GetReplyOptions;
     skillFilter?: string[];


### PR DESCRIPTION
## Summary
- pass the Slack group-channel reasoning/verbose suppression flag into resolveReplyDirectives instead of relying on an out-of-scope variable
- keep native slash command fast-reply calls explicit so they cannot trip the same runtime path
- add a bundle-verification guard that fails if the get-reply chunk references this flag without wiring it into the directive resolver

## Validation
- node --check src/src-tauri/resources/clawdbot/dist/get-reply-DOTqK3jN.js
- targeted grep/diff verification of the new directive wiring and bundle guard
- note: full verify-clawdbot-bundle.cjs in a fresh worktree still requires the usual prepared bundled node/node_modules artifacts and fails for those unrelated bootstrap reasons