### PR TITLE
Fix Google automation auth popup regression

### DIFF
--- a/src/src/hooks/automation/useAutomations.tsx
+++ b/src/src/hooks/automation/useAutomations.tsx
@@ -90,7 +90,7 @@ const checkAutomationAuth = async (
       return { needsAuth: true, requiredGoogleKeys }
     }
 
-    return { needsAuth: true, requiredGoogleKeys }
+    continue
   }
 
   return { needsAuth: false, requiredGoogleKeys }


### PR DESCRIPTION
## Summary
- fix the Google automation auth check so a valid saved connection does not still force the Allow Access popup
- keep the token probe behavior, but continue the loop when the local connection snapshot is already valid

## Testing
- npm run build
