### PR TITLE
Fix TrustedRouter runtime connectivity

### DIFF
--- a/src/src-tauri/src/clawd/chat_agent.rs
+++ b/src/src-tauri/src/clawd/chat_agent.rs
@@ -565,9 +565,13 @@ pub async fn openai_compatible_chat(
   // Use a longer timeout for local providers (Ollama) which may need more time
   let is_local = base_url.contains("localhost") || base_url.contains("127.0.0.1");
   let timeout_secs = if is_local { 300 } else { 60 };
-  let client = reqwest::Client::builder()
-    .timeout(Duration::from_secs(timeout_secs))
-    .build()?;
+  let mut client_builder = reqwest::Client::builder().timeout(Duration::from_secs(timeout_secs));
+  if base_url.contains("trustedrouter.com") {
+    // TrustedRouter has been intermittently failing ALPN negotiation on some
+    // macOS builds with reqwest's default transport. Force HTTP/1.1 there.
+    client_builder = client_builder.http1_only();
+  }
+  let client = client_builder.build()?;
 
   // OpenAI reasoning models (o1, o3, o4-mini, gpt-5.2-pro) only support temperature=1 (default).
   // Ollama models also often reject non-default temperatures for reasoning variants.

--- a/src/src-tauri/src/clawd/gateway_client.rs
+++ b/src/src-tauri/src/clawd/gateway_client.rs
@@ -1243,7 +1243,10 @@ pub fn resolve_default_model() -> String {
     "trustedrouter" => {
       let model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
         .unwrap_or_else(|_| "trustedrouter/auto".to_string());
-      return format!("trustedrouter/{}", model);
+      return format!(
+        "trustedrouter/{}",
+        normalize_provider_model("trustedrouter", &model)
+      );
     }
     "ollama" => {
       let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
@@ -1365,7 +1368,10 @@ pub fn resolve_default_model() -> String {
   if has_key("TRUSTEDROUTER_API_KEY") {
     let model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
       .unwrap_or_else(|_| "trustedrouter/auto".to_string());
-    return format!("trustedrouter/{}", model);
+    return format!(
+      "trustedrouter/{}",
+      normalize_provider_model("trustedrouter", &model)
+    );
   }
   if has_key("OLLAMA_API_KEY") {
     let model = std::env::var("KNAPSACK_OLLAMA_MODEL").unwrap_or_else(|_| "llama3.1".to_string());
@@ -1442,7 +1448,10 @@ pub fn collect_fallback_models(primary: &str) -> Vec<String> {
   if primary_provider != "trustedrouter" && has_key("TRUSTEDROUTER_API_KEY") {
     let model = std::env::var("KNAPSACK_TRUSTEDROUTER_MODEL")
       .unwrap_or_else(|_| "trustedrouter/auto".to_string());
-    fallbacks.push(format!("trustedrouter/{}", model));
+    fallbacks.push(format!(
+      "trustedrouter/{}",
+      normalize_provider_model("trustedrouter", &model)
+    ));
   }
 
   fallbacks
@@ -3230,6 +3239,20 @@ mod tests {
     std::env::remove_var("KNAPSACK_ACCESS_TOKEN");
     std::env::remove_var("KNAPSACK_REFRESH_TOKEN");
     std::env::remove_var("KNAPSACK_USER_EMAIL");
+  }
+
+  #[test]
+  fn resolve_default_model_normalizes_trustedrouter_prefix_once() {
+    std::env::set_var("KNAPSACK_ACTIVE_PROVIDER", "trustedrouter");
+    std::env::set_var("TRUSTEDROUTER_API_KEY", "sk-tr-test");
+    std::env::set_var("KNAPSACK_TRUSTEDROUTER_MODEL", "trustedrouter/auto");
+
+    let model = resolve_default_model();
+    assert_eq!(model, "trustedrouter/auto");
+
+    std::env::remove_var("KNAPSACK_ACTIVE_PROVIDER");
+    std::env::remove_var("TRUSTEDROUTER_API_KEY");
+    std::env::remove_var("KNAPSACK_TRUSTEDROUTER_MODEL");
   }
 
   // ── ensure_browser_config_at: no spurious change when already correct ───

--- a/src/src-tauri/src/clawd/service.rs
+++ b/src/src-tauri/src/clawd/service.rs
@@ -7943,10 +7943,11 @@ pub async fn validate_api_key(payload: web::Json<ValidateApiKeyRequest>) -> impl
     .as_deref()
     .unwrap_or("openai")
     .to_lowercase();
-  let client = reqwest::Client::builder()
-    .timeout(std::time::Duration::from_secs(10))
-    .build()
-    .unwrap_or_default();
+  let mut client_builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10));
+  if provider == "trustedrouter" {
+    client_builder = client_builder.http1_only();
+  }
+  let client = client_builder.build().unwrap_or_default();
 
   let result = match provider.as_str() {
     "anthropic" => {

--- a/src/src-tauri/src/heartbeat/engine.rs
+++ b/src/src-tauri/src/heartbeat/engine.rs
@@ -451,10 +451,14 @@ Respond with ONLY valid JSON, no markdown, no explanation:
 async fn call_llm_for_decision(prompt: &str) -> Result<LlmDecision, String> {
   let provider = resolve_heartbeat_provider()?;
 
-  let client = reqwest::Client::builder()
-    .timeout(std::time::Duration::from_secs(30))
-    .build()
-    .map_err(|e| format!("HTTP client error: {}", e))?;
+  let client = if provider.is_anthropic {
+    reqwest::Client::builder()
+      .timeout(std::time::Duration::from_secs(30))
+      .build()
+      .map_err(|e| format!("HTTP client error: {}", e))?
+  } else {
+    openai_compatible_client(&provider.base_url).map_err(|e| format!("HTTP client error: {}", e))?
+  };
 
   let response_text = if provider.is_anthropic {
     // Anthropic Messages API
@@ -575,6 +579,16 @@ struct HeartbeatProvider {
   model: String,
   base_url: String,
   is_anthropic: bool,
+}
+
+fn openai_compatible_client(base_url: &str) -> Result<reqwest::Client, reqwest::Error> {
+  let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
+  if base_url.contains("trustedrouter.com") {
+    // TrustedRouter has been intermittently failing ALPN negotiation on some
+    // macOS builds with reqwest's default transport. Force HTTP/1.1 there.
+    builder = builder.http1_only();
+  }
+  builder.build()
 }
 
 /// Resolve the cheapest available model for the user's active provider.

--- a/src/src-tauri/src/llm/use_cases/complete.rs
+++ b/src/src-tauri/src/llm/use_cases/complete.rs
@@ -45,6 +45,19 @@ struct ResolvedProvider {
   is_anthropic: bool, // Anthropic uses a different API format
 }
 
+fn openai_compatible_client(
+  provider_name: &str,
+  base_url: &str,
+) -> Result<reqwest::Client, reqwest::Error> {
+  let mut builder = reqwest::Client::builder();
+  if provider_name == "trustedrouter" || base_url.contains("trustedrouter.com") {
+    // TrustedRouter has been intermittently failing ALPN negotiation on some
+    // macOS builds with reqwest's default transport. Force HTTP/1.1 there.
+    builder = builder.http1_only();
+  }
+  builder.build()
+}
+
 /// Try to resolve the best available LLM provider from env vars.
 /// Priority: active_provider setting → OpenAI → Anthropic → Gemini → Groq → TrustedRouter → OpenRouter → Knapsack
 fn resolve_provider() -> Result<ResolvedProvider, LLMError> {
@@ -604,7 +617,12 @@ async fn openai_compatible_completion(
   provider: &ResolvedProvider,
   messages: &[LlmMessage],
 ) -> Result<String, LLMError> {
-  let client = reqwest::Client::new();
+  let client = openai_compatible_client(&provider.name, &provider.base_url).map_err(|e| {
+    LLMError::ChatCompletionFailed(format!(
+      "{} client initialization failed: {}",
+      provider.name, e
+    ))
+  })?;
   let msgs: Vec<serde_json::Value> = messages
     .iter()
     .map(|m| {


### PR DESCRIPTION
## Summary
- avoid double-prefixing TrustedRouter model ids when resolving gateway defaults and fallbacks
- force HTTP/1.1 for TrustedRouter openai-compatible requests used by chat, heartbeat, completions, and API-key validation
- add a regression test covering trustedrouter model normalization

## Root cause
TrustedRouter requests were failing in two different ways:
1. some paths could transform `trustedrouter/auto` into `trustedrouter/trustedrouter/auto`
2. reqwest calls to `https://api.trustedrouter.com/v1` were negotiating a protocol TrustedRouter rejected, surfacing `bad protocol version` in logs

## Verification
- `cargo test --manifest-path src/src-tauri/Cargo.toml resolve_default_model_normalizes_trustedrouter_prefix_once -- --nocapture`
- `cargo test --manifest-path src/src-tauri/Cargo.toml resolve_default_model_rewrites_knapsack_auto_for_gateway_use -- --nocapture`