### PR TITLE
Fix stale Google auth popup gating

### DIFF
--- a/src/src/hooks/automation/useAutomations.tsx
+++ b/src/src/hooks/automation/useAutomations.tsx
@@ -77,13 +77,20 @@ const checkAutomationAuth = async (
   const requiredGoogleKeys = getAutomationGoogleConnectionKeys(automation)
 
   for (const key of requiredGoogleKeys) {
+    try {
+      const accessToken = await getAccessToken(userEmail, key)
+      if (accessToken) {
+        continue
+      }
+    } catch {
+      // Fall through to the local connection snapshot check below.
+    }
+
     if (!hasRequiredConnection(connections, key)) {
       return { needsAuth: true, requiredGoogleKeys }
     }
-  }
 
-  for (const key of requiredGoogleKeys) {
-    await getAccessToken(userEmail, key)
+    return { needsAuth: true, requiredGoogleKeys }
   }
 
   return { needsAuth: false, requiredGoogleKeys }


### PR DESCRIPTION
## Summary
- trust a live Google token probe before showing the automation auth popup
- avoid reblocking automations when backend Google auth is valid but the frontend connection snapshot is stale
- keep the fix scoped to the automation auth gate used by feed-driven agent runs

## Validation
- npm run build
- reviewed Caitlin's July 7 logs showing repeated 200 responses from /api/knapsack/connections/google/auth_token while the popup stayed open
